### PR TITLE
refactor: change admin navigation link title according to client wishes

### DIFF
--- a/app/shared/components/side-navigation/SideNavigation.consts.ts
+++ b/app/shared/components/side-navigation/SideNavigation.consts.ts
@@ -14,7 +14,7 @@ export const NAVIGATION_DATA = {
       element: { title: 'Про фундацію', iconSrc: 'aboutFoundation' },
       collapseElements: [{ title: 'Про нас', href: '/about-us' }]
     },
-    { title: 'Кабінет-Архів', iconSrc: 'archive', href: '/archive', disabled: true }
+    { title: 'Архів', iconSrc: 'archive', href: '/archive', disabled: true }
   ],
   settings: [
     { title: 'Контакти', iconSrc: 'contacts', href: '/contacts', disabled: true },


### PR DESCRIPTION
Refactored the admin navigation link title according to client requirements.

Old version:
<img width="280" height="246" alt="image" src="https://github.com/user-attachments/assets/8302aabe-caee-4e89-b1ee-a82e7d42f412" />

New version:
<img width="256" height="204" alt="image" src="https://github.com/user-attachments/assets/88e62d3c-dda8-42e2-8eec-1085fa6291a9" />
