### PR TITLE
feat(media-modal): add MediaModal container entrypoint to page

### DIFF
--- a/app/shared/components/about-us/Liatoshynsky-foundation/foundation-block/FoundationBlock.tsx
+++ b/app/shared/components/about-us/Liatoshynsky-foundation/foundation-block/FoundationBlock.tsx
@@ -55,6 +55,7 @@ export const FoundationBlock = ({
         cropHeight={300}
         onChangeImage={onImageChange}
         title="Основне зображення"
+        editorMode="mediaModal"
       />
     </Box>
   );

--- a/app/shared/components/design-system/photo-block/PhotoBlock.test.tsx
+++ b/app/shared/components/design-system/photo-block/PhotoBlock.test.tsx
@@ -1,33 +1,80 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { ImagePreviewBlock } from './PhotoBlock';
+import { readFileAsDataURL } from '~/lib/utils/readFileAsDataURL';
+import type { MediaModalOpenState, MediaModalResult } from '~/shared/components/media-modal/MediaModal.types';
 
-jest.mock('../../../../lib/utils/readFileAsDataURL.ts', () => ({
-  readFileAsDataURL: () => Promise.resolve('data:image/png;base64,mockImage')
+jest.mock('~/lib/utils/readFileAsDataURL', () => ({
+  readFileAsDataURL: jest.fn()
 }));
 
-jest.mock('../../../../../public/icons/image.svg', () => ({
-  __esModule: true,
-  default: () => <span>ImageIcon</span>
-}));
-
-jest.mock('../../../../../public/icons/pencil.svg', () => ({
-  __esModule: true,
-  default: () => <span>PencilIcon</span>
-}));
-
-jest.mock('../../../hooks/use-image-metadata/useImageMetadata.ts', () => ({
+jest.mock('~/shared/hooks/use-image-metadata/useImageMetadata', () => ({
   useImageMetadata: () => ({
     dimensions: { width: 200, height: 150 },
     fileName: 'test.jpg'
   })
 }));
 
+jest.mock('~/public/icons/image.svg', () => ({
+  __esModule: true,
+  default: () => null
+}));
+
+jest.mock('~/public/icons/pencil.svg', () => ({
+  __esModule: true,
+  default: () => null
+}));
+
+type MediaModalProps = {
+  open: boolean;
+  initial?: MediaModalOpenState;
+  onClose: () => void;
+  onApply: (result: MediaModalResult) => void;
+};
+
+jest.mock('~/shared/components/media-modal/MediaModal', () => ({
+  MediaModal: ({ open, initial, onApply, onClose }: MediaModalProps) => {
+    if (!open) return null;
+
+    return (
+      <div data-testid="media-modal">
+        <div data-testid="initial-step">{initial?.step ?? ''}</div>
+        <div data-testid="initial-tab">{initial?.tab ?? ''}</div>
+
+        <button type="button" data-testid="close" onClick={onClose}>
+          close
+        </button>
+
+        <button
+          type="button"
+          data-testid="apply-upload"
+          onClick={() =>
+            onApply({
+              selected: {
+                kind: 'upload',
+                id: 'upload-1',
+                fileName: 'x.png',
+                file: new File(['x'], 'x.png', { type: 'image/png' })
+              },
+              crop: null
+            })
+          }
+        >
+          apply
+        </button>
+      </div>
+    );
+  }
+}));
+
 describe('ImagePreviewBlock', () => {
-  const mockOnChangeImage = jest.fn();
+  const onChangeImage = jest.fn();
 
   beforeEach(() => {
-    mockOnChangeImage.mockClear();
+    onChangeImage.mockClear();
+    (readFileAsDataURL as jest.Mock).mockReset();
+    (readFileAsDataURL as jest.Mock).mockResolvedValue('data:image/png;base64,mockImage');
   });
 
   it('should render correctly with initial image', () => {
@@ -36,32 +83,92 @@ describe('ImagePreviewBlock', () => {
         imageUrl="https://example.com/test.jpg"
         cropWidth={300}
         cropHeight={200}
-        onChangeImage={mockOnChangeImage}
+        onChangeImage={onChangeImage}
         title="Основне зображення"
       />
     );
 
     expect(screen.getByText(/Основне зображення/)).toBeInTheDocument();
     expect(screen.getByAltText('Preview')).toHaveAttribute('src', 'https://example.com/test.jpg');
-    expect(screen.getByText(/Назва файлу test.jpg/)).toBeInTheDocument();
+    expect(screen.getByText(/Назва файлу test\.jpg/)).toBeInTheDocument();
     expect(screen.getByText(/Розмір: 200 × 150/)).toBeInTheDocument();
   });
 
-  it('should open cropper modal on "Редагувати" click', async () => {
+  it('should open cropper modal on "Редагувати" click (legacy)', async () => {
+    const user = userEvent.setup();
+
     render(
       <ImagePreviewBlock
         imageUrl="https://example.com/test.jpg"
         cropWidth={300}
         cropHeight={200}
-        onChangeImage={mockOnChangeImage}
+        onChangeImage={onChangeImage}
       />
     );
 
-    const editButton = screen.getByRole('button', { name: /Редагувати/i });
-    fireEvent.click(editButton);
+    await user.click(screen.getByRole('button', { name: /Редагувати/i }));
 
     await waitFor(() => {
       expect(screen.getByText('Редагування зображення')).toBeInTheDocument();
+    });
+  });
+
+  it('should open MediaModal with CROP step in mediaModal mode and close it', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ImagePreviewBlock
+        imageUrl="https://example.com/test.jpg"
+        cropWidth={300}
+        cropHeight={200}
+        onChangeImage={onChangeImage}
+        editorMode="mediaModal"
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /Редагувати/i }));
+
+    expect(screen.getByTestId('media-modal')).toBeInTheDocument();
+    expect(screen.getByTestId('initial-step')).toHaveTextContent('CROP');
+
+    await user.click(screen.getByTestId('close'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('media-modal')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should apply upload result in mediaModal mode (updates preview + calls onChangeImage + closes)', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ImagePreviewBlock
+        imageUrl="https://example.com/test.jpg"
+        cropWidth={300}
+        cropHeight={200}
+        onChangeImage={onChangeImage}
+        editorMode="mediaModal"
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /Змінити зображення/i }));
+
+    expect(screen.getByTestId('media-modal')).toBeInTheDocument();
+    expect(screen.getByTestId('initial-tab')).toHaveTextContent('UPLOAD');
+
+    await user.click(screen.getByTestId('apply-upload'));
+
+    await waitFor(() => {
+      expect(onChangeImage).toHaveBeenCalledTimes(1);
+      expect(readFileAsDataURL).toHaveBeenCalledTimes(1);
+      expect(screen.getByAltText('Preview')).toHaveAttribute(
+        'src',
+        expect.stringContaining('data:image/png;base64,mockImage')
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('media-modal')).not.toBeInTheDocument();
     });
   });
 });

--- a/app/shared/components/design-system/photo-block/PhotoBlock.tsx
+++ b/app/shared/components/design-system/photo-block/PhotoBlock.tsx
@@ -1,15 +1,19 @@
 'use client';
 
-import { Box, Stack, StackProps, Typography } from '@mui/material';
-import { readFileAsDataURL } from 'app/lib/utils/readFileAsDataURL';
-import { useImageMetadata } from 'app/shared/hooks/use-image-metadata/useImageMetadata';
-import { useEffect, useRef, useState } from 'react';
+import { Box, Stack, type StackProps, Typography } from '@mui/material';
+import { type ChangeEvent, useEffect, useRef, useState } from 'react';
 
 import Button from '../button/Button';
 import { CropperModal } from '../cropper-modal/CropperModal';
 import { styles } from './PhotoBlock.styles';
+import { readFileAsDataURL } from '~/lib/utils/readFileAsDataURL';
 import ImageIcon from '~/public/icons/image.svg';
 import PencilIcon from '~/public/icons/pencil.svg';
+import { MediaModal } from '~/shared/components/media-modal/MediaModal';
+import type { MediaModalOpenState, MediaModalResult } from '~/shared/components/media-modal/MediaModal.types';
+import { useImageMetadata } from '~/shared/hooks/use-image-metadata/useImageMetadata';
+
+type EditorMode = 'legacy' | 'mediaModal';
 
 interface ImagePreviewBlockProps extends StackProps {
   imageUrl: string;
@@ -19,6 +23,7 @@ interface ImagePreviewBlockProps extends StackProps {
   cropHeight: number;
   oval?: boolean;
   onChangeImage: (file: File) => void;
+  editorMode?: EditorMode;
   direction?: 'row' | 'row-reverse' | 'column' | 'column-reverse';
   buttonSpacing?: string;
   stackSpacing?: string;
@@ -33,6 +38,7 @@ export const ImagePreviewBlock = ({
   cropHeight,
   oval = false,
   onChangeImage,
+  editorMode = 'legacy',
   direction = 'row',
   buttonSpacing = '16px',
   stackSpacing = '32px',
@@ -42,17 +48,23 @@ export const ImagePreviewBlock = ({
   const [isCropperOpen, setIsCropperOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
+  const [isMediaModalOpen, setIsMediaModalOpen] = useState(false);
+  const [mediaInitial, setMediaInitial] = useState<MediaModalOpenState | undefined>(undefined);
+
   useEffect(() => {
     setPreviewImage(imageUrl);
   }, [imageUrl]);
 
   const { dimensions, fileName: finalFileName } = useImageMetadata(previewImage, fileName);
 
+  const openLegacyCropper = () => setIsCropperOpen(true);
+  const closeLegacyCropper = () => setIsCropperOpen(false);
+
   const handleClickSelectImage = () => {
     inputRef.current?.click();
   };
 
-  const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (!file) return;
 
@@ -61,13 +73,53 @@ export const ImagePreviewBlock = ({
     onChangeImage(file);
   };
 
+  const openEditCrop = () => {
+    setMediaInitial({
+      step: 'CROP',
+      selected: {
+        kind: 'used',
+        id: 'current-image',
+        fileName: finalFileName ?? fileName ?? 'image',
+        src: previewImage,
+        locale: 'uk'
+      },
+      crop: null
+    });
+
+    setIsMediaModalOpen(true);
+  };
+
+  const openChangeImage = () => {
+    setMediaInitial({ tab: 'UPLOAD' });
+    setIsMediaModalOpen(true);
+  };
+
+  const closeMediaModal = () => {
+    setIsMediaModalOpen(false);
+    setMediaInitial(undefined);
+  };
+
+  const handleApplyMediaModal = async (result: MediaModalResult) => {
+    if (result.selected.kind !== 'upload') return;
+
+    const dataUrl = await readFileAsDataURL(result.selected.file);
+    setPreviewImage(dataUrl);
+    onChangeImage(result.selected.file);
+
+    closeMediaModal();
+  };
+
+  const handleEditClick = editorMode === 'mediaModal' ? openEditCrop : openLegacyCropper;
+  const handleChangeClick = editorMode === 'mediaModal' ? openChangeImage : handleClickSelectImage;
+
   return (
     <Box sx={styles.container}>
-      {title && (
+      {title ? (
         <Typography variant="subtitle1" sx={styles.sectionTitle}>
           {title}
         </Typography>
-      )}
+      ) : null}
+
       <Box sx={styles.imageBlock}>
         <Box
           component="img"
@@ -75,6 +127,7 @@ export const ImagePreviewBlock = ({
           alt="Preview"
           sx={oval ? styles.imageOvalPreview : styles.imagePreview}
         />
+
         <Stack spacing={stackSpacing} maxWidth="200px">
           <Stack spacing={typographySpacing}>
             <Typography
@@ -87,47 +140,63 @@ export const ImagePreviewBlock = ({
               Назва файлу {finalFileName}
             </Typography>
 
-            {dimensions && (
+            {dimensions ? (
               <Typography variant="body2" color="text.secondary" sx={styles.imageSizeText}>
                 Розмір: {dimensions.width} × {dimensions.height}
               </Typography>
-            )}
+            ) : null}
           </Stack>
+
           <Stack direction={direction} spacing={buttonSpacing} mt={1} width="330px">
             <Button
               startIcon={<PencilIcon style={{ marginRight: '-8px' }} />}
               variant="outlined"
               color="primary"
               size="small"
-              onClick={() => setIsCropperOpen(true)}
+              onClick={handleEditClick}
               style={styles.editButton}
             >
               Редагувати
             </Button>
+
             <Button
               startIcon={<ImageIcon style={{ marginRight: '-8px' }} />}
               variant="outlined"
               color="primary"
               size="small"
-              onClick={handleClickSelectImage}
+              onClick={handleChangeClick}
               sx={styles.changeButton}
             >
               Змінити зображення
             </Button>
-            <input ref={inputRef} type="file" accept="image/*" hidden onChange={handleFileChange} />
+
+            {editorMode === 'legacy' && (
+              <input ref={inputRef} type="file" accept="image/*" hidden onChange={handleFileChange} />
+            )}
           </Stack>
         </Stack>
       </Box>
 
-      <CropperModal
-        open={isCropperOpen}
-        oval={oval}
-        imageUrl={imageUrl}
-        width={cropWidth}
-        height={cropHeight}
-        handleClose={() => setIsCropperOpen(false)}
-        handleSetNewPic={setPreviewImage}
-      />
+      {editorMode === 'legacy' && (
+        <CropperModal
+          open={isCropperOpen}
+          oval={oval}
+          imageUrl={imageUrl}
+          width={cropWidth}
+          height={cropHeight}
+          handleClose={closeLegacyCropper}
+          handleSetNewPic={setPreviewImage}
+        />
+      )}
+
+      {editorMode === 'mediaModal' && (
+        <MediaModal
+          open={isMediaModalOpen}
+          initial={mediaInitial}
+          onClose={closeMediaModal}
+          onApply={handleApplyMediaModal}
+        />
+      )}
     </Box>
   );
 };

--- a/app/shared/components/media-modal/components/container/MediaModalContainer.tsx
+++ b/app/shared/components/media-modal/components/container/MediaModalContainer.tsx
@@ -35,7 +35,17 @@ export function MediaModalContainer({
   const hasFooter = Boolean(footerTop || footerLeft || footerRight);
 
   return (
-    <Dialog open={open} onClose={onClose} sx={styles.dialog} maxWidth={false} PaperProps={{ sx: styles.paper }}>
+    <Dialog
+      open={open}
+      onClose={onClose}
+      disableScrollLock
+      sx={styles.dialog}
+      maxWidth={false}
+      data-testid={baseTestId}
+      slotProps={{
+        paper: { sx: styles.paper }
+      }}
+    >
       <Box sx={styles.header} data-testid={`${baseTestId}-header`}>
         <Box sx={styles.headerLeft} data-testid={`${baseTestId}-headerLeft`}>
           {headerLeft ?? null}


### PR DESCRIPTION
## Description

This PR adds the new MediaModal container to a real page in an opt-in way, to validate the integration and make sure the modal opens/closes cleanly without breaking layout/responsiveness.

We're not migrating all image editors yet, because the MediaModal views (Gallery / Used / Crop) are still placeholders, and a full switch would be a large and risky change.
For now, we enable the new flow in one place (PhotoBlock via editorMode="mediaModal") to prove the wiring works end-to-end.

### Changes:

ImagePreviewBlock supports editorMode (legacy | mediaModal).
In mediaModal mode:
- edit opens MediaModal at CROP with the current image as "used";
- change image opens MediaModal at UPLOAD and applies the uploaded file back to preview.
Updated FoundationBlock to use editorMode="mediaModal" as the first integration point.
Added unit tests for the new branch (MediaModal mocked).

Note: MediaModalContainer includes a small setup (disableScrollLock) to prevent the page "shift" on modal open.

Next: once final MediaModal views and crop/apply logic are implemented, we can expand onApply handling and gradually adopt the modal in other places.

## Type of change

- [x] New feature
- [x] Bug fix

## How to test

1. Open the page that renders FoundationBlock (`http://localhost:3000/about-us`).
2. Click on block "Фундація Лятошинського".
3. Click Редагувати → MediaModal opens on CROP step.
4. Click Змінити зображення -> MediaModal opens on UPLOAD tab.

## Video / Screenshots

https://github.com/user-attachments/assets/f0159eae-3124-46ad-a2b7-9ca60989392d

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
