### PR TITLE
fix(ui): update toaster width, error icon and background

### DIFF
--- a/app/shared/components/toaster/Toaster.styles.ts
+++ b/app/shared/components/toaster/Toaster.styles.ts
@@ -12,7 +12,7 @@ export const slideOut = keyframes`
 
 export const styles = {
   toastContainer: {
-    width: '320px',
+    width: '375px',
     minHeight: '56px',
     padding: '12px 16px',
     borderRadius: '12px',
@@ -58,12 +58,12 @@ export const styles = {
   },
   success: {
     backgroundColor: '#E2F2DC',
-    borderColor: '#579A40',
+    borderColor: '#E2F2DC',
     color: '#2C4D20'
   },
   error: {
-    backgroundColor: '#fde7e7',
-    borderColor: '#ef4343',
+    backgroundColor: '#FAE2DC',
+    borderColor: '#FAE2DC',
     color: '#981b1b'
   }
 };

--- a/app/shared/components/toaster/Toaster.tsx
+++ b/app/shared/components/toaster/Toaster.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Box, IconButton, Typography } from '@mui/material';
-import { CheckCircle2, X,XCircle } from 'lucide-react';
+import { CheckCircle2, CircleAlert,X } from 'lucide-react';
 import { resolveValue, toast, Toaster as HotToaster } from 'react-hot-toast';
 
 import { slideIn, slideOut, styles } from './Toaster.styles';
@@ -31,7 +31,7 @@ export const Toaster = () => {
               </Box>
             ) : (
               <Box sx={styles.icon} data-testid="error-icon">
-                <XCircle size={32} color="#696C7D" />
+                <CircleAlert size={32} color="#696C7D" />
               </Box>
             )}
 


### PR DESCRIPTION
## Description

Updated the Toast notification UI to align with the latest Figma designs by adjusting the component width and styling for error states. These changes include replacing the error icon with an exclamation mark and updating the background color for better visual consistency.

## Type of change

- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Open the admin panel and navigate to a page where Toast notifications are triggered, such as the Login or About Us page.
2. Trigger an error message to verify that the Toast now has a fixed width of 375px.
3. Confirm that the error notification displays the new exclamation mark icon instead of a cross.
4. Verify that the background color for the error state is updated to `#FAE2DC` and matches the Figma specification.

### Actual result

1. Toast Width: The component currently has a fixed width of `320px`.
2. Error Toast Icon: Error notifications display a "cross" (X) icon at the beginning.
3. Error Toast Background: The background color for error notifications is currently set to `#FDE7E7`.

### Expected result

1. Toast Width: The component width must be updated to `375px` according to the new Figma design.
2. Error Toast Icon: Error notifications should display an "exclamation mark" (!) icon at the beginning.
3. Error Toast Background: The background color for error notifications must be updated to `#FAE2DC`.

<img width="543" height="202" alt="Знімок екрана 2026-03-27 202756" src="https://github.com/user-attachments/assets/6ac4c1ff-bc80-4be7-a984-b5136e571c5c" />

Closes: https://github.com/Liatoshynsky-Foundation/lf-admin/issues/412