### PR TITLE
feat: preserve filters and search state across tab switching in Media Modal

### DIFF
--- a/app/shared/components/media-modal/MediaModal.renderers.ts
+++ b/app/shared/components/media-modal/MediaModal.renderers.ts
@@ -1,10 +1,13 @@
 import type { ReactNode } from 'react';
 
+import type { GalleryFilters, UsedFilters } from './flow/MediaModalFlowState';
 import type { CropResult, GalleryMedia, SelectedMedia, UploadMedia, UsedMedia } from './MediaModal.types';
 
 export type GalleryRendererProps = {
   selected: GalleryMedia | null;
   onPick: (selected: GalleryMedia) => void;
+  filters: GalleryFilters;
+  onFiltersChange: (filters: Partial<GalleryFilters>) => void;
 };
 
 export type UploadRendererProps = {
@@ -15,6 +18,8 @@ export type UploadRendererProps = {
 export type UsedRendererProps = {
   selected: UsedMedia | null;
   onPick: (selected: UsedMedia) => void;
+  filters: UsedFilters;
+  onFiltersChange: (filters: Partial<UsedFilters>) => void;
 };
 
 export type CropRendererProps = {

--- a/app/shared/components/media-modal/MediaModal.test.tsx
+++ b/app/shared/components/media-modal/MediaModal.test.tsx
@@ -4,6 +4,17 @@ import React from 'react';
 import { MediaModalFlow } from './flow/MediaModalFlow';
 import { MediaModal } from './MediaModal';
 
+const mockGalleryFilters = {
+  search: '',
+  favorites: '',
+  usage: ''
+};
+
+const mockUsedFilters = {
+  search: '',
+  language: ''
+};
+
 jest.mock('./flow/MediaModalFlow', () => ({
   __esModule: true,
   MediaModalFlow: jest.fn(() => null)
@@ -47,9 +58,14 @@ describe('MediaModal', () => {
 
     render(
       <>
-        {renderers.gallery({ selected: null, onPick: jest.fn() })}
+        {renderers.gallery({
+          selected: null,
+          onPick: jest.fn(),
+          filters: mockGalleryFilters,
+          onFiltersChange: jest.fn()
+        })}
         {renderers.upload({ selected: null, onPick: jest.fn() })}
-        {renderers.used({ selected: null, onPick: jest.fn() })}
+        {renderers.used({ selected: null, onPick: jest.fn(), filters: mockUsedFilters, onFiltersChange: jest.fn() })}
         {renderers.crop({
           selected: { kind: 'gallery', id: '1', fileName: 'a.png', src: '/x', locale: 'uk' },
           crop: null,
@@ -82,8 +98,13 @@ describe('MediaModal', () => {
 
     render(
       <>
-        {renderers.gallery({ selected: null, onPick: jest.fn() })}
-        {renderers.used({ selected: null, onPick: jest.fn() })}
+        {renderers.gallery({
+          selected: null,
+          onPick: jest.fn(),
+          filters: mockGalleryFilters,
+          onFiltersChange: jest.fn()
+        })}
+        {renderers.used({ selected: null, onPick: jest.fn(), filters: mockUsedFilters, onFiltersChange: jest.fn() })}
       </>
     );
 
@@ -161,9 +182,14 @@ describe('MediaModal', () => {
 
     const views = (
       <>
-        {renderers.gallery({ selected: null, onPick: jest.fn() })}
+        {renderers.gallery({
+          selected: null,
+          onPick: jest.fn(),
+          filters: mockGalleryFilters,
+          onFiltersChange: jest.fn()
+        })}
         {renderers.upload({ selected: null, onPick: jest.fn() })}
-        {renderers.used({ selected: null, onPick: jest.fn() })}
+        {renderers.used({ selected: null, onPick: jest.fn(), filters: mockUsedFilters, onFiltersChange: jest.fn() })}
       </>
     );
 

--- a/app/shared/components/media-modal/flow/MediaModalFlow.tsx
+++ b/app/shared/components/media-modal/flow/MediaModalFlow.tsx
@@ -14,7 +14,7 @@ import type {
   MediaModalTab,
   SelectedMedia
 } from '../MediaModal.types';
-import { buildInitialState, isSameCrop, reducer } from './MediaModalFlowState';
+import { buildInitialState, GalleryFilters, isSameCrop, reducer, UsedFilters } from './MediaModalFlowState';
 import { useMediaModalApply } from './useMediaModalApply';
 import ArrowLeftIcon from '~/public/icons/arrowLeft.svg';
 import IterationIcon from '~/public/icons/iteration.svg';
@@ -107,6 +107,14 @@ export function MediaModalFlow({ open, onClose, onApply, initial, renderers }: R
     [clearApplyError, isApplying]
   );
 
+  const handleGalleryFiltersChange = useCallback((filters: Partial<GalleryFilters>) => {
+    dispatch({ type: 'SET_GALLERY_FILTERS', filters });
+  }, []);
+
+  const handleUsedFiltersChange = useCallback((filters: Partial<UsedFilters>) => {
+    dispatch({ type: 'SET_USED_FILTERS', filters });
+  }, []);
+
   const handleApply = useCallback(() => {
     if (!state.selected) return;
     if (isApplying) return;
@@ -187,7 +195,9 @@ export function MediaModalFlow({ open, onClose, onApply, initial, renderers }: R
     if (state.tab === 'GALLERY') {
       return renderers.gallery({
         selected: state.selected?.kind === 'gallery' ? state.selected : null,
-        onPick: pickAndCrop
+        onPick: pickAndCrop,
+        filters: state.filters.gallery,
+        onFiltersChange: handleGalleryFiltersChange
       });
     }
 
@@ -200,7 +210,9 @@ export function MediaModalFlow({ open, onClose, onApply, initial, renderers }: R
 
     return renderers.used({
       selected: state.selected?.kind === 'used' ? state.selected : null,
-      onPick: pickAndCrop
+      onPick: pickAndCrop,
+      filters: state.filters.used,
+      onFiltersChange: handleUsedFiltersChange
     });
   };
 

--- a/app/shared/components/media-modal/flow/MediaModalFlowState.ts
+++ b/app/shared/components/media-modal/flow/MediaModalFlowState.ts
@@ -6,6 +6,22 @@ import type {
   SelectedMedia
 } from '../MediaModal.types';
 
+export type GalleryFilters = {
+  search: string;
+  favorites: string;
+  usage: string;
+};
+
+export type UsedFilters = {
+  search: string;
+  language: string;
+};
+
+export type TabFilters = {
+  gallery: GalleryFilters;
+  used: UsedFilters;
+};
+
 export type State = {
   tab: MediaModalTab;
   step: MediaModalStep;
@@ -13,6 +29,7 @@ export type State = {
   crop: CropResult | null;
   baselineCrop: CropResult | null;
   resetSeq: number;
+  filters: TabFilters;
 };
 
 export type Action =
@@ -22,7 +39,9 @@ export type Action =
   | { type: 'BACK' }
   | { type: 'RESET_CROP' }
   | { type: 'SET_BASELINE_CROP'; crop: CropResult | null }
-  | { type: 'SET_CROP'; crop: CropResult | null };
+  | { type: 'SET_CROP'; crop: CropResult | null }
+  | { type: 'SET_GALLERY_FILTERS'; filters: Partial<GalleryFilters> }
+  | { type: 'SET_USED_FILTERS'; filters: Partial<UsedFilters> };
 
 export const tabFromSelected = (s: SelectedMedia | null): MediaModalTab | null => {
   if (!s) return null;
@@ -55,7 +74,11 @@ export const buildInitialState = (initial?: MediaModalOpenState): State => {
     selected: initialSelected,
     crop,
     baselineCrop: crop,
-    resetSeq: 0
+    resetSeq: 0,
+    filters: {
+      gallery: { search: '', favorites: '', usage: '' },
+      used: { search: '', language: '' }
+    }
   };
 };
 
@@ -114,7 +137,23 @@ const handlers = {
 
   SET_BASELINE_CROP: (state, action) => setBaselineCrop(state, action.crop),
 
-  SET_CROP: (state, action) => (isSameCrop(state.crop, action.crop) ? state : { ...state, crop: action.crop })
+  SET_CROP: (state, action) => (isSameCrop(state.crop, action.crop) ? state : { ...state, crop: action.crop }),
+
+  SET_GALLERY_FILTERS: (state, action) => ({
+    ...state,
+    filters: {
+      ...state.filters,
+      gallery: { ...state.filters.gallery, ...action.filters }
+    }
+  }),
+
+  SET_USED_FILTERS: (state, action) => ({
+    ...state,
+    filters: {
+      ...state.filters,
+      used: { ...state.filters.used, ...action.filters }
+    }
+  })
 } satisfies {
   [K in Action['type']]: ActionHandler<K>;
 };

--- a/app/shared/components/media-modal/test-utils/sharedMocks.tsx
+++ b/app/shared/components/media-modal/test-utils/sharedMocks.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+export const MockSearchButton = ({
+  value,
+  onSearch,
+  testId
+}: {
+  value: string;
+  onSearch: (v: string) => void;
+  testId: string;
+}) => <input data-testid={testId} value={value} onChange={(e) => onSearch(e.target.value)} placeholder="Search" />;
+
+export const MockFilterDropdown = ({
+  label,
+  value,
+  onChange,
+  testId
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  testId: string;
+}) => (
+  <select data-testid={testId} value={value} onChange={(e) => onChange(e.target.value)}>
+    <option value="">{label}</option>
+  </select>
+);
+
+export const MockMediaGrid = ({
+  items,
+  renderCard
+}: {
+  items: unknown[];
+  renderCard: (item: unknown, index?: number) => React.ReactNode;
+}) => (
+  <div data-testid="mocked-media-grid" role="grid">
+    {items.map((item: unknown, index: number) => (
+      <div key={(item as { _id: string })._id}>{renderCard(item, index)}</div>
+    ))}
+  </div>
+);

--- a/app/shared/components/media-modal/views/gallery-view/GalleryView.test.tsx
+++ b/app/shared/components/media-modal/views/gallery-view/GalleryView.test.tsx
@@ -37,39 +37,56 @@ jest.mock('../../components/gallery-card/GalleryCard', () => ({
 
 describe('GalleryView', () => {
   const mockOnPick = jest.fn();
+  const mockOnFiltersChange = jest.fn();
+  const mockFilters = {
+    search: '',
+    favorites: '',
+    usage: ''
+  };
 
   beforeEach(() => {
     mockOnPick.mockClear();
+    mockOnFiltersChange.mockClear();
   });
 
   it('should render gallery view with title', () => {
-    render(<GalleryView selected={null} onPick={mockOnPick} />);
+    render(
+      <GalleryView selected={null} onPick={mockOnPick} filters={mockFilters} onFiltersChange={mockOnFiltersChange} />
+    );
 
     expect(screen.getByText('Усі зображення')).toBeInTheDocument();
   });
 
   it('should render search button', () => {
-    render(<GalleryView selected={null} onPick={mockOnPick} />);
+    render(
+      <GalleryView selected={null} onPick={mockOnPick} filters={mockFilters} onFiltersChange={mockOnFiltersChange} />
+    );
 
     expect(screen.getByTestId('GalleryView-search')).toBeInTheDocument();
   });
 
   it('should render filter dropdowns', () => {
-    render(<GalleryView selected={null} onPick={mockOnPick} />);
+    render(
+      <GalleryView selected={null} onPick={mockOnPick} filters={mockFilters} onFiltersChange={mockOnFiltersChange} />
+    );
 
     expect(screen.getByTestId('GalleryView-favoritesFilter')).toBeInTheDocument();
     expect(screen.getByTestId('GalleryView-usageFilter')).toBeInTheDocument();
   });
 
   it('should render media grid with mock assets', () => {
-    render(<GalleryView selected={null} onPick={mockOnPick} />);
+    render(
+      <GalleryView selected={null} onPick={mockOnPick} filters={mockFilters} onFiltersChange={mockOnFiltersChange} />
+    );
 
     expect(screen.getByTestId('mocked-media-grid')).toBeInTheDocument();
   });
 
   it('should call onPick when card is clicked', async () => {
     const user = userEvent.setup();
-    render(<GalleryView selected={null} onPick={mockOnPick} />);
+    render(
+      <GalleryView selected={null} onPick={mockOnPick} filters={mockFilters} onFiltersChange={mockOnFiltersChange} />
+    );
 
     const firstCard = screen.getByText('piano-studio.jpg');
     await user.click(firstCard);
@@ -83,18 +100,22 @@ describe('GalleryView', () => {
     );
   });
 
-  it('should update search value when typing', async () => {
+  it('should call onFiltersChange when typing in search', async () => {
     const user = userEvent.setup();
-    render(<GalleryView selected={null} onPick={mockOnPick} />);
+    render(
+      <GalleryView selected={null} onPick={mockOnPick} filters={mockFilters} onFiltersChange={mockOnFiltersChange} />
+    );
 
     const searchInput = screen.getByTestId('GalleryView-search');
-    await user.type(searchInput, 'test search');
+    await user.type(searchInput, 'a');
 
-    expect(searchInput).toHaveValue('test search');
+    expect(mockOnFiltersChange).toHaveBeenCalledWith({ search: 'a' });
   });
 
   it('should render multiple gallery cards', () => {
-    render(<GalleryView selected={null} onPick={mockOnPick} />);
+    render(
+      <GalleryView selected={null} onPick={mockOnPick} filters={mockFilters} onFiltersChange={mockOnFiltersChange} />
+    );
 
     expect(screen.getByText('piano-studio.jpg')).toBeInTheDocument();
     expect(screen.getByText('composer-portrait.jpg')).toBeInTheDocument();
@@ -103,7 +124,9 @@ describe('GalleryView', () => {
 
   it('should handle multiple card clicks', async () => {
     const user = userEvent.setup();
-    render(<GalleryView selected={null} onPick={mockOnPick} />);
+    render(
+      <GalleryView selected={null} onPick={mockOnPick} filters={mockFilters} onFiltersChange={mockOnFiltersChange} />
+    );
 
     const firstCard = screen.getByText('piano-studio.jpg');
     const secondCard = screen.getByText('composer-portrait.jpg');
@@ -114,14 +137,21 @@ describe('GalleryView', () => {
     expect(mockOnPick).toHaveBeenCalledTimes(2);
   });
 
-  it('should clear search value', async () => {
+  it('should call onFiltersChange when clearing search', async () => {
     const user = userEvent.setup();
-    render(<GalleryView selected={null} onPick={mockOnPick} />);
+    const filtersWithSearch = { search: 'test', favorites: '', usage: '' };
+    render(
+      <GalleryView
+        selected={null}
+        onPick={mockOnPick}
+        filters={filtersWithSearch}
+        onFiltersChange={mockOnFiltersChange}
+      />
+    );
 
     const searchInput = screen.getByTestId('GalleryView-search');
-    await user.type(searchInput, 'test');
     await user.clear(searchInput);
 
-    expect(searchInput).toHaveValue('');
+    expect(mockOnFiltersChange).toHaveBeenCalledWith({ search: '' });
   });
 });

--- a/app/shared/components/media-modal/views/gallery-view/GalleryView.test.tsx
+++ b/app/shared/components/media-modal/views/gallery-view/GalleryView.test.tsx
@@ -1,46 +1,19 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { MockFilterDropdown, MockMediaGrid, MockSearchButton } from '../../test-utils/sharedMocks';
 import { GalleryView } from './GalleryView';
 
 jest.mock('../../components/search-button/SearchButton', () => ({
-  SearchButton: ({ value, onSearch, testId }: { value: string; onSearch: (v: string) => void; testId: string }) => (
-    <input data-testid={testId} value={value} onChange={(e) => onSearch(e.target.value)} placeholder="Search" />
-  )
+  SearchButton: MockSearchButton
 }));
 
 jest.mock('../../components/filter-dropdown/FilterDropdown', () => ({
-  FilterDropdown: ({
-    label,
-    value,
-    onChange,
-    testId
-  }: {
-    label: string;
-    value: string;
-    onChange: (v: string) => void;
-    testId: string;
-  }) => (
-    <select data-testid={testId} value={value} onChange={(e) => onChange(e.target.value)}>
-      <option value="">{label}</option>
-    </select>
-  )
+  FilterDropdown: MockFilterDropdown
 }));
 
 jest.mock('../../components/media-grid/MediaGrid', () => ({
-  MediaGrid: ({
-    items,
-    renderCard
-  }: {
-    items: unknown[];
-    renderCard: (item: unknown, index: number) => React.ReactNode;
-  }) => (
-    <div data-testid="mocked-media-grid" role="grid">
-      {items.map((item: unknown, index: number) => (
-        <div key={(item as { _id: string })._id}>{renderCard(item, index)}</div>
-      ))}
-    </div>
-  )
+  MediaGrid: MockMediaGrid
 }));
 
 jest.mock('../../components/gallery-card/GalleryCard', () => ({

--- a/app/shared/components/media-modal/views/gallery-view/GalleryView.test.tsx
+++ b/app/shared/components/media-modal/views/gallery-view/GalleryView.test.tsx
@@ -4,13 +4,23 @@ import userEvent from '@testing-library/user-event';
 import { GalleryView } from './GalleryView';
 
 jest.mock('../../components/search-button/SearchButton', () => ({
-  SearchButton: ({ value, onSearch, testId }: any) => (
+  SearchButton: ({ value, onSearch, testId }: { value: string; onSearch: (v: string) => void; testId: string }) => (
     <input data-testid={testId} value={value} onChange={(e) => onSearch(e.target.value)} placeholder="Search" />
   )
 }));
 
 jest.mock('../../components/filter-dropdown/FilterDropdown', () => ({
-  FilterDropdown: ({ label, value, onChange, testId }: any) => (
+  FilterDropdown: ({
+    label,
+    value,
+    onChange,
+    testId
+  }: {
+    label: string;
+    value: string;
+    onChange: (v: string) => void;
+    testId: string;
+  }) => (
     <select data-testid={testId} value={value} onChange={(e) => onChange(e.target.value)}>
       <option value="">{label}</option>
     </select>
@@ -18,17 +28,23 @@ jest.mock('../../components/filter-dropdown/FilterDropdown', () => ({
 }));
 
 jest.mock('../../components/media-grid/MediaGrid', () => ({
-  MediaGrid: ({ items, renderCard }: any) => (
+  MediaGrid: ({
+    items,
+    renderCard
+  }: {
+    items: unknown[];
+    renderCard: (item: unknown, index: number) => React.ReactNode;
+  }) => (
     <div data-testid="mocked-media-grid" role="grid">
-      {items.map((item: any, index: number) => (
-        <div key={item._id}>{renderCard(item, index)}</div>
+      {items.map((item: unknown, index: number) => (
+        <div key={(item as { _id: string })._id}>{renderCard(item, index)}</div>
       ))}
     </div>
   )
 }));
 
 jest.mock('../../components/gallery-card/GalleryCard', () => ({
-  GalleryCard: ({ fileName, onClick, testId }: any) => (
+  GalleryCard: ({ fileName, onClick, testId }: { fileName: string; onClick: () => void; testId: string }) => (
     <button data-testid={testId} onClick={onClick}>
       {fileName}
     </button>

--- a/app/shared/components/media-modal/views/gallery-view/GalleryView.tsx
+++ b/app/shared/components/media-modal/views/gallery-view/GalleryView.tsx
@@ -123,10 +123,6 @@ export function GalleryView({ selected: _selected, onPick, filters, onFiltersCha
     onPick(galleryMedia);
   };
 
-  // const [searchValue, setSearchValue] = useState('');
-  // const debouncedSearchValue = useDebounce(searchValue, 200);
-  // const [favoritesFilter, setFavoritesFilter] = useState('');
-  // const [usageFilter, setUsageFilter] = useState('');
   const debouncedSearchValue = useDebounce(filters.search, 200);
 
   const filteredAndSortedAssets = useMemo(

--- a/app/shared/components/media-modal/views/gallery-view/GalleryView.tsx
+++ b/app/shared/components/media-modal/views/gallery-view/GalleryView.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import { Box } from '@mui/material';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 import { FilterDropdown } from '../../components/filter-dropdown/FilterDropdown';
 import { GalleryCard } from '../../components/gallery-card/GalleryCard';
 import { MediaGrid } from '../../components/media-grid/MediaGrid';
 import { SearchButton } from '../../components/search-button/SearchButton';
+import type { GalleryFilters } from '../../flow/MediaModalFlowState';
 import type { GalleryMedia } from '../../MediaModal.types';
 import { sharedViewStyles } from '../shared-view.styles';
 import { useDebounce } from '~/hooks/use-debounce/useDebounce';
@@ -15,6 +16,8 @@ import { matchesSearch, sortByDateAndName } from '~/lib/utils/filterHelpers';
 type Props = Readonly<{
   selected: GalleryMedia | null;
   onPick: (selected: GalleryMedia) => void;
+  filters: GalleryFilters;
+  onFiltersChange: (filters: Partial<GalleryFilters>) => void;
 }>;
 
 type MockAsset = {
@@ -107,7 +110,7 @@ const matchesUsageFilter = (asset: MockAsset, filter: string): boolean => {
   return asset.tags.includes(filter as MockAsset['tags'][number]);
 };
 
-export function GalleryView({ selected: _selected, onPick }: Props) {
+export function GalleryView({ selected: _selected, onPick, filters, onFiltersChange }: Props) {
   const handleCardClick = (asset: MockAsset) => {
     const galleryMedia: GalleryMedia = {
       kind: 'gallery',
@@ -120,10 +123,11 @@ export function GalleryView({ selected: _selected, onPick }: Props) {
     onPick(galleryMedia);
   };
 
-  const [searchValue, setSearchValue] = useState('');
-  const debouncedSearchValue = useDebounce(searchValue, 200);
-  const [favoritesFilter, setFavoritesFilter] = useState('');
-  const [usageFilter, setUsageFilter] = useState('');
+  // const [searchValue, setSearchValue] = useState('');
+  // const debouncedSearchValue = useDebounce(searchValue, 200);
+  // const [favoritesFilter, setFavoritesFilter] = useState('');
+  // const [usageFilter, setUsageFilter] = useState('');
+  const debouncedSearchValue = useDebounce(filters.search, 200);
 
   const filteredAndSortedAssets = useMemo(
     () =>
@@ -131,12 +135,12 @@ export function GalleryView({ selected: _selected, onPick }: Props) {
         mockAssets.filter((asset) => {
           return (
             matchesSearch(asset, debouncedSearchValue, ['filename']) &&
-            matchesFavoritesFilter(asset, favoritesFilter) &&
-            matchesUsageFilter(asset, usageFilter)
+            matchesFavoritesFilter(asset, filters.favorites) &&
+            matchesUsageFilter(asset, filters.usage)
           );
         })
       ),
-    [debouncedSearchValue, favoritesFilter, usageFilter]
+    [debouncedSearchValue, filters.favorites, filters.usage]
   );
 
   return (
@@ -146,25 +150,25 @@ export function GalleryView({ selected: _selected, onPick }: Props) {
 
         <Box sx={sharedViewStyles.controlsGroup}>
           <SearchButton
-            value={searchValue}
-            onSearch={setSearchValue}
+            value={filters.search}
+            onSearch={(search) => onFiltersChange({ search })}
             placeholder="Пошук..."
             testId="GalleryView-search"
           />
 
           <FilterDropdown
             label="Позначення"
-            value={favoritesFilter}
+            value={filters.favorites}
             options={favoritesFilterOptions}
-            onChange={setFavoritesFilter}
+            onChange={(favorites) => onFiltersChange({ favorites })}
             testId="GalleryView-favoritesFilter"
           />
 
           <FilterDropdown
             label="Використання"
-            value={usageFilter}
+            value={filters.usage}
             options={usageFilterOptions}
-            onChange={setUsageFilter}
+            onChange={(usage) => onFiltersChange({ usage })}
             testId="GalleryView-usageFilter"
           />
         </Box>

--- a/app/shared/components/media-modal/views/used-view/UsedView.test.tsx
+++ b/app/shared/components/media-modal/views/used-view/UsedView.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { MockFilterDropdown, MockMediaGrid, MockSearchButton } from '../../test-utils/sharedMocks';
 import { UsedView } from './UsedView';
 
 jest.mock('../../components/used-card/UsedCard', () => ({
@@ -11,38 +12,16 @@ jest.mock('../../components/used-card/UsedCard', () => ({
   )
 }));
 
-jest.mock('../../components/media-grid/MediaGrid', () => ({
-  MediaGrid: ({ items, renderCard }: { items: unknown[]; renderCard: (item: unknown) => React.ReactNode }) => (
-    <div data-testid="mocked-media-grid" role="grid">
-      {items.map((item: unknown) => (
-        <div key={(item as { _id: string })._id}>{renderCard(item)}</div>
-      ))}
-    </div>
-  )
-}));
-
 jest.mock('../../components/search-button/SearchButton', () => ({
-  SearchButton: ({ value, onSearch, testId }: { value: string; onSearch: (v: string) => void; testId: string }) => (
-    <input data-testid={testId} value={value} onChange={(e) => onSearch(e.target.value)} placeholder="Search" />
-  )
+  SearchButton: MockSearchButton
 }));
 
 jest.mock('../../components/filter-dropdown/FilterDropdown', () => ({
-  FilterDropdown: ({
-    label,
-    value,
-    onChange,
-    testId
-  }: {
-    label: string;
-    value: string;
-    onChange: (v: string) => void;
-    testId: string;
-  }) => (
-    <select data-testid={testId} value={value} onChange={(e) => onChange(e.target.value)}>
-      <option value="">{label}</option>
-    </select>
-  )
+  FilterDropdown: MockFilterDropdown
+}));
+
+jest.mock('../../components/media-grid/MediaGrid', () => ({
+  MediaGrid: MockMediaGrid
 }));
 
 describe('UsedView', () => {

--- a/app/shared/components/media-modal/views/used-view/UsedView.test.tsx
+++ b/app/shared/components/media-modal/views/used-view/UsedView.test.tsx
@@ -37,31 +37,45 @@ jest.mock('../../components/filter-dropdown/FilterDropdown', () => ({
 
 describe('UsedView', () => {
   const mockOnPick = jest.fn();
+  const mockOnFiltersChange = jest.fn();
+  const mockFilters = {
+    search: '',
+    language: ''
+  };
 
   beforeEach(() => {
     mockOnPick.mockClear();
+    mockOnFiltersChange.mockClear();
   });
 
   it('should render used view component', () => {
-    render(<UsedView selected={null} onPick={mockOnPick} />);
+    render(
+      <UsedView selected={null} onPick={mockOnPick} filters={mockFilters} onFiltersChange={mockOnFiltersChange} />
+    );
 
     expect(screen.getByTestId('UsedView')).toBeInTheDocument();
   });
 
   it('should render title', () => {
-    render(<UsedView selected={null} onPick={mockOnPick} />);
+    render(
+      <UsedView selected={null} onPick={mockOnPick} filters={mockFilters} onFiltersChange={mockOnFiltersChange} />
+    );
 
     expect(screen.getByText('Зображення на сторінці')).toBeInTheDocument();
   });
 
   it('should render media grid', () => {
-    render(<UsedView selected={null} onPick={mockOnPick} />);
+    render(
+      <UsedView selected={null} onPick={mockOnPick} filters={mockFilters} onFiltersChange={mockOnFiltersChange} />
+    );
 
     expect(screen.getByTestId('mocked-media-grid')).toBeInTheDocument();
   });
 
   it('should render multiple used cards', () => {
-    render(<UsedView selected={null} onPick={mockOnPick} />);
+    render(
+      <UsedView selected={null} onPick={mockOnPick} filters={mockFilters} onFiltersChange={mockOnFiltersChange} />
+    );
 
     const pianoCards = screen.getAllByText('piano-studio.jpg');
     const composerCards = screen.getAllByText('composer-portrait.jpg');
@@ -72,7 +86,9 @@ describe('UsedView', () => {
 
   it('should call onPick when card is clicked', async () => {
     const user = userEvent.setup();
-    render(<UsedView selected={null} onPick={mockOnPick} />);
+    render(
+      <UsedView selected={null} onPick={mockOnPick} filters={mockFilters} onFiltersChange={mockOnFiltersChange} />
+    );
 
     const firstCard = screen.getByText('2025-01-10-newest.jpg');
     await user.click(firstCard);

--- a/app/shared/components/media-modal/views/used-view/UsedView.test.tsx
+++ b/app/shared/components/media-modal/views/used-view/UsedView.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { UsedView } from './UsedView';
 
 jest.mock('../../components/used-card/UsedCard', () => ({
-  UsedCard: ({ fileName, onClick, testId }: any) => (
+  UsedCard: ({ fileName, onClick, testId }: { fileName: string; onClick: () => void; testId: string }) => (
     <button data-testid={testId} onClick={onClick}>
       {fileName}
     </button>
@@ -12,23 +12,33 @@ jest.mock('../../components/used-card/UsedCard', () => ({
 }));
 
 jest.mock('../../components/media-grid/MediaGrid', () => ({
-  MediaGrid: ({ items, renderCard }: any) => (
+  MediaGrid: ({ items, renderCard }: { items: unknown[]; renderCard: (item: unknown) => React.ReactNode }) => (
     <div data-testid="mocked-media-grid" role="grid">
-      {items.map((item: any) => (
-        <div key={item._id}>{renderCard(item)}</div>
+      {items.map((item: unknown) => (
+        <div key={(item as { _id: string })._id}>{renderCard(item)}</div>
       ))}
     </div>
   )
 }));
 
 jest.mock('../../components/search-button/SearchButton', () => ({
-  SearchButton: ({ value, onSearch, testId }: any) => (
+  SearchButton: ({ value, onSearch, testId }: { value: string; onSearch: (v: string) => void; testId: string }) => (
     <input data-testid={testId} value={value} onChange={(e) => onSearch(e.target.value)} placeholder="Search" />
   )
 }));
 
 jest.mock('../../components/filter-dropdown/FilterDropdown', () => ({
-  FilterDropdown: ({ label, value, onChange, testId }: any) => (
+  FilterDropdown: ({
+    label,
+    value,
+    onChange,
+    testId
+  }: {
+    label: string;
+    value: string;
+    onChange: (v: string) => void;
+    testId: string;
+  }) => (
     <select data-testid={testId} value={value} onChange={(e) => onChange(e.target.value)}>
       <option value="">{label}</option>
     </select>

--- a/app/shared/components/media-modal/views/used-view/UsedView.tsx
+++ b/app/shared/components/media-modal/views/used-view/UsedView.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import { Box } from '@mui/material';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 import { FilterDropdown } from '../../components/filter-dropdown/FilterDropdown';
 import { MediaGrid } from '../../components/media-grid/MediaGrid';
 import { SearchButton } from '../../components/search-button/SearchButton';
 import { UsedCard } from '../../components/used-card/UsedCard';
+import type { UsedFilters } from '../../flow/MediaModalFlowState';
 import type { UsedMedia } from '../../MediaModal.types';
 import { sharedViewStyles } from '../shared-view.styles';
 import { useDebounce } from '~/hooks/use-debounce/useDebounce';
@@ -15,6 +16,8 @@ import { matchesSearch, sortByDateAndName } from '~/lib/utils/filterHelpers';
 type Props = Readonly<{
   selected: UsedMedia | null;
   onPick: (selected: UsedMedia) => void;
+  filters: UsedFilters;
+  onFiltersChange: (filters: Partial<UsedFilters>) => void;
 }>;
 
 type MockUsedAsset = {
@@ -61,10 +64,11 @@ const languageFilterOptions = [
   { value: 'en', label: 'English' }
 ];
 
-export function UsedView({ onPick }: Props) {
-  const [searchValue, setSearchValue] = useState('');
-  const debouncedSearchValue = useDebounce(searchValue, 200);
-  const [languageFilter, setLanguageFilter] = useState('');
+export function UsedView({ onPick, filters, onFiltersChange }: Props) {
+  // const [searchValue, setSearchValue] = useState('');
+  // const debouncedSearchValue = useDebounce(searchValue, 200);
+  // const [languageFilter, setLanguageFilter] = useState('');
+  const debouncedSearchValue = useDebounce(filters.search, 200);
 
   const handleCardClick = (asset: MockUsedAsset) => {
     const usedMedia: UsedMedia = {
@@ -86,14 +90,14 @@ export function UsedView({ onPick }: Props) {
             return false;
           }
 
-          if (languageFilter && asset.locale !== languageFilter) {
+          if (filters.language && asset.locale !== filters.language) {
             return false;
           }
 
           return true;
         })
       ),
-    [debouncedSearchValue, languageFilter]
+    [debouncedSearchValue, filters.language]
   );
 
   return (
@@ -102,13 +106,17 @@ export function UsedView({ onPick }: Props) {
         <Box sx={sharedViewStyles.title}>Зображення на сторінці</Box>
 
         <Box sx={sharedViewStyles.controlsGroup}>
-          <SearchButton value={searchValue} onSearch={setSearchValue} placeholder="Пошук..." testId="UsedView-search" />
-
+          <SearchButton
+            value={filters.search}
+            onSearch={(search) => onFiltersChange({ search })}
+            placeholder="Пошук..."
+            testId="UsedView-search"
+          />
           <FilterDropdown
             label="Мова"
-            value={languageFilter}
+            value={filters.language}
             options={languageFilterOptions}
-            onChange={setLanguageFilter}
+            onChange={(language) => onFiltersChange({ language })}
             testId="UsedView-languageFilter"
           />
         </Box>

--- a/app/shared/components/media-modal/views/used-view/UsedView.tsx
+++ b/app/shared/components/media-modal/views/used-view/UsedView.tsx
@@ -65,9 +65,6 @@ const languageFilterOptions = [
 ];
 
 export function UsedView({ onPick, filters, onFiltersChange }: Props) {
-  // const [searchValue, setSearchValue] = useState('');
-  // const debouncedSearchValue = useDebounce(searchValue, 200);
-  // const [languageFilter, setLanguageFilter] = useState('');
   const debouncedSearchValue = useDebounce(filters.search, 200);
 
   const handleCardClick = (asset: MockUsedAsset) => {


### PR DESCRIPTION
## Description

When users applied filters or entered a search query in the Gallery or Used tabs, switching to another tab (e.g., Upload) and returning would reset all selections. This forced users to re-enter their search criteria every time they switched tabs.
Implemented the "Lift State Up" pattern by moving filter and search state from individual view components (GalleryView, UsedView) to the parent MediaModalFlow component. This ensures state persists across tab changes while the modal is open.

## Type of change

- [x] New feature

### State Management:

**Added new types in `MediaModalFlowState.ts`:**
- `GalleryFilters` - search, favorites, usage filters
- `UsedFilters` - search, language filters
- `TabFilters` - combines filters for all tabs
- Added `filters: TabFilters` to State type

**Added new actions:**
- `SET_GALLERY_FILTERS` - update Gallery tab filters
- `SET_USED_FILTERS` - update Used tab filters

**Updated reducer:**
- Initialize filters with empty values in `buildInitialState`
- Preserve filters through state spread in `toSelectState` and `toCropState`
- Added handlers for new filter actions

## How to test

1. Go to `http://localhost:3000/about-us` -> `Фундація Лятошинського` -> `Змінити зображення` button
2. **Open Media Modal** (Gallery tab)
3. **Apply filters:**
   - Enter "piano" in search
   - Select "Із зірочкою" (Favorites filter)
   - Select "Опуси" (Usage filter)
4. **Switch to Upload tab**
5. **Return to Gallery tab**
6. **Verify:** All filters and search should be preserved

7. **Switch to Used tab**
8. **Apply filters:**
   - Enter "portrait" in search
   - Select "Українська" (Language filter)
9. **Switch to Gallery tab**
10. **Return to Used tab**
11. **Verify:** Search and language filter should be preserved

12. **Test multiple tab switches:**
    - Gallery → Used → Upload → Gallery → Used
    - Each tab should maintain its own independent filter state

## Video / Screenshots


https://github.com/user-attachments/assets/a66bda7f-6b6f-4880-856f-b22d7872f48f



## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
