### PR TITLE
feat(store): create navigation store slice

### DIFF
--- a/app/store/index.ts
+++ b/app/store/index.ts
@@ -2,9 +2,11 @@ import { create } from 'zustand';
 
 import { createAdminSlice } from './slices/adminSlice';
 import { createEditSlice } from './slices/editSlice';
+import { createNavigationSlice } from './slices/navigationSlice';
 import type { StoreState } from './types';
 
 export const useStore = create<StoreState>()((...a) => ({
   ...createAdminSlice(...a),
-  ...createEditSlice(...a)
+  ...createEditSlice(...a),
+  ...createNavigationSlice(...a)
 }));

--- a/app/store/slices/navigationSlice.ts
+++ b/app/store/slices/navigationSlice.ts
@@ -1,0 +1,11 @@
+import { StateCreator } from 'zustand';
+
+import { type NavigationState } from '../types';
+
+export const createNavigationSlice: StateCreator<NavigationState> = (set) => ({
+  dirtyPaths: {},
+  setDirtyPath: (path, isDirty) =>
+    set((state) => ({
+      dirtyPaths: { ...state.dirtyPaths, [path]: isDirty }
+    }))
+});

--- a/app/store/types.ts
+++ b/app/store/types.ts
@@ -1,6 +1,6 @@
 import { BlocksMap } from '~/types/store/pages';
 
-export type StoreState = AdminUserState & EditState;
+export type StoreState = AdminUserState & EditState & NavigationState;
 
 export interface Admin {
   email: string;
@@ -58,5 +58,11 @@ export interface EditState {
   publishPage: (pageId: string) => void;
   discardChanges: (pageId: string) => void;
 }
+
+export interface NavigationState {
+  dirtyPaths: Record<string, boolean>;
+  setDirtyPath: (path: string, isDirty: boolean) => void;
+}
+
 
 export type BlockData<K extends keyof BlocksMap = keyof BlocksMap> = BlocksMap[K];


### PR DESCRIPTION
## Description

This PR is indented to creation of lightweight store slice for tracking specific routes for having the unsaved/dirty data . This makes us possible to use `DiscardModalProvider`  that calls the `DiscardChangesModal`  which depends on Zustand store.

## Key changes

- Created new store slice `NavigationSlice.ts` to globally track unsaved changes.
- Fused slice into `index.ts` among other slices, so the slice will be available.
- Created an interface `NavigationState` to type the `NavigationSlice`.

## Type of change

- [x] New feature

## How to test

1. Go to your IDE by this path: `app/(logged_in)/store/slices` and ensure the `NavigationSlice.ts` is there.

## Task deviations

1. Reconsidered the requirements regarding `useHasUnsavedChanges` hook, the step should be apparently implemented in another task, since this task is more specific.

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [x] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board
