### PR TITLE
feat: define and add custom typography variants to theme

### DIFF
--- a/app/providers/ThemeProvider.test.tsx
+++ b/app/providers/ThemeProvider.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from './ThemeProvider';
+import { Typography } from '@mui/material';
+
+describe('ThemeProvider', () => {
+  it('applies the adminTheme correctly', () => {
+    render(
+      <ThemeProvider>
+        <Typography variant="customBold32">Test Theme</Typography>
+      </ThemeProvider>
+    );
+
+    const element = screen.getByText('Test Theme');
+    expect(element).toHaveStyle({
+      fontWeight: 700,
+      fontSize: '32px',
+      lineHeight: '140%',
+    });
+  });
+
+  it('renders children without crashing', () => {
+    render(
+      <ThemeProvider>
+        <div>Child Component</div>
+      </ThemeProvider>
+    );
+
+    expect(screen.getByText('Child Component')).toBeInTheDocument();
+  });
+});

--- a/app/providers/ThemeProvider.test.tsx
+++ b/app/providers/ThemeProvider.test.tsx
@@ -1,9 +1,13 @@
+<<<<<<< HEAD
 import { Typography } from '@mui/material';
+=======
+>>>>>>> c675860 (add tests for theme and themeProvider)
 import { render, screen } from '@testing-library/react';
 
 import { ThemeProvider } from './ThemeProvider';
 
 describe('ThemeProvider', () => {
+<<<<<<< HEAD
   it('should render children components', () => {
     render(
       <ThemeProvider>
@@ -26,5 +30,16 @@ describe('ThemeProvider', () => {
     expect(styles.fontWeight).toBe('700');
     expect(styles.fontSize).toBe('32px');
     expect(styles.lineHeight).toBe('140%');
+=======
+  test('renders children correctly', () => {
+    render(
+      <ThemeProvider>
+        <div data-testid="test-child">Test Content</div>
+      </ThemeProvider>
+    );
+
+    expect(screen.getByTestId('test-child')).toBeInTheDocument();
+    expect(screen.getByText('Test Content')).toBeInTheDocument();
+>>>>>>> c675860 (add tests for theme and themeProvider)
   });
 });

--- a/app/providers/ThemeProvider.test.tsx
+++ b/app/providers/ThemeProvider.test.tsx
@@ -1,30 +1,30 @@
-import { render, screen } from '@testing-library/react';
-import { ThemeProvider } from './ThemeProvider';
 import { Typography } from '@mui/material';
+import { render, screen } from '@testing-library/react';
+
+import { ThemeProvider } from './ThemeProvider';
 
 describe('ThemeProvider', () => {
-  it('applies the adminTheme correctly', () => {
+  it('should render children components', () => {
     render(
       <ThemeProvider>
-        <Typography variant="customBold32">Test Theme</Typography>
+        <div>Test Child</div>
       </ThemeProvider>
     );
-
-    const element = screen.getByText('Test Theme');
-    expect(element).toHaveStyle({
-      fontWeight: 700,
-      fontSize: '32px',
-      lineHeight: '140%',
-    });
+    expect(screen.getByText('Test Child')).toBeInTheDocument();
   });
 
-  it('renders children without crashing', () => {
+  it('should apply the adminTheme to children components', () => {
     render(
       <ThemeProvider>
-        <div>Child Component</div>
+        <Typography variant="customBold32">Themed Text</Typography>
       </ThemeProvider>
     );
 
-    expect(screen.getByText('Child Component')).toBeInTheDocument();
+    const textElement = screen.getByText('Themed Text');
+    const styles = window.getComputedStyle(textElement);
+
+    expect(styles.fontWeight).toBe('700');
+    expect(styles.fontSize).toBe('32px');
+    expect(styles.lineHeight).toBe('140%');
   });
 });

--- a/app/providers/ThemeProvider.test.tsx
+++ b/app/providers/ThemeProvider.test.tsx
@@ -21,7 +21,7 @@ describe('ThemeProvider', () => {
     );
 
     const textElement = screen.getByText('Themed Text');
-    const styles = window.getComputedStyle(textElement);
+    const styles = globalThis.getComputedStyle(textElement);
 
     expect(styles.fontWeight).toBe('700');
     expect(styles.fontSize).toBe('32px');
@@ -46,7 +46,7 @@ describe('ThemeProvider', () => {
     const themedElement = screen.getByTestId('themed-component');
     expect(themedElement).toBeInTheDocument();
 
-    const styles = window.getComputedStyle(themedElement);
+    const styles = globalThis.getComputedStyle(themedElement);
     expect(styles.fontSize).toBe('18px');
     expect(styles.fontWeight).toBe('500');
   });
@@ -67,8 +67,8 @@ describe('ThemeProvider', () => {
     const firstChild = screen.getByText('First Child');
     const secondChild = screen.getByText('Second Child');
 
-    const firstStyles = window.getComputedStyle(firstChild);
-    const secondStyles = window.getComputedStyle(secondChild);
+    const firstStyles = globalThis.getComputedStyle(firstChild);
+    const secondStyles = globalThis.getComputedStyle(secondChild);
 
     expect(firstStyles.fontSize).toBe('16px');
     expect(firstStyles.fontWeight).toBe('400');

--- a/app/providers/ThemeProvider.test.tsx
+++ b/app/providers/ThemeProvider.test.tsx
@@ -28,14 +28,52 @@ describe('ThemeProvider', () => {
     expect(styles.lineHeight).toBe('140%');
   });
 
-  test('renders children correctly', () => {
+  it('should provide theme context to nested components', () => {
+    const TestComponent = () => {
+      return (
+        <Typography variant="customMedium18Tight" data-testid="themed-component">
+          Nested Component
+        </Typography>
+      );
+    };
+
     render(
       <ThemeProvider>
-        <div data-testid="test-child">Test Content</div>
+        <TestComponent />
       </ThemeProvider>
     );
 
-    expect(screen.getByTestId('test-child')).toBeInTheDocument();
-    expect(screen.getByText('Test Content')).toBeInTheDocument();
+    const themedElement = screen.getByTestId('themed-component');
+    expect(themedElement).toBeInTheDocument();
+
+    const styles = window.getComputedStyle(themedElement);
+    expect(styles.fontSize).toBe('18px');
+    expect(styles.fontWeight).toBe('500');
+  });
+
+  it('should handle multiple nested children', () => {
+    render(
+      <ThemeProvider>
+        <div>
+          <Typography variant="customRegular16">First Child</Typography>
+          <Typography variant="customItalic14">Second Child</Typography>
+        </div>
+      </ThemeProvider>
+    );
+
+    expect(screen.getByText('First Child')).toBeInTheDocument();
+    expect(screen.getByText('Second Child')).toBeInTheDocument();
+
+    const firstChild = screen.getByText('First Child');
+    const secondChild = screen.getByText('Second Child');
+
+    const firstStyles = window.getComputedStyle(firstChild);
+    const secondStyles = window.getComputedStyle(secondChild);
+
+    expect(firstStyles.fontSize).toBe('16px');
+    expect(firstStyles.fontWeight).toBe('400');
+
+    expect(secondStyles.fontSize).toBe('14px');
+    expect(secondStyles.fontStyle).toBe('italic');
   });
 });

--- a/app/providers/ThemeProvider.test.tsx
+++ b/app/providers/ThemeProvider.test.tsx
@@ -1,13 +1,9 @@
-<<<<<<< HEAD
 import { Typography } from '@mui/material';
-=======
->>>>>>> c675860 (add tests for theme and themeProvider)
 import { render, screen } from '@testing-library/react';
 
 import { ThemeProvider } from './ThemeProvider';
 
 describe('ThemeProvider', () => {
-<<<<<<< HEAD
   it('should render children components', () => {
     render(
       <ThemeProvider>
@@ -30,7 +26,8 @@ describe('ThemeProvider', () => {
     expect(styles.fontWeight).toBe('700');
     expect(styles.fontSize).toBe('32px');
     expect(styles.lineHeight).toBe('140%');
-=======
+  });
+
   test('renders children correctly', () => {
     render(
       <ThemeProvider>
@@ -40,6 +37,5 @@ describe('ThemeProvider', () => {
 
     expect(screen.getByTestId('test-child')).toBeInTheDocument();
     expect(screen.getByText('Test Content')).toBeInTheDocument();
->>>>>>> c675860 (add tests for theme and themeProvider)
   });
 });

--- a/app/providers/ThemeProvider.tsx
+++ b/app/providers/ThemeProvider.tsx
@@ -1,9 +1,12 @@
 'use client';
 import { ThemeProvider as MuiThemeProvider } from '@mui/material/styles';
-import React, { PropsWithChildren } from 'react';
+import React, { PropsWithChildren, useMemo } from 'react';
 
-import { adminTheme } from '../shared/theme/theme';
+import { createAdminTheme } from '../shared/theme/theme';
 
-export const ThemeProvider = ({ children }: PropsWithChildren) => (
-  <MuiThemeProvider theme={adminTheme}>{children}</MuiThemeProvider>
-);
+export const ThemeProvider = ({ children }: PropsWithChildren) => {
+  // Create theme instance client-side to avoid serialization issues
+  const theme = useMemo(() => createAdminTheme(), []);
+
+  return <MuiThemeProvider theme={theme}>{children}</MuiThemeProvider>;
+};

--- a/app/providers/ThemeProvider.tsx
+++ b/app/providers/ThemeProvider.tsx
@@ -5,7 +5,6 @@ import React, { PropsWithChildren, useMemo } from 'react';
 import { createAdminTheme } from '../shared/theme/theme';
 
 export const ThemeProvider = ({ children }: PropsWithChildren) => {
-  // Create theme instance client-side to avoid serialization issues
   const theme = useMemo(() => createAdminTheme(), []);
 
   return <MuiThemeProvider theme={theme}>{children}</MuiThemeProvider>;

--- a/app/providers/ThemeProvider.tsx
+++ b/app/providers/ThemeProvider.tsx
@@ -1,0 +1,9 @@
+'use client';
+import { ThemeProvider as MuiThemeProvider } from '@mui/material/styles';
+import React, { PropsWithChildren } from 'react';
+
+import { adminTheme } from '../shared/theme/theme';
+
+export const ThemeProvider = ({ children }: PropsWithChildren) => (
+  <MuiThemeProvider theme={adminTheme}>{children}</MuiThemeProvider>
+);

--- a/app/shared/components/design-system/cropper-modal/CropperModal.styles.ts
+++ b/app/shared/components/design-system/cropper-modal/CropperModal.styles.ts
@@ -25,6 +25,12 @@ export const styles = {
     color: 'white',
     gap: '8px'
   },
+  mainTitle: {
+    fontSize: '1.5rem',
+    fontWeight: 'bold',
+    marginBottom: '1rem',
+    textAlign: 'center'
+  },
   subTitle: {
     color: '#C1C9D6'
   },

--- a/app/shared/components/design-system/cropper-modal/CropperModal.styles.ts
+++ b/app/shared/components/design-system/cropper-modal/CropperModal.styles.ts
@@ -25,17 +25,8 @@ export const styles = {
     color: 'white',
     gap: '8px'
   },
-  mainTitle: {
-    fontFamily: 'Mulish',
-    fontWeight: '400',
-    fontSize: '20px',
-    lineHeight: '140%'
-  },
+  mainTitle: {},
   subTitle: {
-    fontFamily: 'Mulish',
-    fontWeight: '500',
-    fontSize: '18px',
-    lineHeight: '135%',
     color: '#C1C9D6'
   },
   buttonSection: {
@@ -47,10 +38,6 @@ export const styles = {
   buttons: {
     borderColor: 'white',
     borderRadius: '28px',
-    textTransform: 'none',
-    fontFamily: 'Mulish',
-    fontWeight: '500',
-    fontSize: '16px',
-    lineHeight: '150%'
+    textTransform: 'none'
   }
 };

--- a/app/shared/components/design-system/cropper-modal/CropperModal.styles.ts
+++ b/app/shared/components/design-system/cropper-modal/CropperModal.styles.ts
@@ -25,7 +25,6 @@ export const styles = {
     color: 'white',
     gap: '8px'
   },
-  mainTitle: {},
   subTitle: {
     color: '#C1C9D6'
   },

--- a/app/shared/components/design-system/cropper-modal/CropperModal.tsx
+++ b/app/shared/components/design-system/cropper-modal/CropperModal.tsx
@@ -60,8 +60,12 @@ export const CropperModal: React.FC<CropperModalProps> = ({
         )}
         <Box sx={styles.topSection}>
           <Box sx={styles.textSection}>
-            <Typography sx={styles.mainTitle}>Редагування зображення</Typography>
-            <Typography sx={styles.subTitle}>{imageName}</Typography>
+            <Typography variant="customRegular20Tight" sx={styles.mainTitle}>
+              Редагування зображення
+            </Typography>
+            <Typography variant="customMedium18Tight" sx={styles.subTitle}>
+              {imageName}
+            </Typography>
           </Box>
           <Box sx={styles.buttonSection}>
             <Button

--- a/app/shared/components/design-system/discard-changes-modal/DiscardChangesModal.styles.ts
+++ b/app/shared/components/design-system/discard-changes-modal/DiscardChangesModal.styles.ts
@@ -22,20 +22,12 @@ export const styles = {
   },
 
   headerTitle: {
-    fontSize: '32px',
-    fontWeight: '700',
-    color: '#190D03',
-    lineHeight: '140%',
-    fontFamily: 'Mulish'
+    color: '#190D03'
   },
 
   mainContent: {
-    fontSize: '18px',
-    fontWeight: '400',
-    color: '#190D03',
-    lineHeight: '160%',
     marginTop: '16px',
-    fontFamily: 'Mulish'
+    color: '#190D03'
   },
 
   modalFooter: {

--- a/app/shared/components/design-system/discard-changes-modal/DiscardChangesModal.tsx
+++ b/app/shared/components/design-system/discard-changes-modal/DiscardChangesModal.tsx
@@ -19,9 +19,11 @@ const DiscardChangesModal: React.FC<DiscardChangesModalProps> = ({ open, handleC
       <Box sx={styles.contentWrapper}>
         <Box sx={styles.modalHeader}>
           <Image src="/icons/warning.svg" alt="warning" width={40} height={40} />
-          <Typography sx={styles.headerTitle}>Скасувати зміни?</Typography>
+          <Typography variant="customBold32" sx={styles.headerTitle}>
+            Скасувати зміни?
+          </Typography>
         </Box>
-        <Typography sx={styles.mainContent}>
+        <Typography variant="customMedium18Loose" sx={styles.mainContent}>
           Усі внесені зміни буде втрачено. Ви впевнені, що хочете вийти без збереження?
         </Typography>
         <Box sx={styles.modalFooter}>

--- a/app/shared/providers/body-provider/BodyProvider.tsx
+++ b/app/shared/providers/body-provider/BodyProvider.tsx
@@ -1,8 +1,10 @@
+import { ThemeProvider } from '@mui/material/styles';
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono, Mulish } from 'next/font/google';
 
 import { ApolloClientProvider } from '~/providers/apollo-client-provider/apolloClientProvider';
 import EmotionProvider from '~/providers/EmotionProvider';
+import { adminTheme } from '~/shared/theme/theme';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -30,7 +32,9 @@ export default function BodyProvider({ children }: Readonly<{ children: React.Re
     <html lang="en" className={`${geistSans.variable} ${geistMono.variable} ${mulish.variable}`}>
       <body className={`${geistSans.variable} ${geistMono.variable} ${mulish.variable}`}>
         <EmotionProvider>
-          <ApolloClientProvider>{children}</ApolloClientProvider>
+          <ThemeProvider theme={adminTheme}>
+            <ApolloClientProvider>{children}</ApolloClientProvider>
+          </ThemeProvider>
         </EmotionProvider>
       </body>
     </html>

--- a/app/shared/providers/body-provider/BodyProvider.tsx
+++ b/app/shared/providers/body-provider/BodyProvider.tsx
@@ -1,10 +1,9 @@
-import { ThemeProvider } from '@mui/material/styles';
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono, Mulish } from 'next/font/google';
 
+import { ThemeProvider } from '../../../providers/ThemeProvider';
 import { ApolloClientProvider } from '~/providers/apollo-client-provider/apolloClientProvider';
 import EmotionProvider from '~/providers/EmotionProvider';
-import { adminTheme } from '~/shared/theme/theme';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -32,7 +31,7 @@ export default function BodyProvider({ children }: Readonly<{ children: React.Re
     <html lang="en" className={`${geistSans.variable} ${geistMono.variable} ${mulish.variable}`}>
       <body className={`${geistSans.variable} ${geistMono.variable} ${mulish.variable}`}>
         <EmotionProvider>
-          <ThemeProvider theme={adminTheme}>
+          <ThemeProvider>
             <ApolloClientProvider>{children}</ApolloClientProvider>
           </ThemeProvider>
         </EmotionProvider>

--- a/app/shared/theme/theme.test.tsx
+++ b/app/shared/theme/theme.test.tsx
@@ -16,7 +16,7 @@ describe('Custom Typography Variants', () => {
       </ThemeProvider>
     );
 
-  it('renders customBold32 variant correctly', () => {
+  it('should render customBold32 variant correctly', () => {
     const { getByText } = renderWithTheme('customBold32');
     const element = getByText('Test');
     expect(element).toHaveStyle({
@@ -27,7 +27,7 @@ describe('Custom Typography Variants', () => {
     });
   });
 
-  it('renders customMedium22Tight variant correctly', () => {
+  it('should render customMedium22Tight variant correctly', () => {
     const { getByText } = renderWithTheme('customMedium22Tight');
     const element = getByText('Test');
     expect(element).toHaveStyle({
@@ -37,7 +37,7 @@ describe('Custom Typography Variants', () => {
     });
   });
 
-  it('renders customRegular20Tight variant correctly', () => {
+  it('should render customRegular20Tight variant correctly', () => {
     const { getByText } = renderWithTheme('customRegular20Tight');
     const element = getByText('Test');
     expect(element).toHaveStyle({
@@ -47,7 +47,7 @@ describe('Custom Typography Variants', () => {
     });
   });
 
-  it('renders customMedium18Tight variant correctly', () => {
+  it('should render customMedium18Tight variant correctly', () => {
     const { getByText } = renderWithTheme('customMedium18Tight');
     const element = getByText('Test');
     expect(element).toHaveStyle({
@@ -57,7 +57,7 @@ describe('Custom Typography Variants', () => {
     });
   });
 
-  it('renders customMedium18Loose variant correctly', () => {
+  it('should render customMedium18Loose variant correctly', () => {
     const { getByText } = renderWithTheme('customMedium18Loose');
     const element = getByText('Test');
     expect(element).toHaveStyle({
@@ -67,7 +67,7 @@ describe('Custom Typography Variants', () => {
     });
   });
 
-  it('renders customSemiBold18 variant correctly', () => {
+  it('should render customSemiBold18 variant correctly', () => {
     const { getByText } = renderWithTheme('customSemiBold18');
     const element = getByText('Test');
     expect(element).toHaveStyle({
@@ -77,7 +77,7 @@ describe('Custom Typography Variants', () => {
     });
   });
 
-  it('renders customRegular16 variant correctly', () => {
+  it('should render customRegular16 variant correctly', () => {
     const { getByText } = renderWithTheme('customRegular16');
     const element = getByText('Test');
     expect(element).toHaveStyle({
@@ -87,7 +87,7 @@ describe('Custom Typography Variants', () => {
     });
   });
 
-  it('renders customBold16 variant correctly', () => {
+  it('should render customBold16 variant correctly', () => {
     const { getByText } = renderWithTheme('customBold16');
     const element = getByText('Test');
     expect(element).toHaveStyle({
@@ -97,7 +97,7 @@ describe('Custom Typography Variants', () => {
     });
   });
 
-  it('renders customMedium16 variant correctly', () => {
+  it('should render customMedium16 variant correctly', () => {
     const { getByText } = renderWithTheme('customMedium16');
     const element = getByText('Test');
     expect(element).toHaveStyle({
@@ -107,7 +107,7 @@ describe('Custom Typography Variants', () => {
     });
   });
 
-  it('renders customItalic16 variant correctly', () => {
+  it('should render customItalic16 variant correctly', () => {
     const { getByText } = renderWithTheme('customItalic16');
     const element = getByText('Test');
     expect(element).toHaveStyle({
@@ -117,7 +117,7 @@ describe('Custom Typography Variants', () => {
     });
   });
 
-  it('renders customItalic14 variant correctly', () => {
+  it('should render customItalic14 variant correctly', () => {
     const { getByText } = renderWithTheme('customItalic14');
     const element = getByText('Test');
     expect(element).toHaveStyle({

--- a/app/shared/theme/theme.test.tsx
+++ b/app/shared/theme/theme.test.tsx
@@ -1,0 +1,78 @@
+import { render } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { Typography } from '@mui/material';
+import { adminTheme } from './theme';
+import { TypographyPropsVariantOverrides } from '@mui/material/Typography';
+import { OverridableStringUnion } from '@mui/types';
+
+type CustomVariant = OverridableStringUnion<keyof TypographyPropsVariantOverrides, {}>;
+
+describe('Custom Typography Variants', () => {
+  const renderWithTheme = (variant: CustomVariant) =>
+    render(
+      <ThemeProvider theme={adminTheme}>
+        <Typography variant={variant}>Test</Typography>
+      </ThemeProvider>
+    );
+
+  it('renders customBold32 variant correctly', () => {
+    const { getByText } = renderWithTheme('customBold32');
+    const element = getByText('Test');
+    expect(element).toHaveStyle({
+      fontWeight: 700,
+      fontSize: '32px',
+      lineHeight: '140%',
+      letterSpacing: '0px',
+    });
+  });
+
+  it('renders customMedium22Tight variant correctly', () => {
+    const { getByText } = renderWithTheme('customMedium22Tight');
+    const element = getByText('Test');
+    expect(element).toHaveStyle({
+      fontWeight: 500,
+      fontSize: '22px',
+      lineHeight: '135%',
+    });
+  });
+
+  it('renders customItalic16 variant correctly', () => {
+    const { getByText } = renderWithTheme('customItalic16');
+    const element = getByText('Test');
+    expect(element).toHaveStyle({
+      fontStyle: 'italic',
+      fontSize: '16px',
+      lineHeight: '140%',
+    });
+  });
+
+  it('renders customItalic14 variant correctly', () => {
+    const { getByText } = renderWithTheme('customItalic14');
+    const element = getByText('Test');
+    expect(element).toHaveStyle({
+      fontStyle: 'italic',
+      fontSize: '14px',
+      lineHeight: '140%',
+    });
+  });
+
+  it('renders customMedium18Loose variant correctly', () => {
+    const { getByText } = renderWithTheme('customMedium18Loose');
+    const element = getByText('Test');
+    expect(element).toHaveStyle({
+      fontWeight: 500,
+      fontSize: '18px',
+      lineHeight: '155%',
+    });
+  });
+
+  it('renders customSemiBold18 variant correctly', () => {
+    const { getByText } = renderWithTheme('customSemiBold18');
+    const element = getByText('Test');
+    expect(element).toHaveStyle({
+      fontWeight: 600,
+      fontSize: '18px',
+      lineHeight: '155%',
+    });
+  });
+});

--- a/app/shared/theme/theme.test.tsx
+++ b/app/shared/theme/theme.test.tsx
@@ -144,9 +144,10 @@ describe('Admin Theme Configuration', () => {
       'customItalic14'
     ];
 
-    customVariants.forEach((variant: string) => {
+    for (const variant of customVariants) {
       expect((adminTheme.typography as any)[variant]).toBeDefined();
-    });
+    }
+
   });
 
   it('should have correct variant mapping for custom typography', () => {

--- a/app/shared/theme/theme.test.tsx
+++ b/app/shared/theme/theme.test.tsx
@@ -1,11 +1,12 @@
-import { render } from '@testing-library/react';
-import { ThemeProvider } from '@mui/material/styles';
 import { Typography } from '@mui/material';
-import { adminTheme } from './theme';
+import { ThemeProvider } from '@mui/material/styles';
 import { TypographyPropsVariantOverrides } from '@mui/material/Typography';
 import { OverridableStringUnion } from '@mui/types';
+import { render } from '@testing-library/react';
 
-type CustomVariant = OverridableStringUnion<keyof TypographyPropsVariantOverrides, {}>;
+import { adminTheme } from './theme';
+
+type CustomVariant = OverridableStringUnion<keyof TypographyPropsVariantOverrides, unknown>;
 
 describe('Custom Typography Variants', () => {
   const renderWithTheme = (variant: CustomVariant) =>
@@ -22,7 +23,7 @@ describe('Custom Typography Variants', () => {
       fontWeight: 700,
       fontSize: '32px',
       lineHeight: '140%',
-      letterSpacing: '0px',
+      letterSpacing: '0px'
     });
   });
 
@@ -32,27 +33,27 @@ describe('Custom Typography Variants', () => {
     expect(element).toHaveStyle({
       fontWeight: 500,
       fontSize: '22px',
-      lineHeight: '135%',
+      lineHeight: '135%'
     });
   });
 
-  it('renders customItalic16 variant correctly', () => {
-    const { getByText } = renderWithTheme('customItalic16');
+  it('renders customRegular20Tight variant correctly', () => {
+    const { getByText } = renderWithTheme('customRegular20Tight');
     const element = getByText('Test');
     expect(element).toHaveStyle({
-      fontStyle: 'italic',
-      fontSize: '16px',
-      lineHeight: '140%',
+      fontWeight: 400,
+      fontSize: '20px',
+      lineHeight: '140%'
     });
   });
 
-  it('renders customItalic14 variant correctly', () => {
-    const { getByText } = renderWithTheme('customItalic14');
+  it('renders customMedium18Tight variant correctly', () => {
+    const { getByText } = renderWithTheme('customMedium18Tight');
     const element = getByText('Test');
     expect(element).toHaveStyle({
-      fontStyle: 'italic',
-      fontSize: '14px',
-      lineHeight: '140%',
+      fontWeight: 500,
+      fontSize: '18px',
+      lineHeight: '135%'
     });
   });
 
@@ -62,7 +63,7 @@ describe('Custom Typography Variants', () => {
     expect(element).toHaveStyle({
       fontWeight: 500,
       fontSize: '18px',
-      lineHeight: '155%',
+      lineHeight: '155%'
     });
   });
 
@@ -72,7 +73,109 @@ describe('Custom Typography Variants', () => {
     expect(element).toHaveStyle({
       fontWeight: 600,
       fontSize: '18px',
-      lineHeight: '155%',
+      lineHeight: '155%'
     });
+  });
+
+  it('renders customRegular16 variant correctly', () => {
+    const { getByText } = renderWithTheme('customRegular16');
+    const element = getByText('Test');
+    expect(element).toHaveStyle({
+      fontWeight: 400,
+      fontSize: '16px',
+      lineHeight: '150%'
+    });
+  });
+
+  it('renders customBold16 variant correctly', () => {
+    const { getByText } = renderWithTheme('customBold16');
+    const element = getByText('Test');
+    expect(element).toHaveStyle({
+      fontWeight: 700,
+      fontSize: '16px',
+      lineHeight: '100%'
+    });
+  });
+
+  it('renders customMedium16 variant correctly', () => {
+    const { getByText } = renderWithTheme('customMedium16');
+    const element = getByText('Test');
+    expect(element).toHaveStyle({
+      fontWeight: 500,
+      fontSize: '16px',
+      lineHeight: '150%'
+    });
+  });
+
+  it('renders customItalic16 variant correctly', () => {
+    const { getByText } = renderWithTheme('customItalic16');
+    const element = getByText('Test');
+    expect(element).toHaveStyle({
+      fontStyle: 'italic',
+      fontSize: '16px',
+      lineHeight: '140%'
+    });
+  });
+
+  it('renders customItalic14 variant correctly', () => {
+    const { getByText } = renderWithTheme('customItalic14');
+    const element = getByText('Test');
+    expect(element).toHaveStyle({
+      fontStyle: 'italic',
+      fontSize: '14px',
+      lineHeight: '140%'
+    });
+  });
+});
+
+describe('Admin Theme Configuration', () => {
+  it('should have all custom typography variants defined', () => {
+    const customVariants = [
+      'customBold32',
+      'customMedium22Tight',
+      'customRegular20Tight',
+      'customMedium18Tight',
+      'customMedium18Loose',
+      'customSemiBold18',
+      'customRegular16',
+      'customBold16',
+      'customMedium16',
+      'customItalic16',
+      'customItalic14'
+    ];
+
+    customVariants.forEach((variant: string) => {
+      expect((adminTheme.typography as any)[variant]).toBeDefined();
+    });
+  });
+
+  it('should have correct variant mapping for custom typography', () => {
+    const variantMapping = adminTheme.components?.MuiTypography?.defaultProps?.variantMapping;
+
+    expect(variantMapping?.customBold32).toBe('p');
+    expect(variantMapping?.customMedium22Tight).toBe('p');
+    expect(variantMapping?.customRegular20Tight).toBe('p');
+    expect(variantMapping?.customMedium18Tight).toBe('p');
+    expect(variantMapping?.customMedium18Loose).toBe('p');
+    expect(variantMapping?.customSemiBold18).toBe('p');
+    expect(variantMapping?.customRegular16).toBe('p');
+    expect(variantMapping?.customBold16).toBe('p');
+    expect(variantMapping?.customMedium16).toBe('p');
+    expect(variantMapping?.customItalic16).toBe('p');
+    expect(variantMapping?.customItalic14).toBe('p');
+  });
+
+  it('should export AdminTheme type', () => {
+    expect(typeof adminTheme).toBe('object');
+    expect(adminTheme.typography).toBeDefined();
+    expect(adminTheme.components).toBeDefined();
+  });
+
+  it('should have correct font families for custom variants', () => {
+    const customBold32 = (adminTheme.typography as any).customBold32;
+    const customItalic16 = (adminTheme.typography as any).customItalic16;
+
+    expect(customBold32.fontFamily).toBeDefined();
+    expect(customItalic16.fontFamily).toBeDefined();
   });
 });

--- a/app/shared/theme/theme.test.tsx
+++ b/app/shared/theme/theme.test.tsx
@@ -178,4 +178,25 @@ describe('Admin Theme Configuration', () => {
     expect(customBold32.fontFamily).toBeDefined();
     expect(customItalic16.fontFamily).toBeDefined();
   });
+
+  it('should have standard MUI typography variants', () => {
+    expect(adminTheme.typography.h1).toBeDefined();
+    expect(adminTheme.typography.h2).toBeDefined();
+    expect(adminTheme.typography.h3).toBeDefined();
+    expect(adminTheme.typography.h4).toBeDefined();
+  });
+
+  it('should have correct properties for standard variants', () => {
+    expect(adminTheme.typography.h1).toMatchObject({
+      fontWeight: 700,
+      fontSize: '116px',
+      lineHeight: '100%'
+    });
+
+    expect(adminTheme.typography.h4).toMatchObject({
+      fontWeight: 700,
+      fontSize: '28px',
+      lineHeight: '160%'
+    });
+  });
 });

--- a/app/shared/theme/theme.test.tsx
+++ b/app/shared/theme/theme.test.tsx
@@ -147,7 +147,6 @@ describe('Admin Theme Configuration', () => {
     for (const variant of customVariants) {
       expect((adminTheme.typography as any)[variant]).toBeDefined();
     }
-
   });
 
   it('should have correct variant mapping for custom typography', () => {

--- a/app/shared/theme/theme.ts
+++ b/app/shared/theme/theme.ts
@@ -49,7 +49,6 @@ declare module '@mui/material/Typography' {
   }
 }
 
-// Create theme inside a function to avoid serialization issues
 export const createAdminTheme = () =>
   createTheme({
     typography: {
@@ -167,7 +166,6 @@ export const createAdminTheme = () =>
     }
   });
 
-// Export a single instance for consistency
 export const adminTheme = createAdminTheme();
 
 export type AdminTheme = ReturnType<typeof createAdminTheme>;

--- a/app/shared/theme/theme.ts
+++ b/app/shared/theme/theme.ts
@@ -1,0 +1,168 @@
+import { createTheme } from '@mui/material/styles';
+import { Mulish, Oswald } from 'next/font/google';
+
+const oswald = Oswald({ subsets: ['latin'] });
+const mulish = Mulish({ subsets: ['latin'] });
+
+declare module '@mui/material/styles' {
+  interface TypographyVariants {
+    customBold32: React.CSSProperties;
+    customMedium22Tight: React.CSSProperties;
+    customRegular20Tight: React.CSSProperties;
+    customMedium18Tight: React.CSSProperties;
+    customMedium18Loose: React.CSSProperties;
+    customSemiBold18: React.CSSProperties;
+    customRegular16: React.CSSProperties;
+    customBold16: React.CSSProperties;
+    customMedium16: React.CSSProperties;
+    customItalic16: React.CSSProperties;
+    customItalic14: React.CSSProperties;
+  }
+  interface TypographyVariantsOptions {
+    customBold32?: React.CSSProperties;
+    customMedium22Tight?: React.CSSProperties;
+    customRegular20Tight?: React.CSSProperties;
+    customMedium18Tight?: React.CSSProperties;
+    customMedium18Loose?: React.CSSProperties;
+    customSemiBold18?: React.CSSProperties;
+    customRegular16?: React.CSSProperties;
+    customBold16?: React.CSSProperties;
+    customMedium16?: React.CSSProperties;
+    customItalic16?: React.CSSProperties;
+    customItalic14?: React.CSSProperties;
+  }
+}
+
+declare module '@mui/material/Typography' {
+  interface TypographyPropsVariantOverrides {
+    customBold32: true;
+    customMedium22Tight: true;
+    customRegular20Tight: true;
+    customMedium18Tight: true;
+    customMedium18Loose: true;
+    customSemiBold18: true;
+    customRegular16: true;
+    customBold16: true;
+    customMedium16: true;
+    customItalic16: true;
+    customItalic14: true;
+  }
+}
+
+export const adminTheme = createTheme({
+  typography: {
+    fontFamily: mulish.style.fontFamily,
+    h1: {
+      fontFamily: oswald.style.fontFamily,
+      fontWeight: 700,
+      fontSize: '116px',
+      lineHeight: '100%'
+    },
+    h2: {
+      fontFamily: oswald.style.fontFamily,
+      fontWeight: 600,
+      fontSize: '64px',
+      lineHeight: '100%'
+    },
+    h3: {
+      fontFamily: oswald.style.fontFamily,
+      fontWeight: 400,
+      fontSize: '64px',
+      lineHeight: '100%'
+    },
+    h4: {
+      fontFamily: oswald.style.fontFamily,
+      fontWeight: 700,
+      fontSize: '28px',
+      lineHeight: '160%'
+    },
+    customBold32: {
+      fontFamily: mulish.style.fontFamily,
+      fontWeight: 700,
+      fontSize: '32px',
+      lineHeight: '140%',
+      letterSpacing: '0px'
+    },
+    customMedium22Tight: {
+      fontFamily: mulish.style.fontFamily,
+      fontWeight: 500,
+      fontSize: '22px',
+      lineHeight: '135%'
+    },
+    customRegular20Tight: {
+      fontFamily: mulish.style.fontFamily,
+      fontWeight: 400,
+      fontSize: '20px',
+      lineHeight: '140%'
+    },
+    customMedium18Tight: {
+      fontFamily: mulish.style.fontFamily,
+      fontWeight: 500,
+      fontSize: '18px',
+      lineHeight: '135%'
+    },
+    customMedium18Loose: {
+      fontFamily: mulish.style.fontFamily,
+      fontWeight: 500,
+      fontSize: '18px',
+      lineHeight: '155%'
+    },
+    customSemiBold18: {
+      fontFamily: mulish.style.fontFamily,
+      fontWeight: 600,
+      fontSize: '18px',
+      lineHeight: '155%'
+    },
+    customBold16: {
+      fontFamily: mulish.style.fontFamily,
+      fontWeight: 700,
+      fontSize: '16px',
+      lineHeight: '100%'
+    },
+    customRegular16: {
+      fontFamily: mulish.style.fontFamily,
+      fontWeight: 400,
+      fontSize: '16px',
+      lineHeight: '150%'
+    },
+    customMedium16: {
+      fontFamily: mulish.style.fontFamily,
+      fontWeight: 500,
+      fontSize: '16px',
+      lineHeight: '150%'
+    },
+    customItalic16: {
+      fontFamily: mulish.style.fontFamily,
+      fontStyle: 'italic',
+      fontSize: '16px',
+      lineHeight: '140%'
+    },
+    customItalic14: {
+      fontFamily: mulish.style.fontFamily,
+      fontStyle: 'italic',
+      fontSize: '14px',
+      lineHeight: '140%'
+    }
+  },
+  components: {
+    MuiTypography: {
+      defaultProps: {
+        variantMapping: {
+          customBold32: 'p',
+          customMedium22Tight: 'p',
+          customRegular20Tight: 'p',
+          customMedium18Tight: 'p',
+          customMedium18Loose: 'p',
+          customSemiBold18: 'p',
+          customRegular16: 'p',
+          customBold16: 'p',
+          customMedium16: 'p',
+          customItalic16: 'p',
+          customItalic14: 'p'
+        }
+      }
+    }
+  }
+});
+
+export type AdminTheme = typeof adminTheme;

--- a/app/shared/theme/theme.ts
+++ b/app/shared/theme/theme.ts
@@ -49,120 +49,125 @@ declare module '@mui/material/Typography' {
   }
 }
 
-export const adminTheme = createTheme({
-  typography: {
-    fontFamily: mulish.style.fontFamily,
-    h1: {
-      fontFamily: oswald.style.fontFamily,
-      fontWeight: 700,
-      fontSize: '116px',
-      lineHeight: '100%'
-    },
-    h2: {
-      fontFamily: oswald.style.fontFamily,
-      fontWeight: 600,
-      fontSize: '64px',
-      lineHeight: '100%'
-    },
-    h3: {
-      fontFamily: oswald.style.fontFamily,
-      fontWeight: 400,
-      fontSize: '64px',
-      lineHeight: '100%'
-    },
-    h4: {
-      fontFamily: oswald.style.fontFamily,
-      fontWeight: 700,
-      fontSize: '28px',
-      lineHeight: '160%'
-    },
-    customBold32: {
+// Create theme inside a function to avoid serialization issues
+export const createAdminTheme = () =>
+  createTheme({
+    typography: {
       fontFamily: mulish.style.fontFamily,
-      fontWeight: 700,
-      fontSize: '32px',
-      lineHeight: '140%',
-      letterSpacing: '0px'
+      h1: {
+        fontFamily: oswald.style.fontFamily,
+        fontWeight: 700,
+        fontSize: '116px',
+        lineHeight: '100%'
+      },
+      h2: {
+        fontFamily: oswald.style.fontFamily,
+        fontWeight: 600,
+        fontSize: '64px',
+        lineHeight: '100%'
+      },
+      h3: {
+        fontFamily: oswald.style.fontFamily,
+        fontWeight: 400,
+        fontSize: '64px',
+        lineHeight: '100%'
+      },
+      h4: {
+        fontFamily: oswald.style.fontFamily,
+        fontWeight: 700,
+        fontSize: '28px',
+        lineHeight: '160%'
+      },
+      customBold32: {
+        fontFamily: mulish.style.fontFamily,
+        fontWeight: 700,
+        fontSize: '32px',
+        lineHeight: '140%',
+        letterSpacing: '0px'
+      },
+      customMedium22Tight: {
+        fontFamily: mulish.style.fontFamily,
+        fontWeight: 500,
+        fontSize: '22px',
+        lineHeight: '135%'
+      },
+      customRegular20Tight: {
+        fontFamily: mulish.style.fontFamily,
+        fontWeight: 400,
+        fontSize: '20px',
+        lineHeight: '140%'
+      },
+      customMedium18Tight: {
+        fontFamily: mulish.style.fontFamily,
+        fontWeight: 500,
+        fontSize: '18px',
+        lineHeight: '135%'
+      },
+      customMedium18Loose: {
+        fontFamily: mulish.style.fontFamily,
+        fontWeight: 500,
+        fontSize: '18px',
+        lineHeight: '155%'
+      },
+      customSemiBold18: {
+        fontFamily: mulish.style.fontFamily,
+        fontWeight: 600,
+        fontSize: '18px',
+        lineHeight: '155%'
+      },
+      customBold16: {
+        fontFamily: mulish.style.fontFamily,
+        fontWeight: 700,
+        fontSize: '16px',
+        lineHeight: '100%'
+      },
+      customRegular16: {
+        fontFamily: mulish.style.fontFamily,
+        fontWeight: 400,
+        fontSize: '16px',
+        lineHeight: '150%'
+      },
+      customMedium16: {
+        fontFamily: mulish.style.fontFamily,
+        fontWeight: 500,
+        fontSize: '16px',
+        lineHeight: '150%'
+      },
+      customItalic16: {
+        fontFamily: mulish.style.fontFamily,
+        fontStyle: 'italic',
+        fontSize: '16px',
+        lineHeight: '140%'
+      },
+      customItalic14: {
+        fontFamily: mulish.style.fontFamily,
+        fontStyle: 'italic',
+        fontSize: '14px',
+        lineHeight: '140%'
+      }
     },
-    customMedium22Tight: {
-      fontFamily: mulish.style.fontFamily,
-      fontWeight: 500,
-      fontSize: '22px',
-      lineHeight: '135%'
-    },
-    customRegular20Tight: {
-      fontFamily: mulish.style.fontFamily,
-      fontWeight: 400,
-      fontSize: '20px',
-      lineHeight: '140%'
-    },
-    customMedium18Tight: {
-      fontFamily: mulish.style.fontFamily,
-      fontWeight: 500,
-      fontSize: '18px',
-      lineHeight: '135%'
-    },
-    customMedium18Loose: {
-      fontFamily: mulish.style.fontFamily,
-      fontWeight: 500,
-      fontSize: '18px',
-      lineHeight: '155%'
-    },
-    customSemiBold18: {
-      fontFamily: mulish.style.fontFamily,
-      fontWeight: 600,
-      fontSize: '18px',
-      lineHeight: '155%'
-    },
-    customBold16: {
-      fontFamily: mulish.style.fontFamily,
-      fontWeight: 700,
-      fontSize: '16px',
-      lineHeight: '100%'
-    },
-    customRegular16: {
-      fontFamily: mulish.style.fontFamily,
-      fontWeight: 400,
-      fontSize: '16px',
-      lineHeight: '150%'
-    },
-    customMedium16: {
-      fontFamily: mulish.style.fontFamily,
-      fontWeight: 500,
-      fontSize: '16px',
-      lineHeight: '150%'
-    },
-    customItalic16: {
-      fontFamily: mulish.style.fontFamily,
-      fontStyle: 'italic',
-      fontSize: '16px',
-      lineHeight: '140%'
-    },
-    customItalic14: {
-      fontFamily: mulish.style.fontFamily,
-      fontStyle: 'italic',
-      fontSize: '14px',
-      lineHeight: '140%'
-    }
-  },
-  components: {
-    MuiTypography: {
-      defaultProps: {
-        variantMapping: {
-          customBold32: 'p',
-          customMedium22Tight: 'p',
-          customRegular20Tight: 'p',
-          customMedium18Tight: 'p',
-          customMedium18Loose: 'p',
-          customSemiBold18: 'p',
-          customRegular16: 'p',
-          customBold16: 'p',
-          customMedium16: 'p',
-          customItalic16: 'p',
-          customItalic14: 'p'
+    components: {
+      MuiTypography: {
+        defaultProps: {
+          variantMapping: {
+            customBold32: 'p',
+            customMedium22Tight: 'p',
+            customRegular20Tight: 'p',
+            customMedium18Tight: 'p',
+            customMedium18Loose: 'p',
+            customSemiBold18: 'p',
+            customRegular16: 'p',
+            customBold16: 'p',
+            customMedium16: 'p',
+            customItalic16: 'p',
+            customItalic14: 'p'
+          }
         }
       }
     }
-  }
-});
+  });
 
-export type AdminTheme = typeof adminTheme;
+// Export a single instance for consistency
+export const adminTheme = createAdminTheme();
+
+export type AdminTheme = ReturnType<typeof createAdminTheme>;


### PR DESCRIPTION
## Description

Add admin-specific typography design system. Introduced custom Mulish-based variants (customBold32, customMedium22Tight, customRegular20Tight, customMedium18Tight, customMedium18Loose, customSemiBold18, customBold16, customRegular16, customMedium16, customItalic16, customItalic14). Integrated theme via BodyProvider ThemeProvider wrap. Replaced hard‑coded styles in DiscardChangesModal and CropperModal with new variants.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Checkout branch feature/219/custom-typography.
2. Run app (yarn dev or npm run dev).
3. Open admin UI:
Discard changes modal: trigger an action that opens it; verify header uses customBold32 (32px, 700, 140%) and body text uses customMedium18Loose (18px, 500, 155%).
Cropper modal: open image crop; verify title (20px 400 140%) uses customRegular20Tight and subtitle (18px 500 135%) uses customMedium18Tight.
4. Inspect elements: confirm no inline fontSize/fontWeight remnants for those parts.
5. Run tests and lint (npm test, npm run lint) to ensure no typing errors.

## Video / Screenshots

<!-- Attach a video recording or screenshots demonstrating the changes, if applicable -->

## Checklist

- [ ] Code compiles and runs correctly
- [ ] Tests pass successfully
- [ ] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [ ] Linked issue/task included
- [ ] Task moved to the review column on the board

---
