### PR TITLE
Enforce minimum layout width of 1280px for admin panel

### DIFF
--- a/app/(logged_in)/layout.styles.ts
+++ b/app/(logged_in)/layout.styles.ts
@@ -6,16 +6,13 @@ export const styles: Record<string, SxProps> = {
     display: 'flex',
     gap: '20px',
     alignItems: 'flex-start',
-    justifyContent: 'flex-start',
+    justifyContent: 'flex-start'
   },
   container: {
     display: 'flex',
     flexGrow: 1,
-    minWidth: 0,
-    minHeight: 0,
-    height: '100vh',
     alignItems: 'center',
     flexDirection: 'column',
-    padding: '20px',
+    padding: '20px'
   }
 };

--- a/app/(logged_in)/layout.styles.ts
+++ b/app/(logged_in)/layout.styles.ts
@@ -5,10 +5,8 @@ export const styles: Record<string, SxProps> = {
     margin: '0 auto',
     display: 'flex',
     gap: '20px',
-    alignItems: 'stretch',
+    alignItems: 'flex-start',
     justifyContent: 'flex-start',
-    height: '100vh',
-    overflow: 'hidden'
   },
   container: {
     display: 'flex',
@@ -19,11 +17,5 @@ export const styles: Record<string, SxProps> = {
     alignItems: 'center',
     flexDirection: 'column',
     padding: '20px',
-    overflowY: 'auto',
-    overflowX: 'hidden',
-    scrollbarWidth: 'none',
-    '&::-webkit-scrollbar': {
-      display: 'none'
-    }
   }
 };

--- a/app/(logged_in)/layout.styles.ts
+++ b/app/(logged_in)/layout.styles.ts
@@ -5,14 +5,21 @@ export const styles: Record<string, SxProps> = {
     margin: '0 auto',
     display: 'flex',
     gap: '20px',
-    alignItems: 'flex-start',
-    justifyContent: 'flex-start'
+    alignItems: 'stretch',
+    justifyContent: 'flex-start',
+    height: '100vh',
+    overflow: 'hidden'
   },
   container: {
     display: 'flex',
     flexGrow: 1,
+    minWidth: 0,
+    minHeight: 0,
+    height: '100vh',
     alignItems: 'center',
     flexDirection: 'column',
-    padding: '20px'
+    padding: '20px',
+    overflowY: 'auto',
+    overflowX: 'hidden'
   }
 };

--- a/app/(logged_in)/layout.styles.ts
+++ b/app/(logged_in)/layout.styles.ts
@@ -20,6 +20,10 @@ export const styles: Record<string, SxProps> = {
     flexDirection: 'column',
     padding: '20px',
     overflowY: 'auto',
-    overflowX: 'hidden'
+    overflowX: 'hidden',
+    scrollbarWidth: 'none',
+    '&::-webkit-scrollbar': {
+      display: 'none'
+    }
   }
 };

--- a/app/globals.css
+++ b/app/globals.css
@@ -5,8 +5,10 @@
 
 html,
 body {
-  max-width: 100vw;
-  overflow-x: hidden;
+  width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  height: 100%;
 }
 
 html {
@@ -19,6 +21,7 @@ body {
   font-family: Arial, Helvetica, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  min-width: 1280px;
 }
 
 * {

--- a/app/globals.css
+++ b/app/globals.css
@@ -28,9 +28,6 @@ body {
   box-sizing: border-box;
   padding: 0;
   margin: 0;
-}
-
-* {
   max-height: 1000000px;
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -5,13 +5,13 @@
 
 html,
 body {
-  max-width: 100vw;
   overflow-x: hidden;
   padding: 0;
 }
 
 html {
   scrollbar-width: none;
+  height: 100%;
 }
 
 body {
@@ -21,12 +21,17 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   min-width: 1280px;
+  scroll-behavior: smooth;
 }
 
 * {
   box-sizing: border-box;
   padding: 0;
   margin: 0;
+}
+
+* {
+  max-height: 1000000px;
 }
 
 a {

--- a/app/globals.css
+++ b/app/globals.css
@@ -5,18 +5,13 @@
 
 html,
 body {
-  width: 100%;
-  overflow-x: auto;
-  overflow-y: hidden;
-  height: 100%;
+  max-width: 100vw;
+  overflow-x: hidden;
+  padding: 0;
 }
 
 html {
   scrollbar-width: none;
-}
-
-html::-webkit-scrollbar {
-  display: none;
 }
 
 body {

--- a/app/globals.css
+++ b/app/globals.css
@@ -10,7 +10,7 @@ body {
 }
 
 html {
-  scrollbar-width: none;
+  scrollbar-gutter: stable;
   height: 100%;
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -12,7 +12,11 @@ body {
 }
 
 html {
-  scrollbar-gutter: stable;
+  scrollbar-width: none;
+}
+
+html::-webkit-scrollbar {
+  display: none;
 }
 
 body {

--- a/app/shared/components/side-navigation/SideNavigation.styles.ts
+++ b/app/shared/components/side-navigation/SideNavigation.styles.ts
@@ -2,12 +2,12 @@ export const styles = {
   drawerPaper: {
     backgroundColor: '#F1F2F7',
     borderRight: '1px solid #DCDDE5',
-    position: 'relative',
-    width: '280px',
+    position: 'fixed',
+    maxWidth: '280px',
     padding: '32px 0',
     scrollbarWidth: 'none',
     height: '100vh',
-    overflowY: 'auto',
+    overflowY: 'scroll',
     overflowX: 'visible',
     '&::-webkit-scrollbar': {
       display: 'none'

--- a/app/shared/components/side-navigation/SideNavigation.styles.ts
+++ b/app/shared/components/side-navigation/SideNavigation.styles.ts
@@ -4,7 +4,6 @@ export const styles = {
     borderRight: '1px solid #DCDDE5',
     position: 'relative',
     width: '280px',
-    minWidth: '280px',
     padding: '32px 0',
     scrollbarWidth: 'none',
     height: '100vh',

--- a/app/shared/components/side-navigation/SideNavigation.styles.ts
+++ b/app/shared/components/side-navigation/SideNavigation.styles.ts
@@ -1,13 +1,14 @@
 export const styles = {
   drawerPaper: {
     backgroundColor: '#F1F2F7',
-    border: 'border-right: 1px solid #DCDDE5',
-    position: 'fixed',
-    maxWidth: '280px',
+    borderRight: '1px solid #DCDDE5',
+    position: 'relative',
+    width: '280px',
+    minWidth: '280px',
     padding: '32px 0',
     scrollbarWidth: 'none',
     height: '100vh',
-    overflowY: 'scroll',
+    overflowY: 'auto',
     overflowX: 'visible',
     '&::-webkit-scrollbar': {
       display: 'none'

--- a/app/shared/components/side-navigation/SideNavigation.tsx
+++ b/app/shared/components/side-navigation/SideNavigation.tsx
@@ -59,7 +59,7 @@ export const SideBarNavigation = () => {
   const l = open || hasExpandedSubmenu ? 264 - 16 : 80 - 16;
 
   return (
-    <Box sx={{ position: 'sticky', top: 0, height: '100vh', width: w, flexShrink: 0, zIndex: 1 }}>
+    <Box sx={{ height: '100vh', width: w, flexShrink: 0 }}>
       <IconButton onClick={handleToggle} sx={{ ...styles.hideBtn, left: l }}>
         <Image src={`/icons/chevron${open ? 'Left' : 'Right'}.svg`} alt="close button" width={24} height={24} />
       </IconButton>

--- a/app/shared/components/side-navigation/SideNavigation.tsx
+++ b/app/shared/components/side-navigation/SideNavigation.tsx
@@ -59,8 +59,7 @@ export const SideBarNavigation = () => {
   const l = open || hasExpandedSubmenu ? 264 - 16 : 80 - 16;
 
   return (
-    <>
-      <Box sx={{ height: '100vh', width: w, flexShrink: 0 }} />
+    <Box sx={{ position: 'sticky', top: 0, height: '100vh', width: w, flexShrink: 0, zIndex: 1 }}>
       <IconButton onClick={handleToggle} sx={{ ...styles.hideBtn, left: l }}>
         <Image src={`/icons/chevron${open ? 'Left' : 'Right'}.svg`} alt="close button" width={24} height={24} />
       </IconButton>
@@ -86,6 +85,6 @@ export const SideBarNavigation = () => {
           {renderItems(NAVIGATION_DATA.other)}
         </List>
       </Box>
-    </>
+    </Box>
   );
 };


### PR DESCRIPTION
## Description

This PR enforces a minimum layout width of **1280px** for the admin panel.

Previously, the admin panel did not restrict smaller screen widths, which could lead to layout breaking and inconsistent UI rendering.

Now:
- A minimum width of 1280px is applied globally
- Layout remains stable on smaller screens
- Horizontal scrolling is enabled when the viewport is less than 1280px
- No mobile or tablet responsive behavior is introduced

This ensures a consistent desktop-only experience across the admin panel.

link:
https://github.com/Liatoshynsky-Foundation/lf-admin/issues/393

## Type of change

- [x] New feature

## How to test

1. Open the **admin panel**.
2. Resize the browser window:
   - ≥1280px → verify normal layout
   - <1280px → verify:
     - layout does not break
     - horizontal scrolling appears
3. Navigate through different pages of the admin panel.
4. Ensure UI elements remain consistent and aligned.
5. Confirm no mobile/tablet responsive layout is applied.

## Video / Screenshots

Before:
<img width="531" height="752" alt="Screenshot 2026-03-20 at 23 57 40" src="https://github.com/user-attachments/assets/4691e251-c817-4ea6-973b-26b179864269" />

After:
<img width="999" height="1292" alt="Screenshot 2026-03-20 at 23 58 52" src="https://github.com/user-attachments/assets/ebb34333-1538-4227-be53-12391a79144b" />

