### PR TITLE
fix(ui): resolve image cropping state management and interaction issues

### DIFF
--- a/app/shared/components/design-system/photo-block/PhotoBlock.tsx
+++ b/app/shared/components/design-system/photo-block/PhotoBlock.tsx
@@ -51,6 +51,8 @@ export const ImagePreviewBlock = ({
   const [isMediaModalOpen, setIsMediaModalOpen] = useState(false);
   const [mediaInitial, setMediaInitial] = useState<MediaModalOpenState | undefined>(undefined);
 
+  const [savedCrop, setSavedCrop] = useState<MediaModalResult['crop']>(null);
+
   useEffect(() => {
     setPreviewImage(imageUrl);
   }, [imageUrl]);
@@ -83,7 +85,7 @@ export const ImagePreviewBlock = ({
         src: previewImage,
         locale: 'uk'
       },
-      crop: null
+      crop: savedCrop
     });
 
     setIsMediaModalOpen(true);
@@ -100,11 +102,13 @@ export const ImagePreviewBlock = ({
   };
 
   const handleApplyMediaModal = async (result: MediaModalResult) => {
-    if (result.selected.kind !== 'upload') return;
+    setSavedCrop(result.crop);
 
-    const dataUrl = await readFileAsDataURL(result.selected.file);
-    setPreviewImage(dataUrl);
-    onChangeImage(result.selected.file);
+    if (result.selected.kind === 'upload') {
+      const dataUrl = await readFileAsDataURL(result.selected.file);
+      setPreviewImage(dataUrl);
+      onChangeImage(result.selected.file);
+    }
 
     closeMediaModal();
   };

--- a/app/shared/components/design-system/photo-block/PhotoBlock.tsx
+++ b/app/shared/components/design-system/photo-block/PhotoBlock.tsx
@@ -159,12 +159,12 @@ export const ImagePreviewBlock = ({
                 ...styles.trimmedTypography
               }}
             >
-                Назва файлу {finalFileName}
+              Назва файлу {finalFileName}
             </Typography>
 
             {dimensions ? (
               <Typography variant="body2" color="text.secondary" sx={styles.imageSizeText}>
-                    Розмір: {dimensions.width} × {dimensions.height}
+                Розмір: {dimensions.width} × {dimensions.height}
               </Typography>
             ) : null}
           </Stack>
@@ -178,7 +178,7 @@ export const ImagePreviewBlock = ({
               onClick={handleEditClick}
               style={styles.editButton}
             >
-                Редагувати
+              Редагувати
             </Button>
 
             <Button
@@ -189,7 +189,7 @@ export const ImagePreviewBlock = ({
               onClick={handleChangeClick}
               sx={styles.changeButton}
             >
-                Змінити зображення
+              Змінити зображення
             </Button>
 
             {editorMode === 'legacy' && (

--- a/app/shared/components/media-modal/flow/MediaModalFlowState.ts
+++ b/app/shared/components/media-modal/flow/MediaModalFlowState.ts
@@ -105,16 +105,10 @@ const toCropState = (state: State, selected: SelectedMedia): State => ({
 const setBaselineCrop = (state: State, crop: CropResult | null): State => {
   if (state.step !== 'CROP') return state;
 
-  const userHasChanged = !isSameCrop(state.crop, state.baselineCrop);
-  if (userHasChanged) return state;
-
-  const noChange = isSameCrop(state.baselineCrop, crop) && isSameCrop(state.crop, crop);
-  if (noChange) return state;
-
   return {
     ...state,
     baselineCrop: crop,
-    crop
+    crop: state.crop ?? crop
   };
 };
 

--- a/app/shared/components/media-modal/views/crop-view/CropView.tsx
+++ b/app/shared/components/media-modal/views/crop-view/CropView.tsx
@@ -59,6 +59,33 @@ export function CropView({ selected, resetSeq, onBaseline, onChange }: Readonly<
     }
   }, [selected.id]);
 
+  useEffect(() => {
+    if (resetSeq > 0 && imgRef.current) {
+      const { width, height, naturalWidth, naturalHeight } = imgRef.current;
+      const scaleX = width / naturalWidth;
+      const scaleY = height / naturalHeight;
+
+      const resetPixelCrop: PixelCrop = {
+        unit: 'px',
+        x: MOCK_SERVER_DATA.x * scaleX,
+        y: MOCK_SERVER_DATA.y * scaleY,
+        width: MOCK_SERVER_DATA.width * scaleX,
+        height: MOCK_SERVER_DATA.height * scaleY
+      };
+
+      setCrop(resetPixelCrop);
+
+      onBaseline({
+        rect: {
+          x: MOCK_SERVER_DATA.x,
+          y: MOCK_SERVER_DATA.y,
+          width: MOCK_SERVER_DATA.width,
+          height: MOCK_SERVER_DATA.height
+        }
+      });
+    }
+  }, [resetSeq, onBaseline]);
+
   const onImageLoad = (e: React.SyntheticEvent<HTMLImageElement>) => {
     const { width, height, naturalWidth, naturalHeight } = e.currentTarget;
     const scaleX = width / naturalWidth;

--- a/app/shared/components/media-modal/views/crop-view/CropView.tsx
+++ b/app/shared/components/media-modal/views/crop-view/CropView.tsx
@@ -3,7 +3,7 @@
 import 'react-image-crop/dist/ReactCrop.css';
 import { Box } from '@mui/material';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import ReactCrop, { Crop, PixelCrop } from 'react-image-crop';
+import ReactCrop, { PixelCrop } from 'react-image-crop';
 
 import type { CropRendererProps } from '../../MediaModal.renderers';
 
@@ -23,7 +23,7 @@ export function CropView({ selected, resetSeq, onBaseline, onChange }: Readonly<
   const uploadFile = selected.kind === 'upload' ? selected.file : null;
   const [uploadObjectUrl, setUploadObjectUrl] = useState('');
 
-  const [crop, setCrop] = useState<Crop>();
+  const [crop, setCrop] = useState<PixelCrop>();
   const imgRef = useRef<HTMLImageElement>(null);
 
   useEffect(() => {
@@ -64,7 +64,7 @@ export function CropView({ selected, resetSeq, onBaseline, onChange }: Readonly<
     const scaleX = width / naturalWidth;
     const scaleY = height / naturalHeight;
 
-    const initialPixelCrop: Crop = {
+    const initialPixelCrop: PixelCrop = {
       unit: 'px',
       x: MOCK_SERVER_DATA.x * scaleX,
       y: MOCK_SERVER_DATA.y * scaleY,
@@ -85,11 +85,7 @@ export function CropView({ selected, resetSeq, onBaseline, onChange }: Readonly<
   };
 
   const handleCropChange = (pixelCrop: PixelCrop) => {
-    setCrop((prevCrop) => ({
-      ...pixelCrop,
-      width: prevCrop?.width || pixelCrop.width,
-      height: prevCrop?.height || pixelCrop.height
-    }));
+    setCrop(pixelCrop);
   };
 
   const handleComplete = (c: PixelCrop) => {
@@ -117,10 +113,6 @@ export function CropView({ selected, resetSeq, onBaseline, onChange }: Readonly<
         flexDirection: 'column',
         gap: 2,
         overflow: 'hidden',
-
-        '& .ReactCrop__drag-handle': {
-          display: 'none !important'
-        },
 
         '& .ReactCrop__crop-selection': {
           animation: 'none !important',

--- a/app/shared/components/media-modal/views/crop-view/CropView.tsx
+++ b/app/shared/components/media-modal/views/crop-view/CropView.tsx
@@ -19,7 +19,7 @@ const MOCK_SERVER_DATA = {
 
 const forCropAngle = Math.min(MOCK_SERVER_DATA.width, MOCK_SERVER_DATA.height) * 0.2;
 
-export function CropView({ selected, resetSeq, onBaseline, onChange }: Readonly<CropRendererProps>) {
+export function CropView({ selected, crop: stateCrop, resetSeq, onBaseline, onChange }: Readonly<CropRendererProps>) {
   const uploadFile = selected.kind === 'upload' ? selected.file : null;
   const [uploadObjectUrl, setUploadObjectUrl] = useState('');
 
@@ -91,23 +91,20 @@ export function CropView({ selected, resetSeq, onBaseline, onChange }: Readonly<
     const scaleX = width / naturalWidth;
     const scaleY = height / naturalHeight;
 
+    const sourceRect = stateCrop?.rect ?? MOCK_SERVER_DATA;
+
     const initialPixelCrop: PixelCrop = {
       unit: 'px',
-      x: MOCK_SERVER_DATA.x * scaleX,
-      y: MOCK_SERVER_DATA.y * scaleY,
-      width: MOCK_SERVER_DATA.width * scaleX,
-      height: MOCK_SERVER_DATA.height * scaleY
+      x: sourceRect.x * scaleX,
+      y: sourceRect.y * scaleY,
+      width: sourceRect.width * scaleX,
+      height: sourceRect.height * scaleY
     };
 
     setCrop(initialPixelCrop);
 
     onBaseline({
-      rect: {
-        x: MOCK_SERVER_DATA.x,
-        y: MOCK_SERVER_DATA.y,
-        width: MOCK_SERVER_DATA.width,
-        height: MOCK_SERVER_DATA.height
-      }
+      rect: sourceRect
     });
   };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7670,6 +7670,111 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "15.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.6.tgz",
+      "integrity": "sha512-ES3nRz7N+L5Umz4KoGfZ4XX6gwHplwPhioVRc25+QNsDa7RtUF/z8wJcbuQ2Tffm5RZwuN2A063eapoJ1u4nPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "15.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.6.tgz",
+      "integrity": "sha512-JIGcytAyk9LQp2/nuVZPAtj8uaJ/zZhsKOASTjxDug0SPU9LAM3wy6nPU735M1OqacR4U20LHVF5v5Wnl9ptTA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.6.tgz",
+      "integrity": "sha512-qvz4SVKQ0P3/Im9zcS2RmfFL/UCQnsJKJwQSkissbngnB/12c6bZTCB0gHTexz1s6d/mD0+egPKXAIRFVS7hQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.6.tgz",
+      "integrity": "sha512-FsbGVw3SJz1hZlvnWD+T6GFgV9/NYDeLTNQB2MXoPN5u9VA9OEDy6fJEfePfsUKAhJufFbZLgp0cPxMuV6SV0w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "15.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.6.tgz",
+      "integrity": "sha512-3QnHGFWlnvAgyxFxt2Ny8PTpXtQD7kVEeaFat5oPAHHI192WKYB+VIKZijtHLGdBBvc16tiAkPTDmQNOQ0dyrA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "15.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.6.tgz",
+      "integrity": "sha512-OsGX148sL+TqMK9YFaPFPoIaJKbFJJxFzkXZljIgA9hjMjdruKht6xDCEv1HLtlLNfkx3c5w2GLKhj7veBQizQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.6.tgz",
+      "integrity": "sha512-ONOMrqWxdzXDJNh2n60H6gGyKed42Ieu6UTVPZteXpuKbLZTH4G4eBMsr5qWgOBA+s7F+uB4OJbZnrkEDnZ5Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@next/swc-win32-x64-msvc": {
       "version": "15.5.6",
       "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.6.tgz",
@@ -27184,111 +27289,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.6.tgz",
-      "integrity": "sha512-ES3nRz7N+L5Umz4KoGfZ4XX6gwHplwPhioVRc25+QNsDa7RtUF/z8wJcbuQ2Tffm5RZwuN2A063eapoJ1u4nPg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.6.tgz",
-      "integrity": "sha512-JIGcytAyk9LQp2/nuVZPAtj8uaJ/zZhsKOASTjxDug0SPU9LAM3wy6nPU735M1OqacR4U20LHVF5v5Wnl9ptTA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.6.tgz",
-      "integrity": "sha512-qvz4SVKQ0P3/Im9zcS2RmfFL/UCQnsJKJwQSkissbngnB/12c6bZTCB0gHTexz1s6d/mD0+egPKXAIRFVS7hQg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.6.tgz",
-      "integrity": "sha512-FsbGVw3SJz1hZlvnWD+T6GFgV9/NYDeLTNQB2MXoPN5u9VA9OEDy6fJEfePfsUKAhJufFbZLgp0cPxMuV6SV0w==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.6.tgz",
-      "integrity": "sha512-3QnHGFWlnvAgyxFxt2Ny8PTpXtQD7kVEeaFat5oPAHHI192WKYB+VIKZijtHLGdBBvc16tiAkPTDmQNOQ0dyrA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.6.tgz",
-      "integrity": "sha512-OsGX148sL+TqMK9YFaPFPoIaJKbFJJxFzkXZljIgA9hjMjdruKht6xDCEv1HLtlLNfkx3c5w2GLKhj7veBQizQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.6.tgz",
-      "integrity": "sha512-ONOMrqWxdzXDJNh2n60H6gGyKed42Ieu6UTVPZteXpuKbLZTH4G4eBMsr5qWgOBA+s7F+uB4OJbZnrkEDnZ5Fg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     }
   }


### PR DESCRIPTION
## Description

This PR addresses multiple state management and interaction bugs within the `MediaModal` image cropping functionality. Key improvements include enabling crop area resizing, fixing the reset functionality, and ensuring that crop boundaries are correctly retained between modal sessions.

**Key changes:**
- **Enabled Resizing:** Removed CSS and logic restrictions that prevented users from scaling the crop box.
- **Fixed Reset Action:** Implemented a listener for `resetSeq` to restore default crop boundaries when the iteration icon is clicked.
- **State Retention:** Integrated logic to store and pass back the last saved crop coordinates, ensuring the modal reflects previous user input upon reopening.
- **Boundary Accuracy:** Simplified the baseline crop logic to prevent coordinate mismatch between the UI and the internal state.

## Type of change

- [x] Bug fix

1. Open the MediaModal and select an image for cropping.
2. Verify that you can drag the corners/edges of the crop box to resize it.
3. Move and resize the crop box, then click the "reset" icon; verify boundaries return to the default position.
4. Apply a crop, close the modal, and reopen it; verify the crop box appears exactly where you left it.
5. Ensure the final selected area matches the preview in the `PhotoBlock` component.

## Video / Screenshots
**Before**
https://github.com/user-attachments/assets/2c84fd1c-e6bf-44b7-817e-265a34418214


**After**
https://github.com/user-attachments/assets/2d6a3f8a-8fd1-4c62-a2d4-3c6c1d4ec444


Closes: #405 