### PR TITLE
feat: migrate blob storage functionality fully to the admin panel

### DIFF
--- a/app/api/blob-url/route.ts
+++ b/app/api/blob-url/route.ts
@@ -1,0 +1,30 @@
+import { errors } from '~/constants/errors';
+import { createRequestContainer } from '~/container/index';
+import logger from '~/middleware/logger/logger';
+import { errorResponse } from '~/utils/apiResponse';
+import { validateWithZod } from '~/utils/validateRequestData';
+import { zBlobQuerySchema } from '~/validators/queryParams.schema';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const validationResult = validateWithZod(
+    {
+      blobName: searchParams.get('blobName'),
+      folderName: searchParams.get('folderName')
+    },
+    zBlobQuerySchema
+  );
+
+  if (!validationResult.valid) return errorResponse(validationResult.errors);
+
+  const { blobName, folderName } = validationResult.value;
+  try {
+    const uploadService = createRequestContainer().resolve('uploadService');
+    const url = uploadService.constructBlobUrl(folderName, blobName);
+    const rangeHeader = request.headers.get('range');
+    return await uploadService.streamBlob(url, rangeHeader);
+  } catch (error) {
+    logger.error('Blob proxy failed:', error);
+    return errorResponse([errors.AZURE_URL_NOT_DEFINED], 503);
+  }
+}

--- a/app/constants/errors.ts
+++ b/app/constants/errors.ts
@@ -4,7 +4,8 @@ export const errors = {
   MISSING_MONGO_URL: '❌ mongoUrl is not defined or is empty',
   FAILED_TO_CONNECT_DB: '❌ Failed to connect to the database',
   RESPONSE_NOT_OK: '❌ HTTP error! Response is not 200 OK',
-  FAILED_TO_REFRESH: 'Failed to refresh token'
+  FAILED_TO_REFRESH: 'Failed to refresh token',
+  AZURE_URL_NOT_DEFINED: 'AZURE_SAS_URL environment variable is not defined'
 };
 
 export const loginErrors = {

--- a/app/lib/utils/validateRequestData.test.ts
+++ b/app/lib/utils/validateRequestData.test.ts
@@ -1,0 +1,45 @@
+import { validateRequestData } from './validateRequestData';
+
+describe('validateRequestData', () => {
+  const mockValidationFn = jest.fn();
+
+  beforeEach(() => {
+    mockValidationFn.mockReset();
+  });
+
+  it('should return valid: true and the value when there are no validation errors', () => {
+    const data = { name: 'John' };
+    mockValidationFn.mockReturnValue([]);
+
+    const result = validateRequestData(data, mockValidationFn);
+
+    expect(result).toEqual({ valid: true, value: data });
+    expect(mockValidationFn).toHaveBeenCalledWith(data);
+  });
+
+  it('should return valid: false and the errors when validation fails', () => {
+    const data = { name: '' };
+    mockValidationFn.mockReturnValue(['Name is required']);
+
+    const result = validateRequestData(data, mockValidationFn);
+
+    expect(result).toEqual({
+      valid: false,
+      errors: ['Name is required']
+    });
+    expect(mockValidationFn).toHaveBeenCalledWith(data);
+  });
+
+  it('should handle multiple validation errors', () => {
+    const data = { name: '', email: 'invalid-email' };
+    mockValidationFn.mockReturnValue(['Name is required', 'Email format is invalid']);
+
+    const result = validateRequestData(data, mockValidationFn);
+
+    expect(result).toEqual({
+      valid: false,
+      errors: ['Name is required', 'Email format is invalid']
+    });
+    expect(mockValidationFn).toHaveBeenCalledWith(data);
+  });
+});

--- a/app/lib/utils/validateRequestData.ts
+++ b/app/lib/utils/validateRequestData.ts
@@ -18,7 +18,7 @@ export function validateWithZod<T extends ZodTypeAny>(
   if (result.success) {
     return { valid: true, value: result.data };
   } else {
-    const errors = result.error.errors.map((e) => e.message);
+    const errors = result.error.issues.map((e) => e.message);
     return { valid: false, errors };
   }
 }

--- a/app/lib/utils/validateRequestData.ts
+++ b/app/lib/utils/validateRequestData.ts
@@ -1,0 +1,24 @@
+import { z, ZodTypeAny } from 'zod';
+
+export function validateRequestData<T>(
+  data: T,
+  validationFunction: (data: T) => string[]
+): { errors: string[]; valid: false } | { valid: true; value: T } {
+  const errors = validationFunction(data);
+
+  return errors.length === 0 ? { valid: true, value: data } : { errors, valid: false };
+}
+
+export function validateWithZod<T extends ZodTypeAny>(
+  data: unknown,
+  schema: T
+): { valid: true; value: z.infer<T> } | { valid: false; errors: string[] } {
+  const result = schema.safeParse(data);
+
+  if (result.success) {
+    return { valid: true, value: result.data };
+  } else {
+    const errors = result.error.errors.map((e) => e.message);
+    return { valid: false, errors };
+  }
+}

--- a/app/types/graphql/generated/graphql.ts
+++ b/app/types/graphql/generated/graphql.ts
@@ -18,6 +18,13 @@ export type Scalars = {
   JSON: { input: any; output: any };
 };
 
+export type BlobPayload = {
+  __typename?: 'BlobPayload';
+  blobName?: Maybe<Scalars['String']['output']>;
+  message?: Maybe<Scalars['String']['output']>;
+  success: Scalars['Boolean']['output'];
+};
+
 export type ErrorPayload = {
   __typename?: 'ErrorPayload';
   message: Scalars['String']['output'];
@@ -42,14 +49,29 @@ export type LoginResult = ErrorPayload | LoginPayload;
 
 export type Mutation = {
   __typename?: 'Mutation';
+  _empty?: Maybe<Scalars['String']['output']>;
+  deleteBlob: BlobPayload;
   login: LoginResult;
   logout: Scalars['Boolean']['output'];
   refreshToken: RefreshTokenPayload;
+  uploadBlob: BlobPayload;
+};
+
+export type MutationDeleteBlobArgs = {
+  blobName: Scalars['String']['input'];
+  folderName: Scalars['String']['input'];
 };
 
 export type MutationLoginArgs = {
   email: Scalars['String']['input'];
   password: Scalars['String']['input'];
+};
+
+export type MutationUploadBlobArgs = {
+  blobName: Scalars['String']['input'];
+  buffer: Scalars['String']['input'];
+  contentType: Scalars['String']['input'];
+  folderName: Scalars['String']['input'];
 };
 
 export type Page = {
@@ -90,6 +112,28 @@ export type LoginMutation = {
   login:
     | { __typename: 'ErrorPayload'; success: boolean; message: string; statusCode: number }
     | { __typename: 'LoginPayload'; success: boolean; adminId?: string | null; adminType?: string | null };
+};
+
+export type DeleteBlobMutationVariables = Exact<{
+  folderName: Scalars['String']['input'];
+  blobName: Scalars['String']['input'];
+}>;
+
+export type DeleteBlobMutation = {
+  __typename?: 'Mutation';
+  deleteBlob: { __typename?: 'BlobPayload'; success: boolean; message?: string | null; blobName?: string | null };
+};
+
+export type UploadBlobMutationVariables = Exact<{
+  folderName: Scalars['String']['input'];
+  blobName: Scalars['String']['input'];
+  buffer: Scalars['String']['input'];
+  contentType: Scalars['String']['input'];
+}>;
+
+export type UploadBlobMutation = {
+  __typename?: 'Mutation';
+  uploadBlob: { __typename?: 'BlobPayload'; success: boolean; message?: string | null; blobName?: string | null };
 };
 
 export type GetAdminProfileQueryVariables = Exact<{ [key: string]: never }>;
@@ -149,6 +193,84 @@ export function useLoginMutation(baseOptions?: Apollo.MutationHookOptions<LoginM
 export type LoginMutationHookResult = ReturnType<typeof useLoginMutation>;
 export type LoginMutationResult = Apollo.MutationResult<LoginMutation>;
 export type LoginMutationOptions = Apollo.BaseMutationOptions<LoginMutation, LoginMutationVariables>;
+export const DeleteBlobDocument = gql`
+  mutation DeleteBlob($folderName: String!, $blobName: String!) {
+    deleteBlob(folderName: $folderName, blobName: $blobName) {
+      success
+      message
+      blobName
+    }
+  }
+`;
+export type DeleteBlobMutationFn = Apollo.MutationFunction<DeleteBlobMutation, DeleteBlobMutationVariables>;
+
+/**
+ * __useDeleteBlobMutation__
+ *
+ * To run a mutation, you first call `useDeleteBlobMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDeleteBlobMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [deleteBlobMutation, { data, loading, error }] = useDeleteBlobMutation({
+ *   variables: {
+ *      folderName: // value for 'folderName'
+ *      blobName: // value for 'blobName'
+ *   },
+ * });
+ */
+export function useDeleteBlobMutation(
+  baseOptions?: Apollo.MutationHookOptions<DeleteBlobMutation, DeleteBlobMutationVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<DeleteBlobMutation, DeleteBlobMutationVariables>(DeleteBlobDocument, options);
+}
+export type DeleteBlobMutationHookResult = ReturnType<typeof useDeleteBlobMutation>;
+export type DeleteBlobMutationResult = Apollo.MutationResult<DeleteBlobMutation>;
+export type DeleteBlobMutationOptions = Apollo.BaseMutationOptions<DeleteBlobMutation, DeleteBlobMutationVariables>;
+export const UploadBlobDocument = gql`
+  mutation UploadBlob($folderName: String!, $blobName: String!, $buffer: String!, $contentType: String!) {
+    uploadBlob(folderName: $folderName, blobName: $blobName, buffer: $buffer, contentType: $contentType) {
+      success
+      message
+      blobName
+    }
+  }
+`;
+export type UploadBlobMutationFn = Apollo.MutationFunction<UploadBlobMutation, UploadBlobMutationVariables>;
+
+/**
+ * __useUploadBlobMutation__
+ *
+ * To run a mutation, you first call `useUploadBlobMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUploadBlobMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [uploadBlobMutation, { data, loading, error }] = useUploadBlobMutation({
+ *   variables: {
+ *      folderName: // value for 'folderName'
+ *      blobName: // value for 'blobName'
+ *      buffer: // value for 'buffer'
+ *      contentType: // value for 'contentType'
+ *   },
+ * });
+ */
+export function useUploadBlobMutation(
+  baseOptions?: Apollo.MutationHookOptions<UploadBlobMutation, UploadBlobMutationVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<UploadBlobMutation, UploadBlobMutationVariables>(UploadBlobDocument, options);
+}
+export type UploadBlobMutationHookResult = ReturnType<typeof useUploadBlobMutation>;
+export type UploadBlobMutationResult = Apollo.MutationResult<UploadBlobMutation>;
+export type UploadBlobMutationOptions = Apollo.BaseMutationOptions<UploadBlobMutation, UploadBlobMutationVariables>;
 export const GetAdminProfileDocument = gql`
   query GetAdminProfile {
     test {

--- a/app/types/graphql/mutations/delete.graphql
+++ b/app/types/graphql/mutations/delete.graphql
@@ -1,0 +1,13 @@
+mutation DeleteBlob(
+    $folderName: String!
+    $blobName: String!
+) {
+    deleteBlob(
+        folderName: $folderName
+        blobName: $blobName
+    ) {
+        success
+        message
+        blobName
+    }
+}

--- a/app/types/graphql/mutations/upload.graphql
+++ b/app/types/graphql/mutations/upload.graphql
@@ -1,0 +1,17 @@
+mutation UploadBlob(
+    $folderName: String!
+    $blobName: String!
+    $buffer: String!
+    $contentType: String!
+) {
+    uploadBlob(
+        folderName: $folderName
+        blobName: $blobName
+        buffer: $buffer
+        contentType: $contentType
+    ) {
+        success
+        message
+        blobName
+    }
+}

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -21,7 +21,8 @@ const config: Config = {
     '!src/domain/**/*.{js,ts}',
     '!src/constants/**/*.{js,ts}',
     '!src/shared/types/**/*.{js,ts}',
-    '!src/infrastructure/models/**/*.{js,ts}'
+    '!src/infrastructure/models/**/*.{js,ts}',
+    '!src/validators/**/*.{js,ts}'
   ],
   coverageDirectory: 'coverage',
   coverageProvider: 'v8',

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@apollo/client": "^3.13.8",
         "@apollo/server": "^4.12.2",
+        "@azure/storage-blob": "^12.28.0",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
         "@graphql-codegen/cli": "^5.0.7",
@@ -38,6 +39,7 @@
         "uuid": "^11.1.0",
         "winston": "^3.17.0",
         "winston-mongodb": "^7.0.0",
+        "zod": "^4.1.4",
         "zustand": "^5.0.7"
       },
       "devDependencies": {
@@ -803,6 +805,206 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
       "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
       "dev": true
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.0.tgz",
+      "integrity": "sha512-88Djs5vBvGbHQHf5ZZcaoNHo6Y8BKZkt3cw2iuJIQzLEgH4Ox6Tm4hjFhbqOxyYsgIG/eJbFEHpxRIfEEWv5Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-util": "^1.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-client": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.0.tgz",
+      "integrity": "sha512-O4aP3CLFNodg8eTHXECaH3B3CjicfzkxVtnrfLkOq0XNP7TIECGfHpK/C6vADZkWP75wzmdBnsIA8ksuJMk18g==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.4.0",
+        "@azure/core-rest-pipeline": "^1.20.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.6.1",
+        "@azure/logger": "^1.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-http-compat": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.3.0.tgz",
+      "integrity": "sha512-qLQujmUypBBG0gxHd0j6/Jdmul6ttl24c8WGiLXIk7IHXdBlfoBqW27hyz3Xn6xbfdyVSarl1Ttbk0AwnZBYCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-client": "^1.3.0",
+        "@azure/core-rest-pipeline": "^1.20.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-lro": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.7.2.tgz",
+      "integrity": "sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-util": "^1.2.0",
+        "@azure/logger": "^1.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-paging": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.6.2.tgz",
+      "integrity": "sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.22.0.tgz",
+      "integrity": "sha512-OKHmb3/Kpm06HypvB3g6Q3zJuvyXcpxDpCS1PnU8OV6AJgSFaee/covXBcPbWc6XDDxtEPlbi3EMQ6nUiPaQtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.8.0",
+        "@azure/core-tracing": "^1.0.1",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.0.0",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.0.tgz",
+      "integrity": "sha512-+XvmZLLWPe67WXNZo9Oc9CrPj/Tm8QnHR92fFAFdnbzwNdCH1h+7UdpaQgRSBsMY+oW1kHXNUZQLdZ1gHX3ROw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.0.tgz",
+      "integrity": "sha512-o0psW8QWQ58fq3i24Q1K2XfS/jYTxr7O1HRcyUE9bV9NttLU+kYOH82Ixj8DGlMTOWgxm1Sss2QAfKK5UkSPxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-xml": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-xml/-/core-xml-1.5.0.tgz",
+      "integrity": "sha512-D/sdlJBMJfx7gqoj66PKVmhDDaU6TKA49ptcolxdas29X7AfvLTmfAGLjAcIMBK7UZ2o4lygHIqVckOlQU3xWw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.0.7",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+      "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/storage-blob": {
+      "version": "12.28.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.28.0.tgz",
+      "integrity": "sha512-VhQHITXXO03SURhDiGuHhvc/k/sD2WvJUS7hqhiVNbErVCuQoLtWql7r97fleBlIRKHJaa9R7DpBjfE0pfLYcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.3",
+        "@azure/core-http-compat": "^2.2.0",
+        "@azure/core-lro": "^2.2.0",
+        "@azure/core-paging": "^1.6.2",
+        "@azure/core-rest-pipeline": "^1.19.1",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/core-xml": "^1.4.5",
+        "@azure/logger": "^1.1.4",
+        "@azure/storage-common": "^12.0.0-beta.2",
+        "events": "^3.0.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/storage-common": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-common/-/storage-common-12.0.0.tgz",
+      "integrity": "sha512-QyEWXgi4kdRo0wc1rHum9/KnaWZKCdQGZK1BjU4fFL6Jtedp7KLbQihgTTVxldFy1z1ZPtuDPx8mQ5l3huPPbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-http-compat": "^2.2.0",
+        "@azure/core-rest-pipeline": "^1.19.1",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.1.4",
+        "events": "^3.3.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -8362,6 +8564,55 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.0.tgz",
+      "integrity": "sha512-sOx1PKSuFwnIl7z4RN0Ls7N9AQawmR9r66eI5rFCzLDIs8HTIYrIpH9QjYWoX0lkgGrkLxXhi4QnK7MizPRrIg==",
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
@@ -12205,6 +12456,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -12417,6 +12677,24 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -19733,6 +20011,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -21514,6 +21804,15 @@
       "license": "MIT",
       "dependencies": {
         "zen-observable": "0.8.15"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.5.tgz",
+      "integrity": "sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@apollo/client": "^3.13.8",
     "@apollo/server": "^4.12.2",
+    "@azure/storage-blob": "^12.28.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@graphql-codegen/cli": "^5.0.7",
@@ -46,6 +47,7 @@
     "uuid": "^11.1.0",
     "winston": "^3.17.0",
     "winston-mongodb": "^7.0.0",
+    "zod": "^4.1.4",
     "zustand": "^5.0.7"
   },
   "devDependencies": {

--- a/src/application/use-cases/uploadService/upload.test.ts
+++ b/src/application/use-cases/uploadService/upload.test.ts
@@ -1,0 +1,217 @@
+import { createHash } from 'crypto';
+
+import { blobStorageService } from './upload';
+import { errors } from '~/back-constants/errors';
+import { CONTAINER_NAME } from '~/back-constants/index';
+import logger from '~/middleware/logger/logger';
+
+const mockUploadData = jest.fn();
+const mockDeleteIfExists = jest.fn();
+const mockExists = jest.fn();
+const mockFetch = jest.fn();
+const mockResponse = jest.fn((body, init) => ({ body, ...init, isMocked: true }));
+const mockSetHeader = jest.fn();
+const mockHeaders = jest.fn().mockImplementation(() => ({
+  set: mockSetHeader,
+  get: jest.fn(),
+  has: jest.fn()
+}));
+
+global.fetch = mockFetch;
+global.Response = mockResponse;
+global.Headers = mockHeaders;
+
+const MOCK_AZURE_SAS_URL = 'url-test';
+process.env.AZURE_SAS_URL = MOCK_AZURE_SAS_URL;
+
+jest.mock('@azure/storage-blob', () => {
+  return {
+    BlobServiceClient: jest.fn().mockImplementation(() => ({
+      getContainerClient: jest.fn(() => ({
+        getBlockBlobClient: jest.fn((path: string) => ({
+          uploadData: mockUploadData,
+          deleteIfExists: mockDeleteIfExists,
+          exists: mockExists,
+          url: `https://mockstorage.blob.core.windows.net/${CONTAINER_NAME}/${path}`
+        }))
+      }))
+    }))
+  };
+});
+
+jest.mock('../../../validators/blob.schema', () => ({
+  zFolderNameSchema: { parse: jest.fn() },
+  zContentTypeSchema: { parse: jest.fn() }
+}));
+
+jest.mock('../../../middleware/logger/logger', () => ({
+  error: jest.fn(),
+  warning: jest.fn()
+}));
+
+describe('azureStorageService', () => {
+  const folderName = 'photos';
+  const blobName = 'image.jpg';
+  const buffer = Buffer.from('mock buffer');
+  const contentType = 'image/jpeg';
+  const fullPath = `${folderName}/${createHash('sha256').update(blobName).digest('hex')}`;
+  const expectedUrl = `https://mockstorage.blob.core.windows.net/${CONTAINER_NAME}/${fullPath}`;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('uploadFile', () => {
+    it('should upload file successfully', async () => {
+      await expect(blobStorageService().uploadFile(folderName, blobName, buffer, contentType)).resolves.toBeUndefined();
+      expect(mockUploadData).toHaveBeenCalledWith(buffer, {
+        blobHTTPHeaders: { blobContentType: contentType }
+      });
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it('should throw an error and log it if upload fails', async () => {
+      const uploadError = new Error('Azure network error');
+      mockUploadData.mockRejectedValue(uploadError);
+      await expect(blobStorageService().uploadFile(folderName, blobName, buffer, contentType)).rejects.toThrow(
+        uploadError
+      );
+      expect(logger.error).toHaveBeenCalledWith(errors.FAILED_TO_UPLOAD_BLOB, uploadError);
+    });
+  });
+
+  describe('deleteFile', () => {
+    it('should delete file successfully', async () => {
+      await expect(blobStorageService().deleteFile(folderName, blobName)).resolves.toBeUndefined();
+      expect(mockDeleteIfExists).toHaveBeenCalled();
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it('should throw an error and log it if deletion fails', async () => {
+      const deleteError = new Error('Azure permission error');
+      mockDeleteIfExists.mockRejectedValue(deleteError);
+      await expect(blobStorageService().deleteFile(folderName, blobName)).rejects.toThrow(deleteError);
+      expect(logger.error).toHaveBeenCalledWith(errors.FAILED_TO_DELETE_BLOB, deleteError);
+    });
+  });
+
+  describe('constructBlobUrl', () => {
+    it('should return the full, correctly formatted URL without checking for existence', () => {
+      const url = blobStorageService().constructBlobUrl(folderName, blobName);
+      expect(url).toBe(expectedUrl);
+      expect(mockExists).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('streamBlob', () => {
+    const mockUrl = 'https://fake-url.com/file.mp3';
+
+    beforeEach(() => {
+      mockFetch.mockClear();
+      mockResponse.mockClear();
+      mockSetHeader.mockClear();
+    });
+
+    it('should call fetch and construct a new Response for a full request', async () => {
+      const fakeBody = 'audio data';
+      const mockAzureHeaders = {
+        get: jest.fn((key: string) => {
+          if (key === 'Content-Type') return 'audio/mpeg';
+          if (key === 'Content-Length') return '1234567';
+          return null;
+        }),
+        has: jest.fn().mockReturnValue(false)
+      };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: mockAzureHeaders,
+        body: fakeBody
+      });
+
+      const result = await blobStorageService().streamBlob(mockUrl, null);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledWith(mockUrl, {
+        method: 'GET',
+        headers: {},
+        next: { revalidate: 0 }
+      });
+      expect(mockResponse).toHaveBeenCalledTimes(1);
+      expect(mockResponse).toHaveBeenCalledWith(fakeBody, {
+        status: 200,
+        statusText: undefined,
+        headers: expect.any(Object)
+      });
+      expect(result.status).toBe(200);
+    });
+
+    it('should handle range requests and construct a 206 Partial Content response', async () => {
+      const fakeBody = 'partial audio data';
+      const mockAzureHeaders = {
+        get: jest.fn((key: string) => {
+          const headersMap = {
+            'Content-Type': 'audio/mpeg',
+            'Content-Length': '500000',
+            'Content-Range': 'bytes 500000-999999/1000000'
+          };
+          return headersMap[key as keyof typeof headersMap] || null;
+        }),
+        has: jest.fn((key: string) => key === 'Content-Range')
+      };
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 206,
+        headers: mockAzureHeaders,
+        body: fakeBody
+      });
+
+      const rangeHeader = 'bytes=500000-';
+
+      await blobStorageService().streamBlob(mockUrl, rangeHeader);
+
+      expect(mockFetch).toHaveBeenCalledWith(mockUrl, {
+        method: 'GET',
+        headers: { Range: rangeHeader },
+        next: { revalidate: 0 }
+      });
+      expect(mockResponse).toHaveBeenCalledWith(fakeBody, {
+        status: 206,
+        statusText: undefined,
+        headers: expect.any(Object)
+      });
+      expect(mockSetHeader).toHaveBeenCalledWith('Content-Type', 'audio/mpeg');
+      expect(mockSetHeader).toHaveBeenCalledWith('Content-Length', '500000');
+      expect(mockSetHeader).toHaveBeenCalledWith('Content-Range', 'bytes 500000-999999/1000000');
+      expect(mockSetHeader).toHaveBeenCalledWith('Accept-Ranges', 'bytes');
+      expect(mockSetHeader).toHaveBeenCalledWith('Cache-Control', expect.any(String));
+    });
+
+    it('should return the original error response from fetch without constructing a new one', async () => {
+      const mockErrorBody = 'Not found';
+      const mockErrorResponseFromFetch = {
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        body: mockErrorBody
+      };
+      mockFetch.mockResolvedValue(mockErrorResponseFromFetch);
+
+      await blobStorageService().streamBlob(mockUrl, null);
+
+      expect(mockResponse).toHaveBeenCalledTimes(1);
+      expect(mockResponse).toHaveBeenCalledWith(mockErrorBody, {
+        status: 404,
+        statusText: 'Not Found'
+      });
+    });
+
+    it('should throw an error if fetch itself fails', async () => {
+      const networkError = new Error('DNS resolution failed');
+      mockFetch.mockRejectedValue(networkError);
+      await expect(blobStorageService().streamBlob(mockUrl, null)).rejects.toThrow(networkError);
+      expect(mockResponse).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/application/use-cases/uploadService/upload.test.ts
+++ b/src/application/use-cases/uploadService/upload.test.ts
@@ -1,5 +1,3 @@
-import { createHash } from 'crypto';
-
 import { blobStorageService } from './upload';
 import { errors } from '~/back-constants/errors';
 import { CONTAINER_NAME } from '~/back-constants/index';
@@ -54,8 +52,6 @@ describe('azureStorageService', () => {
   const blobName = 'image.jpg';
   const buffer = Buffer.from('mock buffer');
   const contentType = 'image/jpeg';
-  const fullPath = `${folderName}/${createHash('sha256').update(blobName).digest('hex')}`;
-  const expectedUrl = `https://mockstorage.blob.core.windows.net/${CONTAINER_NAME}/${fullPath}`;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -92,126 +88,6 @@ describe('azureStorageService', () => {
       mockDeleteIfExists.mockRejectedValue(deleteError);
       await expect(blobStorageService().deleteFile(folderName, blobName)).rejects.toThrow(deleteError);
       expect(logger.error).toHaveBeenCalledWith(errors.FAILED_TO_DELETE_BLOB, deleteError);
-    });
-  });
-
-  describe('constructBlobUrl', () => {
-    it('should return the full, correctly formatted URL without checking for existence', () => {
-      const url = blobStorageService().constructBlobUrl(folderName, blobName);
-      expect(url).toBe(expectedUrl);
-      expect(mockExists).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('streamBlob', () => {
-    const mockUrl = 'https://fake-url.com/file.mp3';
-
-    beforeEach(() => {
-      mockFetch.mockClear();
-      mockResponse.mockClear();
-      mockSetHeader.mockClear();
-    });
-
-    it('should call fetch and construct a new Response for a full request', async () => {
-      const fakeBody = 'audio data';
-      const mockAzureHeaders = {
-        get: jest.fn((key: string) => {
-          if (key === 'Content-Type') return 'audio/mpeg';
-          if (key === 'Content-Length') return '1234567';
-          return null;
-        }),
-        has: jest.fn().mockReturnValue(false)
-      };
-      mockFetch.mockResolvedValue({
-        ok: true,
-        status: 200,
-        headers: mockAzureHeaders,
-        body: fakeBody
-      });
-
-      const result = await blobStorageService().streamBlob(mockUrl, null);
-
-      expect(mockFetch).toHaveBeenCalledTimes(1);
-      expect(mockFetch).toHaveBeenCalledWith(mockUrl, {
-        method: 'GET',
-        headers: {},
-        next: { revalidate: 0 }
-      });
-      expect(mockResponse).toHaveBeenCalledTimes(1);
-      expect(mockResponse).toHaveBeenCalledWith(fakeBody, {
-        status: 200,
-        statusText: undefined,
-        headers: expect.any(Object)
-      });
-      expect(result.status).toBe(200);
-    });
-
-    it('should handle range requests and construct a 206 Partial Content response', async () => {
-      const fakeBody = 'partial audio data';
-      const mockAzureHeaders = {
-        get: jest.fn((key: string) => {
-          const headersMap = {
-            'Content-Type': 'audio/mpeg',
-            'Content-Length': '500000',
-            'Content-Range': 'bytes 500000-999999/1000000'
-          };
-          return headersMap[key as keyof typeof headersMap] || null;
-        }),
-        has: jest.fn((key: string) => key === 'Content-Range')
-      };
-
-      mockFetch.mockResolvedValue({
-        ok: true,
-        status: 206,
-        headers: mockAzureHeaders,
-        body: fakeBody
-      });
-
-      const rangeHeader = 'bytes=500000-';
-
-      await blobStorageService().streamBlob(mockUrl, rangeHeader);
-
-      expect(mockFetch).toHaveBeenCalledWith(mockUrl, {
-        method: 'GET',
-        headers: { Range: rangeHeader },
-        next: { revalidate: 0 }
-      });
-      expect(mockResponse).toHaveBeenCalledWith(fakeBody, {
-        status: 206,
-        statusText: undefined,
-        headers: expect.any(Object)
-      });
-      expect(mockSetHeader).toHaveBeenCalledWith('Content-Type', 'audio/mpeg');
-      expect(mockSetHeader).toHaveBeenCalledWith('Content-Length', '500000');
-      expect(mockSetHeader).toHaveBeenCalledWith('Content-Range', 'bytes 500000-999999/1000000');
-      expect(mockSetHeader).toHaveBeenCalledWith('Accept-Ranges', 'bytes');
-      expect(mockSetHeader).toHaveBeenCalledWith('Cache-Control', expect.any(String));
-    });
-
-    it('should return the original error response from fetch without constructing a new one', async () => {
-      const mockErrorBody = 'Not found';
-      const mockErrorResponseFromFetch = {
-        ok: false,
-        status: 404,
-        statusText: 'Not Found',
-        body: mockErrorBody
-      };
-      mockFetch.mockResolvedValue(mockErrorResponseFromFetch);
-
-      await blobStorageService().streamBlob(mockUrl, null);
-
-      expect(mockResponse).toHaveBeenCalledTimes(1);
-      expect(mockResponse).toHaveBeenCalledWith(mockErrorBody, {
-        status: 404,
-        statusText: 'Not Found'
-      });
-    });
-
-    it('should throw an error if fetch itself fails', async () => {
-      const networkError = new Error('DNS resolution failed');
-      mockFetch.mockRejectedValue(networkError);
-      await expect(blobStorageService().streamBlob(mockUrl, null)).rejects.toThrow(networkError);
-      expect(mockResponse).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/application/use-cases/uploadService/upload.test.ts
+++ b/src/application/use-cases/uploadService/upload.test.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'crypto';
+
 import { blobStorageService } from './upload';
 import { errors } from '~/back-constants/errors';
 import { CONTAINER_NAME } from '~/back-constants/index';
@@ -52,6 +54,8 @@ describe('azureStorageService', () => {
   const blobName = 'image.jpg';
   const buffer = Buffer.from('mock buffer');
   const contentType = 'image/jpeg';
+  const fullPath = `${folderName}/${createHash('sha256').update(blobName).digest('hex')}`;
+  const expectedUrl = `https://mockstorage.blob.core.windows.net/${CONTAINER_NAME}/${fullPath}`;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -88,6 +92,125 @@ describe('azureStorageService', () => {
       mockDeleteIfExists.mockRejectedValue(deleteError);
       await expect(blobStorageService().deleteFile(folderName, blobName)).rejects.toThrow(deleteError);
       expect(logger.error).toHaveBeenCalledWith(errors.FAILED_TO_DELETE_BLOB, deleteError);
+    });
+  });
+  describe('constructBlobUrl', () => {
+    it('should return the full, correctly formatted URL without checking for existence', () => {
+      const url = blobStorageService().constructBlobUrl(folderName, blobName);
+      expect(url).toBe(expectedUrl);
+      expect(mockExists).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('streamBlob', () => {
+    const mockUrl = 'https://fake-url.com/file.mp3';
+
+    beforeEach(() => {
+      mockFetch.mockClear();
+      mockResponse.mockClear();
+      mockSetHeader.mockClear();
+    });
+
+    it('should call fetch and construct a new Response for a full request', async () => {
+      const fakeBody = 'audio data';
+      const mockAzureHeaders = {
+        get: jest.fn((key: string) => {
+          if (key === 'Content-Type') return 'audio/mpeg';
+          if (key === 'Content-Length') return '1234567';
+          return null;
+        }),
+        has: jest.fn().mockReturnValue(false)
+      };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: mockAzureHeaders,
+        body: fakeBody
+      });
+
+      const result = await blobStorageService().streamBlob(mockUrl, null);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledWith(mockUrl, {
+        method: 'GET',
+        headers: {},
+        next: { revalidate: 0 }
+      });
+      expect(mockResponse).toHaveBeenCalledTimes(1);
+      expect(mockResponse).toHaveBeenCalledWith(fakeBody, {
+        status: 200,
+        statusText: undefined,
+        headers: expect.any(Object)
+      });
+      expect(result.status).toBe(200);
+    });
+
+    it('should handle range requests and construct a 206 Partial Content response', async () => {
+      const fakeBody = 'partial audio data';
+      const mockAzureHeaders = {
+        get: jest.fn((key: string) => {
+          const headersMap = {
+            'Content-Type': 'audio/mpeg',
+            'Content-Length': '500000',
+            'Content-Range': 'bytes 500000-999999/1000000'
+          };
+          return headersMap[key as keyof typeof headersMap] || null;
+        }),
+        has: jest.fn((key: string) => key === 'Content-Range')
+      };
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 206,
+        headers: mockAzureHeaders,
+        body: fakeBody
+      });
+
+      const rangeHeader = 'bytes=500000-';
+
+      await blobStorageService().streamBlob(mockUrl, rangeHeader);
+
+      expect(mockFetch).toHaveBeenCalledWith(mockUrl, {
+        method: 'GET',
+        headers: { Range: rangeHeader },
+        next: { revalidate: 0 }
+      });
+      expect(mockResponse).toHaveBeenCalledWith(fakeBody, {
+        status: 206,
+        statusText: undefined,
+        headers: expect.any(Object)
+      });
+      expect(mockSetHeader).toHaveBeenCalledWith('Content-Type', 'audio/mpeg');
+      expect(mockSetHeader).toHaveBeenCalledWith('Content-Length', '500000');
+      expect(mockSetHeader).toHaveBeenCalledWith('Content-Range', 'bytes 500000-999999/1000000');
+      expect(mockSetHeader).toHaveBeenCalledWith('Accept-Ranges', 'bytes');
+      expect(mockSetHeader).toHaveBeenCalledWith('Cache-Control', expect.any(String));
+    });
+
+    it('should return the original error response from fetch without constructing a new one', async () => {
+      const mockErrorBody = 'Not found';
+      const mockErrorResponseFromFetch = {
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        body: mockErrorBody
+      };
+      mockFetch.mockResolvedValue(mockErrorResponseFromFetch);
+
+      await blobStorageService().streamBlob(mockUrl, null);
+
+      expect(mockResponse).toHaveBeenCalledTimes(1);
+      expect(mockResponse).toHaveBeenCalledWith(mockErrorBody, {
+        status: 404,
+        statusText: 'Not Found'
+      });
+    });
+
+    it('should throw an error if fetch itself fails', async () => {
+      const networkError = new Error('DNS resolution failed');
+      mockFetch.mockRejectedValue(networkError);
+      await expect(blobStorageService().streamBlob(mockUrl, null)).rejects.toThrow(networkError);
+      expect(mockResponse).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/application/use-cases/uploadService/upload.ts
+++ b/src/application/use-cases/uploadService/upload.ts
@@ -60,6 +60,47 @@ export const blobStorageService = () => {
         logger.error(errors.FAILED_TO_DELETE_BLOB, error);
         throw error;
       }
+    },
+    constructBlobUrl: (folderName: string, blobName: string): string => {
+      try {
+        zFolderNameSchema.parse(folderName);
+        const blobNameHash = createHash('sha256').update(blobName).digest('hex');
+        const containerClient = getContainerClient();
+        const blockBlobClient = getFullPathToBlob(containerClient, folderName, blobNameHash);
+        return blockBlobClient.url;
+      } catch (error) {
+        logger.error(errors.BLOB_DOES_NOT_EXIST, error);
+        throw error;
+      }
+    },
+    streamBlob: async (url: string, rangeHeader: string | null): Promise<Response> => {
+      const azureResponse = await fetch(url, {
+        method: 'GET',
+        headers: rangeHeader ? { Range: rangeHeader } : {},
+        next: { revalidate: 0 }
+      });
+
+      if (!azureResponse.ok) {
+        return new Response(azureResponse.body, {
+          status: azureResponse.status,
+          statusText: azureResponse.statusText
+        });
+      }
+
+      const headers = new Headers();
+      headers.set('Content-Type', azureResponse.headers.get('Content-Type') ?? 'application/octet-stream');
+      headers.set('Content-Length', azureResponse.headers.get('Content-Length') ?? '');
+      if (azureResponse.headers.has('Content-Range')) {
+        headers.set('Content-Range', azureResponse.headers.get('Content-Range')!);
+      }
+      headers.set('Accept-Ranges', 'bytes');
+      headers.set('Cache-Control', 'public, max-age=604800, immutable');
+
+      return new Response(azureResponse.body, {
+        status: azureResponse.status,
+        statusText: azureResponse.statusText,
+        headers
+      });
     }
   };
 };

--- a/src/application/use-cases/uploadService/upload.ts
+++ b/src/application/use-cases/uploadService/upload.ts
@@ -1,0 +1,65 @@
+import { BlobServiceClient, BlockBlobClient, ContainerClient } from '@azure/storage-blob';
+import { createHash } from 'crypto';
+
+import { errors } from '~/back-constants/errors';
+import { CONTAINER_NAME } from '~/back-constants/index';
+import logger from '~/middleware/logger/logger';
+import { zContentTypeSchema, zFolderNameSchema } from '~/validators/blob.schema';
+
+export const blobStorageService = () => {
+  let blobServiceClient: BlobServiceClient | null = null;
+
+  const getClient = (): BlobServiceClient => {
+    if (blobServiceClient) {
+      return blobServiceClient;
+    }
+    const { AZURE_SAS_URL } = process.env;
+    if (!AZURE_SAS_URL) {
+      throw new Error(errors.AZURE_URL_NOT_DEFINED);
+    }
+    blobServiceClient = new BlobServiceClient(AZURE_SAS_URL);
+    return blobServiceClient;
+  };
+
+  const getContainerClient = (): ContainerClient => {
+    return getClient().getContainerClient(CONTAINER_NAME);
+  };
+
+  const getFullPathToBlob = (
+    containerClient: ContainerClient,
+    folderName: string,
+    blobName: string
+  ): BlockBlobClient => {
+    return containerClient.getBlockBlobClient(`${folderName}/${blobName}`);
+  };
+
+  return {
+    uploadFile: async (folderName: string, blobName: string, buffer: Buffer, contentType?: string): Promise<void> => {
+      try {
+        zFolderNameSchema.parse(folderName);
+        zContentTypeSchema.parse(contentType);
+        const blobNameHash = createHash('sha256').update(blobName).digest('hex');
+        const containerClient = getContainerClient();
+        const blockBlobClient = getFullPathToBlob(containerClient, folderName, blobNameHash);
+        await blockBlobClient.uploadData(buffer, {
+          blobHTTPHeaders: { blobContentType: contentType }
+        });
+      } catch (error) {
+        logger.error(errors.FAILED_TO_UPLOAD_BLOB, error);
+        throw error;
+      }
+    },
+    deleteFile: async (folderName: string, blobName: string): Promise<void> => {
+      try {
+        zFolderNameSchema.parse(folderName);
+        const blobNameHash = createHash('sha256').update(blobName).digest('hex');
+        const containerClient = getContainerClient();
+        const blockBlobClient = getFullPathToBlob(containerClient, folderName, blobNameHash);
+        await blockBlobClient.deleteIfExists();
+      } catch (error) {
+        logger.error(errors.FAILED_TO_DELETE_BLOB, error);
+        throw error;
+      }
+    }
+  };
+};

--- a/src/constants/errors.ts
+++ b/src/constants/errors.ts
@@ -1,4 +1,9 @@
 export const errors = {
   REFRESH_TOKEN_REVOKED: 'Refresh token has been revoked',
-  EXPIRED_ACCESS_TOKEN: 'You must be logged in to access this resource'
+  EXPIRED_ACCESS_TOKEN: 'You must be logged in to access this resource',
+  FAILED_TO_UPLOAD_BLOB: 'Error during upload blob file',
+  FAILED_TO_DELETE_BLOB: 'Error during delete blob file',
+  FAILED_TO_GET_BLOB: 'Error during get blob file',
+  BLOB_DOES_NOT_EXIST: 'Blob with this name does not exist',
+  AZURE_URL_NOT_DEFINED: 'AZURE_SAS_URL environment variable is not defined'
 };

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -9,3 +9,4 @@ export const commonCookieOptions = {
 };
 export const ACCESS_TOKEN_COOKIE_NAME = 'accessToken';
 export const REFRESH_TOKEN_COOKIE_NAME = 'refreshToken';
+export const CONTAINER_NAME = 'materials';

--- a/src/container/modules/use-cases.ts
+++ b/src/container/modules/use-cases.ts
@@ -3,9 +3,11 @@ import { asFunction } from 'awilix';
 import { loginAdmin } from '~/application/use-cases/loginAdmin/loginAdmin';
 import { createTokenService } from '~/application/use-cases/tokenService/createToken/createToken.service';
 import { refreshTokenService } from '~/application/use-cases/tokenService/refreshToken/refreshToken.service';
+import { blobStorageService } from '~/application/use-cases/uploadService/upload';
 
 export const registerUseCases = () => ({
   loginAdmin: asFunction(loginAdmin).scoped(),
   createTokenService: asFunction(createTokenService).scoped(),
-  refreshTokenService: asFunction(refreshTokenService).scoped()
+  refreshTokenService: asFunction(refreshTokenService).scoped(),
+  uploadService: asFunction(blobStorageService).scoped()
 });

--- a/src/interfaces/graphql/resolvers/admin/AuthMutation.test.ts
+++ b/src/interfaces/graphql/resolvers/admin/AuthMutation.test.ts
@@ -1,6 +1,6 @@
 import { GraphQLError } from 'graphql';
 
-import { Mutation } from './Mutation';
+import { authMutation } from './AuthMutation';
 import { LoginError } from '~/back-constants/apolloCustomErrors/adminErrors';
 import { GraphQLContext } from '~/back-shared/types/container/types';
 
@@ -45,7 +45,7 @@ describe('GraphQL Mutations', () => {
     it('should successfully log in the admin, set cookies and return LoginPayload', async () => {
       mockLoginAdmin.execute.mockResolvedValue(mockAdmin);
       mockTokenService.generateTokens.mockReturnValue(mockTokens);
-      const result = await Mutation.login(null, mockArgs, baseMockContext as GraphQLContext);
+      const result = await authMutation.login(null, mockArgs, baseMockContext as GraphQLContext);
       expect(mockLoginAdmin.execute).toHaveBeenCalledWith(mockArgs.email, mockArgs.password);
       expect(mockTokenService.generateTokens).toHaveBeenCalledWith(mockAdmin);
       expect(mockRefreshTokenService.addJTI).toHaveBeenCalledWith(
@@ -67,7 +67,7 @@ describe('GraphQL Mutations', () => {
       const loginError = new LoginError();
       mockLoginAdmin.execute.mockRejectedValue(loginError);
 
-      const result = await Mutation.login(null, mockArgs, baseMockContext as GraphQLContext);
+      const result = await authMutation.login(null, mockArgs, baseMockContext as GraphQLContext);
 
       expect(result).toEqual({
         __typename: 'ErrorPayload',
@@ -81,7 +81,7 @@ describe('GraphQL Mutations', () => {
     it('should throw an error if it is not of type LoginError', async () => {
       const genericError = new Error('Database connection failed');
       mockLoginAdmin.execute.mockRejectedValue(genericError);
-      await expect(Mutation.login(null, mockArgs, baseMockContext as GraphQLContext)).rejects.toThrow(genericError);
+      await expect(authMutation.login(null, mockArgs, baseMockContext as GraphQLContext)).rejects.toThrow(genericError);
     });
   });
 
@@ -90,7 +90,7 @@ describe('GraphQL Mutations', () => {
       const mockContext = { ...baseMockContext, refreshTokenFromCookie: 'valid-refresh-token' };
       const mockPayload = { id: 'admin-1', jti: 'jti-to-delete' };
       mockTokenService.verifyRefreshToken.mockReturnValue(mockPayload);
-      const result = await Mutation.logout(null, {}, mockContext as GraphQLContext);
+      const result = await authMutation.logout(null, {}, mockContext as GraphQLContext);
       expect(mockTokenService.verifyRefreshToken).toHaveBeenCalledWith('valid-refresh-token');
       expect(mockRefreshTokenService.deleteJTI).toHaveBeenCalledWith(mockPayload.jti);
       expect(mockContext.deleteCookie).toHaveBeenCalledTimes(2);
@@ -98,7 +98,7 @@ describe('GraphQL Mutations', () => {
     });
 
     it('should only delete cookies if there is no token', async () => {
-      const result = await Mutation.logout(null, {}, baseMockContext as GraphQLContext);
+      const result = await authMutation.logout(null, {}, baseMockContext as GraphQLContext);
       expect(mockTokenService.verifyRefreshToken).not.toHaveBeenCalled();
       expect(mockRefreshTokenService.deleteJTI).not.toHaveBeenCalled();
       expect(baseMockContext.deleteCookie).toHaveBeenCalledTimes(2);
@@ -111,7 +111,7 @@ describe('GraphQL Mutations', () => {
         throw new Error('jwt expired');
       });
 
-      await Mutation.logout(null, {}, mockContext as GraphQLContext);
+      await authMutation.logout(null, {}, mockContext as GraphQLContext);
 
       expect(mockRefreshTokenService.deleteJTI).not.toHaveBeenCalled();
       expect(mockContext.deleteCookie).toHaveBeenCalledTimes(2);
@@ -135,7 +135,7 @@ describe('GraphQL Mutations', () => {
       mockRefreshTokenService.isExistsJTI.mockResolvedValue(true);
       mockTokenService.generateTokens.mockReturnValue(newTokens);
 
-      const result = await Mutation.refreshToken(null, {}, mockContext as GraphQLContext);
+      const result = await authMutation.refreshToken(null, {}, mockContext as GraphQLContext);
 
       expect(mockRefreshTokenService.isExistsJTI).toHaveBeenCalledWith(oldPayload.jti);
       expect(mockRefreshTokenService.deleteJTI).toHaveBeenCalledWith(oldPayload.jti);
@@ -148,7 +148,7 @@ describe('GraphQL Mutations', () => {
       mockTokenService.verifyRefreshToken.mockReturnValue(oldPayload);
       mockRefreshTokenService.isExistsJTI.mockResolvedValue(false);
 
-      await expect(Mutation.refreshToken(null, {}, mockContext as GraphQLContext)).rejects.toThrow(GraphQLError);
+      await expect(authMutation.refreshToken(null, {}, mockContext as GraphQLContext)).rejects.toThrow(GraphQLError);
 
       expect(mockRefreshTokenService.deleteAllForAdmin).toHaveBeenCalledWith(oldPayload.id);
       expect(mockContext.deleteCookie).toHaveBeenCalledTimes(2);
@@ -166,7 +166,7 @@ describe('GraphQL Mutations', () => {
         throw new Error('jwt expired');
       });
 
-      await expect(Mutation.refreshToken(null, {}, mockContext as GraphQLContext)).rejects.toThrow(GraphQLError);
+      await expect(authMutation.refreshToken(null, {}, mockContext as GraphQLContext)).rejects.toThrow(GraphQLError);
       expect(mockContext.deleteCookie).toHaveBeenCalledTimes(2);
     });
   });

--- a/src/interfaces/graphql/resolvers/admin/AuthMutation.ts
+++ b/src/interfaces/graphql/resolvers/admin/AuthMutation.ts
@@ -12,7 +12,7 @@ import {
 import { LoginArgs } from '~/back-shared/types/admin/types';
 import { GraphQLContext } from '~/back-shared/types/container/types';
 
-export const Mutation = {
+export const authMutation = {
   login: async (_: unknown, args: LoginArgs, context: GraphQLContext) => {
     const loginAdmin = context.requestContainer.resolve('loginAdmin');
     const createTokenService = context.requestContainer.resolve('createTokenService');

--- a/src/interfaces/graphql/resolvers/blobStorage/blobMutation.test.ts
+++ b/src/interfaces/graphql/resolvers/blobStorage/blobMutation.test.ts
@@ -1,0 +1,129 @@
+import { AwilixContainer } from 'awilix';
+import { GraphQLError } from 'graphql';
+
+import { blobMutations } from './blobMutation';
+import { GraphQLContext } from '~/back-shared/types/container/types';
+
+const mockUploadService = {
+  uploadFile: jest.fn(),
+  deleteFile: jest.fn()
+};
+
+const mockRequestContainer = {
+  resolve: jest.fn().mockReturnValue(mockUploadService)
+} as unknown as AwilixContainer;
+
+const adminContext: GraphQLContext = {
+  requestContainer: mockRequestContainer,
+  admin: {
+    id: 'admin123',
+    type: 'admin',
+    refreshJti: 'jti123'
+  },
+  setCookie: jest.fn(),
+  deleteCookie: jest.fn(),
+  cookieActions: []
+};
+
+const noAdminContext: GraphQLContext = {
+  requestContainer: mockRequestContainer,
+  admin: null,
+  setCookie: jest.fn(),
+  deleteCookie: jest.fn(),
+  cookieActions: []
+};
+
+describe('blobMutations', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('uploadBlob', () => {
+    const uploadArgs = {
+      folderName: 'test-folder',
+      blobName: 'test-blob.jpg',
+      buffer: 'data:image/jpeg;base64,/9j/4AAQSkZJRg==',
+      contentType: 'image/jpeg'
+    };
+
+    it('should throw UNAUTHENTICATED error if no admin', async () => {
+      await expect(blobMutations.uploadBlob(null, uploadArgs, noAdminContext)).rejects.toThrow(
+        new GraphQLError('You must be logged in to access this resource.', {
+          extensions: { code: 'UNAUTHENTICATED' }
+        })
+      );
+      expect(mockRequestContainer.resolve).not.toHaveBeenCalled();
+    });
+
+    it('should upload file successfully and return success response', async () => {
+      mockUploadService.uploadFile.mockResolvedValue(undefined);
+
+      const result = await blobMutations.uploadBlob(null, uploadArgs, adminContext);
+
+      expect(mockRequestContainer.resolve).toHaveBeenCalledWith('uploadService');
+      expect(mockUploadService.uploadFile).toHaveBeenCalledWith(
+        uploadArgs.folderName,
+        uploadArgs.blobName,
+        expect.any(Buffer),
+        uploadArgs.contentType
+      );
+      expect(result).toEqual({
+        success: true,
+        blobName: uploadArgs.blobName
+      });
+    });
+
+    it('should return failure response if upload fails', async () => {
+      mockUploadService.uploadFile.mockRejectedValue(new Error('Upload failed'));
+
+      const result = await blobMutations.uploadBlob(null, uploadArgs, adminContext);
+
+      expect(mockRequestContainer.resolve).toHaveBeenCalledWith('uploadService');
+      expect(mockUploadService.uploadFile).toHaveBeenCalled();
+      expect(result).toEqual({
+        success: false
+      });
+    });
+  });
+
+  describe('deleteBlob', () => {
+    const deleteArgs = {
+      folderName: 'test-folder',
+      blobName: 'test-blob.jpg'
+    };
+
+    it('should throw UNAUTHENTICATED error if no admin', async () => {
+      await expect(blobMutations.deleteBlob(null, deleteArgs, noAdminContext)).rejects.toThrow(
+        new GraphQLError('You must be logged in to access this resource.', {
+          extensions: { code: 'UNAUTHENTICATED' }
+        })
+      );
+      expect(mockRequestContainer.resolve).not.toHaveBeenCalled();
+    });
+
+    it('should delete file successfully and return success response', async () => {
+      mockUploadService.deleteFile.mockResolvedValue(undefined);
+
+      const result = await blobMutations.deleteBlob(null, deleteArgs, adminContext);
+
+      expect(mockRequestContainer.resolve).toHaveBeenCalledWith('uploadService');
+      expect(mockUploadService.deleteFile).toHaveBeenCalledWith(deleteArgs.folderName, deleteArgs.blobName);
+      expect(result).toEqual({
+        success: true,
+        blobName: deleteArgs.blobName
+      });
+    });
+
+    it('should return failure response if delete fails', async () => {
+      mockUploadService.deleteFile.mockRejectedValue(new Error('Delete failed'));
+
+      const result = await blobMutations.deleteBlob(null, deleteArgs, adminContext);
+
+      expect(mockRequestContainer.resolve).toHaveBeenCalledWith('uploadService');
+      expect(mockUploadService.deleteFile).toHaveBeenCalled();
+      expect(result).toEqual({
+        success: false
+      });
+    });
+  });
+});

--- a/src/interfaces/graphql/resolvers/blobStorage/blobMutation.ts
+++ b/src/interfaces/graphql/resolvers/blobStorage/blobMutation.ts
@@ -1,0 +1,50 @@
+import { GraphQLError } from 'graphql';
+
+import { DeleteBlobArgs, UploadBlobArgs } from '~/back-shared/types/blob/types';
+import { GraphQLContext } from '~/back-shared/types/container/types';
+
+export const blobMutations = {
+  uploadBlob: async (_: unknown, args: UploadBlobArgs, context: GraphQLContext) => {
+    if (!context.admin) {
+      throw new GraphQLError('You must be logged in to access this resource.', {
+        extensions: {
+          code: 'UNAUTHENTICATED'
+        }
+      });
+    }
+    const uploadService = context.requestContainer.resolve('uploadService');
+    const buffer = Buffer.from(args.buffer, 'base64');
+    try {
+      await uploadService.uploadFile(args.folderName, args.blobName, buffer, args.contentType);
+      return {
+        success: true,
+        blobName: args.blobName
+      };
+    } catch {
+      return {
+        success: false
+      };
+    }
+  },
+  deleteBlob: async (_: unknown, args: DeleteBlobArgs, context: GraphQLContext) => {
+    if (!context.admin) {
+      throw new GraphQLError('You must be logged in to access this resource.', {
+        extensions: {
+          code: 'UNAUTHENTICATED'
+        }
+      });
+    }
+    const uploadService = context.requestContainer.resolve('uploadService');
+    try {
+      await uploadService.deleteFile(args.folderName, args.blobName);
+      return {
+        success: true,
+        blobName: args.blobName
+      };
+    } catch {
+      return {
+        success: false
+      };
+    }
+  }
+};

--- a/src/interfaces/graphql/resolvers/index.ts
+++ b/src/interfaces/graphql/resolvers/index.ts
@@ -1,9 +1,11 @@
-import { Mutation as AdminMutation } from './admin/Mutation';
+import { authMutation as AdminMutation } from './admin/AuthMutation';
 import { Query as AdminQuery } from './admin/Query';
+import { blobMutations as BlobMutation } from './blobStorage/blobMutation';
 
 export const resolvers = {
   Mutation: {
-    ...AdminMutation
+    ...AdminMutation,
+    ...BlobMutation
   },
   Query: {
     ...AdminQuery

--- a/src/interfaces/graphql/schemas/auth.graphql
+++ b/src/interfaces/graphql/schemas/auth.graphql
@@ -1,6 +1,6 @@
 union LoginResult = LoginPayload | ErrorPayload
 
-type Mutation {
+extend type Mutation {
   login(email: String!, password: String!): LoginResult!
   logout: Boolean!
   refreshToken: RefreshTokenPayload!
@@ -20,27 +20,4 @@ type ErrorPayload {
   success: Boolean!
   message: String!
   statusCode: Int!
-}
-scalar JSON
-
-type Page {
-  id: ID!
-  slug: String!
-  title: LocalizedString!
-  status: String!
-  pageType: String!
-  blocks: JSON!
-  createdAt: String!
-  updatedAt: String!
-}
-
-type LocalizedString {
-  uk: String
-  en: String
-}
-
-type Query {
-  _empty: String
-  test: RefreshTokenPayload!
-  pageBlocks(slug: String!): Page
 }

--- a/src/interfaces/graphql/schemas/blob.graphql
+++ b/src/interfaces/graphql/schemas/blob.graphql
@@ -1,0 +1,18 @@
+extend type Mutation {
+    uploadBlob(
+        folderName: String!
+        blobName: String!
+        buffer: String!
+        contentType: String!
+    ): BlobPayload!
+    deleteBlob(
+        folderName: String!
+        blobName: String!
+    ): BlobPayload!
+}
+
+type BlobPayload {
+    success: Boolean!
+    message: String
+    blobName: String
+}

--- a/src/interfaces/graphql/schemas/common.graphql
+++ b/src/interfaces/graphql/schemas/common.graphql
@@ -1,0 +1,8 @@
+type Query {
+    _empty: String
+    test: RefreshTokenPayload!
+}
+
+type Mutation {
+    _empty: String
+}

--- a/src/interfaces/graphql/schemas/page.graphql
+++ b/src/interfaces/graphql/schemas/page.graphql
@@ -1,0 +1,21 @@
+scalar JSON
+
+type Page {
+    id: ID!
+    slug: String!
+    title: LocalizedString!
+    status: String!
+    pageType: String!
+    blocks: JSON!
+    createdAt: String!
+    updatedAt: String!
+}
+
+type LocalizedString {
+    uk: String
+    en: String
+}
+
+extend type Query {
+    pageBlocks(slug: String!): Page
+}

--- a/src/shared/types/blob/types.ts
+++ b/src/shared/types/blob/types.ts
@@ -1,0 +1,11 @@
+export interface UploadBlobArgs {
+  folderName: string;
+  blobName: string;
+  buffer: string;
+  contentType?: string;
+}
+
+export interface DeleteBlobArgs {
+  folderName: string;
+  blobName: string;
+}

--- a/src/validators/blob.schema.ts
+++ b/src/validators/blob.schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const zFolderNameSchema = z.enum(['photos', 'notes', 'compositions', 'works']);
+export const zContentTypeSchema = z.enum([
+  'image/jpeg',
+  'image/jpg',
+  'image/png',
+  'application/pdf',
+  'text/plain',
+  'application/json',
+  'audio/mpeg',
+  'audio/wav',
+  'video/mp4'
+]);

--- a/src/validators/queryParams.schema.ts
+++ b/src/validators/queryParams.schema.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+import { zFolderNameSchema } from '~/validators/blob.schema';
+
+export const zBlobQuerySchema = z.object({
+  blobName: z.string().min(1),
+  folderName: zFolderNameSchema
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,7 @@
       "~/infrastructure/*": ["./src/infrastructure/*"],
       "~/interfaces/*": ["./src/interfaces/*"],
       "~/back-shared/*": ["./src/shared/*"],
+      "~/validators/*": ["./src/validators/*"],
       "~/public/*": ["./public/*"] // Path alias for easier imports
     }
   },


### PR DESCRIPTION
## Description

Migrated blob storage service to admin panel and did little refactor, so now it can work with GraphQL resolver for upload and delete blobs and REST GET endpoint to get blobs with proxy on backend from blob storage 

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

**trust me**

## Video / Screenshots

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [ ] Linked issue/task included
- [x] Task moved to the review column on the board

---
