### PR TITLE
feat: add sticky header for Gallery and Used tabs in Media Modal

### DIFF
--- a/app/shared/components/media-modal/views/shared-view.styles.ts
+++ b/app/shared/components/media-modal/views/shared-view.styles.ts
@@ -9,9 +9,12 @@ export const sharedViewStyles = {
   } as SxProps<Theme>,
 
   header: {
+    position: 'sticky',
+    top: 0,
+    zIndex: 1,
+    paddingBottom: '24px',
     display: 'flex',
     alignItems: 'center',
-    marginBottom: '24px',
     '@media (max-width: 1023px)': {
       flexDirection: 'column',
       alignItems: 'flex-start',


### PR DESCRIPTION
## Description

Implemented sticky header for Gallery and Used tabs in Media Modal. The header with search and filters now remains fixed at the top while scrolling through media assets, keeping controls always accessible.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement

## How to test

1. Go to http://localhost:3000/about-us.
2. To open Media Modal choose `Фундація Лятошинського` and click `Змінити зображення` button.
3. Click `Gallery tab`.
4. Add more photo in `mockAssets`. Scroll down through the media grid.
5. Verify header with search and filters stays fixed at the top.
6. Switch to Used tab and repeat.
7. Test applying filters while scrolled - verify header remains accessible.

## Video / Screenshots


https://github.com/user-attachments/assets/28e673af-d528-45f3-8712-23d3814367cb


## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
