### PR TITLE
feat: implement image upload in temporary storage

### DIFF
--- a/app/api/blob-url/route.test.ts
+++ b/app/api/blob-url/route.test.ts
@@ -48,7 +48,7 @@ describe('GET /api/blob-url', () => {
       errors: validationErrors
     });
 
-    const request = new Request('http://localhost/api/blob-url?blobName=&folderName=test');
+    const request = new Request('https://localhost/api/blob-url?blobName=&folderName=test');
     const response = await GET(request);
 
     expect(response.status).toBe(400);
@@ -58,7 +58,7 @@ describe('GET /api/blob-url', () => {
   });
 
   it('should return a streamed blob if validation passes and service call is successful', async () => {
-    const mockBlobUrl = 'http://mock.blob.url/test-folder/test-blob';
+    const mockBlobUrl = 'https://mock.blob.url/test-folder/test-blob';
     const mockStreamResponse = new Response('mock-blob-data', { status: 200 });
 
     mockValidateWithZod.mockReturnValue({
@@ -89,7 +89,7 @@ describe('GET /api/blob-url', () => {
       throw mockError;
     });
 
-    const request = new Request('http://localhost/api/blob-url?blobName=test-blob&folderName=test-folder');
+    const request = new Request('https://localhost/api/blob-url?blobName=test-blob&folderName=test-folder');
     const response = await GET(request);
 
     expect(response.status).toBe(503);
@@ -97,7 +97,7 @@ describe('GET /api/blob-url', () => {
   });
 
   it('should pass no range header if not present in request', async () => {
-    const mockBlobUrl = 'http://mock.blob.url/test-folder/test-blob';
+    const mockBlobUrl = 'https://mock.blob.url/test-folder/test-blob';
     const mockStreamResponse = new Response('mock-blob-data', { status: 200 });
 
     mockValidateWithZod.mockReturnValue({
@@ -107,7 +107,7 @@ describe('GET /api/blob-url', () => {
     mockConstructBlobUrl.mockReturnValue(mockBlobUrl);
     mockStreamBlob.mockResolvedValue(mockStreamResponse);
 
-    const request = new Request('http://localhost/api/blob-url?blobName=test-blob&folderName=test-folder');
+    const request = new Request('https://localhost/api/blob-url?blobName=test-blob&folderName=test-folder');
     const response = await GET(request);
 
     expect(response).toEqual(mockStreamResponse);

--- a/app/api/blob-url/route.test.ts
+++ b/app/api/blob-url/route.test.ts
@@ -1,0 +1,116 @@
+import 'whatwg-fetch';
+
+import { GET } from './route';
+import { errors } from '~/constants/errors';
+import { validateWithZod } from '~/utils/validateRequestData';
+
+jest.mock('next/server', () => ({
+  __esModule: true,
+  NextResponse: {
+    json: (body: any, init: ResponseInit) => new Response(JSON.stringify(body), init)
+  }
+}));
+
+const mockUploadService = {
+  constructBlobUrl: jest.fn(),
+  streamBlob: jest.fn()
+};
+
+jest.mock('~/src/middleware/logger/logger', () => ({
+  __esModule: true,
+  default: {
+    error: jest.fn()
+  }
+}));
+
+jest.mock('~/src/container/index', () => ({
+  createRequestContainer: jest.fn(() => ({
+    resolve: jest.fn().mockReturnValue(mockUploadService)
+  }))
+}));
+
+jest.mock('~/utils/validateRequestData', () => ({
+  validateWithZod: jest.fn()
+}));
+
+const mockValidateWithZod = validateWithZod as jest.Mock;
+const { constructBlobUrl: mockConstructBlobUrl, streamBlob: mockStreamBlob } = mockUploadService;
+
+describe('GET /api/blob-url', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return 400 if validation fails', async () => {
+    const validationErrors = [{ field: 'blobName', message: 'Invalid blobName' }];
+    mockValidateWithZod.mockReturnValue({
+      valid: false,
+      errors: validationErrors
+    });
+
+    const request = new Request('http://localhost/api/blob-url?blobName=&folderName=test');
+    const response = await GET(request);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ success: false, errors: validationErrors });
+    expect(mockValidateWithZod).toHaveBeenCalledTimes(1);
+    expect(mockConstructBlobUrl).not.toHaveBeenCalled();
+  });
+
+  it('should return a streamed blob if validation passes and service call is successful', async () => {
+    const mockBlobUrl = 'http://mock.blob.url/test-folder/test-blob';
+    const mockStreamResponse = new Response('mock-blob-data', { status: 200 });
+
+    mockValidateWithZod.mockReturnValue({
+      valid: true,
+      value: { blobName: 'test-blob', folderName: 'test-folder' }
+    });
+    mockConstructBlobUrl.mockReturnValue(mockBlobUrl);
+    mockStreamBlob.mockResolvedValue(mockStreamResponse);
+
+    const request = new Request('http://localhost/api/blob-url?blobName=test-blob&folderName=test-folder');
+    request.headers.set('range', 'bytes=0-100');
+
+    const response = await GET(request);
+
+    expect(response).toEqual(mockStreamResponse);
+    expect(await response.text()).toBe('mock-blob-data');
+    expect(mockConstructBlobUrl).toHaveBeenCalledWith('test-folder', 'test-blob');
+    expect(mockStreamBlob).toHaveBeenCalledWith(mockBlobUrl, 'bytes=0-100');
+  });
+
+  it('should return 503 and log error if uploadService fails', async () => {
+    const mockError = new Error('Service connection failed');
+    mockValidateWithZod.mockReturnValue({
+      valid: true,
+      value: { blobName: 'test-blob', folderName: 'test-folder' }
+    });
+    mockConstructBlobUrl.mockImplementation(() => {
+      throw mockError;
+    });
+
+    const request = new Request('http://localhost/api/blob-url?blobName=test-blob&folderName=test-folder');
+    const response = await GET(request);
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({ success: false, errors: [errors.AZURE_URL_NOT_DEFINED] });
+  });
+
+  it('should pass no range header if not present in request', async () => {
+    const mockBlobUrl = 'http://mock.blob.url/test-folder/test-blob';
+    const mockStreamResponse = new Response('mock-blob-data', { status: 200 });
+
+    mockValidateWithZod.mockReturnValue({
+      valid: true,
+      value: { blobName: 'test-blob', folderName: 'test-folder' }
+    });
+    mockConstructBlobUrl.mockReturnValue(mockBlobUrl);
+    mockStreamBlob.mockResolvedValue(mockStreamResponse);
+
+    const request = new Request('http://localhost/api/blob-url?blobName=test-blob&folderName=test-folder');
+    const response = await GET(request);
+
+    expect(response).toEqual(mockStreamResponse);
+    expect(mockStreamBlob).toHaveBeenCalledWith(mockBlobUrl, null);
+  });
+});

--- a/app/api/health/route.test.ts
+++ b/app/api/health/route.test.ts
@@ -1,0 +1,109 @@
+import 'whatwg-fetch';
+import mongoose from 'mongoose';
+
+import { GET } from './route';
+import { errors } from '~/constants/errors';
+import dbConnect from '~/infrastructure/db/connect';
+
+jest.mock('mongoose', () => {
+  const mockDbCommand = jest.fn();
+  const mockServerStatus = jest.fn();
+  const mockAdmin = jest.fn(() => ({
+    serverStatus: mockServerStatus
+  }));
+
+  return {
+    __esModule: true,
+    default: {
+      connection: {
+        readyState: 0,
+        db: {
+          command: mockDbCommand,
+          admin: mockAdmin
+        },
+        host: 'mock-host',
+        port: 27017,
+        name: 'mock-db-name'
+      }
+    }
+  };
+});
+
+jest.mock('next/server', () => ({
+  __esModule: true,
+  NextResponse: {
+    json: (body: any, init?: ResponseInit) => new Response(JSON.stringify(body), init)
+  }
+}));
+jest.mock('~/utils/apiResponse', () => ({
+  successResponse: jest.fn((data) => new Response(JSON.stringify(data), { status: 200 }))
+}));
+jest.mock('~/src/infrastructure/db/connect', () => ({
+  __esModule: true,
+  default: jest.fn()
+}));
+
+const mockDbCommand = mongoose.connection.db!.command as jest.Mock;
+const mockServerStatus = mongoose.connection.db!.admin().serverStatus as jest.Mock;
+
+describe('GET /api/health', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (mongoose.connection as any).readyState = 0;
+  });
+
+  it('should return status UP when database connection is successful', async () => {
+    (dbConnect as jest.Mock).mockResolvedValue(true);
+    (mongoose.connection as any).readyState = 1;
+
+    mockDbCommand.mockResolvedValue({ collections: 10, objects: 1000 });
+    mockServerStatus.mockResolvedValue({ version: '5.0.0', uptime: 3600 });
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    const responseJson = await response.json();
+    expect(responseJson.status).toBe('UP');
+    expect(responseJson.dependencies.database.status).toBe('UP');
+    expect(responseJson.dependencies.database.details).toEqual(
+      expect.objectContaining({ connectionStatus: 'CONNECTED' })
+    );
+  });
+
+  it('should return status DOWN with 503 if database is not connected', async () => {
+    (dbConnect as jest.Mock).mockResolvedValue(true);
+    (mongoose.connection as any).readyState = 2;
+
+    const response = await GET();
+
+    expect(response.status).toBe(503);
+    const responseJson = await response.json();
+    expect(responseJson.status).toBe('DOWN');
+    expect(responseJson.dependencies.database.message).toBe('Database connection state is: CONNECTING');
+    expect(mockDbCommand).not.toHaveBeenCalled();
+  });
+
+  it('should return status DOWN with 503 if dbConnect throws an error', async () => {
+    const mockError = new Error('Connection failed');
+    (dbConnect as jest.Mock).mockRejectedValue(mockError);
+
+    const response = await GET();
+
+    expect(response.status).toBe(503);
+    const responseJson = await response.json();
+    expect(responseJson.dependencies.database.message).toBe(errors.FAILED_TO_CONNECT_DB);
+  });
+
+  it('should return status DOWN with 503 if db.command throws an error', async () => {
+    (dbConnect as jest.Mock).mockResolvedValue(true);
+    (mongoose.connection as any).readyState = 1;
+    const mockError = new Error('Command failed');
+    mockDbCommand.mockRejectedValue(mockError);
+
+    const response = await GET();
+
+    expect(response.status).toBe(503);
+    const responseJson = await response.json();
+    expect(responseJson.dependencies.database.message).toBe(errors.FAILED_TO_CONNECT_DB);
+  });
+});

--- a/app/lib/utils/getImageUrl.ts
+++ b/app/lib/utils/getImageUrl.ts
@@ -1,0 +1,6 @@
+import { ImageBlock } from '~/types/common';
+
+export function getImageUrl(image: ImageBlock) {
+  const folder = image.isTmp ? 'tmp' : 'photos';
+  return `/api/blob-url?folderName=${folder}&blobName=${image.src}`;
+}

--- a/app/lib/utils/uploadToTmpFolder.test.ts
+++ b/app/lib/utils/uploadToTmpFolder.test.ts
@@ -35,7 +35,7 @@ describe('handleUploadImage', () => {
       }
     });
 
-    const result = await handleUploadImage(file, 'page1', BLOCK_IDS.INTRO_SECTION, 'tmp', 'image', uploadBlobMock);
+    const result = await handleUploadImage(file, 'page1', BLOCK_IDS.INTRO_SECTION, 'image', uploadBlobMock, 'tmp');
 
     expect(file.arrayBuffer).toHaveBeenCalled();
     expect(uploadBlobMock).toHaveBeenCalledWith({
@@ -76,7 +76,7 @@ describe('handleUploadImage', () => {
       }
     });
 
-    const result = await handleUploadImage(file, 'page1', BLOCK_IDS.INTRO_SECTION, 'tmp', 'image', uploadBlobMock);
+    const result = await handleUploadImage(file, 'page1', BLOCK_IDS.INTRO_SECTION, 'image', uploadBlobMock, 'tmp');
 
     expect(setFieldMock).not.toHaveBeenCalled();
     expect(result).toBeUndefined();

--- a/app/lib/utils/uploadToTmpFolder.test.ts
+++ b/app/lib/utils/uploadToTmpFolder.test.ts
@@ -1,0 +1,84 @@
+import { handleUploadImage } from './uploadToTmpFolder';
+import { BLOCK_IDS } from '~/constants/pageBlocks';
+import { useStore } from '~/store';
+
+jest.mock('~/store', () => ({
+  useStore: {
+    getState: jest.fn()
+  }
+}));
+
+describe('handleUploadImage', () => {
+  const setFieldMock = jest.fn();
+  const uploadBlobMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useStore.getState as jest.Mock).mockReturnValue({
+      setField: setFieldMock
+    });
+  });
+
+  it('should upload image and update store with blob data', async () => {
+    const file = {
+      name: 'test.png',
+      type: 'image/png',
+      arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(4))
+    } as unknown as File;
+
+    uploadBlobMock.mockResolvedValue({
+      data: {
+        uploadBlob: {
+          success: true,
+          blobName: 'uploaded_test.png'
+        }
+      }
+    });
+
+    const result = await handleUploadImage(file, 'page1', BLOCK_IDS.INTRO_SECTION, 'tmp', 'image', uploadBlobMock);
+
+    expect(file.arrayBuffer).toHaveBeenCalled();
+    expect(uploadBlobMock).toHaveBeenCalledWith({
+      variables: expect.objectContaining({
+        folderName: 'tmp',
+        blobName: 'test.png',
+        contentType: 'image/png',
+        buffer: expect.any(String)
+      })
+    });
+    expect(setFieldMock).toHaveBeenCalledWith(
+      'page1',
+      BLOCK_IDS.INTRO_SECTION,
+      'image',
+      expect.objectContaining({
+        src: 'uploaded_test.png',
+        alt: { uk: '', en: '' },
+        caption: { uk: '', en: '' },
+        isTmp: true
+      })
+    );
+    expect(result).toBe('uploaded_test.png');
+  });
+
+  it('should not update store if uploadBlob fails', async () => {
+    const file = {
+      name: 'fail.png',
+      type: 'image/png',
+      arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(4))
+    } as unknown as File;
+
+    uploadBlobMock.mockResolvedValue({
+      data: {
+        uploadBlob: {
+          success: false,
+          blobName: null
+        }
+      }
+    });
+
+    const result = await handleUploadImage(file, 'page1', BLOCK_IDS.INTRO_SECTION, 'tmp', 'image', uploadBlobMock);
+
+    expect(setFieldMock).not.toHaveBeenCalled();
+    expect(result).toBeUndefined();
+  });
+});

--- a/app/lib/utils/uploadToTmpFolder.ts
+++ b/app/lib/utils/uploadToTmpFolder.ts
@@ -6,9 +6,9 @@ export const handleUploadImage = async <K extends keyof BlocksMap, F extends key
   file: File,
   pageId: string,
   blockId: K,
-  folderName = 'tmp',
   key: F,
-  uploadBlob: UploadBlobMutationFn
+  uploadBlob: UploadBlobMutationFn,
+  folderName: string = 'tmp'
 ) => {
   const buffer = await file.arrayBuffer();
   const base64 = Buffer.from(buffer).toString('base64');

--- a/app/lib/utils/uploadToTmpFolder.ts
+++ b/app/lib/utils/uploadToTmpFolder.ts
@@ -1,0 +1,35 @@
+import { useStore } from '~/store';
+import { UploadBlobMutationFn } from '~/types/graphql/generated/graphql';
+import { BlocksMap } from '~/types/store/pages';
+
+export const handleUploadImage = async <K extends keyof BlocksMap, F extends keyof BlocksMap[K]>(
+  file: File,
+  pageId: string,
+  blockId: K,
+  folderName = 'tmp',
+  key: F,
+  uploadBlob: UploadBlobMutationFn
+) => {
+  const buffer = await file.arrayBuffer();
+  const base64 = Buffer.from(buffer).toString('base64');
+
+  const res = await uploadBlob({
+    variables: {
+      folderName,
+      blobName: file.name,
+      buffer: base64,
+      contentType: file.type
+    }
+  });
+
+  if (res.data?.uploadBlob.success) {
+    const blobName = res.data.uploadBlob.blobName;
+    useStore.getState().setField(pageId, blockId, key, {
+      src: blobName ?? '',
+      alt: { uk: '', en: '' },
+      caption: { uk: '', en: '' },
+      isTmp: true
+    } as BlocksMap[K][F]);
+    return blobName;
+  }
+};

--- a/app/shared/components/about-us/Intro-section/IntroSection.test.tsx
+++ b/app/shared/components/about-us/Intro-section/IntroSection.test.tsx
@@ -3,10 +3,20 @@ import { fireEvent, render, screen, within } from '@testing-library/react';
 import { IntroSection } from './IntroSection';
 
 const setFieldMock = jest.fn();
+const handleUploadImageMock = jest.fn();
+const useUploadBlobMutationMock = jest.fn();
 
 jest.mock('~/store', () => ({
   useStore: (selector: (state: { locale: string; setField: typeof setFieldMock }) => void) =>
     selector({ locale: 'uk', setField: setFieldMock })
+}));
+
+jest.mock('~/utils/uploadToTmpFolder', () => ({
+  handleUploadImage: (...args: any[]) => handleUploadImageMock(...args)
+}));
+
+jest.mock('~/types/graphql/generated/graphql', () => ({
+  useUploadBlobMutation: () => [useUploadBlobMutationMock]
 }));
 
 const usePageBlockMock = jest.fn();
@@ -117,7 +127,9 @@ describe('EntrySection', () => {
 
   it('should pass correct props to ImagePreviewBlock', () => {
     const preview = screen.getByTestId('image-preview');
-    expect(within(preview).getByTestId('image-url')).toHaveTextContent('/images/test-image.png');
+    expect(within(preview).getByTestId('image-url')).toHaveTextContent(
+      '/api/blob-url?folderName=photos&blobName=test-image'
+    );
     expect(within(preview).getByTestId('file-name')).toHaveTextContent('test-image');
   });
 
@@ -129,11 +141,6 @@ describe('EntrySection', () => {
   it('should call setField when updating title', () => {
     updateField('textfield-Заголовок сторінки', 'New Title');
     expectSetField('title', { uk: 'New Title' });
-  });
-
-  it('should call setField when uploading new image', () => {
-    fireEvent.click(screen.getByText('Upload Image'));
-    expectSetField('image', { src: 'new.png', generatedSrc: expect.stringContaining('new.png') });
   });
 
   it('should call setField when updating image caption', () => {

--- a/app/shared/components/about-us/Intro-section/IntroSection.tsx
+++ b/app/shared/components/about-us/Intro-section/IntroSection.tsx
@@ -2,13 +2,16 @@
 import { Box, Skeleton } from '@mui/material';
 
 import CollapsibleBlock from '../../design-system/collapsible-block/CollapsibleBlock';
-import { ImagePreviewBlock } from '../../design-system/photo-block/PhotoBlock';
-import { CustomTextField } from '../../design-system/text-field/TextField';
 import { QuoteBlock } from '../Liatoshynsky-office/quote-block/QuoteBlock';
 import { BLOCK_IDS, PAGE_IDS } from '~/constants/pageBlocks';
+import { ImagePreviewBlock } from '~/ds-components/photo-block/PhotoBlock';
+import { CustomTextField } from '~/ds-components/text-field/TextField';
 import { usePageBlock } from '~/shared/hooks/use-page-block/usePageBlock';
 import { useStore } from '~/store';
 import { LocalizedString } from '~/types/common';
+import { useUploadBlobMutation } from '~/types/graphql/generated/graphql';
+import { getImageUrl } from '~/utils/getImageUrl';
+import { handleUploadImage } from '~/utils/uploadToTmpFolder';
 
 export const IntroSection = () => {
   const pageId = PAGE_IDS.ABOUT_US;
@@ -17,6 +20,7 @@ export const IntroSection = () => {
   const { block } = usePageBlock(pageId, blockId);
 
   const currentLocale: keyof LocalizedString = useStore((state) => state.locale);
+  const [uploadBlob] = useUploadBlobMutation();
 
   const setField = useStore((state) => state.setField);
 
@@ -39,16 +43,12 @@ export const IntroSection = () => {
 
       <Box sx={{ marginLeft: '-16px', marginTop: '15px' }}>
         <ImagePreviewBlock
-          imageUrl={`/images/${block.image.src}.png`}
+          imageUrl={getImageUrl(block.image)}
           fileName={block.image.src || ''}
           cropHeight={50}
           cropWidth={50}
           onChangeImage={(file) =>
-            setField(pageId, blockId, 'image', {
-              ...block.image,
-              src: file.name,
-              generatedSrc: `/api/blob-url?folderName=photos&blobName=${file.name}`
-            })
+            handleUploadImage(file, PAGE_IDS.ABOUT_US, BLOCK_IDS.INTRO_SECTION, 'tmp', 'image', uploadBlob)
           }
         />
       </Box>
@@ -61,7 +61,8 @@ export const IntroSection = () => {
         onChange={(e) =>
           setField(pageId, blockId, 'image', {
             ...block.image,
-            caption: { ...block.image.caption, [currentLocale]: e.target.value }
+            caption: { ...block.image.caption, [currentLocale]: e.target.value },
+            alt: { ...block.image.alt, [currentLocale]: e.target.value }
           })
         }
       />

--- a/app/shared/components/about-us/Intro-section/IntroSection.tsx
+++ b/app/shared/components/about-us/Intro-section/IntroSection.tsx
@@ -48,7 +48,7 @@ export const IntroSection = () => {
           cropHeight={50}
           cropWidth={50}
           onChangeImage={(file) =>
-            handleUploadImage(file, PAGE_IDS.ABOUT_US, BLOCK_IDS.INTRO_SECTION, 'tmp', 'image', uploadBlob)
+            handleUploadImage(file, PAGE_IDS.ABOUT_US, BLOCK_IDS.INTRO_SECTION, 'image', uploadBlob, 'tmp')
           }
         />
       </Box>

--- a/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.test.tsx
+++ b/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.test.tsx
@@ -4,15 +4,25 @@ import React from 'react';
 import { LiatoshynskyFoundation } from './LiatoshynskyFoundation';
 
 const setFieldMock = jest.fn();
+const handleUploadImageMock = jest.fn();
+const useUploadBlobMutationMock = jest.fn();
 
 jest.mock('~/store', () => ({
-  useStore: (selector: (state: { locale: string; setField: typeof setFieldMock }) => void) =>
+  useStore: (selector: (state: { locale: 'uk'; setField: typeof setFieldMock }) => void) =>
     selector({ locale: 'uk', setField: setFieldMock })
 }));
 
 const usePageBlockMock = jest.fn();
 jest.mock('~/shared/hooks/use-page-block/usePageBlock', () => ({
   usePageBlock: (pageId: string, blockId: string) => usePageBlockMock(pageId, blockId)
+}));
+
+jest.mock('~/utils/uploadToTmpFolder', () => ({
+  handleUploadImage: (...args: any[]) => handleUploadImageMock(...args)
+}));
+
+jest.mock('~/types/graphql/generated/graphql', () => ({
+  useUploadBlobMutation: () => [useUploadBlobMutationMock]
 }));
 
 interface Paragraph {
@@ -23,6 +33,7 @@ interface FoundationBlockProps {
   mainText: string;
   paragraphs: Paragraph[];
   imageUrl: string;
+  fileName: string;
   onMainTextChange: (value: string) => void;
   onParagraphChange: (idx: number, value: string) => void;
   onImageChange: (file: File) => void;
@@ -33,13 +44,14 @@ jest.mock('./foundation-block/FoundationBlock', () => ({
     mainText,
     paragraphs,
     imageUrl,
+    fileName,
     onMainTextChange,
     onParagraphChange,
     onImageChange
   }: FoundationBlockProps) => (
     <div>
       <input data-testid="main-text" value={mainText} onChange={(e) => onMainTextChange(e.target.value)} />
-      {paragraphs.map((p, idx) => (
+      {paragraphs.map((p: any, idx: number) => (
         <input
           key={`${p.text}-${idx}`}
           data-testid={`paragraph-${idx}`}
@@ -48,6 +60,7 @@ jest.mock('./foundation-block/FoundationBlock', () => ({
         />
       ))}
       <img src={imageUrl} alt="Foundation" data-testid="image" />
+      <span data-testid="file-name">{fileName}</span>
       <input
         type="file"
         data-testid="image-input"
@@ -67,49 +80,21 @@ jest.mock('~/ds-components/collapsible-block/CollapsibleBlock', () => ({
   )
 }));
 
-global.URL.createObjectURL = jest.fn((file: File) => `mock-url/${file.name}`);
-
 describe('LiatoshynskyFoundation', () => {
   const mockBlock = {
     ourOrganisation: {
       uk: { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Organisation Text' }] }] }
     },
-    ourName: { uk: { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Name' }] }] } },
-    ourBelief: { uk: { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Belief' }] }] } },
+    ourName: {
+      uk: { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Name' }] }] }
+    },
+    ourBelief: {
+      uk: { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Belief' }] }] }
+    },
     image: { src: 'image-src', caption: { uk: 'Image Caption' } }
   };
 
   const renderFoundation = () => render(<LiatoshynskyFoundation />);
-
-  const expectSetFieldCalled = (field: string, content: object) => {
-    expect(setFieldMock).toHaveBeenCalledWith(
-      'about-us',
-      'FoundationInfo',
-      field,
-      expect.objectContaining({ uk: expect.objectContaining(content) })
-    );
-  };
-
-  const changeInputAndExpect = (testId: string, value: string, field: string) => {
-    fireEvent.change(screen.getByTestId(testId), { target: { value } });
-    expectSetFieldCalled(field, {
-      content: [{ type: 'paragraph', content: [{ type: 'text', text: value }] }]
-    });
-  };
-
-  const uploadFileAndExpect = (file: File, field: string, caption = 'Image Caption') => {
-    fireEvent.change(screen.getByTestId('image-input'), { target: { files: [file] } });
-    expect(setFieldMock).toHaveBeenCalledWith(
-      'about-us',
-      'FoundationInfo',
-      field,
-      expect.objectContaining({
-        src: `mock-url/${file.name}`,
-        generatedSrc: `mock-url/${file.name}`,
-        caption: { uk: caption }
-      })
-    );
-  };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -119,27 +104,61 @@ describe('LiatoshynskyFoundation', () => {
   it('should render all fields when block exists', () => {
     renderFoundation();
     expect(screen.getByTestId('main-text')).toHaveValue('Organisation Text');
+    expect(screen.getByTestId('paragraph-0')).toHaveValue('Name');
+    expect(screen.getByTestId('paragraph-1')).toHaveValue('Belief');
 
-    ['Name', 'Belief'].forEach((val, idx) => {
-      expect(screen.getByTestId(`paragraph-${idx}`)).toHaveValue(val);
-    });
+    expect(screen.getByTestId('image')).toHaveAttribute('src', '/api/blob-url?folderName=photos&blobName=image-src');
 
-    expect(screen.getByTestId('image')).toHaveAttribute('src', '/images/image-src.png');
+    expect(screen.getByTestId('file-name')).toHaveTextContent('Image Caption');
   });
 
   it('should update main text when edited', () => {
     renderFoundation();
-    changeInputAndExpect('main-text', 'New Organisation Text', 'ourOrganisation');
+    fireEvent.change(screen.getByTestId('main-text'), { target: { value: 'New Organisation Text' } });
+
+    expect(setFieldMock).toHaveBeenCalledWith(
+      'about-us',
+      'FoundationInfo',
+      'ourOrganisation',
+      expect.objectContaining({
+        uk: {
+          type: 'doc',
+          content: [{ type: 'paragraph', content: [{ type: 'text', text: 'New Organisation Text' }] }]
+        }
+      })
+    );
   });
 
   it('should update paragraph when edited', () => {
     renderFoundation();
-    changeInputAndExpect('paragraph-0', 'New Name', 'ourName');
+    fireEvent.change(screen.getByTestId('paragraph-0'), { target: { value: 'New Name' } });
+
+    expect(setFieldMock).toHaveBeenCalledWith(
+      'about-us',
+      'FoundationInfo',
+      'ourName',
+      expect.objectContaining({
+        uk: {
+          type: 'doc',
+          content: [{ type: 'paragraph', content: [{ type: 'text', text: 'New Name' }] }]
+        }
+      })
+    );
   });
 
-  it('should update image when a new file is uploaded', () => {
+  it('should call handleUploadImage when a new file is uploaded', () => {
     renderFoundation();
     const file = new File(['test'], 'new-image.png', { type: 'image/png' });
-    uploadFileAndExpect(file, 'image');
+
+    fireEvent.change(screen.getByTestId('image-input'), { target: { files: [file] } });
+
+    expect(handleUploadImageMock).toHaveBeenCalledWith(
+      file,
+      'about-us',
+      'FoundationInfo',
+      'tmp',
+      'image',
+      useUploadBlobMutationMock
+    );
   });
 });

--- a/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.test.tsx
+++ b/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.test.tsx
@@ -142,7 +142,7 @@ describe('LiatoshynskyFoundation', () => {
     const testCases = [
       {
         description: 'main text',
-        element: () => mainTextInput, // Використовуємо функцію, щоб отримати елемент в момент виконання тесту
+        element: () => mainTextInput,
         newValue: 'New Organisation Text',
         fieldId: 'ourOrganisation'
       },

--- a/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.test.tsx
+++ b/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.test.tsx
@@ -94,63 +94,76 @@ describe('LiatoshynskyFoundation', () => {
     image: { src: 'image-src', caption: { uk: 'Image Caption' } }
   };
 
-  const renderFoundation = () => render(<LiatoshynskyFoundation />);
+  let mainTextInput: HTMLElement;
+  let paragraph0Input: HTMLElement;
+  let paragraph1Input: HTMLElement;
+  let image: HTMLElement;
+  let fileNameSpan: HTMLElement;
+  let imageInput: HTMLElement;
 
   beforeEach(() => {
     jest.clearAllMocks();
     usePageBlockMock.mockReturnValue({ block: mockBlock, blockId: 'FoundationInfo' });
+
+    render(<LiatoshynskyFoundation />);
+
+    mainTextInput = screen.getByTestId('main-text');
+    paragraph0Input = screen.getByTestId('paragraph-0');
+    paragraph1Input = screen.getByTestId('paragraph-1');
+    image = screen.getByTestId('image');
+    fileNameSpan = screen.getByTestId('file-name');
+    imageInput = screen.getByTestId('image-input');
   });
 
-  it('should render all fields when block exists', () => {
-    renderFoundation();
-    expect(screen.getByTestId('main-text')).toHaveValue('Organisation Text');
-    expect(screen.getByTestId('paragraph-0')).toHaveValue('Name');
-    expect(screen.getByTestId('paragraph-1')).toHaveValue('Belief');
-
-    expect(screen.getByTestId('image')).toHaveAttribute('src', '/api/blob-url?folderName=photos&blobName=image-src');
-
-    expect(screen.getByTestId('file-name')).toHaveTextContent('Image Caption');
+  it('should render all fields with initial data from the block', () => {
+    expect(mainTextInput).toHaveValue('Organisation Text');
+    expect(paragraph0Input).toHaveValue('Name');
+    expect(paragraph1Input).toHaveValue('Belief');
+    expect(image).toHaveAttribute('src', '/api/blob-url?folderName=photos&blobName=image-src');
+    expect(fileNameSpan).toHaveTextContent('Image Caption');
   });
 
-  it('should update main text when edited', () => {
-    renderFoundation();
-    fireEvent.change(screen.getByTestId('main-text'), { target: { value: 'New Organisation Text' } });
-
-    expect(setFieldMock).toHaveBeenCalledWith(
-      'about-us',
-      'FoundationInfo',
-      'ourOrganisation',
-      expect.objectContaining({
+  describe('when updating text fields', () => {
+    const expectSetFieldMockToHaveBeenCalledWith = (fieldId: string, text: string) => {
+      const expectedPayload = {
         uk: {
           type: 'doc',
-          content: [{ type: 'paragraph', content: [{ type: 'text', text: 'New Organisation Text' }] }]
+          content: [{ type: 'paragraph', content: [{ type: 'text', text }] }]
         }
-      })
-    );
+      };
+      expect(setFieldMock).toHaveBeenCalledWith(
+        'about-us',
+        'FoundationInfo',
+        fieldId,
+        expect.objectContaining(expectedPayload)
+      );
+    };
+
+    const testCases = [
+      {
+        description: 'main text',
+        element: () => mainTextInput, // Використовуємо функцію, щоб отримати елемент в момент виконання тесту
+        newValue: 'New Organisation Text',
+        fieldId: 'ourOrganisation'
+      },
+      {
+        description: 'first paragraph',
+        element: () => paragraph0Input,
+        newValue: 'New Name',
+        fieldId: 'ourName'
+      }
+    ];
+
+    it.each(testCases)('should update the store when the $description is edited', ({ element, newValue, fieldId }) => {
+      fireEvent.change(element(), { target: { value: newValue } });
+      expectSetFieldMockToHaveBeenCalledWith(fieldId, newValue);
+    });
   });
 
-  it('should update paragraph when edited', () => {
-    renderFoundation();
-    fireEvent.change(screen.getByTestId('paragraph-0'), { target: { value: 'New Name' } });
-
-    expect(setFieldMock).toHaveBeenCalledWith(
-      'about-us',
-      'FoundationInfo',
-      'ourName',
-      expect.objectContaining({
-        uk: {
-          type: 'doc',
-          content: [{ type: 'paragraph', content: [{ type: 'text', text: 'New Name' }] }]
-        }
-      })
-    );
-  });
-
-  it('should call handleUploadImage when a new file is uploaded', () => {
-    renderFoundation();
+  it('should call handleUploadImage when a new file is selected', () => {
     const file = new File(['test'], 'new-image.png', { type: 'image/png' });
 
-    fireEvent.change(screen.getByTestId('image-input'), { target: { files: [file] } });
+    fireEvent.change(imageInput, { target: { files: [file] } });
 
     expect(handleUploadImageMock).toHaveBeenCalledWith(
       file,

--- a/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.test.tsx
+++ b/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.test.tsx
@@ -169,9 +169,9 @@ describe('LiatoshynskyFoundation', () => {
       file,
       'about-us',
       'FoundationInfo',
-      'tmp',
       'image',
-      useUploadBlobMutationMock
+      useUploadBlobMutationMock,
+      'tmp'
     );
   });
 });

--- a/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.tsx
+++ b/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.tsx
@@ -9,11 +9,15 @@ import CollapsibleBlock from '~/ds-components/collapsible-block/CollapsibleBlock
 import { proseToText, textToProse } from '~/lib/utils/prose';
 import { usePageBlock } from '~/shared/hooks/use-page-block/usePageBlock';
 import { useStore } from '~/store';
+import { useUploadBlobMutation } from '~/types/graphql/generated/graphql';
 import { ProseDoc } from '~/types/store/pages/about-us';
+import { getImageUrl } from '~/utils/getImageUrl';
+import { handleUploadImage } from '~/utils/uploadToTmpFolder';
 
 export const LiatoshynskyFoundation = () => {
   const pageId = PAGE_IDS.ABOUT_US;
   const blockId = BLOCK_IDS.LIATOSHYNSKY_FOUNDATION;
+  const [uploadBlob] = useUploadBlobMutation();
 
   const { block } = usePageBlock(pageId, blockId);
 
@@ -50,26 +54,16 @@ export const LiatoshynskyFoundation = () => {
     });
   };
 
-  const handleImageChange = (file: File) => {
-    const newUrl = URL.createObjectURL(file);
-
-    setField(pageId, blockId, 'image', {
-      ...block.image,
-      src: newUrl,
-      generatedSrc: newUrl
-    });
-  };
-
   return (
     <CollapsibleBlock title="Фундація Лятошинського">
       <FoundationBlock
         mainText={mainText}
         paragraphs={paragraphs}
-        imageUrl={`/images/${block.image?.src}.png`}
+        imageUrl={getImageUrl(block.image)}
         fileName={block.image?.caption?.[currentLocale]}
         onMainTextChange={handleMainTextChange}
         onParagraphChange={handleParagraphChange}
-        onImageChange={handleImageChange}
+        onImageChange={(file) => handleUploadImage(file, pageId, blockId, 'tmp', 'image', uploadBlob)}
       />
     </CollapsibleBlock>
   );

--- a/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.tsx
+++ b/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.tsx
@@ -63,7 +63,7 @@ export const LiatoshynskyFoundation = () => {
         fileName={block.image?.caption?.[currentLocale]}
         onMainTextChange={handleMainTextChange}
         onParagraphChange={handleParagraphChange}
-        onImageChange={(file) => handleUploadImage(file, pageId, blockId, 'tmp', 'image', uploadBlob)}
+        onImageChange={(file) => handleUploadImage(file, pageId, blockId, 'image', uploadBlob, 'tmp')}
       />
     </CollapsibleBlock>
   );

--- a/app/shared/components/about-us/our-mission/OurMission.test.tsx
+++ b/app/shared/components/about-us/our-mission/OurMission.test.tsx
@@ -3,6 +3,17 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import OurMission from './OurMission';
 import { BLOCK_IDS, PAGE_IDS } from '~/constants/pageBlocks';
 
+const handleUploadImageMock = jest.fn();
+const useUploadBlobMutationMock = jest.fn();
+
+jest.mock('~/utils/uploadToTmpFolder', () => ({
+  handleUploadImage: (...args: any[]) => handleUploadImageMock(...args)
+}));
+
+jest.mock('~/types/graphql/generated/graphql', () => ({
+  useUploadBlobMutation: () => [useUploadBlobMutationMock]
+}));
+
 const setFieldMock = jest.fn();
 
 type StoreState = { locale: 'uk'; setField: typeof setFieldMock };
@@ -155,11 +166,5 @@ describe('OurMission', () => {
       target: { value: 'Updated mission' }
     });
     expect(setFieldMock).toHaveBeenCalledWith(PAGE_IDS.ABOUT_US, BLOCK_IDS.OUR_MISSION, 'list', expect.any(Array));
-  });
-
-  it.each([0, 1])('should upload image file for image index %i', (index) => {
-    render(<OurMission />);
-    fireEvent.click(screen.getAllByText('Upload')[index]);
-    expect(setFieldMock).toHaveBeenCalled();
   });
 });

--- a/app/shared/components/about-us/our-mission/OurMission.tsx
+++ b/app/shared/components/about-us/our-mission/OurMission.tsx
@@ -168,7 +168,7 @@ const OurMission = () => {
           locale={currentLocale}
           title="Перше зображення секції"
           onChangeCaption={(value, file) => handleImageChange('smallImage', value, file)}
-          onChangeImage={(file) => handleUploadImage(file, pageId, blockId, 'tmp', 'smallImage', uploadBlob)}
+          onChangeImage={(file) => handleUploadImage(file, pageId, blockId, 'smallImage', uploadBlob, 'tmp')}
         />
       )}
 
@@ -178,7 +178,7 @@ const OurMission = () => {
           locale={currentLocale}
           title="Друге зображення секції"
           onChangeCaption={(value, file) => handleImageChange('bigImage', value, file)}
-          onChangeImage={(file) => handleUploadImage(file, pageId, blockId, 'tmp', 'bigImage', uploadBlob)}
+          onChangeImage={(file) => handleUploadImage(file, pageId, blockId, 'bigImage', uploadBlob, 'tmp')}
         />
       )}
     </CollapsibleBlock>

--- a/app/shared/components/about-us/our-mission/OurMission.tsx
+++ b/app/shared/components/about-us/our-mission/OurMission.tsx
@@ -15,7 +15,10 @@ import { proseToText, textToProse } from '~/lib/utils/prose';
 import { usePageBlock } from '~/shared/hooks/use-page-block/usePageBlock';
 import { useStore } from '~/store';
 import { ConfigurableListItem } from '~/types/accordionBlocks';
+import { useUploadBlobMutation } from '~/types/graphql/generated/graphql';
 import { MissionListItemWithId } from '~/types/store/pages/about-us/blocks/missionBlock';
+import { getImageUrl } from '~/utils/getImageUrl';
+import { handleUploadImage } from '~/utils/uploadToTmpFolder';
 
 export type MissionPoint = ConfigurableListItem & { value: string };
 
@@ -47,7 +50,7 @@ const MissionImageBlock = ({
 }: MissionImageBlockProps) => (
   <Box sx={styles.imageBlockWrapper}>
     <ImagePreviewBlock
-      imageUrl={`/images/${image.src}.png`}
+      imageUrl={getImageUrl(image)}
       title={title}
       fileName={image.src || ''}
       cropWidth={cropWidth}
@@ -69,6 +72,8 @@ const OurMission = () => {
   const pageId = PAGE_IDS.ABOUT_US;
   const blockId = BLOCK_IDS.OUR_MISSION;
   const currentLocale: 'uk' | 'en' = useStore((state) => state.locale);
+  const [uploadBlob] = useUploadBlobMutation();
+
   const { block } = usePageBlock(pageId, blockId);
   const setField = useStore((state) => state.setField);
 
@@ -114,19 +119,6 @@ const OurMission = () => {
     };
 
     setField(pageId, blockId, key, updated);
-  };
-
-  const handleImageFileChange = (key: 'smallImage' | 'bigImage', file: File) => {
-    const image = block[key];
-    if (!image) return;
-
-    const newSrc = URL.createObjectURL(file);
-
-    setField(pageId, blockId, key, {
-      ...image,
-      src: newSrc,
-      generatedSrc: newSrc
-    });
   };
 
   return (
@@ -176,7 +168,7 @@ const OurMission = () => {
           locale={currentLocale}
           title="Перше зображення секції"
           onChangeCaption={(value, file) => handleImageChange('smallImage', value, file)}
-          onChangeImage={(file) => handleImageFileChange('smallImage', file)}
+          onChangeImage={(file) => handleUploadImage(file, pageId, blockId, 'tmp', 'smallImage', uploadBlob)}
         />
       )}
 
@@ -186,7 +178,7 @@ const OurMission = () => {
           locale={currentLocale}
           title="Друге зображення секції"
           onChangeCaption={(value, file) => handleImageChange('bigImage', value, file)}
-          onChangeImage={(file) => handleImageFileChange('bigImage', file)}
+          onChangeImage={(file) => handleUploadImage(file, pageId, blockId, 'tmp', 'bigImage', uploadBlob)}
         />
       )}
     </CollapsibleBlock>

--- a/app/store/slices/editSlice.ts
+++ b/app/store/slices/editSlice.ts
@@ -1,6 +1,7 @@
 import { StateCreator } from 'zustand';
 
 import type { BlockData, EditState } from '../types';
+import { BlocksMap } from '~/types/store/pages';
 
 export const createEditSlice: StateCreator<EditState> = (set, get) => ({
   isChanged: false,
@@ -8,21 +9,29 @@ export const createEditSlice: StateCreator<EditState> = (set, get) => ({
   blocks: {},
   locale: 'uk',
 
-  setField: (pageId, blockId, field, value) => {
+  setField: <K extends keyof BlocksMap, F extends keyof BlocksMap[K]>(
+    pageId: string,
+    blockId: K,
+    field: F,
+    value: BlocksMap[K][F]
+  ) => {
     const prevPageBlocks = get().blocks[pageId] || {};
-    const prevBlock = (prevPageBlocks[blockId] ?? {}) as BlockData<typeof blockId>;
+    const prevBlock = (prevPageBlocks[blockId] ?? {}) as BlocksMap[K];
 
     if (prevBlock[field] === value) return;
+
+    const newBlock = {
+      ...prevBlock,
+      [field]: value,
+      isTmp: field === 'image' && value && typeof value === 'object' && 'src' in value
+    };
 
     set({
       blocks: {
         ...get().blocks,
         [pageId]: {
           ...prevPageBlocks,
-          [blockId]: {
-            ...prevBlock,
-            [field]: value
-          }
+          [blockId]: newBlock
         }
       },
       isChanged: true
@@ -35,16 +44,21 @@ export const createEditSlice: StateCreator<EditState> = (set, get) => ({
 
     const isDifferent = Object.entries(data).some(([key, val]) => prevBlock[key as keyof typeof data] !== val);
     if (!isDifferent) return;
+    let newBlock = { ...prevBlock, ...data };
+
+    if ('image' in data) {
+      const img = data.image;
+      if (img && typeof img === 'object' && 'src' in img) {
+        newBlock = { ...newBlock, isTmp: true };
+      }
+    }
 
     set({
       blocks: {
         ...get().blocks,
         [pageId]: {
           ...prevPageBlocks,
-          [blockId]: {
-            ...prevBlock,
-            ...data
-          }
+          [blockId]: newBlock
         }
       },
       isChanged: isInit ? get().isChanged : true,

--- a/app/types/common.ts
+++ b/app/types/common.ts
@@ -7,7 +7,7 @@ export interface ImageBlock {
   src: string;
   alt: LocalizedString;
   caption: LocalizedString;
-  generatedSrc: string;
+  isTmp?: boolean;
 }
 
 export interface QuoteBlock {

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -44,14 +44,15 @@ const config: Config = {
     '^~/ds-components/(.*)$': '<rootDir>/app/shared/components/design-system/$1',
     '^~/components/(.*)$': '<rootDir>/app/shared/components/$1',
     '^~/hooks/(.*)$': '<rootDir>/app/shared/hooks/$1',
+    '^~/src/(.*)$': '<rootDir>/src/$1',
     '^~/(.*)$': '<rootDir>/app/$1'
   },
-  modulePaths: ['<rootDir>/app'],
+  modulePaths: ['<rootDir>/app', '<rootDir>/src'],
   testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/dist/', '<rootDir>/coverage/'],
   transform: {
     '^.+\\.(js|jsx|ts|tsx)$': 'ts-jest'
   },
-  transformIgnorePatterns: ['node_modules/(?!(lodash-es)/)'],
+  transformIgnorePatterns: ['node_modules/(?!(lodash-es|bson|mongodb)/)'],
   setupFilesAfterEnv: ['@testing-library/jest-dom']
 };
 

--- a/src/application/use-cases/uploadService/upload.test.ts
+++ b/src/application/use-cases/uploadService/upload.test.ts
@@ -94,6 +94,7 @@ describe('azureStorageService', () => {
       expect(logger.error).toHaveBeenCalledWith(errors.FAILED_TO_DELETE_BLOB, deleteError);
     });
   });
+
   describe('constructBlobUrl', () => {
     it('should return the full, correctly formatted URL without checking for existence', () => {
       const url = blobStorageService().constructBlobUrl(folderName, blobName);

--- a/src/application/use-cases/uploadService/upload.test.ts
+++ b/src/application/use-cases/uploadService/upload.test.ts
@@ -1,5 +1,3 @@
-import { createHash } from 'crypto';
-
 import { blobStorageService } from './upload';
 import { errors } from '~/back-constants/errors';
 import { CONTAINER_NAME } from '~/back-constants/index';
@@ -54,8 +52,6 @@ describe('azureStorageService', () => {
   const blobName = 'image.jpg';
   const buffer = Buffer.from('mock buffer');
   const contentType = 'image/jpeg';
-  const fullPath = `${folderName}/${createHash('sha256').update(blobName).digest('hex')}`;
-  const expectedUrl = `https://mockstorage.blob.core.windows.net/${CONTAINER_NAME}/${fullPath}`;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -92,126 +88,6 @@ describe('azureStorageService', () => {
       mockDeleteIfExists.mockRejectedValue(deleteError);
       await expect(blobStorageService().deleteFile(folderName, blobName)).rejects.toThrow(deleteError);
       expect(logger.error).toHaveBeenCalledWith(errors.FAILED_TO_DELETE_BLOB, deleteError);
-    });
-  });
-
-  describe('constructBlobUrl', () => {
-    it('should return the full, correctly formatted URL without checking for existence', () => {
-      const url = blobStorageService().constructBlobUrl(folderName, blobName);
-      expect(url).toBe(expectedUrl);
-      expect(mockExists).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('streamBlob', () => {
-    const mockUrl = 'https://fake-url.com/file.mp3';
-
-    beforeEach(() => {
-      mockFetch.mockClear();
-      mockResponse.mockClear();
-      mockSetHeader.mockClear();
-    });
-
-    it('should call fetch and construct a new Response for a full request', async () => {
-      const fakeBody = 'audio data';
-      const mockAzureHeaders = {
-        get: jest.fn((key: string) => {
-          if (key === 'Content-Type') return 'audio/mpeg';
-          if (key === 'Content-Length') return '1234567';
-          return null;
-        }),
-        has: jest.fn().mockReturnValue(false)
-      };
-      mockFetch.mockResolvedValue({
-        ok: true,
-        status: 200,
-        headers: mockAzureHeaders,
-        body: fakeBody
-      });
-
-      const result = await blobStorageService().streamBlob(mockUrl, null);
-
-      expect(mockFetch).toHaveBeenCalledTimes(1);
-      expect(mockFetch).toHaveBeenCalledWith(mockUrl, {
-        method: 'GET',
-        headers: {},
-        next: { revalidate: 0 }
-      });
-      expect(mockResponse).toHaveBeenCalledTimes(1);
-      expect(mockResponse).toHaveBeenCalledWith(fakeBody, {
-        status: 200,
-        statusText: undefined,
-        headers: expect.any(Object)
-      });
-      expect(result.status).toBe(200);
-    });
-
-    it('should handle range requests and construct a 206 Partial Content response', async () => {
-      const fakeBody = 'partial audio data';
-      const mockAzureHeaders = {
-        get: jest.fn((key: string) => {
-          const headersMap = {
-            'Content-Type': 'audio/mpeg',
-            'Content-Length': '500000',
-            'Content-Range': 'bytes 500000-999999/1000000'
-          };
-          return headersMap[key as keyof typeof headersMap] || null;
-        }),
-        has: jest.fn((key: string) => key === 'Content-Range')
-      };
-
-      mockFetch.mockResolvedValue({
-        ok: true,
-        status: 206,
-        headers: mockAzureHeaders,
-        body: fakeBody
-      });
-
-      const rangeHeader = 'bytes=500000-';
-
-      await blobStorageService().streamBlob(mockUrl, rangeHeader);
-
-      expect(mockFetch).toHaveBeenCalledWith(mockUrl, {
-        method: 'GET',
-        headers: { Range: rangeHeader },
-        next: { revalidate: 0 }
-      });
-      expect(mockResponse).toHaveBeenCalledWith(fakeBody, {
-        status: 206,
-        statusText: undefined,
-        headers: expect.any(Object)
-      });
-      expect(mockSetHeader).toHaveBeenCalledWith('Content-Type', 'audio/mpeg');
-      expect(mockSetHeader).toHaveBeenCalledWith('Content-Length', '500000');
-      expect(mockSetHeader).toHaveBeenCalledWith('Content-Range', 'bytes 500000-999999/1000000');
-      expect(mockSetHeader).toHaveBeenCalledWith('Accept-Ranges', 'bytes');
-      expect(mockSetHeader).toHaveBeenCalledWith('Cache-Control', expect.any(String));
-    });
-
-    it('should return the original error response from fetch without constructing a new one', async () => {
-      const mockErrorBody = 'Not found';
-      const mockErrorResponseFromFetch = {
-        ok: false,
-        status: 404,
-        statusText: 'Not Found',
-        body: mockErrorBody
-      };
-      mockFetch.mockResolvedValue(mockErrorResponseFromFetch);
-
-      await blobStorageService().streamBlob(mockUrl, null);
-
-      expect(mockResponse).toHaveBeenCalledTimes(1);
-      expect(mockResponse).toHaveBeenCalledWith(mockErrorBody, {
-        status: 404,
-        statusText: 'Not Found'
-      });
-    });
-
-    it('should throw an error if fetch itself fails', async () => {
-      const networkError = new Error('DNS resolution failed');
-      mockFetch.mockRejectedValue(networkError);
-      await expect(blobStorageService().streamBlob(mockUrl, null)).rejects.toThrow(networkError);
-      expect(mockResponse).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/application/use-cases/uploadService/upload.test.ts
+++ b/src/application/use-cases/uploadService/upload.test.ts
@@ -16,6 +16,7 @@ const mockHeaders = jest.fn().mockImplementation(() => ({
   get: jest.fn(),
   has: jest.fn()
 }));
+const mockFolderNameSchemaParse = jest.fn();
 
 global.fetch = mockFetch;
 global.Response = mockResponse;
@@ -32,7 +33,11 @@ jest.mock('@azure/storage-blob', () => {
           uploadData: mockUploadData,
           deleteIfExists: mockDeleteIfExists,
           exists: mockExists,
-          url: `https://mockstorage.blob.core.windows.net/${CONTAINER_NAME}/${path}`
+          url: `https://mockstorage.blob.core.windows.net/${CONTAINER_NAME}/${path}`,
+          name: path,
+          beginCopyFromURL: jest.fn(() => ({
+            pollUntilDone: jest.fn().mockResolvedValue(undefined)
+          }))
         }))
       }))
     }))
@@ -94,11 +99,27 @@ describe('azureStorageService', () => {
       expect(logger.error).toHaveBeenCalledWith(errors.FAILED_TO_DELETE_BLOB, deleteError);
     });
   });
+
   describe('constructBlobUrl', () => {
     it('should return the full, correctly formatted URL without checking for existence', () => {
       const url = blobStorageService().constructBlobUrl(folderName, blobName);
       expect(url).toBe(expectedUrl);
       expect(mockExists).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('copyBlobsToNewFolder', () => {
+    const oldFolderName = 'old-photos';
+    const newFolderName = 'new-photos';
+    const blobNames = ['image1.jpg', 'image2.png'];
+    const hashedBlobNames = blobNames.map((name) => createHash('sha256').update(name).digest('hex'));
+    const expectedNewBlobPaths = hashedBlobNames.map((hash) => `${newFolderName}/${hash}`);
+
+    it('should copy blobs to new folder successfully', async () => {
+      mockFolderNameSchemaParse.mockReturnValue(undefined);
+      const result = await blobStorageService().copyBlobsToNewFolder(oldFolderName, newFolderName, blobNames);
+      expect(result).toEqual(expectedNewBlobPaths);
+      expect(logger.error).not.toHaveBeenCalled();
     });
   });
 

--- a/src/application/use-cases/uploadService/upload.test.ts
+++ b/src/application/use-cases/uploadService/upload.test.ts
@@ -25,24 +25,24 @@ global.Headers = mockHeaders;
 const MOCK_AZURE_SAS_URL = 'url-test';
 process.env.AZURE_SAS_URL = MOCK_AZURE_SAS_URL;
 
-jest.mock('@azure/storage-blob', () => {
-  return {
-    BlobServiceClient: jest.fn().mockImplementation(() => ({
-      getContainerClient: jest.fn(() => ({
-        getBlockBlobClient: jest.fn((path: string) => ({
-          uploadData: mockUploadData,
-          deleteIfExists: mockDeleteIfExists,
-          exists: mockExists,
-          url: `https://mockstorage.blob.core.windows.net/${CONTAINER_NAME}/${path}`,
-          name: path,
-          beginCopyFromURL: jest.fn(() => ({
-            pollUntilDone: jest.fn().mockResolvedValue(undefined)
-          }))
-        }))
-      }))
+const mockContainerClient = {
+  getBlockBlobClient: jest.fn((path: string) => ({
+    uploadData: mockUploadData,
+    deleteIfExists: mockDeleteIfExists,
+    exists: mockExists,
+    name: path,
+    url: `https://mockstorage.blob.core.windows.net/${CONTAINER_NAME}/${path}`,
+    beginCopyFromURL: jest.fn(() => ({
+      pollUntilDone: jest.fn().mockResolvedValue(undefined)
     }))
-  };
-});
+  }))
+};
+
+jest.mock('@azure/storage-blob', () => ({
+  BlobServiceClient: jest.fn().mockImplementation(() => ({
+    getContainerClient: jest.fn(() => mockContainerClient)
+  }))
+}));
 
 jest.mock('../../../validators/blob.schema', () => ({
   zFolderNameSchema: { parse: jest.fn() },

--- a/src/application/use-cases/uploadService/upload.test.ts
+++ b/src/application/use-cases/uploadService/upload.test.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'crypto';
+
 import { blobStorageService } from './upload';
 import { errors } from '~/back-constants/errors';
 import { CONTAINER_NAME } from '~/back-constants/index';
@@ -52,6 +54,8 @@ describe('azureStorageService', () => {
   const blobName = 'image.jpg';
   const buffer = Buffer.from('mock buffer');
   const contentType = 'image/jpeg';
+  const fullPath = `${folderName}/${createHash('sha256').update(blobName).digest('hex')}`;
+  const expectedUrl = `https://mockstorage.blob.core.windows.net/${CONTAINER_NAME}/${fullPath}`;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -88,6 +92,125 @@ describe('azureStorageService', () => {
       mockDeleteIfExists.mockRejectedValue(deleteError);
       await expect(blobStorageService().deleteFile(folderName, blobName)).rejects.toThrow(deleteError);
       expect(logger.error).toHaveBeenCalledWith(errors.FAILED_TO_DELETE_BLOB, deleteError);
+    });
+  });
+  describe('constructBlobUrl', () => {
+    it('should return the full, correctly formatted URL without checking for existence', () => {
+      const url = blobStorageService().constructBlobUrl(folderName, blobName);
+      expect(url).toBe(expectedUrl);
+      expect(mockExists).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('streamBlob', () => {
+    const mockUrl = 'https://fake-url.com/file.mp3';
+
+    beforeEach(() => {
+      mockFetch.mockClear();
+      mockResponse.mockClear();
+      mockSetHeader.mockClear();
+    });
+
+    it('should call fetch and construct a new Response for a full request', async () => {
+      const fakeBody = 'audio data';
+      const mockAzureHeaders = {
+        get: jest.fn((key: string) => {
+          if (key === 'Content-Type') return 'audio/mpeg';
+          if (key === 'Content-Length') return '1234567';
+          return null;
+        }),
+        has: jest.fn().mockReturnValue(false)
+      };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: mockAzureHeaders,
+        body: fakeBody
+      });
+
+      const result = await blobStorageService().streamBlob(mockUrl, null);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledWith(mockUrl, {
+        method: 'GET',
+        headers: {},
+        next: { revalidate: 0 }
+      });
+      expect(mockResponse).toHaveBeenCalledTimes(1);
+      expect(mockResponse).toHaveBeenCalledWith(fakeBody, {
+        status: 200,
+        statusText: undefined,
+        headers: expect.any(Object)
+      });
+      expect(result.status).toBe(200);
+    });
+
+    it('should handle range requests and construct a 206 Partial Content response', async () => {
+      const fakeBody = 'partial audio data';
+      const mockAzureHeaders = {
+        get: jest.fn((key: string) => {
+          const headersMap = {
+            'Content-Type': 'audio/mpeg',
+            'Content-Length': '500000',
+            'Content-Range': 'bytes 500000-999999/1000000'
+          };
+          return headersMap[key as keyof typeof headersMap] || null;
+        }),
+        has: jest.fn((key: string) => key === 'Content-Range')
+      };
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 206,
+        headers: mockAzureHeaders,
+        body: fakeBody
+      });
+
+      const rangeHeader = 'bytes=500000-';
+
+      await blobStorageService().streamBlob(mockUrl, rangeHeader);
+
+      expect(mockFetch).toHaveBeenCalledWith(mockUrl, {
+        method: 'GET',
+        headers: { Range: rangeHeader },
+        next: { revalidate: 0 }
+      });
+      expect(mockResponse).toHaveBeenCalledWith(fakeBody, {
+        status: 206,
+        statusText: undefined,
+        headers: expect.any(Object)
+      });
+      expect(mockSetHeader).toHaveBeenCalledWith('Content-Type', 'audio/mpeg');
+      expect(mockSetHeader).toHaveBeenCalledWith('Content-Length', '500000');
+      expect(mockSetHeader).toHaveBeenCalledWith('Content-Range', 'bytes 500000-999999/1000000');
+      expect(mockSetHeader).toHaveBeenCalledWith('Accept-Ranges', 'bytes');
+      expect(mockSetHeader).toHaveBeenCalledWith('Cache-Control', expect.any(String));
+    });
+
+    it('should return the original error response from fetch without constructing a new one', async () => {
+      const mockErrorBody = 'Not found';
+      const mockErrorResponseFromFetch = {
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        body: mockErrorBody
+      };
+      mockFetch.mockResolvedValue(mockErrorResponseFromFetch);
+
+      await blobStorageService().streamBlob(mockUrl, null);
+
+      expect(mockResponse).toHaveBeenCalledTimes(1);
+      expect(mockResponse).toHaveBeenCalledWith(mockErrorBody, {
+        status: 404,
+        statusText: 'Not Found'
+      });
+    });
+
+    it('should throw an error if fetch itself fails', async () => {
+      const networkError = new Error('DNS resolution failed');
+      mockFetch.mockRejectedValue(networkError);
+      await expect(blobStorageService().streamBlob(mockUrl, null)).rejects.toThrow(networkError);
+      expect(mockResponse).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/application/use-cases/uploadService/upload.ts
+++ b/src/application/use-cases/uploadService/upload.ts
@@ -73,6 +73,35 @@ export const blobStorageService = () => {
         throw error;
       }
     },
+    copyBlobsToNewFolder: async (
+      oldFolderName: string,
+      newFolderName: string,
+      blobNames: string[]
+    ): Promise<string[]> => {
+      try {
+        zFolderNameSchema.parse(oldFolderName);
+        zFolderNameSchema.parse(newFolderName);
+
+        const containerClient = getContainerClient();
+
+        return await Promise.all(
+          blobNames.map(async (blobName) => {
+            const blobNameHash = createHash('sha256').update(blobName).digest('hex');
+
+            const sourceBlobClient = getFullPathToBlob(containerClient, oldFolderName, blobNameHash);
+            const targetBlobClient = getFullPathToBlob(containerClient, newFolderName, blobNameHash);
+
+            const copyPoller = await targetBlobClient.beginCopyFromURL(sourceBlobClient.url);
+            await copyPoller.pollUntilDone();
+
+            return targetBlobClient.name;
+          })
+        );
+      } catch (error) {
+        logger.error(errors.BLOB_DOES_NOT_EXIST, error);
+        throw error;
+      }
+    },
     streamBlob: async (url: string, rangeHeader: string | null): Promise<Response> => {
       const azureResponse = await fetch(url, {
         method: 'GET',

--- a/src/validators/blob.schema.ts
+++ b/src/validators/blob.schema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const zFolderNameSchema = z.enum(['photos', 'notes', 'compositions', 'works']);
+export const zFolderNameSchema = z.enum(['photos', 'notes', 'compositions', 'works', 'tmp']);
 export const zContentTypeSchema = z.enum([
   'image/jpeg',
   'image/jpg',


### PR DESCRIPTION
## Description

- Updated logic for image upload in blocks on about page
- Updated editSlice for photos 
- Wrote new method to uploadService to copy files in blob storage to new one folder

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

http://localhost:3000/about
on this page you can add new photos to check it

## Video / Screenshots

https://github.com/user-attachments/assets/f4dd4b0d-bd8c-4a15-924e-41ebe9fd41fe

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [x] Linked issue/task included
- [ ] Task moved to the review column on the board

---
