### PR TITLE
feat: create image crop

### DIFF
--- a/app/shared/components/media-modal/views/crop-view/CropView.test.tsx
+++ b/app/shared/components/media-modal/views/crop-view/CropView.test.tsx
@@ -1,135 +1,155 @@
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { fireEvent, render, screen } from '@testing-library/react';
 
+import { SelectedMedia } from '../../MediaModal.types';
 import { CropView } from './CropView';
 
-jest.mock('~/shared/components/design-system/button/Button', () => ({
+beforeAll(() => {
+  global.URL.createObjectURL = jest.fn(() => 'blob:test-url');
+  global.URL.revokeObjectURL = jest.fn();
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+jest.mock('react-image-crop', () => ({
   __esModule: true,
-  default: ({ label, onClick, ...props }: any) => (
-    <button onClick={onClick} {...props}>
-      {label}
-    </button>
+  default: ({ children, onChange, onComplete }: any) => (
+    <div data-testid="mock-react-crop">
+      {children}
+      <button
+        data-testid="trigger-change"
+        onClick={() => onChange({ x: 10, y: 10, width: 50, height: 50, unit: 'px' })}
+      >
+        Trigger Change
+      </button>
+      <button
+        data-testid="trigger-complete"
+        onClick={() => onComplete({ x: 20, y: 20, width: 100, height: 100, unit: 'px' })}
+      >
+        Trigger Complete
+      </button>
+    </div>
   )
 }));
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: ({ alt = '', ...props }: any) => <img alt={alt} {...props} />
-}));
+const defaultSelected: SelectedMedia = {
+  kind: 'gallery',
+  id: '1',
+  fileName: 'test.jpg',
+  src: '/test.jpg',
+  locale: 'uk'
+};
 
 describe('CropView', () => {
-  const mockOnChange = jest.fn();
-  const mockOnBaseline = jest.fn();
-
-  beforeEach(() => {
-    mockOnChange.mockClear();
-    mockOnBaseline.mockClear();
-  });
-
-  it('should render crop view component', () => {
+  it('should render CropView container', () => {
     render(
-      <CropView
-        selected={{ kind: 'gallery', id: '1', fileName: 'test.jpg', src: '/test.jpg', locale: 'uk' }}
-        crop={null}
-        onChange={mockOnChange}
-        onBaseline={mockOnBaseline}
-        resetSeq={0}
-      />
+      <CropView selected={defaultSelected} crop={null} resetSeq={0} onBaseline={jest.fn()} onChange={jest.fn()} />
     );
-
     expect(screen.getByTestId('CropView')).toBeInTheDocument();
   });
 
-  it('should render placeholder text', () => {
+  it('should render image with correct src', () => {
     render(
-      <CropView
-        selected={{ kind: 'gallery', id: '1', fileName: 'test.jpg', src: '/test.jpg', locale: 'uk' }}
-        crop={null}
-        onChange={mockOnChange}
-        onBaseline={mockOnBaseline}
-        resetSeq={0}
-      />
+      <CropView selected={defaultSelected} crop={null} resetSeq={0} onBaseline={jest.fn()} onChange={jest.fn()} />
     );
-
-    expect(screen.getByText('Crop placeholder')).toBeInTheDocument();
+    const img = screen.getByAltText('');
+    expect(img).toHaveAttribute('src', '/test.jpg');
   });
 
-  it('should render resize button', () => {
+  it('should call onBaseline on image load', () => {
+    const onBaseline = jest.fn();
     render(
-      <CropView
-        selected={{ kind: 'gallery', id: '1', fileName: 'test.jpg', src: '/test.jpg', locale: 'uk' }}
-        crop={null}
-        onChange={mockOnChange}
-        onBaseline={mockOnBaseline}
-        resetSeq={0}
-      />
+      <CropView selected={defaultSelected} crop={null} resetSeq={0} onBaseline={onBaseline} onChange={jest.fn()} />
     );
 
-    expect(screen.getByText('Mock resize')).toBeInTheDocument();
+    const img = screen.getByAltText('');
+
+    fireEvent.load(img, {
+      currentTarget: {
+        width: 500,
+        height: 500,
+        naturalWidth: 1000,
+        naturalHeight: 1000
+      }
+    });
+
+    expect(onBaseline).toHaveBeenCalledWith({
+      rect: { x: 50, y: 50, width: 200, height: 250 }
+    });
   });
 
-  it('should call onChange when resize button clicked', async () => {
-    const user = userEvent.setup();
+  it('should update internal crop state when crop changes', () => {
     render(
-      <CropView
-        selected={{ kind: 'gallery', id: '1', fileName: 'test.jpg', src: '/test.jpg', locale: 'uk' }}
-        crop={null}
-        onChange={mockOnChange}
-        onBaseline={mockOnBaseline}
-        resetSeq={0}
-      />
+      <CropView selected={defaultSelected} crop={null} resetSeq={0} onBaseline={jest.fn()} onChange={jest.fn()} />
     );
 
-    const button = screen.getByTestId('CropView-resize');
-    await user.click(button);
-
-    expect(mockOnChange).toHaveBeenCalledWith(
-      expect.objectContaining({
-        rect: expect.objectContaining({
-          x: 24,
-          y: 18,
-          width: 160,
-          height: 220
-        })
-      })
-    );
+    const triggerChangeBtn = screen.getByTestId('trigger-change');
+    fireEvent.click(triggerChangeBtn);
   });
 
-  it('should call onBaseline on mount', () => {
-    render(
-      <CropView
-        selected={{ kind: 'gallery', id: '1', fileName: 'test.jpg', src: '/test.jpg', locale: 'uk' }}
-        crop={null}
-        onChange={mockOnChange}
-        onBaseline={mockOnBaseline}
-        resetSeq={0}
-      />
-    );
+  it('should calculate real coordinates and call onChange on complete', () => {
+    const onChange = jest.fn();
+    render(<CropView selected={defaultSelected} crop={null} resetSeq={0} onBaseline={jest.fn()} onChange={onChange} />);
 
-    expect(mockOnBaseline).toHaveBeenCalledWith(
-      expect.objectContaining({
-        rect: expect.objectContaining({
-          x: 0,
-          y: 0,
-          width: 200,
-          height: 200
-        })
-      })
-    );
+    const img = screen.getByAltText('');
+
+    Object.defineProperty(img, 'width', { value: 500, configurable: true });
+    Object.defineProperty(img, 'height', { value: 500, configurable: true });
+    Object.defineProperty(img, 'naturalWidth', { value: 1000, configurable: true });
+    Object.defineProperty(img, 'naturalHeight', { value: 1000, configurable: true });
+
+    fireEvent.load(img, {
+      currentTarget: { width: 500, height: 500, naturalWidth: 1000, naturalHeight: 1000 }
+    });
+
+    const triggerCompleteBtn = screen.getByTestId('trigger-complete');
+    fireEvent.click(triggerCompleteBtn);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith({
+      rect: {
+        x: 40,
+        y: 40,
+        width: 200,
+        height: 200
+      }
+    });
   });
 
-  it('should render with resetSeq attribute', () => {
-    render(
-      <CropView
-        selected={{ kind: 'gallery', id: '1', fileName: 'test.jpg', src: '/test.jpg', locale: 'uk' }}
-        crop={null}
-        onChange={mockOnChange}
-        onBaseline={mockOnBaseline}
-        resetSeq={5}
-      />
+  it('should create and revoke object URL when selected kind is upload', () => {
+    const file = new File(['dummy'], 'test.png', { type: 'image/png' });
+    const uploadSelected: any = {
+      kind: 'upload',
+      id: '2',
+      file: file,
+      src: '',
+      locale: 'uk'
+    };
+
+    const { unmount, rerender } = render(
+      <CropView selected={uploadSelected} crop={null} resetSeq={0} onBaseline={jest.fn()} onChange={jest.fn()} />
     );
 
-    const cropView = screen.getByTestId('CropView');
-    expect(cropView).toHaveAttribute('data-reset-seq', '5');
+    expect(global.URL.createObjectURL).toHaveBeenCalledWith(file);
+
+    rerender(
+      <CropView
+        selected={{ ...uploadSelected, file: null } as const}
+        crop={null}
+        resetSeq={0}
+        onBaseline={jest.fn()}
+        onChange={jest.fn()}
+      />
+    );
+    unmount();
+    expect(global.URL.revokeObjectURL).toHaveBeenCalled();
+  });
+
+  it('should set data-reset-seq attribute', () => {
+    render(
+      <CropView selected={defaultSelected} crop={null} resetSeq={5} onBaseline={jest.fn()} onChange={jest.fn()} />
+    );
+    expect(screen.getByTestId('CropView')).toHaveAttribute('data-reset-seq', '5');
   });
 });

--- a/app/shared/components/media-modal/views/crop-view/CropView.test.tsx
+++ b/app/shared/components/media-modal/views/crop-view/CropView.test.tsx
@@ -4,8 +4,8 @@ import { SelectedMedia } from '../../MediaModal.types';
 import { CropView } from './CropView';
 
 beforeAll(() => {
-  global.URL.createObjectURL = jest.fn(() => 'blob:test-url');
-  global.URL.revokeObjectURL = jest.fn();
+  globalThis.URL.createObjectURL = jest.fn(() => 'blob:test-url');
+  globalThis.URL.revokeObjectURL = jest.fn();
 });
 
 afterEach(() => {
@@ -131,7 +131,7 @@ describe('CropView', () => {
       <CropView selected={uploadSelected} crop={null} resetSeq={0} onBaseline={jest.fn()} onChange={jest.fn()} />
     );
 
-    expect(global.URL.createObjectURL).toHaveBeenCalledWith(file);
+    expect(globalThis.URL.createObjectURL).toHaveBeenCalledWith(file);
 
     rerender(
       <CropView
@@ -143,7 +143,7 @@ describe('CropView', () => {
       />
     );
     unmount();
-    expect(global.URL.revokeObjectURL).toHaveBeenCalled();
+    expect(globalThis.URL.revokeObjectURL).toHaveBeenCalled();
   });
 
   it('should set data-reset-seq attribute', () => {

--- a/app/shared/components/media-modal/views/crop-view/CropView.tsx
+++ b/app/shared/components/media-modal/views/crop-view/CropView.tsx
@@ -17,8 +17,7 @@ const MOCK_SERVER_DATA = {
   y: 50
 };
 
-const forCropAngle =
-  (MOCK_SERVER_DATA.width < MOCK_SERVER_DATA.height ? MOCK_SERVER_DATA.width : MOCK_SERVER_DATA.height) * 0.2;
+const forCropAngle = Math.min(MOCK_SERVER_DATA.width, MOCK_SERVER_DATA.height) * 0.2;
 
 export function CropView({ selected, resetSeq, onBaseline, onChange }: Readonly<CropRendererProps>) {
   const uploadFile = selected.kind === 'upload' ? selected.file : null;

--- a/app/shared/components/media-modal/views/crop-view/CropView.tsx
+++ b/app/shared/components/media-modal/views/crop-view/CropView.tsx
@@ -1,39 +1,41 @@
 'use client';
 
+import 'react-image-crop/dist/ReactCrop.css';
 import { Box } from '@mui/material';
-import Image from 'next/image';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import ReactCrop, { Crop, PixelCrop } from 'react-image-crop';
 
 import type { CropRendererProps } from '../../MediaModal.renderers';
-import type { CropResult } from '../../MediaModal.types';
-import Button from '~/shared/components/design-system/button/Button';
 
 const canCreateObjectUrl = () => typeof URL !== 'undefined' && typeof URL.createObjectURL === 'function';
 const canRevokeObjectUrl = () => typeof URL !== 'undefined' && typeof URL.revokeObjectURL === 'function';
 
-const initialCropForPlaceholder = (): CropResult => ({
-  rect: { x: 0, y: 0, width: 200, height: 200 }
-});
+const MOCK_SERVER_DATA = {
+  width: 200,
+  height: 250,
+  x: 50,
+  y: 50
+};
 
-const resizedCropForPlaceholder = (): CropResult => ({
-  rect: { x: 24, y: 18, width: 160, height: 220 }
-});
+const forCropAngle =
+  (MOCK_SERVER_DATA.width < MOCK_SERVER_DATA.height ? MOCK_SERVER_DATA.width : MOCK_SERVER_DATA.height) * 0.2;
 
 export function CropView({ selected, resetSeq, onBaseline, onChange }: Readonly<CropRendererProps>) {
   const uploadFile = selected.kind === 'upload' ? selected.file : null;
   const [uploadObjectUrl, setUploadObjectUrl] = useState('');
+
+  const [crop, setCrop] = useState<Crop>();
+  const imgRef = useRef<HTMLImageElement>(null);
 
   useEffect(() => {
     if (!uploadFile) {
       setUploadObjectUrl('');
       return;
     }
-
     if (!canCreateObjectUrl()) {
       setUploadObjectUrl('');
       return;
     }
-
     const url = URL.createObjectURL(uploadFile);
     setUploadObjectUrl(url);
 
@@ -52,41 +54,155 @@ export function CropView({ selected, resetSeq, onBaseline, onChange }: Readonly<
   const didInitForSelectedRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (didInitForSelectedRef.current === selected.id) return;
-    didInitForSelectedRef.current = selected.id;
+    if (didInitForSelectedRef.current !== selected.id) {
+      setCrop(undefined);
+      didInitForSelectedRef.current = selected.id;
+    }
+  }, [selected.id]);
 
-    onBaseline(initialCropForPlaceholder());
-  }, [onBaseline, selected.id]);
+  const onImageLoad = (e: React.SyntheticEvent<HTMLImageElement>) => {
+    const { width, height, naturalWidth, naturalHeight } = e.currentTarget;
+    const scaleX = width / naturalWidth;
+    const scaleY = height / naturalHeight;
+
+    const initialPixelCrop: Crop = {
+      unit: 'px',
+      x: MOCK_SERVER_DATA.x * scaleX,
+      y: MOCK_SERVER_DATA.y * scaleY,
+      width: MOCK_SERVER_DATA.width * scaleX,
+      height: MOCK_SERVER_DATA.height * scaleY
+    };
+
+    setCrop(initialPixelCrop);
+
+    onBaseline({
+      rect: {
+        x: MOCK_SERVER_DATA.x,
+        y: MOCK_SERVER_DATA.y,
+        width: MOCK_SERVER_DATA.width,
+        height: MOCK_SERVER_DATA.height
+      }
+    });
+  };
+
+  const handleCropChange = (pixelCrop: PixelCrop) => {
+    setCrop((prevCrop) => ({
+      ...pixelCrop,
+      width: prevCrop?.width || pixelCrop.width,
+      height: prevCrop?.height || pixelCrop.height
+    }));
+  };
+
+  const handleComplete = (c: PixelCrop) => {
+    if (!imgRef.current) return;
+    const image = imgRef.current;
+    const scaleX = image.naturalWidth / image.width;
+    const scaleY = image.naturalHeight / image.height;
+    onChange({
+      rect: {
+        x: c.x * scaleX,
+        y: c.y * scaleY,
+        width: c.width * scaleX,
+        height: c.height * scaleY
+      }
+    });
+  };
 
   return (
-    <Box data-testid="CropView" data-reset-seq={resetSeq} sx={{ height: '100%', display: 'grid', gap: 2 }}>
-      <Box data-testid="CropView-placeholder" sx={{ opacity: 0.7 }}>
-        Crop placeholder
-      </Box>
+    <Box
+      data-testid="CropView"
+      data-reset-seq={resetSeq}
+      sx={{
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 2,
+        overflow: 'hidden',
 
+        '& .ReactCrop__drag-handle': {
+          display: 'none !important'
+        },
+
+        '& .ReactCrop__crop-selection': {
+          animation: 'none !important',
+          backgroundImage: 'none !important',
+
+          border: '1px solid #fff',
+
+          background: `
+            linear-gradient(#fff, #fff), linear-gradient(#fff, #fff),
+            linear-gradient(#fff, #fff), linear-gradient(#fff, #fff),
+            linear-gradient(#fff, #fff), linear-gradient(#fff, #fff),
+            linear-gradient(#fff, #fff), linear-gradient(#fff, #fff)
+           !important`,
+
+          backgroundPosition: `
+            top left, top left,        
+            top right, top right,      
+            bottom left, bottom left,   
+            bottom right, bottom right 
+          !important`,
+
+          backgroundRepeat: 'no-repeat !important',
+
+          backgroundSize: `
+            ${forCropAngle}px 4px, 4px ${forCropAngle}px,  
+            ${forCropAngle}px 4px, 4px ${forCropAngle}px,  
+            ${forCropAngle}px 4px, 4px ${forCropAngle}px,  
+            ${forCropAngle}px 4px, 4px ${forCropAngle}px    
+          !important`,
+          '&::after': { display: 'none !important', content: 'none' },
+          '&::before': { display: 'none !important', content: 'none' }
+        },
+
+        '& .ReactCrop__rule-of-thirds-vt': {
+          width: '1px !important',
+          height: '100% !important'
+        },
+        '& .ReactCrop__rule-of-thirds-hz': {
+          height: '1px !important',
+          width: '100% !important'
+        }
+      }}
+    >
       {previewSrc ? (
-        <Box sx={{ width: '100%', maxWidth: 420 }}>
-          <Image
-            src={previewSrc}
-            alt=""
-            width={420}
-            height={280}
-            sizes="(max-width: 600px) 100vw, 420px"
-            style={{ width: '100%', height: 'auto', display: 'block' }}
-            unoptimized
-          />
+        <Box
+          sx={{
+            width: '100%',
+            flex: 1,
+            overflowY: 'auto',
+            overflowX: 'hidden',
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center'
+          }}
+        >
+          <ReactCrop
+            crop={crop}
+            onChange={handleCropChange}
+            onComplete={handleComplete}
+            keepSelection
+            ruleOfThirds
+            style={{
+              maxWidth: '100%',
+              display: 'block'
+            }}
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              ref={imgRef}
+              src={previewSrc}
+              alt=""
+              onLoad={onImageLoad}
+              style={{
+                maxWidth: '100%',
+                height: 'auto',
+                display: 'block'
+              }}
+            />
+          </ReactCrop>
         </Box>
       ) : null}
-
-      <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-        <Button
-          color="secondary"
-          variant="outlined"
-          label="Mock resize"
-          data-testid="CropView-resize"
-          onClick={() => onChange(resizedCropForPlaceholder())}
-        />
-      </Box>
     </Box>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19574,7 +19574,6 @@
       "version": "11.0.10",
       "resolved": "https://registry.npmjs.org/react-image-crop/-/react-image-crop-11.0.10.tgz",
       "integrity": "sha512-+5FfDXUgYLLqBh1Y/uQhIycpHCbXkI50a+nbfkB1C0xXXUTwkisHDo2QCB1SQJyHCqIuia4FeyReqXuMDKWQTQ==",
-      "license": "ISC",
       "peerDependencies": {
         "react": ">=16.13.1"
       }


### PR DESCRIPTION
## Description

In this PR was created visual image cropping that is integrated into previous written code for Modal components. User can not resize crop area, just change a position. Users can adjust the crop only within the allowed boundaries.

## Type of change

- [x] New feature

## How to test

1. Go to /about-us page.
2. Choose Liatoshynsky Foundation section.
3. Here you can click Edit or Change image as well.
4. After that just choose image or download it and here crop area should appear.

## Video / Screenshots


https://github.com/user-attachments/assets/a69e2311-2cb5-4390-8506-b34b3859557c


## Checklist

- [ ] Code compiles and runs correctly
- [ ] Tests pass successfully
- [ ] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [ ] Linked issue/task included
- [ ] Task moved to the review column on the board

---
