### PR TITLE
fix(ds-button): use focus-visible and fix variant handling

### DIFF
--- a/app/lib/utils/sxToArray.test.ts
+++ b/app/lib/utils/sxToArray.test.ts
@@ -1,0 +1,17 @@
+import { sxToArray } from './sxToArray';
+
+describe('sxToArray', () => {
+  it('should return empty array when sx is not provided', () => {
+    expect(sxToArray()).toEqual([]);
+  });
+
+  it('should wrap a single sx object into an array', () => {
+    const sx = { p: 1 };
+    expect(sxToArray(sx)).toEqual([sx]);
+  });
+
+  it('should return the same array reference when sx is already an array', () => {
+    const sx = [{ p: 1 }, { m: 2 }];
+    expect(sxToArray(sx)).toBe(sx);
+  });
+});

--- a/app/lib/utils/sxToArray.ts
+++ b/app/lib/utils/sxToArray.ts
@@ -1,0 +1,13 @@
+import type { SxProps, Theme } from '@mui/material';
+
+export const sxToArray = (s?: SxProps<Theme>) => {
+  if (!s) {
+    return [];
+  }
+
+  if (Array.isArray(s)) {
+    return s;
+  }
+
+  return [s];
+};

--- a/app/shared/components/design-system/button/Button.styles.ts
+++ b/app/shared/components/design-system/button/Button.styles.ts
@@ -109,6 +109,8 @@ export const typographyStyles = {
   }
 };
 
+const focusVisible = '&.Mui-focusVisible, &:focus-visible';
+
 export const buttonBaseStyles = {
   borderRadius: '28px',
   textTransform: 'none',
@@ -146,7 +148,7 @@ export const variantStyles = {
       '&:hover': {
         backgroundColor: colors.primaryFilledHovered
       },
-      '&:focus': {
+      [focusVisible]: {
         backgroundColor: colors.black
       },
       '&:active': {
@@ -165,7 +167,7 @@ export const variantStyles = {
       '&:hover': {
         backgroundColor: colors.primaryOutlinedHovered
       },
-      '&:focus': {
+      [focusVisible]: {
         backgroundColor: colors.white
       },
       '&:active': {
@@ -183,7 +185,7 @@ export const variantStyles = {
       '&:hover': {
         backgroundColor: colors.primaryOutlinedHovered
       },
-      '&:focus': {
+      [focusVisible]: {
         backgroundColor: colors.primaryOutlinedPressed
       },
       '&:active': {
@@ -203,7 +205,7 @@ export const variantStyles = {
       '&:hover': {
         boxShadow: `inset 0 0 0 1000px ${colors.secondaryFilledHovered}`
       },
-      '&:focus': {
+      [focusVisible]: {
         backgroundColor: colors.brown[200]
       },
       '&:active': {
@@ -222,7 +224,7 @@ export const variantStyles = {
       '&:hover': {
         backgroundColor: colors.secondaryHovered
       },
-      '&:focus': {
+      [focusVisible]: {
         backgroundColor: colors.secondaryPressed
       },
       '&:active': {
@@ -240,7 +242,7 @@ export const variantStyles = {
       '&:hover': {
         backgroundColor: colors.secondaryHovered
       },
-      '&:focus': {
+      [focusVisible]: {
         backgroundColor: colors.secondaryPressed
       },
       '&:active': {
@@ -260,7 +262,7 @@ export const variantStyles = {
         backgroundColor: colors.black,
         color: colors.white
       },
-      '&:focus': {
+      [focusVisible]: {
         backgroundColor: colors.black,
         color: colors.white
       },

--- a/app/shared/components/design-system/button/Button.tsx
+++ b/app/shared/components/design-system/button/Button.tsx
@@ -1,11 +1,12 @@
 'use client';
+
 import { Button as MuiButton, ButtonProps as MuiButtonProps, CircularProgress } from '@mui/material';
-import { forwardRef, ReactNode } from 'react';
+import { forwardRef, type ReactNode } from 'react';
 
 import { buttonBaseStyles, sizeStyles, typographyStyles, variantStyles } from './Button.styles';
+import { sxToArray } from '~/lib/utils/sxToArray';
 
 type Size = 'large' | 'medium' | 'small';
-
 type Variant = 'filled' | 'outlined' | 'text';
 
 type BaseButtonProps = {
@@ -45,28 +46,35 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     },
     ref
   ) => {
-    const isDisabled = disabled ?? loading;
+    const isDisabled = Boolean(disabled) || Boolean(loading);
+    const content = label ?? children;
 
-    const buttonContent = label ?? children;
+    const muiVariant: MuiButtonProps['variant'] = (
+      { filled: 'contained', outlined: 'outlined', text: 'text' } as const
+    )[variant];
+
+    const visualSx = color === 'tertiary' ? variantStyles.tertiary.filled : variantStyles[color][variant];
+
+    const mergedSx: MuiButtonProps['sx'] = [
+      buttonBaseStyles,
+      sizeStyles[size],
+      typographyStyles[color][size],
+      visualSx,
+      ...sxToArray(sx)
+    ];
 
     return (
       <MuiButton
         ref={ref}
         size={size}
-        variant="contained"
+        variant={muiVariant}
+        disabled={isDisabled}
         startIcon={!loading ? startIcon : undefined}
         endIcon={!loading ? endIcon : undefined}
-        disabled={isDisabled}
-        sx={{
-          ...buttonBaseStyles,
-          ...sizeStyles[size],
-          ...typographyStyles[color]?.[size],
-          ...(color === 'tertiary' ? variantStyles.tertiary.filled : variantStyles[color]?.[variant]),
-          ...(sx as object)
-        }}
+        sx={mergedSx}
         {...props}
       >
-        {loading ? <CircularProgress size={25} color="inherit" data-testid="loader" /> : buttonContent}
+        {loading ? <CircularProgress size={25} color="inherit" data-testid="loader" /> : content}
       </MuiButton>
     );
   }


### PR DESCRIPTION
## Description

This PR fixes a visual “weird focus” state for the design-system Button.

After mouse click, some buttons (notably tab-like buttons and the language switcher) kept a focus background that looked like an extra "selected" state and only disappeared on hover/blur.

Changes:

1. Switched focus styles from :focus to :focus-visible / .Mui-focusVisible (keyboard focus only).
2. Updated DS Button to:
- map DS variants (filled/outlined/text) to correct MUI variants;
- correctly disable the button when loading is true;
- merge sx safely (supports sx arrays).
3. Added a small shared util sxToArray (+ unit test) to normalize sx to an array.

## Type of change

- [x] Bug fix
- [x] Refactoring / Tech debt

## How to test

1. Click DS buttons with the mouse (Language switcher, MediaModal tabs)
2. Verify no "stuck" focus background after click.

## Video / Screenshots

Was:
<img width="944" height="69" alt="image" src="https://github.com/user-attachments/assets/7272c2a6-6d35-405d-a247-cfe77acc2c3d" />
<img width="871" height="72" alt="image" src="https://github.com/user-attachments/assets/dc9d7124-d0c5-4932-a534-5dc81cffcd45" />

Now:
<img width="1186" height="63" alt="image" src="https://github.com/user-attachments/assets/68cbe4c0-1d56-4c1d-8dfb-ce1a2307010d" />
<img width="841" height="54" alt="image" src="https://github.com/user-attachments/assets/2821acbf-6799-4a56-8675-d8c12cde08b6" />

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
