### PR TITLE
fix: enable image selection from gallery and used tabs in MediaModal

### DIFF
--- a/app/shared/components/design-system/photo-block/PhotoBlock.tsx
+++ b/app/shared/components/design-system/photo-block/PhotoBlock.tsx
@@ -2,6 +2,7 @@
 
 import { Box, Stack, type StackProps, Typography } from '@mui/material';
 import { type ChangeEvent, useEffect, useRef, useState } from 'react';
+import toast from 'react-hot-toast';
 
 import Button from '../button/Button';
 import { CropperModal } from '../cropper-modal/CropperModal';
@@ -117,8 +118,9 @@ export const ImagePreviewBlock = ({
         setPreviewImage(selected.src);
         onChangeImage(file);
       }
-    } catch (error) {
-      console.error('Помилка при обробці зображення з MediaModal:', error);
+      toast.success('Зображення змінено');
+    } catch {
+      toast.error('Не вдалося змінити');
     } finally {
       closeMediaModal();
     }

--- a/app/shared/components/design-system/photo-block/PhotoBlock.tsx
+++ b/app/shared/components/design-system/photo-block/PhotoBlock.tsx
@@ -100,13 +100,28 @@ export const ImagePreviewBlock = ({
   };
 
   const handleApplyMediaModal = async (result: MediaModalResult) => {
-    if (result.selected.kind !== 'upload') return;
+    const { selected } = result;
 
-    const dataUrl = await readFileAsDataURL(result.selected.file);
-    setPreviewImage(dataUrl);
-    onChangeImage(result.selected.file);
+    try {
+      if (selected.kind === 'upload') {
+        const dataUrl = await readFileAsDataURL(selected.file);
+        setPreviewImage(dataUrl);
+        onChangeImage(selected.file);
+      } else if (selected.kind === 'gallery' || selected.kind === 'used') {
+        const response = await fetch(selected.src);
+        const blob = await response.blob();
+        const file = new File([blob], selected.fileName || 'image.jpg', {
+          type: blob.type
+        });
 
-    closeMediaModal();
+        setPreviewImage(selected.src);
+        onChangeImage(file);
+      }
+    } catch (error) {
+      console.error('Помилка при обробці зображення з MediaModal:', error);
+    } finally {
+      closeMediaModal();
+    }
   };
 
   const handleEditClick = editorMode === 'mediaModal' ? openEditCrop : openLegacyCropper;


### PR DESCRIPTION
## Description

Fixed a bug where the MediaModal failed to process images selected from the "Галерея" (Gallery) and "Використані" (Used) tabs.
The issue occurred because the onImageChange handler strictly expects a File object, but selecting an existing image only provided a URL string.

## Type of change

- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Navigate to the About us page.
2. Open the "Фундація Лятошинського" section.
3. Click "Змінити зображення" to open the Media Modal.
4. Navigate to the "Галерея" or "Використані" tab.
5. Select any existing image and click "Застосувати" (Apply).
6. Verify that the image is successfully selected, the modal closes, and the preview is updated.

### Actual result: 
As a result we've got preview block unchanged.
<img width="277" height="47" alt="image" src="https://github.com/user-attachments/assets/57d86d0a-80c7-4cd7-b378-dc7fb07ac512" />

### Expected result: 
1. The image selection logic (onSelect or active state selection) must work universally across all three tabs.
2. Clicking an image in "Галерея" or "Використані" and application of the selection should change the preview image .

https://github.com/user-attachments/assets/a19bfff1-dd04-47e4-b01b-b7b08e6960e5




Closes: https://github.com/Liatoshynsky-Foundation/lf-admin/issues/406
