### PR TITLE
fix(ui): prevent layout shift when expanding sections by reserving scrollbar gutter

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -9,6 +9,10 @@ body {
     overflow-x: hidden;
 }
 
+html {
+    scrollbar-gutter: stable;
+}
+
 body {
     color: var(--foreground);
     background: var(--background);


### PR DESCRIPTION
## Description

Prevented layout shift when expanding collapsible sections by reserving scrollbar space with `scrollbar-gutter: stable;`

## Type of change

- [x] Bug fix

## How to test

1. Log in to lf-admin.
2. Go "to Про нас" -> open any collapsible section (e.g., "Вступна секція", "Фундація Лятошинського").
3. Observe the layout during the expand/collapse.

## Video

Was:

https://github.com/user-attachments/assets/b776658a-3dc8-45bc-80b6-32287e2d2243

Now:

https://github.com/user-attachments/assets/62b5de82-e42e-44e0-84ee-f3e45df43c3c

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
