### PR TITLE
feat: now preview mode work

### DIFF
--- a/app/api/config/route.ts
+++ b/app/api/config/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  const clientAppUrl = process.env.CLIENT_BASE_URL;
+  return NextResponse.json({ clientAppUrl });
+}

--- a/app/lib/utils/fetchPreview.test.ts
+++ b/app/lib/utils/fetchPreview.test.ts
@@ -9,7 +9,7 @@ interface PreviewProps {
 describe('fetchPreview', () => {
   beforeEach(() => {
     global.fetch = jest.fn();
-    (window as any).open = jest.fn();
+    (globalThis.window as any).open = jest.fn();
   });
 
   afterEach(() => {
@@ -26,8 +26,8 @@ describe('fetchPreview', () => {
 
     await fetchPreview(props);
 
-    expect(global.fetch).toHaveBeenCalledWith('/api/config');
-    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(globalThis.global.fetch).toHaveBeenCalledWith('/api/config');
+    expect(globalThis.global.fetch).toHaveBeenCalledTimes(1);
 
     const expectedUrl = 'http://localhost:3000/api/preview?lang=uk&slug=about&draftId=123';
     expect(window.open).toHaveBeenCalledWith(expectedUrl, '_blank');

--- a/app/lib/utils/fetchPreview.test.ts
+++ b/app/lib/utils/fetchPreview.test.ts
@@ -1,56 +1,50 @@
 import { fetchPreview } from './fetchPreview';
 
-describe('fetchPreview', () => {
-  const OLD_ENV = process.env;
+interface PreviewProps {
+  slug: string;
+  lang: 'uk' | 'en';
+  draftId: string | number;
+}
 
+describe('fetchPreview', () => {
   beforeEach(() => {
-    jest.resetModules();
-    process.env = { ...OLD_ENV };
-    process.env.NEXT_PUBLIC_CLIENT_BASE_URL = 'http://localhost:3000';
     global.fetch = jest.fn();
-    (window as unknown as { open: unknown }).open = jest.fn();
+    (window as any).open = jest.fn();
   });
 
   afterEach(() => {
-    process.env = OLD_ENV;
     jest.restoreAllMocks();
-    jest.clearAllMocks();
   });
 
-  it('should open previewUrl in a new tab and resolve on success', async () => {
+  it('should fetch config and open the constructed preview URL in a new tab', async () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ previewUrl: 'http://localhost:3000/uk/about?draftId=123' })
+      json: async () => ({ clientAppUrl: 'http://localhost:3000' })
     });
 
-    await expect(fetchPreview({ slug: 'about', lang: 'uk', draftId: 123 })).resolves.toBeUndefined();
+    const props: PreviewProps = { slug: 'about', lang: 'uk', draftId: 123 };
 
-    expect(global.fetch).toHaveBeenCalledWith('http://localhost:3000/api/preview?lang=uk&slug=about&draftId=123', {
-      method: 'GET',
-      credentials: 'include'
-    });
-    expect(window.open).toHaveBeenCalledWith('http://localhost:3000/uk/about?draftId=123', '_blank');
+    await fetchPreview(props);
+
+    expect(global.fetch).toHaveBeenCalledWith('/api/config');
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+
+    const expectedUrl = 'http://localhost:3000/api/preview?lang=uk&slug=about&draftId=123';
+    expect(window.open).toHaveBeenCalledWith(expectedUrl, '_blank');
   });
 
-  it('should throw when response is not ok', async () => {
+  it('should throw an error if fetching the config fails', async () => {
+    const fetchError = new Error('Failed to parse JSON');
     (global.fetch as jest.Mock).mockResolvedValueOnce({
       ok: false,
-      json: async () => ({ message: 'Not found' })
+      json: async () => {
+        throw fetchError;
+      }
     });
 
-    await expect(fetchPreview({ slug: 'about', lang: 'en', draftId: 456 })).rejects.toThrow('Failed to start preview');
+    const props: PreviewProps = { slug: 'about', lang: 'en', draftId: 456 };
 
-    expect(window.open).not.toHaveBeenCalled();
-  });
-
-  it('should throw when previewUrl is missing', async () => {
-    (global.fetch as jest.Mock).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({})
-    });
-
-    await expect(fetchPreview({ slug: 'about', lang: 'uk', draftId: 789 })).rejects.toThrow('Failed to start preview');
-
+    await expect(fetchPreview(props)).rejects.toThrow('Failed to parse JSON');
     expect(window.open).not.toHaveBeenCalled();
   });
 });

--- a/app/lib/utils/fetchPreview.ts
+++ b/app/lib/utils/fetchPreview.ts
@@ -4,18 +4,12 @@ interface PreviewProps {
   draftId: string | number;
 }
 
+type ConfigResponse = {
+  clientAppUrl: string;
+};
+
 export const fetchPreview = async ({ slug, lang, draftId }: PreviewProps) => {
-  const clientUrl = process.env.NEXT_PUBLIC_CLIENT_BASE_URL;
-  const res = await fetch(`${clientUrl}/api/preview?lang=${lang}&slug=${slug}&draftId=${draftId}`, {
-    method: 'GET',
-    credentials: 'include'
-  });
-
-  const data = await res.json();
-
-  if (!res.ok || !data.previewUrl) {
-    throw new Error('Failed to start preview');
-  }
-
-  window.open(data.previewUrl, '_blank');
+  const response = await fetch('/api/config');
+  const data: ConfigResponse = await response.json();
+  window.open(`${data.clientAppUrl}/api/preview?lang=${lang}&slug=${slug}&draftId=${draftId}`, '_blank');
 };

--- a/src/shared/types/env.d.ts
+++ b/src/shared/types/env.d.ts
@@ -9,5 +9,6 @@ namespace NodeJS {
     AZURE_SAS_URL: string;
     JWT_ACCESS_TOKEN_SECRET: string;
     JWT_REFRESH_TOKEN_SECRET: string;
+    CLIENT_BASE_URL: string;
   }
 }


### PR DESCRIPTION
## Description

The problem was in NEXT_PUBLIC prefix
We used this prefix to give an opportunity to our client to work with this env variable
But these types of variables must be inserted at the `npm run build` stage, which is incorrect from a security point of view
So i move it to server side

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Start client app (client repo from develop)
- Run the client app.

2. Start admin app (this repo)
- Run the admin app on this PR branch.

3. Do some changes and click on 'Попередній перегляд' button

## Video / Screenshots

https://github.com/user-attachments/assets/61bdb2f0-021a-4f75-acaa-4d7d7a4715bb

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
