### PR TITLE
feat: add disabled state to side navigation items

### DIFF
--- a/app/shared/components/side-navigation/SideNavigation.consts.ts
+++ b/app/shared/components/side-navigation/SideNavigation.consts.ts
@@ -1,24 +1,24 @@
 export const NAVIGATION_DATA = {
   mainGroup: [
     { title: 'Головна', iconSrc: 'house', href: '/' },
-    { title: 'Новини', iconSrc: 'news', href: '/news' },
-    { title: 'Архів творів', iconSrc: 'musicArchive', href: '/musicArchive' },
-    { title: 'Медіатека', iconSrc: 'media', href: '/media' }
+    { title: 'Новини', iconSrc: 'news', href: '/news', disabled: true },
+    { title: 'Архів творів', iconSrc: 'musicArchive', href: '/musicArchive', disabled: true },
+    { title: 'Медіатека', iconSrc: 'media', href: '/media', disabled: true }
   ],
   pages: [
     {
       element: { title: 'Борис Лятошинський', iconSrc: 'biography' },
-      collapseElements: [{ title: 'Дослідження та наукові роботи', href: '/research' }]
+      collapseElements: [{ title: 'Дослідження та наукові роботи', href: '/research', disabled: true }]
     },
     {
       element: { title: 'Про фундацію', iconSrc: 'aboutFoundation' },
       collapseElements: [{ title: 'Про нас', href: '/about-us' }]
     },
-    { title: 'Кабінет-Архів', iconSrc: 'archive', href: '/archive' }
+    { title: 'Кабінет-Архів', iconSrc: 'archive', href: '/archive', disabled: true }
   ],
   settings: [
-    { title: 'Контакти', iconSrc: 'contacts', href: '/contacts' },
-    { title: 'Футер сайту', iconSrc: 'footer', href: '/footer' },
-    { title: 'Мапа сайту', iconSrc: 'siteMap', href: '/map' }
+    { title: 'Контакти', iconSrc: 'contacts', href: '/contacts', disabled: true },
+    { title: 'Футер сайту', iconSrc: 'footer', href: '/footer', disabled: true },
+    { title: 'Мапа сайту', iconSrc: 'siteMap', href: '/map', disabled: true }
   ]
 };

--- a/app/shared/components/side-navigation/link-element/LinkElement.tsx
+++ b/app/shared/components/side-navigation/link-element/LinkElement.tsx
@@ -4,6 +4,12 @@ import Link from 'next/link';
 import { ListElement } from '../list-element/ListElement';
 
 export const LinkElement: React.FC<LinkElementProps> = ({ element, open, handleClick, sxItem = {}, children }) => {
+  if (element.disabled) {
+    return (
+      <ListElement element={element} open={open} sxItem={{ cursor: 'not-allowed', color: 'grey.500', ...sxItem }} />
+    );
+  }
+
   return (
     <Link href={element.href ?? '/'} key={element.href}>
       <ListElement element={element} open={open} handleClick={handleClick} sxItem={sxItem} />

--- a/app/types/sideNavigation.ts
+++ b/app/types/sideNavigation.ts
@@ -4,6 +4,7 @@ export interface ListElementType {
   title: string;
   iconSrc?: string;
   href?: string;
+  disabled?: boolean;
 }
 export interface AdditionalElement {
   element: ListElementType;


### PR DESCRIPTION
## Description
Our side navigation contained links to pages that didn't exist yet. Next.js was prefetching them, so we were getting dropped requests. To fix this, I added a disabled: true flag to the navigation data for all pages that weren't ready. The component that displays the link now checks for this flag. If it's true, the component displays the menu item as plain text (grayed out and not clickable) instead of a real link.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->
go to the page, go to dev tools and the network tab, see if there are any requests that are failing

## Video / Screenshots

https://github.com/user-attachments/assets/eff74c86-f497-4c84-a286-e9d6aeeff0de


<!-- Attach a video recording or screenshots demonstrating the changes, if applicable -->

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
