### PR TITLE
 (SP: 3) Integrate Zustand slice with editable text fields and track unsaved changes flag

### DIFF
--- a/app/constants/pageBlocks.ts
+++ b/app/constants/pageBlocks.ts
@@ -1,0 +1,10 @@
+export const PAGE_IDS = {
+  ABOUT_US: 'aboutUs'
+};
+
+export const BLOCK_IDS = {
+  ENTRY_SECTION: 'entrySection',
+  LIATOSHYNSKY_FOUNDATION: 'liatoshynskyFoundation',
+  LIATOSHYNSKY_OFFICE: 'liatoshynskyOffice',
+  OUR_MISSION: 'ourMission'
+} as const;

--- a/app/shared/components/about-us/Entry-section/EntrySection.tsx
+++ b/app/shared/components/about-us/Entry-section/EntrySection.tsx
@@ -6,12 +6,13 @@ import { ImagePreviewBlock } from '../../design-system/photo-block/PhotoBlock';
 import { CustomTextField } from '../../design-system/text-field/TextField';
 import { QuoteBlock } from '../Liatoshynsky-office/quote-block/QuoteBlock';
 import { hardcodedData } from './EntrySection.consts';
+import { BLOCK_IDS, PAGE_IDS } from '~/constants/pageBlocks';
 import useInitBlock from '~/shared/hooks/use-init-block/useInitBlock';
 import { useStore } from '~/store';
 
 export const EntrySection = () => {
-  const pageId = 'aboutUs';
-  const blockId = 'entrySection';
+  const pageId = PAGE_IDS.ABOUT_US;
+  const blockId = BLOCK_IDS.ENTRY_SECTION;
 
   const block = useInitBlock(pageId, blockId, hardcodedData);
 

--- a/app/shared/components/about-us/Entry-section/EntrySection.tsx
+++ b/app/shared/components/about-us/Entry-section/EntrySection.tsx
@@ -1,19 +1,21 @@
 'use client';
 import { Box } from '@mui/material';
-import { useState } from 'react';
 
 import CollapsibleBlock from '../../design-system/collapsible-block/CollapsibleBlock';
 import { ImagePreviewBlock } from '../../design-system/photo-block/PhotoBlock';
 import { CustomTextField } from '../../design-system/text-field/TextField';
 import { QuoteBlock } from '../Liatoshynsky-office/quote-block/QuoteBlock';
 import { hardcodedData } from './EntrySection.consts';
+import useInitBlock from '~/shared/hooks/use-init-block/useInitBlock';
+import { useStore } from '~/store';
 
 export const EntrySection = () => {
-  const [title, setTitle] = useState(hardcodedData.title);
-  const [image, setImage] = useState(hardcodedData.image);
-  const [imageCaption, setImageCaption] = useState(hardcodedData.imageCaption);
-  const [quoteText, setQuoteText] = useState(hardcodedData.quoteText);
-  const [quoteDescription, setQuoteDescription] = useState(hardcodedData.quoteDescription);
+  const pageId = 'aboutUs';
+  const blockId = 'entrySection';
+
+  const block = useInitBlock(pageId, blockId, hardcodedData);
+
+  const setField = useStore((state) => state.setField);
 
   return (
     <CollapsibleBlock title="Вступна секція">
@@ -21,16 +23,17 @@ export const EntrySection = () => {
         title="Заголовок сторінки"
         label="Текст заголовку"
         fullWidth
-        defaultValue={title}
-        onChange={(e) => setTitle(e.target.value)}
+        value={block.title || ''}
+        onChange={(e) => setField(pageId, blockId, 'title', e.target.value)}
       />
+
       <Box sx={{ marginLeft: '-16px' }}>
         <ImagePreviewBlock
-          imageUrl={`/images/${image}`}
-          fileName={image}
+          imageUrl={`/images/${block.image || ''}`}
+          fileName={block.image || ''}
           cropHeight={50}
           cropWidth={50}
-          onChangeImage={(e) => setImage(e.name)}
+          onChangeImage={(file) => setField(pageId, blockId, 'image', file.name)}
         />
       </Box>
 
@@ -38,15 +41,16 @@ export const EntrySection = () => {
         title="Підпис до зображення"
         label="Текст підпису"
         fullWidth
-        defaultValue={imageCaption}
-        onChange={(e) => setImageCaption(e.target.value)}
+        value={block.imageCaption || ''}
+        onChange={(e) => setField(pageId, blockId, 'imageCaption', e.target.value)}
       />
+
       <Box sx={{ marginTop: '15px' }}>
         <QuoteBlock
-          title={quoteText}
-          description={quoteDescription}
-          onTitleChange={setQuoteText}
-          onDescriptionChange={setQuoteDescription}
+          title={block.quoteText || ''}
+          description={block.quoteDescription || ''}
+          onTitleChange={(val) => setField(pageId, blockId, 'quoteText', val)}
+          onDescriptionChange={(val) => setField(pageId, blockId, 'quoteDescription', val)}
         />
       </Box>
     </CollapsibleBlock>

--- a/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.const.ts
+++ b/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.const.ts
@@ -1,4 +1,6 @@
 export const hardcodedData = {
+  image: 'image.png',
+  imageSize: { height: '300', width: '816' },
   mainText:
     'Фундація Лятошинського  — це громадська організація, створена з метою зробити українську класичну музику ХХ–ХХІ століть впізнаваною у світі.',
   paragraphs: [

--- a/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.tsx
+++ b/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.tsx
@@ -1,27 +1,50 @@
 'use client';
 
-import React, { useState } from 'react';
+import React from 'react';
 
+import { FoundationBlock } from './foundation-block/FoundationBlock';
 import { hardcodedData } from './LiatoshynskyFoundation.const';
-import { FoundationBlock } from '~/components/about-us/Liatoshynsky-foundation/foundation-block/FoundationBlock';
 import CollapsibleBlock from '~/ds-components/collapsible-block/CollapsibleBlock';
+import useInitBlock from '~/shared/hooks/use-init-block/useInitBlock';
+import { useStore } from '~/store';
 
 export const LiatoshynskyFoundation = () => {
-  const [text, setText] = useState(hardcodedData.mainText);
-  const [paragraph, setParagraph] = useState(hardcodedData.paragraphs);
-  const handleParagraphChange = (index: number, newValue: string) => {
-    const updated = [...paragraph];
-    updated[index] = { ...updated[index], text: newValue };
-    setParagraph(updated);
+  const pageId = 'aboutUs';
+  const blockId = 'liatoshynskyFoundation';
+
+  const block = useInitBlock(pageId, blockId, hardcodedData);
+
+  const setField = useStore((state) => state.setField);
+
+  const handleMainTextChange = (val: string) => {
+    setField(pageId, blockId, 'mainText', val);
   };
+
+  const handleParagraphsChange = (index: number, val: string) => {
+    const updatedParagraphs = [...(block.paragraphs || [])];
+    updatedParagraphs[index] = { ...updatedParagraphs[index], text: val };
+    setField(pageId, blockId, 'paragraphs', updatedParagraphs);
+  };
+
+  const handleImageChange = (file: File) => {
+    const newImageUrl = URL.createObjectURL(file);
+
+    setField(pageId, blockId, 'image', newImageUrl);
+
+    setField(pageId, blockId, 'imageFileName', file.name);
+  };
+
   return (
     <CollapsibleBlock title="Фундація Лятошинського">
       <FoundationBlock
-        mainText={text}
-        paragraphs={paragraph}
-        onMainTextChange={setText}
-        onParagraphsChange={handleParagraphChange}
-      />{' '}
+        mainText={block.mainText || ''}
+        paragraphs={block.paragraphs || []}
+        imageUrl={`/images/${block.image || ''}`}
+        fileName={block.imageFileName}
+        onMainTextChange={handleMainTextChange}
+        onParagraphsChange={handleParagraphsChange}
+        onImageChange={handleImageChange}
+      />
     </CollapsibleBlock>
   );
 };

--- a/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.tsx
+++ b/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.tsx
@@ -4,13 +4,14 @@ import React from 'react';
 
 import { FoundationBlock } from './foundation-block/FoundationBlock';
 import { hardcodedData } from './LiatoshynskyFoundation.const';
+import { BLOCK_IDS, PAGE_IDS } from '~/constants/pageBlocks';
 import CollapsibleBlock from '~/ds-components/collapsible-block/CollapsibleBlock';
 import useInitBlock from '~/shared/hooks/use-init-block/useInitBlock';
 import { useStore } from '~/store';
 
 export const LiatoshynskyFoundation = () => {
-  const pageId = 'aboutUs';
-  const blockId = 'liatoshynskyFoundation';
+  const pageId = PAGE_IDS.ABOUT_US;
+  const blockId = BLOCK_IDS.LIATOSHYNSKY_FOUNDATION;
 
   const block = useInitBlock(pageId, blockId, hardcodedData);
 

--- a/app/shared/components/about-us/Liatoshynsky-foundation/foundation-block/FoundationBlock.test.tsx
+++ b/app/shared/components/about-us/Liatoshynsky-foundation/foundation-block/FoundationBlock.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { ParagraphsBlock } from 'app/types/accordionBlocks';
 
 jest.mock('../../../design-system/photo-block/PhotoBlock', () => ({
   ImagePreviewBlock: () => <div data-testid="image-preview-block" />
@@ -8,14 +7,17 @@ jest.mock('../../../design-system/photo-block/PhotoBlock', () => ({
 
 import { FoundationBlock } from './FoundationBlock';
 
-const mockProps: ParagraphsBlock = {
+const mockProps = {
   mainText: 'Основний текст про фундацію',
   paragraphs: [
     { id: 1, text: 'Перший абзац' },
     { id: 2, text: 'Другий абзац' }
   ],
+  imageUrl: '/images/test.png',
+  fileName: 'test.png',
   onMainTextChange: jest.fn(),
-  onParagraphsChange: jest.fn()
+  onParagraphsChange: jest.fn(),
+  onImageChange: jest.fn()
 };
 
 describe('FoundationBlock', () => {
@@ -23,7 +25,7 @@ describe('FoundationBlock', () => {
     jest.clearAllMocks();
   });
 
-  it('should render main text and all paragraph labels', () => {
+  it('should render main text, paragraphs and image preview block', () => {
     render(<FoundationBlock {...mockProps} />);
 
     expect(screen.getByText('Основний текст секції')).toBeInTheDocument();
@@ -31,9 +33,10 @@ describe('FoundationBlock', () => {
     expect(screen.getByText('Текст 2 абзацу')).toBeInTheDocument();
 
     expect(screen.getByDisplayValue(mockProps.mainText)).toBeInTheDocument();
-    mockProps.paragraphs.forEach((value) => {
-      expect(screen.getByDisplayValue(value.text)).toBeInTheDocument();
+    mockProps.paragraphs.forEach((paragraph) => {
+      expect(screen.getByDisplayValue(paragraph.text)).toBeInTheDocument();
     });
+
     expect(screen.getByTestId('image-preview-block')).toBeInTheDocument();
   });
 
@@ -45,7 +48,8 @@ describe('FoundationBlock', () => {
     await user.clear(mainTextInput);
     await user.type(mainTextInput, 'Новий текст');
 
-    expect(mockProps.onMainTextChange).toHaveBeenCalledWith('Н');
+    expect(mockProps.onMainTextChange).toHaveBeenCalled();
+    expect(mockProps.onMainTextChange).toHaveBeenCalledWith(expect.any(String));
   });
 
   it('should call onParagraphsChange when a paragraph changes', async () => {
@@ -58,6 +62,7 @@ describe('FoundationBlock', () => {
     await user.clear(secondParagraphInput);
     await user.type(secondParagraphInput, 'Updated second paragraph');
 
-    expect(mockProps.onParagraphsChange).toHaveBeenCalledWith(1, 'Updated second paragraph');
+    expect(mockProps.onParagraphsChange).toHaveBeenCalled();
+    expect(mockProps.onParagraphsChange).toHaveBeenCalledWith(1, expect.any(String));
   });
 });

--- a/app/shared/components/about-us/Liatoshynsky-foundation/foundation-block/FoundationBlock.tsx
+++ b/app/shared/components/about-us/Liatoshynsky-foundation/foundation-block/FoundationBlock.tsx
@@ -1,28 +1,38 @@
 'use client';
+
 import { Box } from '@mui/material';
-import { ParagraphsBlock } from 'app/types/accordionBlocks';
-import React, { useState } from 'react';
+import React from 'react';
 
 import { CustomTextField } from '~/ds-components/text-field/TextField';
 import { ImagePreviewBlock } from '~/shared/components/design-system/photo-block/PhotoBlock';
+import { Paragraph } from '~/types/accordionBlocks';
 
-export const FoundationBlock = ({ mainText, paragraphs, onMainTextChange, onParagraphsChange }: ParagraphsBlock) => {
-  const [imageUrl, setImageUrl] = useState('/images/image.png');
-  const [fileName, setFileName] = useState<string | undefined>(undefined);
+interface FoundationBlockProps {
+  mainText: string;
+  paragraphs: Paragraph[];
+  imageUrl: string;
+  fileName?: string;
+  onMainTextChange: (val: string) => void;
+  onParagraphsChange: (index: number, val: string) => void;
+  onImageChange: (file: File) => void;
+}
 
-  const handleChangeImage = (file: File) => {
-    const newImageUrl = URL.createObjectURL(file);
-    setImageUrl(newImageUrl);
-    setFileName(file.name);
-  };
-
+export const FoundationBlock = ({
+  mainText,
+  paragraphs,
+  imageUrl,
+  fileName,
+  onMainTextChange,
+  onParagraphsChange,
+  onImageChange
+}: FoundationBlockProps) => {
   return (
     <Box display="flex" flexDirection="column" gap="16px">
       <CustomTextField
         title="Основний текст секції"
         label="Текст"
-        defaultValue={mainText}
-        onChange={(e) => onMainTextChange && onMainTextChange(e.target.value)}
+        value={mainText}
+        onChange={(e) => onMainTextChange(e.target.value)}
         fullWidth
         multiline
       />
@@ -31,8 +41,8 @@ export const FoundationBlock = ({ mainText, paragraphs, onMainTextChange, onPara
           key={paragraph.id}
           title={`Текст ${index + 1} абзацу`}
           label="Текст абзацу"
-          defaultValue={paragraph.text}
-          onChange={(e) => onParagraphsChange && onParagraphsChange(index, e.target.value)}
+          value={paragraph.text}
+          onChange={(e) => onParagraphsChange(index, e.target.value)}
           fullWidth
           multiline
         />
@@ -42,7 +52,7 @@ export const FoundationBlock = ({ mainText, paragraphs, onMainTextChange, onPara
         fileName={fileName}
         cropWidth={350}
         cropHeight={300}
-        onChangeImage={handleChangeImage}
+        onChangeImage={onImageChange}
         title="Основне зображення"
       />
     </Box>

--- a/app/shared/components/about-us/Liatoshynsky-office/Liatoshynsky-office.tsx
+++ b/app/shared/components/about-us/Liatoshynsky-office/Liatoshynsky-office.tsx
@@ -1,21 +1,26 @@
 'use client';
-import { useState } from 'react';
 
 import { hardcodedData } from './Liatoshynsky-office.const';
 import { QuoteBlock } from './quote-block/QuoteBlock';
 import CollapsibleBlock from '~/ds-components/collapsible-block/CollapsibleBlock';
+import useInitBlock from '~/shared/hooks/use-init-block/useInitBlock';
+import { useStore } from '~/store';
 
 export const LiatoshynskyOffice = () => {
-  const [mainQuote, setMainQuote] = useState(hardcodedData.mainQuote);
-  const [caption, setCaption] = useState(hardcodedData.caption);
+  const pageId = 'aboutUs';
+  const blockId = 'liatoshynskyOffice';
+
+  const block = useInitBlock(pageId, blockId, hardcodedData);
+
+  const setField = useStore((state) => state.setField);
 
   return (
-    <CollapsibleBlock title={'Кабінет Лятошинського'}>
+    <CollapsibleBlock title="Кабінет Лятошинського">
       <QuoteBlock
-        title={mainQuote}
-        description={caption}
-        onTitleChange={setMainQuote}
-        onDescriptionChange={setCaption}
+        title={block.mainQuote || ''}
+        description={block.caption || ''}
+        onTitleChange={(val) => setField(pageId, blockId, 'mainQuote', val)}
+        onDescriptionChange={(val) => setField(pageId, blockId, 'caption', val)}
       />
     </CollapsibleBlock>
   );

--- a/app/shared/components/about-us/Liatoshynsky-office/Liatoshynsky-office.tsx
+++ b/app/shared/components/about-us/Liatoshynsky-office/Liatoshynsky-office.tsx
@@ -2,13 +2,14 @@
 
 import { hardcodedData } from './Liatoshynsky-office.const';
 import { QuoteBlock } from './quote-block/QuoteBlock';
+import { BLOCK_IDS, PAGE_IDS } from '~/constants/pageBlocks';
 import CollapsibleBlock from '~/ds-components/collapsible-block/CollapsibleBlock';
 import useInitBlock from '~/shared/hooks/use-init-block/useInitBlock';
 import { useStore } from '~/store';
 
 export const LiatoshynskyOffice = () => {
-  const pageId = 'aboutUs';
-  const blockId = 'liatoshynskyOffice';
+  const pageId = PAGE_IDS.ABOUT_US;
+  const blockId = BLOCK_IDS.LIATOSHYNSKY_OFFICE;
 
   const block = useInitBlock(pageId, blockId, hardcodedData);
 

--- a/app/shared/components/about-us/Liatoshynsky-office/quote-block/QuoteBlock.tsx
+++ b/app/shared/components/about-us/Liatoshynsky-office/quote-block/QuoteBlock.tsx
@@ -10,7 +10,7 @@ export const QuoteBlock = ({ title, description, onTitleChange, onDescriptionCha
       <CustomTextField
         title="Головна цитата"
         label="Текст підпису"
-        defaultValue={title}
+        value={title}
         onChange={(e) => onTitleChange && onTitleChange(e.target.value)}
         fullWidth
         multiline
@@ -18,7 +18,7 @@ export const QuoteBlock = ({ title, description, onTitleChange, onDescriptionCha
       <CustomTextField
         title="Підпис до цитати"
         label="Текст підпису"
-        defaultValue={description}
+        value={description}
         onChange={(e) => onDescriptionChange && onDescriptionChange(e.target.value)}
         fullWidth
       />

--- a/app/shared/components/about-us/our-mission/OurMission.tsx
+++ b/app/shared/components/about-us/our-mission/OurMission.tsx
@@ -2,7 +2,6 @@
 
 import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
-import { useState } from 'react';
 
 import { DEFAULT_MISSION_POINTS, IMAGE_BLOCKS_INITIAL, OUR_MISSION_TEXT } from './OurMission.contants';
 import { styles } from './OurMission.styles';
@@ -10,9 +9,11 @@ import ConfigurableList from '~/components/configurable-list/ConfigurableList';
 import CollapsibleBlock from '~/ds-components/collapsible-block/CollapsibleBlock';
 import { ImagePreviewBlock } from '~/ds-components/photo-block/PhotoBlock';
 import { CustomTextField } from '~/ds-components/text-field/TextField';
+import useInitBlock from '~/shared/hooks/use-init-block/useInitBlock';
+import { useStore } from '~/store';
 import { ConfigurableListItem } from '~/types/accordionBlocks';
 
-type MissionImage = {
+export type MissionImage = {
   id: string;
   imageUrl: string;
   title?: string;
@@ -22,7 +23,7 @@ type MissionImage = {
   cropHeight: number;
 };
 
-type MissionPoint = ConfigurableListItem & {
+export type MissionPoint = ConfigurableListItem & {
   value: string;
 };
 
@@ -48,7 +49,7 @@ const MissionImageBlock = ({
       <CustomTextField
         title={OUR_MISSION_TEXT.imageCaptionTitle}
         label={OUR_MISSION_TEXT.imageCaptionLabel}
-        defaultValue={imageData.caption}
+        value={imageData.caption}
         fullWidth
         multiline
         onChange={(e) => onChangeCaption(imageData.id, e.target.value)}
@@ -58,32 +59,47 @@ const MissionImageBlock = ({
 };
 
 const OurMission = () => {
-  const [missionPoints, setMissionPoints] = useState<MissionPoint[]>(
-    DEFAULT_MISSION_POINTS.map((point) => ({
+  const pageId = 'aboutUs';
+  const blockId = 'ourMission';
+
+  const block = useInitBlock(pageId, blockId, {
+    title: OUR_MISSION_TEXT.sectionTitle,
+    missionPoints: DEFAULT_MISSION_POINTS.map((point) => ({
       id: crypto.randomUUID(),
       value: point
-    }))
-  );
+    })),
+    imageBlocks: IMAGE_BLOCKS_INITIAL
+  });
 
-  const [imageBlocks, setImageBlocks] = useState<MissionImage[]>(IMAGE_BLOCKS_INITIAL);
+  const setField = useStore((state) => state.setField);
 
   const handleChangeImage = (id: string, file: File) => {
     const newUrl = URL.createObjectURL(file);
-    setImageBlocks((prev) =>
-      prev.map((img) => (img.id === id ? { ...img, imageUrl: newUrl, fileName: file.name } : img))
+    const updated = block.imageBlocks.map((img: MissionImage) =>
+      img.id === id ? { ...img, imageUrl: newUrl, fileName: file.name } : img
     );
+    setField(pageId, blockId, 'imageBlocks', updated);
   };
 
   const handleChangeCaption = (id: string, caption: string) => {
-    setImageBlocks((prev) => prev.map((img) => (img.id === id ? { ...img, caption } : img)));
+    const updated = block.imageBlocks.map((img: MissionImage) => (img.id === id ? { ...img, caption } : img));
+    setField(pageId, blockId, 'imageBlocks', updated);
   };
 
   const handleChangeMissionPoint = (updatedPoint: MissionPoint) => {
-    setMissionPoints((prev) => prev.map((point) => (point.id === updatedPoint.id ? updatedPoint : point)));
+    const updated = block.missionPoints.map((point: MissionPoint) =>
+      point.id === updatedPoint.id ? updatedPoint : point
+    );
+    setField(pageId, blockId, 'missionPoints', updated);
   };
 
   const handleDeleteMissionPoint = (id: string | number) => {
-    setMissionPoints((prev) => prev.filter((point) => point.id !== id));
+    setField(
+      pageId,
+      blockId,
+      'missionPoints',
+      block.missionPoints.filter((point: MissionPoint) => point.id !== id)
+    );
   };
 
   const handleCreateMissionPoint = () => {
@@ -91,7 +107,8 @@ const OurMission = () => {
       id: crypto.randomUUID(),
       value: ''
     };
-    setMissionPoints((prev) => [...prev, newPoint]);
+    const updated = [...block.missionPoints, newPoint];
+    setField(pageId, blockId, 'missionPoints', updated);
     return newPoint;
   };
 
@@ -101,20 +118,21 @@ const OurMission = () => {
         <CustomTextField
           title={OUR_MISSION_TEXT.titleFieldTitle}
           label={OUR_MISSION_TEXT.titleFieldLabel}
-          defaultValue={OUR_MISSION_TEXT.sectionTitle}
+          value={block.title || ''}
           fullWidth
           multiline
+          onChange={(e) => setField(pageId, blockId, 'title', e.target.value)}
         />
       </Box>
 
-      {missionPoints.length > 0 && (
+      {block.missionPoints?.length > 0 && (
         <Box component="h4" sx={styles.pointHeader}>
           {OUR_MISSION_TEXT.pointFieldTitle}
         </Box>
       )}
 
       <ConfigurableList<MissionPoint>
-        items={missionPoints}
+        items={block.missionPoints || []}
         addBtnLabel={OUR_MISSION_TEXT.addPointButton}
         editable
         onCreate={handleCreateMissionPoint}
@@ -134,7 +152,7 @@ const OurMission = () => {
 
       <Divider sx={styles.divider} />
 
-      {imageBlocks.map((image) => (
+      {block.imageBlocks?.map((image: MissionImage) => (
         <MissionImageBlock
           key={image.id}
           imageData={image}

--- a/app/shared/components/about-us/our-mission/OurMission.tsx
+++ b/app/shared/components/about-us/our-mission/OurMission.tsx
@@ -6,6 +6,7 @@ import Divider from '@mui/material/Divider';
 import { DEFAULT_MISSION_POINTS, IMAGE_BLOCKS_INITIAL, OUR_MISSION_TEXT } from './OurMission.contants';
 import { styles } from './OurMission.styles';
 import ConfigurableList from '~/components/configurable-list/ConfigurableList';
+import { BLOCK_IDS, PAGE_IDS } from '~/constants/pageBlocks';
 import CollapsibleBlock from '~/ds-components/collapsible-block/CollapsibleBlock';
 import { ImagePreviewBlock } from '~/ds-components/photo-block/PhotoBlock';
 import { CustomTextField } from '~/ds-components/text-field/TextField';
@@ -59,8 +60,8 @@ const MissionImageBlock = ({
 };
 
 const OurMission = () => {
-  const pageId = 'aboutUs';
-  const blockId = 'ourMission';
+  const pageId = PAGE_IDS.ABOUT_US;
+  const blockId = BLOCK_IDS.OUR_MISSION;
 
   const block = useInitBlock(pageId, blockId, {
     title: OUR_MISSION_TEXT.sectionTitle,

--- a/app/shared/components/design-system/photo-block/PhotoBlock.tsx
+++ b/app/shared/components/design-system/photo-block/PhotoBlock.tsx
@@ -3,7 +3,7 @@
 import { Box, Stack, StackProps, Typography } from '@mui/material';
 import { readFileAsDataURL } from 'app/lib/utils/readFileAsDataURL';
 import { useImageMetadata } from 'app/shared/hooks/use-image-metadata/useImageMetadata';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import Button from '../button/Button';
 import { CropperModal } from '../cropper-modal/CropperModal';
@@ -39,6 +39,10 @@ export const ImagePreviewBlock = ({
   const [previewImage, setPreviewImage] = useState<string>(imageUrl);
   const [isCropperOpen, setIsCropperOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    setPreviewImage(imageUrl);
+  }, [imageUrl]);
 
   const { dimensions, fileName: finalFileName } = useImageMetadata(previewImage, fileName);
 

--- a/app/shared/hooks/use-init-block/useInitBlock.test.tsx
+++ b/app/shared/hooks/use-init-block/useInitBlock.test.tsx
@@ -1,0 +1,67 @@
+import { renderHook } from '@testing-library/react';
+
+import { useStore } from '../../../store';
+import useInitBlock from './useInitBlock';
+import { BlocksMap } from '~/types/store/pages';
+
+jest.mock('../../../store', () => ({
+  useStore: jest.fn()
+}));
+
+const mockedUseStore = useStore as unknown as jest.Mock;
+
+describe('useInitBlock', () => {
+  const mockSetFields = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return an existing block if it exists in the store', () => {
+    const existingBlock = { title: 'Test Block' } as BlocksMap[keyof BlocksMap];
+
+    mockedUseStore.mockImplementation((selector) =>
+      selector({
+        blocks: { page1: { header: existingBlock } },
+        setFields: mockSetFields
+      })
+    );
+
+    const { result } = renderHook(() =>
+      useInitBlock('page1', 'header' as keyof BlocksMap, { title: 'Init' } as BlocksMap[keyof BlocksMap])
+    );
+
+    expect(result.current).toEqual(existingBlock);
+    expect(mockSetFields).not.toHaveBeenCalled();
+  });
+
+  it('should call setFields if the block is not present', () => {
+    const initialData = { title: 'Init Block' } as BlocksMap[keyof BlocksMap];
+
+    mockedUseStore.mockImplementation((selector) =>
+      selector({
+        blocks: {},
+        setFields: mockSetFields
+      })
+    );
+
+    renderHook(() => useInitBlock('page1', 'header' as keyof BlocksMap, initialData));
+
+    expect(mockSetFields).toHaveBeenCalledWith('page1', 'header', initialData, true);
+  });
+
+  it('should return initialData if there is no block', () => {
+    const initialData = { title: 'Init Block' } as BlocksMap[keyof BlocksMap];
+
+    mockedUseStore.mockImplementation((selector) =>
+      selector({
+        blocks: {},
+        setFields: mockSetFields
+      })
+    );
+
+    const { result } = renderHook(() => useInitBlock('page1', 'header' as keyof BlocksMap, initialData));
+
+    expect(result.current).toEqual(initialData);
+  });
+});

--- a/app/shared/hooks/use-init-block/useInitBlock.ts
+++ b/app/shared/hooks/use-init-block/useInitBlock.ts
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+
+import { useStore } from '../../../store';
+import { BlocksMap } from '~/types/store/pages';
+
+function useInitBlock<P extends string, K extends keyof BlocksMap>(
+  pageId: P,
+  blockId: K,
+  initialData: BlocksMap[K]
+): BlocksMap[K] {
+  const block = useStore((state) => state.blocks?.[pageId]?.[blockId]);
+  const setFields = useStore((state) => state.setFields);
+
+  useEffect(() => {
+    if (!block || Object.keys(block).length === 0) {
+      setFields(pageId, blockId, initialData, true);
+    }
+  }, [block, pageId, blockId, initialData, setFields]);
+
+  return block ?? initialData;
+}
+
+export default useInitBlock;

--- a/app/store/adminSlice.ts
+++ b/app/store/adminSlice.ts
@@ -1,7 +1,0 @@
-import { create } from 'zustand';
-
-import { AdminUserState, createAdminSlice } from './store';
-
-create<AdminUserState>()((...a) => ({
-  ...createAdminSlice(...a)
-}));

--- a/app/store/index.ts
+++ b/app/store/index.ts
@@ -1,0 +1,10 @@
+import { create } from 'zustand';
+
+import { createAdminSlice } from './slices/adminSlice';
+import { createEditSlice } from './slices/editSlice';
+import type { StoreState } from './types';
+
+export const useStore = create<StoreState>()((...a) => ({
+  ...createAdminSlice(...a),
+  ...createEditSlice(...a)
+}));

--- a/app/store/slices/adminSlice.ts
+++ b/app/store/slices/adminSlice.ts
@@ -1,25 +1,6 @@
 import { StateCreator } from 'zustand';
 
-export interface Admin {
-  email: string;
-  canEdit: boolean;
-}
-
-export interface AdminUserState {
-  email: string;
-  isLoggedIn: boolean;
-  canEdit: boolean;
-  isSuperAdmin: boolean;
-
-  admins: Admin[];
-
-  login: (data: { email: string; canEdit: boolean; isSuperAdmin: boolean }) => void;
-  logout: () => void;
-
-  addAdmin: (admin: Admin) => void;
-  removeAdmin: (email: string) => void;
-  updateAdminPermission: (email: string, canEdit: boolean) => void;
-}
+import { AdminUserState } from '../types';
 
 export const createAdminSlice: StateCreator<AdminUserState, [], [], AdminUserState> = (set, get) => ({
   email: '',

--- a/app/store/slices/editSlice.ts
+++ b/app/store/slices/editSlice.ts
@@ -1,0 +1,53 @@
+import { StateCreator } from 'zustand';
+
+import type { BlockData, EditState } from '../types';
+
+export const createEditSlice: StateCreator<EditState> = (set, get) => ({
+  isChanged: false,
+  isInitialized: false,
+  blocks: {},
+
+  setField: (pageId, blockId, field, value) => {
+    const prevPageBlocks = get().blocks[pageId] || {};
+    const prevBlock = (prevPageBlocks[blockId] ?? {}) as BlockData<typeof blockId>;
+
+    if (prevBlock[field] === value) return;
+
+    set({
+      blocks: {
+        ...get().blocks,
+        [pageId]: {
+          ...prevPageBlocks,
+          [blockId]: {
+            ...prevBlock,
+            [field]: value
+          }
+        }
+      },
+      isChanged: true
+    });
+  },
+
+  setFields: (pageId, blockId, data, isInit = false) => {
+    const prevPageBlocks = get().blocks[pageId] || {};
+    const prevBlock = (prevPageBlocks[blockId] ?? {}) as BlockData<typeof blockId>;
+
+    const isDifferent = Object.entries(data).some(([key, val]) => prevBlock[key as keyof typeof data] !== val);
+    if (!isDifferent) return;
+
+    set({
+      blocks: {
+        ...get().blocks,
+        [pageId]: {
+          ...prevPageBlocks,
+          [blockId]: {
+            ...prevBlock,
+            ...data
+          }
+        }
+      },
+      isChanged: isInit ? get().isChanged : true,
+      isInitialized: isInit ? true : get().isInitialized
+    });
+  }
+});

--- a/app/store/slices/editSlice.ts
+++ b/app/store/slices/editSlice.ts
@@ -51,13 +51,13 @@ export const createEditSlice: StateCreator<EditState> = (set, get) => ({
     });
   },
   saveAsDraft: () => {
-    const content = get().blocks;
-    void content;
+    const _content = get().blocks;
+
     set({ isChanged: false });
   },
   publishPage: () => {
-    const content = get().blocks;
-    void content;
+    const _content = get().blocks;
+
     set({ isChanged: false });
   }
 });

--- a/app/store/slices/editSlice.ts
+++ b/app/store/slices/editSlice.ts
@@ -49,5 +49,15 @@ export const createEditSlice: StateCreator<EditState> = (set, get) => ({
       isChanged: isInit ? get().isChanged : true,
       isInitialized: isInit ? true : get().isInitialized
     });
+  },
+  saveAsDraft: () => {
+    const content = get().blocks;
+    void content;
+    set({ isChanged: false });
+  },
+  publishPage: () => {
+    const content = get().blocks;
+    void content;
+    set({ isChanged: false });
   }
 });

--- a/app/store/slices/editSlice.ts
+++ b/app/store/slices/editSlice.ts
@@ -50,13 +50,13 @@ export const createEditSlice: StateCreator<EditState> = (set, get) => ({
       isInitialized: isInit ? true : get().isInitialized
     });
   },
-  saveAsDraft: () => {
-    const _content = get().blocks;
+  saveAsDraft: (pageId: string) => {
+    const _pageBlocks = get().blocks[pageId];
 
     set({ isChanged: false });
   },
-  publishPage: () => {
-    const _content = get().blocks;
+  publishPage: (pageId: string) => {
+    const _pageBlocks = get().blocks[pageId];
 
     set({ isChanged: false });
   }

--- a/app/store/types.ts
+++ b/app/store/types.ts
@@ -44,6 +44,8 @@ export interface EditState {
     data: Partial<BlocksMap[K]>,
     isInit?: boolean
   ) => void;
+  saveAsDraft: () => void;
+  publishPage: () => void;
 }
 
 export type BlockData<K extends keyof BlocksMap = keyof BlocksMap> = BlocksMap[K];

--- a/app/store/types.ts
+++ b/app/store/types.ts
@@ -1,0 +1,49 @@
+import { BlocksMap } from '~/types/store/pages';
+
+export type StoreState = AdminUserState & EditState;
+
+export interface Admin {
+  email: string;
+  canEdit: boolean;
+}
+
+export interface AdminUserState {
+  email: string;
+  isLoggedIn: boolean;
+  canEdit: boolean;
+  isSuperAdmin: boolean;
+
+  admins: Admin[];
+
+  login: (data: { email: string; canEdit: boolean; isSuperAdmin: boolean }) => void;
+  logout: () => void;
+
+  addAdmin: (admin: Admin) => void;
+  removeAdmin: (email: string) => void;
+  updateAdminPermission: (email: string, canEdit: boolean) => void;
+}
+
+export interface EditState {
+  isChanged: boolean;
+  isInitialized: boolean;
+
+  blocks: {
+    [pageId: string]: {
+      [blockId in keyof BlocksMap]?: BlocksMap[blockId];
+    };
+  };
+  setField: <P extends string, K extends keyof BlocksMap, F extends keyof BlocksMap[K]>(
+    pageId: P,
+    blockId: K,
+    field: F,
+    value: BlocksMap[K][F]
+  ) => void;
+  setFields: <P extends string, K extends keyof BlocksMap>(
+    pageId: P,
+    blockId: K,
+    data: Partial<BlocksMap[K]>,
+    isInit?: boolean
+  ) => void;
+}
+
+export type BlockData<K extends keyof BlocksMap = keyof BlocksMap> = BlocksMap[K];

--- a/app/store/types.ts
+++ b/app/store/types.ts
@@ -44,8 +44,8 @@ export interface EditState {
     data: Partial<BlocksMap[K]>,
     isInit?: boolean
   ) => void;
-  saveAsDraft: () => void;
-  publishPage: () => void;
+  saveAsDraft: (pageId: string) => void;
+  publishPage: (pageId: string) => void;
 }
 
 export type BlockData<K extends keyof BlocksMap = keyof BlocksMap> = BlocksMap[K];

--- a/app/types/store/pages/about-us/blocks/entrySectionBlock.ts
+++ b/app/types/store/pages/about-us/blocks/entrySectionBlock.ts
@@ -1,0 +1,7 @@
+export interface EntrySectionBlock {
+  title: string;
+  image: string;
+  imageCaption: string;
+  quoteText?: string;
+  quoteDescription?: string;
+}

--- a/app/types/store/pages/about-us/blocks/liatoshynskyFoundationBlock.ts
+++ b/app/types/store/pages/about-us/blocks/liatoshynskyFoundationBlock.ts
@@ -1,0 +1,8 @@
+import { Paragraph } from '~/types/accordionBlocks';
+
+export interface LiatoshynskyFoundationBlock {
+  paragraphs: Paragraph[];
+  mainText: string;
+  image?: string;
+  imageFileName?: string;
+}

--- a/app/types/store/pages/about-us/blocks/liatoshynskyOfficeBlock.ts
+++ b/app/types/store/pages/about-us/blocks/liatoshynskyOfficeBlock.ts
@@ -1,0 +1,4 @@
+export interface LiatoshynskyOfficeBlock {
+  mainQuote: string;
+  caption: string;
+}

--- a/app/types/store/pages/about-us/blocks/missionBlock.ts
+++ b/app/types/store/pages/about-us/blocks/missionBlock.ts
@@ -1,0 +1,7 @@
+import { MissionImage, MissionPoint } from '~/shared/components/about-us/our-mission/OurMission';
+
+export interface MissionBlock {
+  title: string;
+  missionPoints: MissionPoint[];
+  imageBlocks: MissionImage[];
+}

--- a/app/types/store/pages/about-us/index.ts
+++ b/app/types/store/pages/about-us/index.ts
@@ -1,0 +1,16 @@
+export * from './blocks/entrySectionBlock';
+export * from './blocks/liatoshynskyFoundationBlock';
+export * from './blocks/liatoshynskyOfficeBlock';
+export * from './blocks/missionBlock';
+
+import type { EntrySectionBlock } from './blocks/entrySectionBlock';
+import type { LiatoshynskyFoundationBlock } from './blocks/liatoshynskyFoundationBlock';
+import type { LiatoshynskyOfficeBlock } from './blocks/liatoshynskyOfficeBlock';
+import type { MissionBlock } from './blocks/missionBlock';
+
+export interface BlocksMap {
+  ourMission: MissionBlock;
+  entrySection: EntrySectionBlock;
+  liatoshynskyFoundation: LiatoshynskyFoundationBlock;
+  liatoshynskyOffice: LiatoshynskyOfficeBlock;
+}

--- a/app/types/store/pages/index.ts
+++ b/app/types/store/pages/index.ts
@@ -1,0 +1,3 @@
+import type { BlocksMap as AboutUsBlocksMap } from './about-us';
+
+export type BlocksMap = AboutUsBlocksMap;


### PR DESCRIPTION
## Description
Created createEditSlice , a universal Zustand slice for managing editable page blocks.
Added useInitBlock , a generic hook for initializing and retrieving block data from the global store. Ensures that the block is populated with initial data if it's not yet present
Added:

- setField — updates a single field in a block if value changed.
- setFields — updates multiple fields with initialization support (isInit flag)
- introduced isChanged and isInitialized flags for tracking edit state and initialization


## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->
1.Use any block that uses global state
2.Add to this comoponent
```
 const blocks = useStore((state) => state.blocks) || {};
  const isChanged = useStore((state) => state.isChanged);
  console.log(blocks);
  console.log(isChanged);
```

## Video / Screenshots

https://github.com/user-attachments/assets/8960b305-5352-4ae8-98cc-9afa781b27d2


https://github.com/user-attachments/assets/13c00d5a-1f7e-435a-be4e-a185d314289a



## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
