### PR TITLE
Create file cards layout template (grid and list views)

### DIFF
--- a/app/(logged_in)/archive/page.tsx
+++ b/app/(logged_in)/archive/page.tsx
@@ -1,0 +1,234 @@
+'use client';
+
+import FilterListRoundedIcon from '@mui/icons-material/FilterListRounded';
+import SearchRoundedIcon from '@mui/icons-material/SearchRounded';
+import { Box, Button, InputAdornment, OutlinedInput, Typography } from '@mui/material';
+import { useEffect, useMemo, useState } from 'react';
+
+import { ControlPanel } from '~/shared/components/control-panel';
+import { colors } from '~/shared/components/design-system/button/Button.styles';
+import {
+  type FileDetailsSidebarFile,
+  FileInfoSidebar,
+  type FileUsageLink
+} from '~/shared/components/file-info-sidebar/FileInfoSidebar';
+import { SIDEBAR_WIDTH } from '~/shared/components/file-info-sidebar/FileInfoSidebar.styles';
+import {
+  FilesCardsLayout,
+  type FilesCardsLayoutItem,
+  type FilesCardsLayoutView
+} from '~/shared/components/files-cards-layout';
+import { ViewToggle } from '~/shared/components/view-toggle';
+import { useAllAssets } from '~/shared/hooks/use-assets/useAssets';
+import { AssetType } from '~/types/graphql/generated/graphql';
+
+type ArchiveFileItem = FilesCardsLayoutItem & {
+  description?: string;
+  format?: string;
+  size?: string;
+  previewUrl?: string;
+  addedBy?: { name: string; avatarUrl?: string };
+  usage: FileUsageLink[];
+};
+
+const fileTypeMap: Record<AssetType, FilesCardsLayoutItem['type']> = {
+  [AssetType.Image]: 'image',
+  [AssetType.Pdf]: 'pdf',
+  [AssetType.Audio]: 'audio'
+};
+
+const formatDateAdded = (value: string) => {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleDateString('uk-UA');
+};
+
+const formatFileSize = (sizeBytes: number) => {
+  if (sizeBytes < 1024) {
+    return `${sizeBytes} B`;
+  }
+
+  const sizeKb = sizeBytes / 1024;
+  if (sizeKb < 1024) {
+    return `${sizeKb.toFixed(1)} KB`;
+  }
+
+  const sizeMb = sizeKb / 1024;
+  return `${sizeMb.toFixed(1)} MB`;
+};
+
+const formatFromMimeType = (mimeType: string, filename: string) => {
+  const byMime = mimeType.split('/')[1]?.toUpperCase();
+  if (byMime) return byMime;
+
+  const ext = filename.split('.').pop()?.toUpperCase();
+  return ext || undefined;
+};
+
+const usageToLink = (pageId?: string | null) => {
+  if (!pageId) {
+    return undefined;
+  }
+
+  return pageId.startsWith('/') ? pageId : `/${pageId}`;
+};
+
+export default function ArchivePage() {
+  const [view, setView] = useState<FilesCardsLayoutView>('grid');
+  const [selectedFileId, setSelectedFileId] = useState<string | null>(null);
+  const [hasInitializedSelection, setHasInitializedSelection] = useState(false);
+  const { data, loading, error } = useAllAssets();
+
+  const files = useMemo<ArchiveFileItem[]>(() => {
+    return (data?.allAssets ?? []).map((asset) => ({
+      id: asset.id,
+      type: fileTypeMap[asset.type],
+      name: asset.filename,
+      dateAdded: formatDateAdded(asset.createdAt),
+      isStarred: asset.isStarred,
+      usageLinks: asset.usageRefs.length,
+      imageSrc: asset.type === AssetType.Image ? asset.url : undefined,
+      previewUrl: asset.type === AssetType.Image ? asset.url : undefined,
+      format: formatFromMimeType(asset.mimeType, asset.filename),
+      size: formatFileSize(asset.sizeBytes),
+      addedBy: asset.createdBy ? { name: asset.createdBy } : undefined,
+      usage: asset.usageRefs.map((usageRef, index) => ({
+        id: `${asset.id}-${index}`,
+        label: usageRef.pageId ?? 'Невідомий розділ',
+        href: usageToLink(usageRef.pageId)
+      })),
+      description: asset.description ?? undefined
+    }));
+  }, [data?.allAssets]);
+
+  useEffect(() => {
+    if (!files.length) {
+      setSelectedFileId(null);
+      setHasInitializedSelection(false);
+      return;
+    }
+
+    if (!hasInitializedSelection) {
+      setSelectedFileId(files[0].id);
+      setHasInitializedSelection(true);
+      return;
+    }
+
+    if (selectedFileId && !files.some((file) => file.id === selectedFileId)) {
+      setSelectedFileId(files[0].id);
+    }
+  }, [files, hasInitializedSelection, selectedFileId]);
+
+  const selectedFile = useMemo(() => files.find((file) => file.id === selectedFileId) ?? null, [files, selectedFileId]);
+
+  const sidebarFile: FileDetailsSidebarFile | null = selectedFile
+    ? {
+      id: selectedFile.id,
+      type: selectedFile.type,
+      filename: selectedFile.name,
+      previewUrl: selectedFile.previewUrl,
+      addedBy: selectedFile.addedBy,
+      addedAt: selectedFile.dateAdded,
+      format: selectedFile.format,
+      size: selectedFile.size,
+      usageLinks: selectedFile.usage,
+      description: selectedFile.description,
+      isStarred: selectedFile.isStarred
+    }
+    : null;
+
+  return (
+    <Box
+      sx={{
+        width: '100%',
+        maxWidth: '100%',
+        minWidth: 0,
+        overflowX: 'hidden',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '24px',
+        pr: { xs: 0, md: sidebarFile ? `${SIDEBAR_WIDTH + 24}px` : 0 },
+        transition: 'padding-right 0.2s ease'
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '16px', flexWrap: 'wrap' }}>
+        <Typography variant="h4">Файли</Typography>
+      </Box>
+
+      <ControlPanel
+        leftContent={
+          <Box sx={{ width: '100%', display: 'flex', justifyContent: 'flex-start' }}>
+            <OutlinedInput
+              placeholder="Пошук"
+              disabled
+              fullWidth
+              startAdornment={
+                <InputAdornment position="start" sx={{ color: colors.blue[800] }}>
+                  <SearchRoundedIcon />
+                </InputAdornment>
+              }
+              sx={{
+                maxWidth: '456px',
+                borderRadius: '12px',
+                height: '56px',
+                bgcolor: colors.white,
+                '& .MuiOutlinedInput-notchedOutline': {
+                  borderColor: colors.blue[500]
+                },
+                '&:hover .MuiOutlinedInput-notchedOutline': {
+                  borderColor: colors.blue[600]
+                },
+                '& .MuiOutlinedInput-input': {
+                  fontSize: '24px'
+                }
+              }}
+            />
+          </Box>
+        }
+        rightContent={
+          <>
+            <Button
+              variant="outlined"
+              startIcon={<FilterListRoundedIcon />}
+              disabled
+              sx={{
+                borderRadius: '999px',
+                px: '24px',
+                py: '10px',
+                minHeight: '56px',
+                textTransform: 'none',
+                borderColor: colors.black,
+                color: colors.black,
+                bgcolor: colors.white,
+                '&:hover': {
+                  borderColor: colors.black,
+                  bgcolor: colors.blue[50]
+                }
+              }}
+            >
+              Фільтри
+            </Button>
+
+            <ViewToggle value={view} onChange={setView} />
+          </>
+        }
+      />
+
+      <FilesCardsLayout view={view} items={files} onItemClick={(item) => setSelectedFileId(item.id)} />
+
+      {loading && <Typography>Завантаження файлів…</Typography>}
+      {error && <Typography color="error">Не вдалося завантажити файли.</Typography>}
+
+      {sidebarFile && (
+        <FileInfoSidebar
+          file={sidebarFile}
+          onClose={() => setSelectedFileId(null)}
+        />
+      )}
+    </Box>
+  );
+}

--- a/app/shared/components/control-panel/ControlPanel.styles.ts
+++ b/app/shared/components/control-panel/ControlPanel.styles.ts
@@ -1,0 +1,27 @@
+import { SxProps, Theme } from '@mui/material';
+
+export const styles: Record<string, SxProps<Theme>> = {
+  root: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-start',
+    gap: '16px',
+    width: '100%',
+    flexWrap: 'nowrap'
+  },
+  left: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-start',
+    gap: '12px',
+    minWidth: 0,
+    flex: 1
+  },
+  right: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '12px',
+    marginLeft: 'auto',
+    flexShrink: 0
+  }
+};

--- a/app/shared/components/control-panel/ControlPanel.test.tsx
+++ b/app/shared/components/control-panel/ControlPanel.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+
+import { ControlPanel } from './ControlPanel';
+
+describe('ControlPanel', () => {
+  it('renders left and right content', () => {
+    render(
+      <ControlPanel
+        leftContent={<div data-testid="left-content">left</div>}
+        rightContent={<div data-testid="right-content">right</div>}
+      />
+    );
+
+    expect(screen.getByTestId('ControlPanel')).toBeInTheDocument();
+    expect(screen.getByTestId('left-content')).toBeInTheDocument();
+    expect(screen.getByTestId('right-content')).toBeInTheDocument();
+  });
+
+  it('supports custom data-testid', () => {
+    render(<ControlPanel dataTestId="CustomControlPanel" />);
+
+    expect(screen.getByTestId('CustomControlPanel')).toBeInTheDocument();
+  });
+});

--- a/app/shared/components/control-panel/ControlPanel.tsx
+++ b/app/shared/components/control-panel/ControlPanel.tsx
@@ -1,0 +1,19 @@
+import { Box, Stack } from '@mui/material';
+import type { ReactNode } from 'react';
+
+import { styles } from './ControlPanel.styles';
+
+type ControlPanelProps = Readonly<{
+  leftContent?: ReactNode;
+  rightContent?: ReactNode;
+  dataTestId?: string;
+}>;
+
+export function ControlPanel({ leftContent, rightContent, dataTestId = 'ControlPanel' }: ControlPanelProps) {
+  return (
+    <Stack direction="row" sx={styles.root} data-testid={dataTestId}>
+      <Box sx={styles.left}>{leftContent}</Box>
+      <Box sx={styles.right}>{rightContent}</Box>
+    </Stack>
+  );
+}

--- a/app/shared/components/control-panel/index.ts
+++ b/app/shared/components/control-panel/index.ts
@@ -1,0 +1,1 @@
+export * from './ControlPanel';

--- a/app/shared/components/file-card/FileCard.styles.ts
+++ b/app/shared/components/file-card/FileCard.styles.ts
@@ -2,7 +2,8 @@ import { SxProps, Theme } from '@mui/material';
 
 export const styles: Record<string, SxProps<Theme>> = {
   container: {
-    width: '301px',
+    width: '100%',
+    maxWidth: '100%',
     height: '325px',
     borderRadius: '16px',
     borderColor: '#C6C8D3',

--- a/app/shared/components/files-cards-layout/FilesCardsLayout.styles.ts
+++ b/app/shared/components/files-cards-layout/FilesCardsLayout.styles.ts
@@ -1,0 +1,42 @@
+import { SxProps, Theme } from '@mui/material';
+
+export const styles: Record<string, SxProps<Theme>> = {
+  root: {
+    width: '100%',
+    minWidth: 0
+  },
+  grid: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'stretch',
+    gap: '16px',
+    width: '100%'
+  },
+  gridItem: {
+    minWidth: 0,
+    display: 'flex',
+    flex: {
+      xs: '0 0 100%',
+      sm: '0 0 calc((100% - 16px) / 2)',
+      md: '0 0 calc((100% - 32px) / 3)',
+      xl: '0 0 calc((100% - 48px) / 4)'
+    },
+    maxWidth: {
+      xs: '100%',
+      sm: 'calc((100% - 16px) / 2)',
+      md: 'calc((100% - 32px) / 3)',
+      xl: 'calc((100% - 48px) / 4)'
+    },
+    justifyContent: 'flex-start'
+  },
+  list: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '12px',
+    width: '100%'
+  },
+  listItem: {
+    width: '100%',
+    minWidth: 0
+  }
+};

--- a/app/shared/components/files-cards-layout/FilesCardsLayout.test.tsx
+++ b/app/shared/components/files-cards-layout/FilesCardsLayout.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { FilesCardsLayout, type FilesCardsLayoutItem } from './FilesCardsLayout';
+
+jest.mock('~/shared/components/file-card', () => ({
+  __esModule: true,
+  default: ({ onClick }: { onClick?: () => void }) => (
+    <button type="button" data-testid="mock-file-card" onClick={onClick}>
+      file card
+    </button>
+  )
+}));
+
+jest.mock('~/shared/components/minimized-file-card/MinimizedFileCard', () => ({
+  __esModule: true,
+  default: ({ onClick }: { onClick?: () => void }) => (
+    <button type="button" data-testid="mock-minimized-file-card" onClick={onClick}>
+      minimized file card
+    </button>
+  )
+}));
+
+describe('FilesCardsLayout', () => {
+  const items: FilesCardsLayoutItem[] = [
+    {
+      id: '1',
+      type: 'image',
+      name: 'image-1.jpg',
+      dateAdded: '2026-03-01',
+      usageLinks: 2,
+      imageSrc: '/images/foundation-first.png'
+    },
+    {
+      id: '2',
+      type: 'pdf',
+      name: 'report.pdf',
+      dateAdded: '2026-03-02'
+    }
+  ];
+
+  it('renders standard cards in grid view', () => {
+    render(<FilesCardsLayout view="grid" items={items} />);
+
+    expect(screen.getByTestId('FilesCardsLayout-grid')).toBeInTheDocument();
+    expect(screen.getAllByTestId('mock-file-card')).toHaveLength(2);
+    expect(screen.queryByTestId('mock-minimized-file-card')).not.toBeInTheDocument();
+  });
+
+  it('renders minimized cards in list view', () => {
+    render(<FilesCardsLayout view="list" items={items} />);
+
+    expect(screen.getByTestId('FilesCardsLayout-list')).toBeInTheDocument();
+    expect(screen.getAllByTestId('mock-minimized-file-card')).toHaveLength(2);
+    expect(screen.queryByTestId('mock-file-card')).not.toBeInTheDocument();
+  });
+
+  it('calls onItemClick in grid view', () => {
+    const onItemClick = jest.fn();
+
+    render(<FilesCardsLayout view="grid" items={items} onItemClick={onItemClick} />);
+
+    fireEvent.click(screen.getAllByTestId('mock-file-card')[0]);
+
+    expect(onItemClick).toHaveBeenCalledWith(items[0]);
+  });
+
+  it('calls onItemClick in list view', () => {
+    const onItemClick = jest.fn();
+
+    render(<FilesCardsLayout view="list" items={items} onItemClick={onItemClick} />);
+
+    fireEvent.click(screen.getAllByTestId('mock-minimized-file-card')[1]);
+
+    expect(onItemClick).toHaveBeenCalledWith(items[1]);
+  });
+});

--- a/app/shared/components/files-cards-layout/FilesCardsLayout.tsx
+++ b/app/shared/components/files-cards-layout/FilesCardsLayout.tsx
@@ -1,0 +1,74 @@
+import { Box } from '@mui/material';
+
+import FileCard, { type FileType } from '../file-card';
+import MinimizedFileCard from '../minimized-file-card/MinimizedFileCard';
+import { styles } from './FilesCardsLayout.styles';
+
+export type FilesCardsLayoutView = 'grid' | 'list';
+
+export type FilesCardsLayoutItem = {
+  id: string;
+  type: FileType;
+  name: string;
+  dateAdded: string;
+  isStarred?: boolean;
+  usageLinks?: number;
+  imageSrc?: string;
+};
+
+type FilesCardsLayoutProps = Readonly<{
+  view: FilesCardsLayoutView;
+  items: FilesCardsLayoutItem[];
+  onItemClick?: (item: FilesCardsLayoutItem) => void;
+}>;
+
+const minimizedTypeMap: Record<FileType, 'img' | 'audio' | 'pdf'> = {
+  image: 'img',
+  audio: 'audio',
+  pdf: 'pdf'
+};
+
+export function FilesCardsLayout({ view, items, onItemClick }: FilesCardsLayoutProps) {
+  if (view === 'list') {
+    return (
+      <Box sx={styles.root} data-testid="FilesCardsLayout-list">
+        <Box sx={styles.list}>
+          {items.map((item) => (
+            <Box key={item.id} sx={styles.listItem}>
+              <MinimizedFileCard
+                fileType={minimizedTypeMap[item.type]}
+                starred={!!item.isStarred}
+                linked={!!item.usageLinks && item.usageLinks > 0}
+                name={item.name}
+                date={item.dateAdded}
+                onClick={() => onItemClick?.(item)}
+              />
+            </Box>
+          ))}
+        </Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={styles.root} data-testid="FilesCardsLayout-grid">
+      <Box sx={styles.grid}>
+        {items.map((item) => (
+          <Box key={item.id} sx={styles.gridItem}>
+            <FileCard
+              fileType={item.type}
+              fileData={{
+                name: item.name,
+                dateAdded: item.dateAdded,
+                isStarred: item.isStarred,
+                usageLinks: item.usageLinks,
+                imageSrc: item.imageSrc
+              }}
+              onClick={() => onItemClick?.(item)}
+            />
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
+}

--- a/app/shared/components/files-cards-layout/index.ts
+++ b/app/shared/components/files-cards-layout/index.ts
@@ -1,0 +1,1 @@
+export * from './FilesCardsLayout';

--- a/app/shared/components/minimized-file-card/MinimizedFileCard.tsx
+++ b/app/shared/components/minimized-file-card/MinimizedFileCard.tsx
@@ -4,7 +4,7 @@ import { MouseEvent } from 'react';
 
 import { styles } from '~/components/minimized-file-card/MinimizedFileCard.styles';
 
-const ICON_SIZE = 32;
+const ICON_SIZE = 20;
 
 const FILE_TYPES = {
   img: 'img',
@@ -52,7 +52,7 @@ const MinimizedFileCard = ({
           {name}
         </Typography>
 
-        <Stack direction="row">
+        <Stack direction="row" gap={'10px'}>
           {starred && <Image src="/icons/star.svg" width={ICON_SIZE} height={ICON_SIZE} alt="Starred file" />}
           {linked && <Image src="/icons/link.svg" width={ICON_SIZE} height={ICON_SIZE} alt="Linked file" />}
         </Stack>

--- a/app/shared/components/view-toggle/ViewToggle.styles.ts
+++ b/app/shared/components/view-toggle/ViewToggle.styles.ts
@@ -1,0 +1,34 @@
+import { SxProps, Theme } from '@mui/material';
+
+import { colors } from '~/shared/components/design-system/button/Button.styles';
+
+export const styles: Record<string, SxProps<Theme>> = {
+  root: {
+    display: 'flex',
+    alignItems: 'center',
+    p: '4px',
+    borderRadius: '999px',
+    bgcolor: colors.blue[100],
+    width: 'fit-content'
+  },
+  button: {
+    width: 38,
+    height: 38,
+    borderRadius: '999px',
+    p: '4px',
+  },
+  active: {
+    bgcolor: colors.black,
+    color: colors.white,
+    '&:hover': {
+      bgcolor: colors.black
+    }
+  },
+  inactive: {
+    bgcolor: 'transparent',
+    color: colors.black,
+    '&:hover': {
+      bgcolor: colors.blue[200]
+    }
+  }
+};

--- a/app/shared/components/view-toggle/ViewToggle.styles.ts
+++ b/app/shared/components/view-toggle/ViewToggle.styles.ts
@@ -1,8 +1,16 @@
-import { SxProps, Theme } from '@mui/material';
+import { Theme } from '@mui/material';
+import { SystemStyleObject } from '@mui/system';
 
 import { colors } from '~/shared/components/design-system/button/Button.styles';
 
-export const styles: Record<string, SxProps<Theme>> = {
+type ViewToggleStyles = {
+  root: SystemStyleObject<Theme>;
+  button: SystemStyleObject<Theme>;
+  active: SystemStyleObject<Theme>;
+  inactive: SystemStyleObject<Theme>;
+};
+
+export const styles: ViewToggleStyles = {
   root: {
     display: 'flex',
     alignItems: 'center',

--- a/app/shared/components/view-toggle/ViewToggle.test.tsx
+++ b/app/shared/components/view-toggle/ViewToggle.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ViewToggle } from './ViewToggle';
+
+describe('ViewToggle', () => {
+  it('calls onChange with list when list button is clicked', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+
+    render(<ViewToggle value="grid" onChange={onChange} />);
+
+    await user.click(screen.getByLabelText('Список'));
+
+    expect(onChange).toHaveBeenCalledWith('list');
+  });
+
+  it('calls onChange with grid when grid button is clicked', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+
+    render(<ViewToggle value="list" onChange={onChange} />);
+
+    await user.click(screen.getByLabelText('Сітка'));
+
+    expect(onChange).toHaveBeenCalledWith('grid');
+  });
+});

--- a/app/shared/components/view-toggle/ViewToggle.tsx
+++ b/app/shared/components/view-toggle/ViewToggle.tsx
@@ -16,7 +16,7 @@ export function ViewToggle({ value, onChange }: ViewToggleProps) {
       <IconButton
         aria-label="Сітка"
         onClick={() => onChange('grid')}
-        sx={{ ...styles.button, ...(value === 'grid' ? styles.active : styles.inactive) }}
+        sx={[styles.button, value === 'grid' ? styles.active : styles.inactive]}
       >
         <GridViewOutlinedIcon sx={{ fontSize: 28, transform: 'scale(0.94)' }} />
       </IconButton>
@@ -24,7 +24,7 @@ export function ViewToggle({ value, onChange }: ViewToggleProps) {
       <IconButton
         aria-label="Список"
         onClick={() => onChange('list')}
-        sx={{ ...styles.button, ...(value === 'list' ? styles.active : styles.inactive) }}
+        sx={[styles.button, value === 'list' ? styles.active : styles.inactive]}
       >
         <MenuIcon sx={{ fontSize: 28 }} />
       </IconButton>

--- a/app/shared/components/view-toggle/ViewToggle.tsx
+++ b/app/shared/components/view-toggle/ViewToggle.tsx
@@ -1,0 +1,33 @@
+import GridViewOutlinedIcon from '@mui/icons-material/GridViewOutlined';
+import MenuIcon from '@mui/icons-material/Menu';
+import { Box, IconButton } from '@mui/material';
+
+import { styles } from './ViewToggle.styles';
+import { type FilesCardsLayoutView } from '~/shared/components/files-cards-layout';
+
+type ViewToggleProps = Readonly<{
+  value: FilesCardsLayoutView;
+  onChange: (value: FilesCardsLayoutView) => void;
+}>;
+
+export function ViewToggle({ value, onChange }: ViewToggleProps) {
+  return (
+    <Box sx={styles.root} role="group" aria-label="Перемикач вигляду файлів" data-testid="ViewToggle">
+      <IconButton
+        aria-label="Сітка"
+        onClick={() => onChange('grid')}
+        sx={{ ...styles.button, ...(value === 'grid' ? styles.active : styles.inactive) }}
+      >
+        <GridViewOutlinedIcon sx={{ fontSize: 28, transform: 'scale(0.94)' }} />
+      </IconButton>
+
+      <IconButton
+        aria-label="Список"
+        onClick={() => onChange('list')}
+        sx={{ ...styles.button, ...(value === 'list' ? styles.active : styles.inactive) }}
+      >
+        <MenuIcon sx={{ fontSize: 28 }} />
+      </IconButton>
+    </Box>
+  );
+}

--- a/app/shared/components/view-toggle/index.ts
+++ b/app/shared/components/view-toggle/index.ts
@@ -1,0 +1,1 @@
+export * from './ViewToggle';

--- a/app/shared/hooks/use-assets/useAssets.tsx
+++ b/app/shared/hooks/use-assets/useAssets.tsx
@@ -1,0 +1,6 @@
+'use client';
+
+import { AssetsFiltersInput, useAllAssetsQuery } from '~/types/graphql/generated/graphql';
+
+export const useAllAssets = (filters?: AssetsFiltersInput) =>
+  useAllAssetsQuery({ variables: { filters }, fetchPolicy: 'network-only' });

--- a/app/shared/providers/body-provider/BodyProvider.tsx
+++ b/app/shared/providers/body-provider/BodyProvider.tsx
@@ -28,8 +28,15 @@ export const metadata: Metadata = {
 
 export default function BodyProvider({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
-    <html lang="en" className={`${geistSans.variable} ${geistMono.variable} ${mulish.variable}`}>
-      <body className={`${geistSans.variable} ${geistMono.variable} ${mulish.variable}`}>
+    <html
+      lang="en"
+      className={`${geistSans.variable} ${geistMono.variable} ${mulish.variable}`}
+      suppressHydrationWarning
+    >
+      <body
+        className={`${geistSans.variable} ${geistMono.variable} ${mulish.variable}`}
+        suppressHydrationWarning
+      >
         <EmotionProvider>
           <ThemeProvider>
             <ApolloClientProvider>{children}</ApolloClientProvider>

--- a/app/types/graphql/queries/assets.graphql
+++ b/app/types/graphql/queries/assets.graphql
@@ -1,0 +1,20 @@
+query AllAssets($filters: AssetsFiltersInput) {
+  allAssets(filters: $filters) {
+    id
+    type
+    tags
+    usageRefs {
+      pageId
+      blockId
+    }
+    filename
+    mimeType
+    sizeBytes
+    url
+    createdBy
+    description
+    isStarred
+    createdAt
+    updatedAt
+  }
+}

--- a/src/container/modules/repositories.module.ts
+++ b/src/container/modules/repositories.module.ts
@@ -1,9 +1,11 @@
 import { asFunction, asValue, AwilixContainer } from 'awilix';
 
+import { assetModel } from '~/infrastructure/models/asset.model';
 import { DraftPageModel } from '~/infrastructure/models/draftPage.model';
 import NewsModel from '~/infrastructure/models/news.model';
 import PageModel from '~/infrastructure/models/page.model';
 import { AdminRepository } from '~/infrastructure/repositories/adminRepository/adminRepository';
+import { AssetRepository } from '~/infrastructure/repositories/assetRepository/assetRepository';
 import { newMediaMentionRepository } from '~/infrastructure/repositories/mediaMentionRepository/repository';
 import { NewsRepository } from '~/infrastructure/repositories/newsRepository/newsRepository';
 import { PageRepository } from '~/infrastructure/repositories/pageRepository/pageRepository';
@@ -11,6 +13,7 @@ import { RefreshTokenRepository } from '~/infrastructure/repositories/refreshTok
 import { MediaMentionModel } from '~/src/infrastructure/models/mediaMention.model';
 
 export type RepositoriesModule = {
+  assetsRepository: ReturnType<typeof AssetRepository>;
   adminRepository: ReturnType<typeof AdminRepository>;
   refreshTokenRepository: ReturnType<typeof RefreshTokenRepository>;
   pageRepository: ReturnType<typeof PageRepository>;
@@ -20,6 +23,7 @@ export type RepositoriesModule = {
 
 export const registerRepositories = (container: AwilixContainer) => {
   container.register({
+    AssetModel: asValue(assetModel),
     PageModel: asValue(PageModel),
     DraftPageModel: asValue(DraftPageModel),
     NewsModel: asValue(NewsModel),
@@ -30,6 +34,7 @@ export const registerRepositories = (container: AwilixContainer) => {
 
     pageRepository: asFunction(PageRepository).scoped(),
     newsRepository: asFunction(NewsRepository).scoped(),
+    assetsRepository: asFunction(AssetRepository).scoped(),
     mediaMentionsRepository: asFunction(newMediaMentionRepository).scoped()
   });
 };

--- a/src/infrastructure/models/asset.model.ts
+++ b/src/infrastructure/models/asset.model.ts
@@ -1,4 +1,4 @@
-import { type InferSchemaType, type Model, model, Schema, Types } from 'mongoose';
+import { type InferSchemaType, type Model, model, models, Schema, Types } from 'mongoose';
 
 const usageRefSchema = new Schema(
   {
@@ -46,7 +46,5 @@ export type assetDocument = InferSchemaType<typeof assetSchema> & {
   _id: Types.ObjectId;
 };
 
-export const assetModel: Model<assetDocument> = model<assetDocument>(
-  'asset',
-  assetSchema
-) as unknown as Model<assetDocument>;
+export const assetModel: Model<assetDocument> =
+  (models.asset as Model<assetDocument>) ?? model<assetDocument>('asset', assetSchema);

--- a/src/infrastructure/repositories/assetRepository/assetRepository.test.ts
+++ b/src/infrastructure/repositories/assetRepository/assetRepository.test.ts
@@ -1,0 +1,82 @@
+import { Types } from 'mongoose';
+
+import { createBaseRepository } from '../baseRepository/baseRepository';
+import { AssetRepository } from './assetRepository';
+
+jest.mock('../baseRepository/baseRepository', () => ({
+  createBaseRepository: jest.fn((config) => config)
+}));
+
+describe('AssetRepository', () => {
+  const mockedCreateBaseRepository = createBaseRepository as jest.Mock;
+
+  beforeEach(() => {
+    mockedCreateBaseRepository.mockClear();
+  });
+
+  it('should pass model and handlers into base repository factory', () => {
+    const model = {};
+
+    const result = AssetRepository({ AssetModel: model as never }) as Record<string, unknown>;
+
+    expect(mockedCreateBaseRepository).toHaveBeenCalledTimes(1);
+    expect(result.model).toBe(model);
+    expect(typeof result.toEntity).toBe('function');
+    expect(typeof result.buildQuery).toBe('function');
+    expect(typeof result.getDefaultSort).toBe('function');
+  });
+
+  it('should map document to entity and safely convert dates', () => {
+    const result = AssetRepository({ AssetModel: {} as never }) as {
+      toEntity: (doc: Record<string, unknown>) => Record<string, unknown>;
+    };
+
+    const doc = {
+      _id: new Types.ObjectId(),
+      type: 'image',
+      tags: ['archive'],
+      usageRefs: [{ pageId: 'about-us', blockId: 'hero' }],
+      filename: 'piano.jpg',
+      mimeType: 'image/jpeg',
+      sizeBytes: 2048,
+      url: '/tmp/piano.jpg',
+      createdBy: new Types.ObjectId(),
+      description: 'desc',
+      isStarred: true,
+      createdAt: new Date('2026-03-10T10:00:00.000Z'),
+      updatedAt: null
+    };
+
+    const entity = result.toEntity(doc);
+
+    expect(entity.id).toBe(String(doc._id));
+    expect(entity.createdBy).toBe(String(doc.createdBy));
+    expect(entity.createdAt).toBe('2026-03-10T10:00:00.000Z');
+    expect(entity.updatedAt).toBe(new Date(0).toISOString());
+  });
+
+  it('should build query and sort based on filters', () => {
+    const result = AssetRepository({ AssetModel: {} as never }) as {
+      buildQuery: (filters?: Record<string, unknown>) => Record<string, unknown>;
+      getDefaultSort: (filters?: Record<string, unknown>) => Record<string, 1 | -1>;
+    };
+
+    expect(result.buildQuery()).toEqual({});
+
+    const query = result.buildQuery({
+      type: 'pdf',
+      isStarred: false,
+      tag: 'archive',
+      search: '  press  '
+    });
+
+    expect(query.type).toBe('pdf');
+    expect(query.isStarred).toBe(false);
+    expect(query.tags).toBe('archive');
+    expect(query.filename).toBeInstanceOf(RegExp);
+    expect((query.filename as RegExp).test('press-kit.pdf')).toBe(true);
+
+    expect(result.getDefaultSort()).toEqual({ createdAt: -1 });
+    expect(result.getDefaultSort({ sortBy: 'filename', sortOrder: 'asc' })).toEqual({ filename: 1 });
+  });
+});

--- a/src/infrastructure/repositories/assetRepository/assetRepository.test.ts
+++ b/src/infrastructure/repositories/assetRepository/assetRepository.test.ts
@@ -1,5 +1,3 @@
-import { Types } from 'mongoose';
-
 import { createBaseRepository } from '../baseRepository/baseRepository';
 import { AssetRepository } from './assetRepository';
 
@@ -17,53 +15,59 @@ describe('AssetRepository', () => {
   it('should pass model and handlers into base repository factory', () => {
     const model = {};
 
-    const result = AssetRepository({ AssetModel: model as never }) as Record<string, unknown>;
+    AssetRepository({ AssetModel: model as never });
+
+    const config = mockedCreateBaseRepository.mock.calls[0][0] as Record<string, unknown>;
 
     expect(mockedCreateBaseRepository).toHaveBeenCalledTimes(1);
-    expect(result.model).toBe(model);
-    expect(typeof result.toEntity).toBe('function');
-    expect(typeof result.buildQuery).toBe('function');
-    expect(typeof result.getDefaultSort).toBe('function');
+    expect(config.model).toBe(model);
+    expect(typeof config.toEntity).toBe('function');
+    expect(typeof config.buildQuery).toBe('function');
+    expect(typeof config.getDefaultSort).toBe('function');
   });
 
   it('should map document to entity and safely convert dates', () => {
-    const result = AssetRepository({ AssetModel: {} as never }) as {
+    AssetRepository({ AssetModel: {} as never });
+
+    const config = mockedCreateBaseRepository.mock.calls[0][0] as {
       toEntity: (doc: Record<string, unknown>) => Record<string, unknown>;
     };
 
     const doc = {
-      _id: new Types.ObjectId(),
+      _id: { toString: () => 'asset-id-1' },
       type: 'image',
       tags: ['archive'],
       usageRefs: [{ pageId: 'about-us', blockId: 'hero' }],
       filename: 'piano.jpg',
       mimeType: 'image/jpeg',
       sizeBytes: 2048,
-      url: '/tmp/piano.jpg',
-      createdBy: new Types.ObjectId(),
+      url: '/uploads/piano.jpg',
+      createdBy: { toString: () => 'admin-id-1' },
       description: 'desc',
       isStarred: true,
       createdAt: new Date('2026-03-10T10:00:00.000Z'),
       updatedAt: null
     };
 
-    const entity = result.toEntity(doc);
+    const entity = config.toEntity(doc);
 
-    expect(entity.id).toBe(String(doc._id));
-    expect(entity.createdBy).toBe(String(doc.createdBy));
+    expect(entity.id).toBe('asset-id-1');
+    expect(entity.createdBy).toBe('admin-id-1');
     expect(entity.createdAt).toBe('2026-03-10T10:00:00.000Z');
     expect(entity.updatedAt).toBe(new Date(0).toISOString());
   });
 
   it('should build query and sort based on filters', () => {
-    const result = AssetRepository({ AssetModel: {} as never }) as {
+    AssetRepository({ AssetModel: {} as never });
+
+    const config = mockedCreateBaseRepository.mock.calls[0][0] as {
       buildQuery: (filters?: Record<string, unknown>) => Record<string, unknown>;
       getDefaultSort: (filters?: Record<string, unknown>) => Record<string, 1 | -1>;
     };
 
-    expect(result.buildQuery()).toEqual({});
+    expect(config.buildQuery()).toEqual({});
 
-    const query = result.buildQuery({
+    const query = config.buildQuery({
       type: 'pdf',
       isStarred: false,
       tag: 'archive',
@@ -76,7 +80,7 @@ describe('AssetRepository', () => {
     expect(query.filename).toBeInstanceOf(RegExp);
     expect((query.filename as RegExp).test('press-kit.pdf')).toBe(true);
 
-    expect(result.getDefaultSort()).toEqual({ createdAt: -1 });
-    expect(result.getDefaultSort({ sortBy: 'filename', sortOrder: 'asc' })).toEqual({ filename: 1 });
+    expect(config.getDefaultSort()).toEqual({ createdAt: -1 });
+    expect(config.getDefaultSort({ sortBy: 'filename', sortOrder: 'asc' })).toEqual({ filename: 1 });
   });
 });

--- a/src/infrastructure/repositories/assetRepository/assetRepository.ts
+++ b/src/infrastructure/repositories/assetRepository/assetRepository.ts
@@ -1,0 +1,124 @@
+import { FilterQuery, Model, Types } from 'mongoose';
+
+import { createBaseRepository } from '../baseRepository/baseRepository';
+
+type AssetType = 'image' | 'pdf' | 'audio';
+
+type AssetUsageRef = {
+  pageId?: string;
+  blockId?: string;
+};
+
+export type AssetEntity = {
+  id: string;
+  type: AssetType;
+  tags: string[];
+  usageRefs: AssetUsageRef[];
+  filename: string;
+  mimeType: string;
+  sizeBytes: number;
+  url: string;
+  createdBy?: string;
+  description?: string;
+  isStarred: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type AssetFilters = {
+  type?: AssetType;
+  isStarred?: boolean;
+  tag?: string;
+  search?: string;
+  sortBy?: 'createdAt' | 'updatedAt' | 'filename';
+  sortOrder?: 'asc' | 'desc';
+  limit?: number;
+  skip?: number;
+};
+
+type DbAsset = {
+  _id: Types.ObjectId;
+  type: AssetType;
+  tags: string[];
+  usageRefs: AssetUsageRef[];
+  filename: string;
+  mimeType: string;
+  sizeBytes: number;
+  url: string;
+  createdBy?: Types.ObjectId;
+  description?: string;
+  isStarred: boolean;
+  createdAt: Date | string;
+  updatedAt: Date | string;
+};
+
+type AssetRepoDeps = Readonly<{
+  AssetModel: Model<DbAsset>;
+}>;
+
+const dateToIso = (date?: Date | string | null): string => {
+  if (!date) {
+    return new Date(0).toISOString();
+  }
+
+  return date instanceof Date ? date.toISOString() : date;
+};
+
+const toEntity = (doc: DbAsset): AssetEntity => ({
+  id: doc._id.toString(),
+  type: doc.type,
+  tags: doc.tags,
+  usageRefs: doc.usageRefs,
+  filename: doc.filename,
+  mimeType: doc.mimeType,
+  sizeBytes: doc.sizeBytes,
+  url: doc.url,
+  createdBy: doc.createdBy?.toString(),
+  description: doc.description,
+  isStarred: doc.isStarred,
+  createdAt: dateToIso(doc.createdAt),
+  updatedAt: dateToIso(doc.updatedAt)
+});
+
+const buildAssetQuery = (filters?: Omit<AssetFilters, 'limit' | 'skip' | 'sortBy' | 'sortOrder'>): FilterQuery<DbAsset> => {
+  const query: FilterQuery<DbAsset> = {};
+
+  if (!filters) {
+    return query;
+  }
+
+  if (filters.type) {
+    query.type = filters.type;
+  }
+
+  if (typeof filters.isStarred === 'boolean') {
+    query.isStarred = filters.isStarred;
+  }
+
+  if (filters.tag) {
+    query.tags = filters.tag;
+  }
+
+  if (filters.search?.trim()) {
+    query.filename = new RegExp(filters.search.trim(), 'i');
+  }
+
+  return query;
+};
+
+const getAssetSort = (filters?: AssetFilters): Record<string, 1 | -1> => {
+  const sortBy = filters?.sortBy ?? 'createdAt';
+  const sortOrder = filters?.sortOrder ?? 'desc';
+
+  return {
+    [sortBy]: sortOrder === 'asc' ? 1 : -1
+  };
+};
+
+export const AssetRepository = ({ AssetModel }: AssetRepoDeps) =>
+  createBaseRepository<AssetEntity, DbAsset, AssetFilters>({
+    model: AssetModel,
+    toEntity,
+    buildQuery: buildAssetQuery,
+    getDefaultSort: getAssetSort
+  });

--- a/src/interfaces/graphql/resolvers/assets/Query.test.ts
+++ b/src/interfaces/graphql/resolvers/assets/Query.test.ts
@@ -1,0 +1,26 @@
+import { AssetsQuery } from './Query';
+
+describe('AssetsQuery', () => {
+  it('should pass filters to assets repository', async () => {
+    const repo = { findAll: jest.fn().mockResolvedValue(['asset']) };
+    const ctx = { admin: true, requestContainer: { cradle: { assetsRepository: repo } } } as never;
+
+    const filters = {
+      type: 'image',
+      isStarred: true,
+      sortBy: 'createdAt',
+      sortOrder: 'desc',
+      limit: 20,
+      skip: 0
+    };
+
+    const res = await AssetsQuery.allAssets({}, { filters }, ctx);
+
+    expect(res).toEqual(['asset']);
+    expect(repo.findAll).toHaveBeenCalledWith(filters);
+  });
+
+  it('should throw when admin is missing', async () => {
+    await expect(AssetsQuery.allAssets({}, { filters: {} } as never, { admin: false } as never)).rejects.toThrow();
+  });
+});

--- a/src/interfaces/graphql/resolvers/assets/Query.ts
+++ b/src/interfaces/graphql/resolvers/assets/Query.ts
@@ -1,0 +1,7 @@
+import { endpointRepositoryHandler } from '../helpers';
+
+const endpointHandler = endpointRepositoryHandler('assetsRepository');
+
+export const AssetsQuery = {
+  allAssets: endpointHandler(async ({ args: { filters }, repo }) => repo.findAll(filters))
+};

--- a/src/interfaces/graphql/resolvers/index.ts
+++ b/src/interfaces/graphql/resolvers/index.ts
@@ -1,4 +1,5 @@
 import { authMutation as AdminMutation } from './admin/AuthMutation';
+import { AssetsQuery } from './assets/Query';
 import { blobMutations as BlobMutation } from './blobStorage/blobMutation';
 import { MediaMentionsMutation } from './media-mentions/Mutation';
 import { MediaMentionsQuery } from './media-mentions/Query';
@@ -18,6 +19,7 @@ export const resolvers = {
   Query: {
     ...AdminQuery,
     ...NewsQuery,
+    ...AssetsQuery,
     ...MediaMentionsQuery
   }
 };

--- a/src/interfaces/graphql/schemas/assets.graphql
+++ b/src/interfaces/graphql/schemas/assets.graphql
@@ -1,0 +1,47 @@
+enum AssetType {
+  image
+  pdf
+  audio
+}
+
+enum AssetSortBy {
+  createdAt
+  updatedAt
+  filename
+}
+
+type AssetUsageRef {
+  pageId: String
+  blockId: String
+}
+
+type Asset {
+  id: ID!
+  type: AssetType!
+  tags: [String!]!
+  usageRefs: [AssetUsageRef!]!
+  filename: String!
+  mimeType: String!
+  sizeBytes: Int!
+  url: String!
+  createdBy: String
+  description: String
+  isStarred: Boolean!
+  createdAt: String!
+  updatedAt: String!
+}
+
+input AssetsFiltersInput {
+  type: AssetType
+  isStarred: Boolean
+  tag: String
+  search: String
+  sortBy: AssetSortBy
+  sortOrder: SortOrder
+  limit: Int
+  skip: Int
+}
+
+extend type Query {
+  allAssets(filters: AssetsFiltersInput): [Asset!]!
+}


### PR DESCRIPTION
## Description

This PR implements a reusable **file cards layout template** for the Files page.

The new layout supports two display modes:
- **Grid view** for standard file cards
- **List view** for a minimized file representation

Users can switch between the two views, and the layout updates accordingly.  
The template is responsive and adapts correctly to different screen sizes while working with both sidebars.

link:
https://github.com/Liatoshynsky-Foundation/lf-admin/issues/354

## Type of change

- [x] New feature

## How to test

1. Open the **Files page** in the admin panel. '/archive'
2. Verify that files can be displayed in **grid view**.
3. Switch to **list view**.
4. Confirm that the layout updates correctly.
5. Verify that both card types render properly in their respective views.

## Video / Screenshots

<img width="1269" height="673" alt="Screenshot 2026-03-16 at 11 39 26" src="https://github.com/user-attachments/assets/594483ed-2e5f-49ed-97fa-392acb4870f0" />

<img width="1269" height="648" alt="Screenshot 2026-03-16 at 11 39 53" src="https://github.com/user-attachments/assets/bc9d5282-2565-45a4-a090-42c5980b3f89" />

<img width="2008" height="1133" alt="Screenshot 2026-03-16 at 11 40 10" src="https://github.com/user-attachments/assets/a9bcc7a1-bcb4-4b81-945f-b22af8e8e914" />
