### PR TITLE
Create reusable filtering and search components

### DIFF
--- a/app/(logged_in)/files/page.test.tsx
+++ b/app/(logged_in)/files/page.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 
 import Page from './page';
@@ -25,32 +25,6 @@ jest.mock('~/types/graphql/generated/graphql', () => ({
     Audio: 'Audio'
   },
   useUploadBlobMutation: () => [mockUploadBlob]
-}));
-
-jest.mock('~/shared/components/control-panel', () => ({
-  ControlPanel: ({
-    leftContent,
-    rightContent,
-    bottomContent,
-    isBottomOpen
-  }: {
-    leftContent: React.ReactNode;
-    rightContent: React.ReactNode;
-    bottomContent?: React.ReactNode;
-    isBottomOpen?: boolean;
-  }) => (
-    <div data-testid="control-panel">
-      <div data-testid="left-content">{leftContent}</div>
-      <div data-testid="right-content">{rightContent}</div>
-      {isBottomOpen ? <div data-testid="bottom-content">{bottomContent}</div> : null}
-    </div>
-  )
-}));
-
-jest.mock('~/shared/components/dropdown-menu/DropdownMenu', () => ({
-  __esModule: true,
-  default: ({ open, menuList }: { open: boolean; menuList: React.ReactNode }) =>
-    open ? <div data-testid="dropdown-menu">{menuList}</div> : null
 }));
 
 jest.mock('~/shared/components/file-info-sidebar/FileInfoSidebar', () => ({
@@ -86,36 +60,82 @@ jest.mock('~/shared/components/media-modal/views/upload-view/UploadView', () => 
   UploadView: () => null
 }));
 
-jest.mock('~/shared/components/search/Search', () => ({
-  Search: ({ search, setSearch }: { search: string; setSearch: (value: string) => void }) => (
-    <input data-testid="search" value={search} onChange={(event) => setSearch(event.target.value)} />
-  )
-}));
-
-jest.mock('~/shared/components/selector/FilterSelect', () => ({
-  FilterSelect: ({
-    label,
-    options,
-    onAdd
+jest.mock('~/shared/components/filtering-toolbar', () => ({
+  FilteringToolbar: ({
+    search,
+    filters = [],
+    isFiltersOpen,
+    onToggleFilters,
+    rightSlot,
+    bottomTrailingContent
   }: {
-    label: string;
-    options: Array<{ value: string; label: string }>;
-    onAdd: (value: string, label: string, allSelected: string[]) => void;
+    search?: { search: string; setSearch: (value: string) => void };
+    filters?: Array<{
+      id: string;
+      label: string;
+      options: Array<{ value: string; label: string }>;
+      onChange: (value: string[]) => void;
+    }>;
+    isFiltersOpen?: boolean;
+    onToggleFilters?: () => void;
+    rightSlot?: React.ReactNode;
+    bottomTrailingContent?: React.ReactNode;
+  }) => (
+    <div data-testid="control-panel">
+      {search ? (
+        <input
+          data-testid="search"
+          value={search.search}
+          onChange={(event) => search.setSearch(event.target.value)}
+        />
+      ) : null}
+      {onToggleFilters ? (
+        <button type="button" onClick={onToggleFilters}>
+          Фільтри
+        </button>
+      ) : null}
+      {rightSlot}
+      {isFiltersOpen ? (
+        <div data-testid="bottom-content">
+          {filters.map((filter) => (
+            <button
+              key={filter.id}
+              data-testid={`filter-select-${filter.label}`}
+              onClick={() => filter.onChange([filter.options[0].value])}
+            >
+              {filter.label}
+            </button>
+          ))}
+          {bottomTrailingContent}
+        </div>
+      ) : null}
+    </div>
+  ),
+  SortSelect: ({
+    triggerLabel,
+    fieldOptions,
+    fieldValue,
+    orderOptions,
+    onFieldChange,
+    onValueChange
+  }: {
+    triggerLabel: string;
+    fieldOptions: Array<{ value: string; label: string }>;
+    fieldValue: string;
+    orderOptions: Record<string, Array<{ value: string; label: string }>>;
+    onFieldChange: (value: string) => void;
+    onValueChange: (value: string) => void;
   }) => (
     <button
-      data-testid={`filter-select-${label}`}
-      onClick={() => onAdd(options[0].value, options[0].label, [options[0].value])}
+      type="button"
+      data-testid="sort-select"
+      onClick={() => {
+        const nextField = fieldOptions.find((option) => option.value !== fieldValue) ?? fieldOptions[0];
+        onFieldChange(nextField.value);
+        onValueChange(orderOptions[nextField.value][0].value);
+      }}
     >
-      {label}
-    </button>
-  )
-}));
-
-jest.mock('~/shared/components/selector/FilterSelectItem/FilterSelectItem', () => ({
-  __esModule: true,
-  default: ({ label, onClick }: { label: string; onClick: () => void }) => (
-    <button data-testid={`sort-option-${label}`} onClick={onClick}>
-      {label}
+      {triggerLabel}
     </button>
   )
 }));
@@ -218,11 +238,7 @@ describe('Files page', () => {
     render(<Page />);
 
     fireEvent.click(screen.getByRole('button', { name: /Фільтри/i }));
-    fireEvent.click(screen.getByRole('button', { name: /Нові спочатку/i }));
-
-    const dropdown = screen.getByTestId('dropdown-menu');
-    fireEvent.click(within(dropdown).getByTestId('sort-option-Назва файлу'));
-    fireEvent.click(within(dropdown).getByTestId('sort-option-А-Я'));
+    fireEvent.click(screen.getByTestId('sort-select'));
 
     expect(setItemSpy).toHaveBeenCalledWith('files_sort', 'name_asc');
   });

--- a/app/(logged_in)/files/page.tsx
+++ b/app/(logged_in)/files/page.tsx
@@ -1,36 +1,23 @@
 'use client';
 
 import {
-  Badge,
   Box,
   Button,
-  Divider,
-  IconButton,
   Tab,
   Tabs,
-  Tooltip,
   Typography
 } from '@mui/material';
 import Image from 'next/image';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
-import { FORMAT_FILTER_OPTIONS } from '~/constants/file-formats';
 import {
   FILE_TABS,
   FILES_UPLOAD_ACCEPT,
   FILES_UPLOAD_ERROR,
-  type FilesSortValue,
-  type FilesTabValue,
-  SORT_FIELD_OPTIONS,
-  SORT_OPTIONS,
-  SORT_ORDER_OPTIONS,
-  type SortFieldValue,
-  USAGE_FILTER_OPTIONS
+  type FilesTabValue
 } from '~/constants/files';
 import { readFileAsDataURL } from '~/lib/utils/readFileAsDataURL';
-import { ControlPanel } from '~/shared/components/control-panel';
 import { colors } from '~/shared/components/design-system/button/Button.styles';
-import DropdownMenu from '~/shared/components/dropdown-menu/DropdownMenu';
 import {
   type FileDetailsSidebarFile,
   FileInfoSidebar,
@@ -42,17 +29,17 @@ import {
   type FilesCardsLayoutItem,
   type FilesCardsLayoutView
 } from '~/shared/components/files-cards-layout';
+import {
+  FilteringToolbar,
+  SortSelect
+} from '~/shared/components/filtering-toolbar';
 import { MediaModal } from '~/shared/components/media-modal/MediaModal';
 import type { MediaModalRenderers } from '~/shared/components/media-modal/MediaModal.renderers';
 import type { MediaModalOpenState, MediaModalResult } from '~/shared/components/media-modal/MediaModal.types';
 import { UploadView } from '~/shared/components/media-modal/views/upload-view/UploadView';
-import { Search } from '~/shared/components/search/Search';
-import { FilterSelect } from '~/shared/components/selector/FilterSelect';
-import { filterSelectStyles } from '~/shared/components/selector/FilterSelect.styles';
-import FilterSelectItem from '~/shared/components/selector/FilterSelectItem/FilterSelectItem';
 import { ViewToggle } from '~/shared/components/view-toggle';
 import { useAllAssets } from '~/shared/hooks/use-assets/useAssets';
-import { normalizeSearch } from '~/shared/utils/normalizeSearch';
+import { useFilesFiltering } from '~/shared/hooks/use-files';
 import { AssetType, useUploadBlobMutation } from '~/types/graphql/generated/graphql';
 
 type FilesPageFileItem = FilesCardsLayoutItem & {
@@ -130,40 +117,6 @@ const formatFromMimeType = (mimeType: string, filename: string) => {
   return ext || undefined;
 };
 
-const normalizeFormatFilterValue = (value: string): string => {
-  if (value === 'jpeg') {
-    return 'jpg';
-  }
-
-  if (value === 'svg+xml') {
-    return 'svg';
-  }
-
-  if (value === 'msword') {
-    return 'doc';
-  }
-
-  if (value === 'vnd.openxmlformats-officedocument.wordprocessingml.document') {
-    return 'docx';
-  }
-
-  if (value === 'vnd.ms-excel') {
-    return 'xls';
-  }
-
-  if (value === 'vnd.openxmlformats-officedocument.spreadsheetml.sheet') {
-    return 'xlsx';
-  }
-
-  if (value === 'x-zip-compressed') {
-    return 'zip';
-  }
-
-  return value;
-};
-
-const DOCS_FORMAT_VALUES = new Set<string>(['pdf', 'zip', 'doc', 'docx', 'xls', 'xlsx']);
-
 const usageToLink = (pageId?: string | null) => {
   if (!pageId) {
     return undefined;
@@ -172,65 +125,12 @@ const usageToLink = (pageId?: string | null) => {
   return pageId.startsWith('/') ? pageId : `/${pageId}`;
 };
 
-const getUsageFilterValues = (usageLinks: FileUsageLink[]): string[] => {
-  if (!usageLinks.length) {
-    return ['unused'];
-  }
-
-  const categories = new Set<string>();
-
-  usageLinks.forEach((usageLink) => {
-    const normalizedLabel = normalizeSearch(usageLink.label);
-
-    if (/новин|медіа|news|media/.test(normalizedLabel)) {
-      categories.add('news_media');
-      return;
-    }
-
-    if (/поді|event/.test(normalizedLabel)) {
-      categories.add('events');
-      return;
-    }
-
-    if (/творч|creative/.test(normalizedLabel)) {
-      categories.add('creativity');
-      return;
-    }
-
-    if (/файл|files/.test(normalizedLabel)) {
-      categories.add('files');
-      return;
-    }
-
-    if (/науков|scientific|research/.test(normalizedLabel)) {
-      categories.add('research');
-      return;
-    }
-
-    categories.add('main_pages');
-  });
-
-  return Array.from(categories);
-};
-
 export default function FilesPage() {
   const [view, setView] = useState<FilesCardsLayoutView>('grid');
-  const [activeTab, setActiveTab] = useState<FilesTabValue>('all');
   const [selectedFileId, setSelectedFileId] = useState<string | null>(null);
   const [hasInitializedSelection, setHasInitializedSelection] = useState(false);
   const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
   const [uploadModalInitial, setUploadModalInitial] = useState<MediaModalOpenState | undefined>(undefined);
-  const [isFiltersOpen, setIsFiltersOpen] = useState(false);
-  const [search, setSearch] = useState('');
-  const [formatFilters, setFormatFilters] = useState<string[]>([]);
-  const [usageFilters, setUsageFilters] = useState<string[]>([]);
-  const [sortValue, setSortValue] = useState<FilesSortValue>(() => {
-    if (globalThis.window === undefined) return 'date_desc';
-    const saved = localStorage.getItem('files_sort');
-    return (SORT_OPTIONS.some((o) => o.value === saved) ? saved : 'date_desc') as FilesSortValue;
-  });
-  const [sortMenuAnchorEl, setSortMenuAnchorEl] = useState<HTMLElement | null>(null);
-  const sortTriggerRef = useRef<HTMLDivElement | null>(null);
   const { data, loading, error, refetch } = useAllAssets();
   const [uploadBlob] = useUploadBlobMutation();
 
@@ -296,95 +196,7 @@ export default function FilesPage() {
     }));
   }, [data?.allAssets]);
 
-  const titleOptions = useMemo(() => {
-    return Array.from(new Map(allFiles.map((file) => [file.id, { id: file.id, title: file.name }])).values());
-  }, [allFiles]);
-
-  const files = useMemo(() => {
-    const normalizedSearch = normalizeSearch(search);
-
-    const filtered = allFiles.filter((file) => {
-      const matchesSearch = !normalizedSearch || file.name.toLowerCase().includes(normalizedSearch);
-      const normalizedFileFormat = normalizeFormatFilterValue(file.format?.toLowerCase() ?? '');
-      const matchesFormat =
-        !formatFilters.length ||
-        formatFilters.some((formatFilter) => normalizeFormatFilterValue(formatFilter) === normalizedFileFormat);
-      const fileUsageFilterValues = getUsageFilterValues(file.usage);
-      const matchesUsage = !usageFilters.length || usageFilters.some((usageFilter) => fileUsageFilterValues.includes(usageFilter));
-
-      return matchesSearch && matchesFormat && matchesUsage;
-    });
-
-    return [...filtered].sort((left, right) => {
-      if (sortValue === 'name_asc') {
-        return left.name.localeCompare(right.name, 'uk');
-      }
-
-      if (sortValue === 'name_desc') {
-        return right.name.localeCompare(left.name, 'uk');
-      }
-
-      const leftDate = new Date(left.createdAtRaw ?? left.dateAdded).getTime();
-      const rightDate = new Date(right.createdAtRaw ?? right.dateAdded).getTime();
-
-      if (sortValue === 'date_asc') {
-        return leftDate - rightDate;
-      }
-
-      return rightDate - leftDate;
-    });
-  }, [allFiles, formatFilters, search, sortValue, usageFilters]);
-
-  const activeFiltersCount = formatFilters.length + usageFilters.length;
-  const currentSortOption = SORT_OPTIONS.find((option) => option.value === sortValue) ?? SORT_OPTIONS[0];
-  const currentSortField: SortFieldValue = sortValue.startsWith('date') ? 'date' : 'name';
-
-  const handleToggleSortMenu = () => {
-    setSortMenuAnchorEl((previous) => (previous ? null : sortTriggerRef.current));
-  };
-
-  const handleCloseSortMenu = () => {
-    setSortMenuAnchorEl(null);
-    requestAnimationFrame(() => sortTriggerRef.current?.focus());
-  };
-
-  const handleSortFieldChange = (field: SortFieldValue) => {
-    if (field === 'date') {
-      setSortValue((previous) => {
-        const next = previous.startsWith('date') ? previous : 'date_desc';
-        localStorage.setItem('files_sort', next);
-        return next;
-      });
-      return;
-    }
-
-    setSortValue((previous) => {
-      const next = previous.startsWith('name') ? previous : 'name_asc';
-      localStorage.setItem('files_sort', next);
-      return next;
-    });
-  };
-
-  const clearFilters = () => {
-    setFormatFilters([]);
-    setUsageFilters([]);
-  };
-
-  const filteredFiles = useMemo(() => {
-    if (activeTab === 'all') {
-      return files;
-    }
-
-    if (activeTab === 'favorites') {
-      return files.filter((file) => file.isStarred);
-    }
-
-    if (activeTab === 'docs') {
-      return files.filter((file) => DOCS_FORMAT_VALUES.has(normalizeFormatFilterValue(file.format?.toLowerCase() ?? '')));
-    }
-
-    return files.filter((file) => file.type === activeTab);
-  }, [activeTab, files]);
+  const { activeTab, setActiveTab, filteredFiles, toolbarProps, sortProps } = useFilesFiltering(allFiles);
 
   useEffect(() => {
     if (!filteredFiles.length) {
@@ -517,244 +329,16 @@ export default function FilesPage() {
         ))}
       </Tabs>
 
-      <ControlPanel
-        leftContent={
-          <Box sx={{ width: '100%', display: 'flex', justifyContent: 'flex-start' }}>
-            <Search search={search} setSearch={setSearch} options={titleOptions} />
-          </Box>
-        }
-        rightContent={
-          <>
-            <Badge
-              badgeContent={activeFiltersCount}
-              color="error"
-              overlap="circular"
-              invisible={activeFiltersCount === 0}
-              sx={{
-                '& .MuiBadge-badge': {
-                  top: '4px',
-                  fontSize: '14px',
-                  minWidth: '22px',
-                  height: '22px',
-                  borderRadius: '50%',
-                  backgroundColor: '#A32B0E',
-                  transform: 'translate(18px, -50%)'
-                }
-              }}
-            >
-              <Button
-                variant="outlined"
-                startIcon={
-                  <Image src="/icons/filter-dark.svg" alt="filters" width={18} height={18} />
-                }
-                onClick={() => setIsFiltersOpen((previous) => !previous)}
-                sx={{
-                  borderRadius: '28px',
-                  px: '24px',
-                  py: '6px',
-                  minHeight: '40px',
-                  textTransform: 'none',
-                  borderColor: colors.black,
-                  color: colors.black,
-                  bgcolor: isFiltersOpen ? '#190D031A' : colors.white,
-                  fontSize: '16px',
-                  '&:hover': {
-                    borderColor: colors.black,
-                    bgcolor: isFiltersOpen ? '#190D031A' : colors.blue[50]
-                  }
-                }}
-              >
-                Фільтри
-              </Button>
-            </Badge>
-
-            <ViewToggle value={view} onChange={setView} />
-          </>
-        }
-        isBottomOpen={isFiltersOpen}
-        bottomContent={
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
-            <Box
-              sx={{
-                display: 'flex',
-                gap: '12px',
-                flexWrap: 'wrap',
-                justifyContent: 'space-between',
-                alignItems: 'center'
-              }}
-            >
-              <Box sx={{ display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
-                <FilterSelect
-                  label="Формат"
-                  options={FORMAT_FILTER_OPTIONS}
-                  defaultValues={formatFilters}
-                  hideClearAction
-                  menuMinWidth={116}
-                  onAdd={(_, __, allSelected) => setFormatFilters(allSelected)}
-                  onRemove={(_, __, allSelected) => setFormatFilters(allSelected)}
-                />
-
-                <FilterSelect
-                  label="Використання"
-                  options={USAGE_FILTER_OPTIONS}
-                  defaultValues={usageFilters}
-                  hideClearAction
-                  menuMinWidth={190}
-                  onAdd={(_, __, allSelected) => setUsageFilters(allSelected)}
-                  onRemove={(_, __, allSelected) => setUsageFilters(allSelected)}
-                />
-
-                <Tooltip
-                  title="Очистити всі фільтри"
-                  placement="top"
-                  arrow
-                  slotProps={{
-                    transition: {
-                      timeout: 0
-                    },
-                    tooltip: {
-                      sx: {
-                        minWidth: '153px',
-                        height: '28px',
-                        px: '16px',
-                        py: '4px',
-                        borderRadius: '20px',
-                        bgcolor: '#3F444A',
-                        fontStyle: 'italic',
-                        fontSize: '14px',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center'
-                      }
-                    },
-                    arrow: {
-                      sx: {
-                        color: '#3F444A'
-                      }
-                    }
-                  }}
-                >
-                  <span>
-                    {activeFiltersCount > 0 ? (
-                      <IconButton
-                        aria-label="clear-filters"
-                        onClick={clearFilters}
-                        sx={{
-                          width: '40px',
-                          height: '40px',
-                          borderRadius: '8px',
-                          bgcolor: '#fff',
-                          color: '#190D03',
-                          '&:hover': {
-                            bgcolor: '#fff'
-                          },
-                          '&.Mui-disabled': {
-                            opacity: 0.5,
-                            color: '#190D03'
-                          }
-                        }}
-                      >
-                        <Image src="/icons/close.svg" alt="clear" width={22} height={22} />
-                      </IconButton>
-                    ) : null}
-                  </span>
-                </Tooltip>
-              </Box>
-
-              <>
-                <Box
-                  ref={sortTriggerRef}
-                  onClick={handleToggleSortMenu}
-                  role="button"
-                  tabIndex={0}
-                  aria-haspopup="dialog"
-                  aria-expanded={Boolean(sortMenuAnchorEl)}
-                  sx={{
-                    ...filterSelectStyles.root('filled', false),
-                    minWidth: '208px'
-                  }}
-                >
-                  <Typography sx={filterSelectStyles.label(false)}>{currentSortOption.label}</Typography>
-                  <Box sx={filterSelectStyles.dropdownIcon(false)}>
-                    <Image
-                      src="/icons/chevron-down-dark.svg"
-                      alt="chevron-down"
-                      width={12}
-                      height={12}
-                      style={{ transform: 'translateY(2px)' }}
-                    />
-                  </Box>
-                </Box>
-
-                <DropdownMenu
-                  disableScrollLock
-                  anchorEl={sortMenuAnchorEl}
-                  open={Boolean(sortMenuAnchorEl)}
-                  onClose={handleCloseSortMenu}
-                  sx={{
-                    '& .MuiPaper-root': {
-                      minWidth: '208px'
-                    }
-                  }}
-                  anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-                  transformOrigin={{ vertical: 'top', horizontal: 'left' }}
-                  menuList={
-                    <Box sx={{ padding: '8px' }}>
-                      <Typography
-                        sx={{
-                          color: '#4E5061',
-                          fontSize: '12px',
-                          textTransform: 'uppercase',
-                          px: '12px',
-                          py: '4px'
-                        }}
-                      >
-                        Сортувати за
-                      </Typography>
-
-                      {SORT_FIELD_OPTIONS.map((option) => (
-                        <FilterSelectItem
-                          key={option.value}
-                          label={option.label}
-                          selected={currentSortField === option.value}
-                          onClick={() => handleSortFieldChange(option.value)}
-                          sx={filterSelectStyles.menuItem}
-                        />
-                      ))}
-
-                      <Divider sx={{ my: 1 }} />
-
-                      <Typography
-                        sx={{
-                          color: '#4E5061',
-                          fontSize: '12px',
-                          textTransform: 'uppercase',
-                          px: '12px',
-                          py: '4px'
-                        }}
-                      >
-                        Порядок
-                      </Typography>
-
-                      {SORT_ORDER_OPTIONS[currentSortField].map((option) => (
-                        <FilterSelectItem
-                          key={option.value}
-                          label={option.label}
-                          selected={sortValue === option.value}
-                          onClick={() => {
-                            setSortValue(option.value);
-                            localStorage.setItem('files_sort', option.value);
-                            handleCloseSortMenu();
-                          }}
-                          sx={filterSelectStyles.menuItem}
-                        />
-                      ))}
-                    </Box>
-                  }
-                />
-              </>
-            </Box>
-          </Box>
+      <FilteringToolbar
+        {...toolbarProps}
+        dataTestId="control-panel"
+        rightSlot={<ViewToggle value={view} onChange={setView} />}
+        bottomTrailingContent={
+          <SortSelect
+            {...sortProps}
+            minWidth={208}
+            dataTestId="files-sort-select"
+          />
         }
       />
 

--- a/app/shared/components/control-panel/ControlPanel.tsx
+++ b/app/shared/components/control-panel/ControlPanel.tsx
@@ -18,11 +18,14 @@ export function ControlPanel({
   isBottomOpen = false,
   dataTestId = 'ControlPanel'
 }: ControlPanelProps) {
+  const hasLeftContent = leftContent !== undefined && leftContent !== null;
+  const hasRightContent = rightContent !== undefined && rightContent !== null;
+
   return (
     <Box sx={styles.wrapper} data-testid={dataTestId}>
       <Stack direction="row" sx={styles.root}>
-        <Box sx={styles.left}>{leftContent}</Box>
-        <Box sx={styles.right}>{rightContent}</Box>
+        {hasLeftContent ? <Box sx={styles.left}>{leftContent}</Box> : null}
+        {hasRightContent ? <Box sx={styles.right}>{rightContent}</Box> : null}
       </Stack>
 
       {bottomContent && (

--- a/app/shared/components/filtering-toolbar/FilteringToolbar.test.tsx
+++ b/app/shared/components/filtering-toolbar/FilteringToolbar.test.tsx
@@ -1,0 +1,138 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { FilteringToolbar } from './FilteringToolbar';
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => <img {...props} alt={props.alt ?? ''} />
+}));
+
+jest.mock('~/shared/components/search/Search', () => ({
+  Search: ({ search, setSearch }: { search: string; setSearch: (value: string) => void }) => (
+    <input data-testid="search" value={search} onChange={(event) => setSearch(event.target.value)} />
+  )
+}));
+
+jest.mock('~/shared/components/selector/FilterSelect', () => ({
+  FilterSelect: ({
+    label,
+    options,
+    onChange,
+    value = []
+  }: {
+    label: string;
+    options: Array<{ value: string; label: string }>;
+    onChange?: (value: string[]) => void;
+    value?: string[];
+  }) => (
+    <button
+      type="button"
+      data-testid={`filter-select-${label}`}
+      onClick={() => onChange?.([...value, options[0].value])}
+    >
+      {label}
+    </button>
+  )
+}));
+
+describe('FilteringToolbar', () => {
+  it('renders without right slot', () => {
+    render(
+      <FilteringToolbar
+        dataTestId="filtering-toolbar"
+        search={{ search: '', setSearch: jest.fn(), options: [] }}
+      />
+    );
+
+    expect(screen.getByTestId('filtering-toolbar')).toBeInTheDocument();
+    expect(screen.getByTestId('search')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Фільтри/i })).not.toBeInTheDocument();
+  });
+
+  it('renders search, filter toggle and right slot', () => {
+    render(
+      <FilteringToolbar
+        dataTestId="filtering-toolbar"
+        search={{ search: '', setSearch: jest.fn(), options: [] }}
+        filters={[
+          {
+            id: 'format',
+            label: 'Формат',
+            options: [{ value: 'jpg', label: 'JPG' }],
+            value: [],
+            onChange: jest.fn()
+          }
+        ]}
+        isFiltersOpen={false}
+        onToggleFilters={jest.fn()}
+        rightSlot={<div data-testid="right-slot">slot</div>}
+      />
+    );
+
+    expect(screen.getByTestId('filtering-toolbar')).toBeInTheDocument();
+    expect(screen.getByTestId('search')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Фільтри/i })).toBeInTheDocument();
+    expect(screen.getByTestId('right-slot')).toBeInTheDocument();
+  });
+
+  it('calls search setter and filter toggle callbacks', () => {
+    const setSearch = jest.fn();
+    const onToggleFilters = jest.fn();
+
+    render(
+      <FilteringToolbar
+        search={{ search: '', setSearch, options: [] }}
+        filters={[
+          {
+            id: 'format',
+            label: 'Формат',
+            options: [{ value: 'jpg', label: 'JPG' }],
+            value: [],
+            onChange: jest.fn()
+          }
+        ]}
+        isFiltersOpen={false}
+        onToggleFilters={onToggleFilters}
+      />
+    );
+
+    fireEvent.change(screen.getByTestId('search'), { target: { value: 'score' } });
+    fireEvent.click(screen.getByRole('button', { name: /Фільтри/i }));
+
+    expect(setSearch).toHaveBeenCalledWith('score');
+    expect(onToggleFilters).toHaveBeenCalled();
+  });
+
+  it('renders bottom content and clears filters', () => {
+    const onChange = jest.fn();
+    const onClearFilters = jest.fn();
+
+    render(
+      <FilteringToolbar
+        search={{ search: '', setSearch: jest.fn(), options: [] }}
+        filters={[
+          {
+            id: 'format',
+            label: 'Формат',
+            options: [{ value: 'jpg', label: 'JPG' }],
+            value: ['jpg'],
+            onChange
+          }
+        ]}
+        isFiltersOpen
+        onToggleFilters={jest.fn()}
+        activeFiltersCount={1}
+        onClearFilters={onClearFilters}
+        bottomTrailingContent={<div data-testid="sort-slot">sort</div>}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('filter-select-Формат'));
+    fireEvent.click(screen.getByLabelText('clear-filters'));
+
+    expect(onChange).toHaveBeenCalledWith(['jpg', 'jpg']);
+    expect(onClearFilters).toHaveBeenCalled();
+    expect(screen.getByTestId('sort-slot')).toBeInTheDocument();
+  });
+});

--- a/app/shared/components/filtering-toolbar/FilteringToolbar.tsx
+++ b/app/shared/components/filtering-toolbar/FilteringToolbar.tsx
@@ -7,7 +7,7 @@ import {
   IconButton,
   Tooltip
 } from '@mui/material';
-import Image from 'next/image';
+import { Filter, X } from 'lucide-react';
 import type { ReactNode } from 'react';
 
 import { ControlPanel } from '~/shared/components/control-panel';
@@ -112,7 +112,7 @@ function renderFilterToggleButton({
     >
       <Button
         variant="outlined"
-        startIcon={<Image src="/icons/filter-dark.svg" alt="filters" width={18} height={18} />}
+        startIcon={<Filter size={18} strokeWidth={1.75} />}
         onClick={onToggleFilters}
         sx={{
           borderRadius: '28px',
@@ -227,7 +227,7 @@ function renderClearFiltersButton({
               }
             }}
           >
-            <Image src="/icons/close.svg" alt="clear" width={22} height={22} />
+            <X size={22} strokeWidth={1.75} />
           </IconButton>
         ) : null}
       </span>

--- a/app/shared/components/filtering-toolbar/FilteringToolbar.tsx
+++ b/app/shared/components/filtering-toolbar/FilteringToolbar.tsx
@@ -1,0 +1,224 @@
+'use client';
+
+import {
+  Badge,
+  Box,
+  Button,
+  IconButton,
+  Tooltip
+} from '@mui/material';
+import Image from 'next/image';
+import type { ReactNode } from 'react';
+
+import { ControlPanel } from '~/shared/components/control-panel';
+import { colors } from '~/shared/components/design-system/button/Button.styles';
+import { Search, type SearchProps } from '~/shared/components/search/Search';
+import { type FilterOption,FilterSelect } from '~/shared/components/selector/FilterSelect';
+
+export type FilteringToolbarFilterConfig = Readonly<{
+  id: string;
+  label: string;
+  options: readonly FilterOption[];
+  value: string[];
+  onChange: (value: string[]) => void;
+  variant?: 'filled' | 'outlined';
+  disabled?: boolean;
+  maxSelections?: number;
+  hideCounterChip?: boolean;
+  hideClearAction?: boolean;
+  menuMinWidth?: number;
+  clearLabel?: string;
+}>;
+
+export type FilteringToolbarProps = Readonly<{
+  search?: SearchProps;
+  filters?: readonly FilteringToolbarFilterConfig[];
+  isFiltersOpen?: boolean;
+  onToggleFilters?: () => void;
+  activeFiltersCount?: number;
+  onClearFilters?: () => void;
+  clearFiltersTooltip?: string;
+  filtersButtonLabel?: string;
+  rightSlot?: ReactNode;
+  bottomTrailingContent?: ReactNode;
+  dataTestId?: string;
+}>;
+
+export function FilteringToolbar({
+  search,
+  filters = [],
+  isFiltersOpen = false,
+  onToggleFilters,
+  activeFiltersCount,
+  onClearFilters,
+  clearFiltersTooltip = 'Очистити всі фільтри',
+  filtersButtonLabel = 'Фільтри',
+  rightSlot,
+  bottomTrailingContent,
+  dataTestId = 'FilteringToolbar'
+}: FilteringToolbarProps) {
+  const resolvedActiveFiltersCount =
+    activeFiltersCount ?? filters.reduce((count, filter) => count + filter.value.length, 0);
+  const hasBottomContent = filters.length > 0 || Boolean(bottomTrailingContent);
+  const hasRightSlot = rightSlot !== undefined && rightSlot !== null;
+  const hasFilterToggle = hasBottomContent && Boolean(onToggleFilters);
+  const hasRightContent = hasFilterToggle || hasRightSlot;
+
+  return (
+    <ControlPanel
+      dataTestId={dataTestId}
+      leftContent={
+        search ? (
+          <Box sx={{ width: '100%', display: 'flex', justifyContent: 'flex-start' }}>
+            <Search {...search} />
+          </Box>
+        ) : undefined
+      }
+      rightContent={
+        hasRightContent ? (
+          <>
+            {hasFilterToggle ? (
+              <Badge
+                badgeContent={resolvedActiveFiltersCount}
+                color="error"
+                overlap="circular"
+                invisible={resolvedActiveFiltersCount === 0}
+                sx={{
+                  '& .MuiBadge-badge': {
+                    top: '4px',
+                    fontSize: '14px',
+                    minWidth: '22px',
+                    height: '22px',
+                    borderRadius: '50%',
+                    backgroundColor: '#A32B0E',
+                    transform: 'translate(18px, -50%)'
+                  }
+                }}
+              >
+                <Button
+                  variant="outlined"
+                  startIcon={<Image src="/icons/filter-dark.svg" alt="filters" width={18} height={18} />}
+                  onClick={onToggleFilters}
+                  sx={{
+                    borderRadius: '28px',
+                    px: '24px',
+                    py: '6px',
+                    minHeight: '40px',
+                    textTransform: 'none',
+                    borderColor: colors.black,
+                    color: colors.black,
+                    bgcolor: isFiltersOpen ? '#190D031A' : colors.white,
+                    fontSize: '16px',
+                    '&:hover': {
+                      borderColor: colors.black,
+                      bgcolor: isFiltersOpen ? '#190D031A' : colors.blue[50]
+                    }
+                  }}
+                >
+                  {filtersButtonLabel}
+                </Button>
+              </Badge>
+            ) : null}
+
+            {rightSlot}
+          </>
+        ) : undefined
+      }
+      isBottomOpen={hasBottomContent && isFiltersOpen}
+      bottomContent={
+        hasBottomContent ? (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+            <Box
+              sx={{
+                display: 'flex',
+                gap: '12px',
+                flexWrap: 'wrap',
+                justifyContent: 'space-between',
+                alignItems: 'center'
+              }}
+            >
+              <Box sx={{ display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
+                {filters.map((filter) => (
+                  <FilterSelect
+                    key={filter.id}
+                    label={filter.label}
+                    options={filter.options}
+                    value={filter.value}
+                    onChange={filter.onChange}
+                    variant={filter.variant}
+                    disabled={filter.disabled}
+                    maxSelections={filter.maxSelections}
+                    hideCounterChip={filter.hideCounterChip}
+                    hideClearAction={filter.hideClearAction}
+                    menuMinWidth={filter.menuMinWidth}
+                    clearLabel={filter.clearLabel}
+                  />
+                ))}
+
+                {onClearFilters ? (
+                  <Tooltip
+                    title={clearFiltersTooltip}
+                    placement="top"
+                    arrow
+                    slotProps={{
+                      transition: {
+                        timeout: 0
+                      },
+                      tooltip: {
+                        sx: {
+                          minWidth: '153px',
+                          height: '28px',
+                          px: '16px',
+                          py: '4px',
+                          borderRadius: '20px',
+                          bgcolor: '#3F444A',
+                          fontStyle: 'italic',
+                          fontSize: '14px',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center'
+                        }
+                      },
+                      arrow: {
+                        sx: {
+                          color: '#3F444A'
+                        }
+                      }
+                    }}
+                  >
+                    <span>
+                      {resolvedActiveFiltersCount > 0 ? (
+                        <IconButton
+                          aria-label="clear-filters"
+                          onClick={onClearFilters}
+                          sx={{
+                            width: '40px',
+                            height: '40px',
+                            borderRadius: '8px',
+                            bgcolor: '#fff',
+                            color: '#190D03',
+                            '&:hover': {
+                              bgcolor: '#fff'
+                            },
+                            '&.Mui-disabled': {
+                              opacity: 0.5,
+                              color: '#190D03'
+                            }
+                          }}
+                        >
+                          <Image src="/icons/close.svg" alt="clear" width={22} height={22} />
+                        </IconButton>
+                      ) : null}
+                    </span>
+                  </Tooltip>
+                ) : null}
+              </Box>
+
+              {bottomTrailingContent}
+            </Box>
+          </Box>
+        ) : undefined
+      }
+    />
+  );
+}

--- a/app/shared/components/filtering-toolbar/FilteringToolbar.tsx
+++ b/app/shared/components/filtering-toolbar/FilteringToolbar.tsx
@@ -44,6 +44,252 @@ export type FilteringToolbarProps = Readonly<{
   dataTestId?: string;
 }>;
 
+type FilterToggleButtonProps = Readonly<{
+  resolvedActiveFiltersCount: number;
+  filtersButtonLabel: string;
+  isFiltersOpen: boolean;
+  onToggleFilters: () => void;
+}>;
+
+type FilteringToolbarRightContentProps = Readonly<{
+  hasFilterToggle: boolean;
+  resolvedActiveFiltersCount: number;
+  filtersButtonLabel: string;
+  isFiltersOpen: boolean;
+  onToggleFilters?: () => void;
+  rightSlot?: ReactNode;
+}>;
+
+type ClearFiltersButtonProps = Readonly<{
+  clearFiltersTooltip: string;
+  onClearFilters?: () => void;
+  resolvedActiveFiltersCount: number;
+}>;
+
+type FilteringToolbarBottomContentProps = Readonly<{
+  bottomTrailingContent?: ReactNode;
+  clearFiltersTooltip: string;
+  filters: readonly FilteringToolbarFilterConfig[];
+  onClearFilters?: () => void;
+  resolvedActiveFiltersCount: number;
+}>;
+
+function renderSearchContent(search?: SearchProps): ReactNode | undefined {
+  if (!search) {
+    return undefined;
+  }
+
+  return (
+    <Box sx={{ width: '100%', display: 'flex', justifyContent: 'flex-start' }}>
+      <Search {...search} />
+    </Box>
+  );
+}
+
+function renderFilterToggleButton({
+  resolvedActiveFiltersCount,
+  filtersButtonLabel,
+  isFiltersOpen,
+  onToggleFilters
+}: FilterToggleButtonProps) {
+  return (
+    <Badge
+      badgeContent={resolvedActiveFiltersCount}
+      color="error"
+      overlap="circular"
+      invisible={resolvedActiveFiltersCount === 0}
+      sx={{
+        '& .MuiBadge-badge': {
+          top: '4px',
+          fontSize: '14px',
+          minWidth: '22px',
+          height: '22px',
+          borderRadius: '50%',
+          backgroundColor: '#A32B0E',
+          transform: 'translate(18px, -50%)'
+        }
+      }}
+    >
+      <Button
+        variant="outlined"
+        startIcon={<Image src="/icons/filter-dark.svg" alt="filters" width={18} height={18} />}
+        onClick={onToggleFilters}
+        sx={{
+          borderRadius: '28px',
+          px: '24px',
+          py: '6px',
+          minHeight: '40px',
+          textTransform: 'none',
+          borderColor: colors.black,
+          color: colors.black,
+          bgcolor: isFiltersOpen ? '#190D031A' : colors.white,
+          fontSize: '16px',
+          '&:hover': {
+            borderColor: colors.black,
+            bgcolor: isFiltersOpen ? '#190D031A' : colors.blue[50]
+          }
+        }}
+      >
+        {filtersButtonLabel}
+      </Button>
+    </Badge>
+  );
+}
+
+function renderRightContent({
+  hasFilterToggle,
+  resolvedActiveFiltersCount,
+  filtersButtonLabel,
+  isFiltersOpen,
+  onToggleFilters,
+  rightSlot
+}: FilteringToolbarRightContentProps): ReactNode | undefined {
+  const hasRightSlot = rightSlot !== undefined && rightSlot !== null;
+
+  if (!hasFilterToggle && !hasRightSlot) {
+    return undefined;
+  }
+
+  if (!hasFilterToggle || !onToggleFilters) {
+    return <>{rightSlot}</>;
+  }
+
+  return (
+    <>
+      {renderFilterToggleButton({
+        resolvedActiveFiltersCount,
+        filtersButtonLabel,
+        isFiltersOpen,
+        onToggleFilters
+      })}
+      {rightSlot}
+    </>
+  );
+}
+
+function renderClearFiltersButton({
+  clearFiltersTooltip,
+  onClearFilters,
+  resolvedActiveFiltersCount
+}: ClearFiltersButtonProps) {
+  if (!onClearFilters) {
+    return null;
+  }
+
+  return (
+    <Tooltip
+      title={clearFiltersTooltip}
+      placement="top"
+      arrow
+      slotProps={{
+        transition: {
+          timeout: 0
+        },
+        tooltip: {
+          sx: {
+            minWidth: '153px',
+            height: '28px',
+            px: '16px',
+            py: '4px',
+            borderRadius: '20px',
+            bgcolor: '#3F444A',
+            fontStyle: 'italic',
+            fontSize: '14px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center'
+          }
+        },
+        arrow: {
+          sx: {
+            color: '#3F444A'
+          }
+        }
+      }}
+    >
+      <span>
+        {resolvedActiveFiltersCount > 0 ? (
+          <IconButton
+            aria-label="clear-filters"
+            onClick={onClearFilters}
+            sx={{
+              width: '40px',
+              height: '40px',
+              borderRadius: '8px',
+              bgcolor: '#fff',
+              color: '#190D03',
+              '&:hover': {
+                bgcolor: '#fff'
+              },
+              '&.Mui-disabled': {
+                opacity: 0.5,
+                color: '#190D03'
+              }
+            }}
+          >
+            <Image src="/icons/close.svg" alt="clear" width={22} height={22} />
+          </IconButton>
+        ) : null}
+      </span>
+    </Tooltip>
+  );
+}
+
+function renderBottomContent({
+  bottomTrailingContent,
+  clearFiltersTooltip,
+  filters,
+  onClearFilters,
+  resolvedActiveFiltersCount
+}: FilteringToolbarBottomContentProps): ReactNode | undefined {
+  const hasBottomContent = filters.length > 0 || Boolean(bottomTrailingContent);
+
+  if (!hasBottomContent) {
+    return undefined;
+  }
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          gap: '12px',
+          flexWrap: 'wrap',
+          justifyContent: 'space-between',
+          alignItems: 'center'
+        }}
+      >
+        <Box sx={{ display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
+          {filters.map((filter) => (
+            <FilterSelect
+              key={filter.id}
+              label={filter.label}
+              options={filter.options}
+              value={filter.value}
+              onChange={filter.onChange}
+              variant={filter.variant}
+              disabled={filter.disabled}
+              maxSelections={filter.maxSelections}
+              hideCounterChip={filter.hideCounterChip}
+              hideClearAction={filter.hideClearAction}
+              menuMinWidth={filter.menuMinWidth}
+              clearLabel={filter.clearLabel}
+            />
+          ))}
+
+          {renderClearFiltersButton({
+            clearFiltersTooltip,
+            onClearFilters,
+            resolvedActiveFiltersCount
+          })}
+        </Box>
+
+        {bottomTrailingContent}
+      </Box>
+    </Box>
+  );
+}
+
 export function FilteringToolbar({
   search,
   filters = [],
@@ -59,166 +305,30 @@ export function FilteringToolbar({
 }: FilteringToolbarProps) {
   const resolvedActiveFiltersCount =
     activeFiltersCount ?? filters.reduce((count, filter) => count + filter.value.length, 0);
-  const hasBottomContent = filters.length > 0 || Boolean(bottomTrailingContent);
-  const hasRightSlot = rightSlot !== undefined && rightSlot !== null;
+  const bottomContent = renderBottomContent({
+    bottomTrailingContent,
+    clearFiltersTooltip,
+    filters,
+    onClearFilters,
+    resolvedActiveFiltersCount
+  });
+  const hasBottomContent = bottomContent !== undefined;
   const hasFilterToggle = hasBottomContent && Boolean(onToggleFilters);
-  const hasRightContent = hasFilterToggle || hasRightSlot;
 
   return (
     <ControlPanel
       dataTestId={dataTestId}
-      leftContent={
-        search ? (
-          <Box sx={{ width: '100%', display: 'flex', justifyContent: 'flex-start' }}>
-            <Search {...search} />
-          </Box>
-        ) : undefined
-      }
-      rightContent={
-        hasRightContent ? (
-          <>
-            {hasFilterToggle ? (
-              <Badge
-                badgeContent={resolvedActiveFiltersCount}
-                color="error"
-                overlap="circular"
-                invisible={resolvedActiveFiltersCount === 0}
-                sx={{
-                  '& .MuiBadge-badge': {
-                    top: '4px',
-                    fontSize: '14px',
-                    minWidth: '22px',
-                    height: '22px',
-                    borderRadius: '50%',
-                    backgroundColor: '#A32B0E',
-                    transform: 'translate(18px, -50%)'
-                  }
-                }}
-              >
-                <Button
-                  variant="outlined"
-                  startIcon={<Image src="/icons/filter-dark.svg" alt="filters" width={18} height={18} />}
-                  onClick={onToggleFilters}
-                  sx={{
-                    borderRadius: '28px',
-                    px: '24px',
-                    py: '6px',
-                    minHeight: '40px',
-                    textTransform: 'none',
-                    borderColor: colors.black,
-                    color: colors.black,
-                    bgcolor: isFiltersOpen ? '#190D031A' : colors.white,
-                    fontSize: '16px',
-                    '&:hover': {
-                      borderColor: colors.black,
-                      bgcolor: isFiltersOpen ? '#190D031A' : colors.blue[50]
-                    }
-                  }}
-                >
-                  {filtersButtonLabel}
-                </Button>
-              </Badge>
-            ) : null}
-
-            {rightSlot}
-          </>
-        ) : undefined
-      }
+      leftContent={renderSearchContent(search)}
+      rightContent={renderRightContent({
+        hasFilterToggle,
+        resolvedActiveFiltersCount,
+        filtersButtonLabel,
+        isFiltersOpen,
+        onToggleFilters,
+        rightSlot
+      })}
       isBottomOpen={hasBottomContent && isFiltersOpen}
-      bottomContent={
-        hasBottomContent ? (
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
-            <Box
-              sx={{
-                display: 'flex',
-                gap: '12px',
-                flexWrap: 'wrap',
-                justifyContent: 'space-between',
-                alignItems: 'center'
-              }}
-            >
-              <Box sx={{ display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
-                {filters.map((filter) => (
-                  <FilterSelect
-                    key={filter.id}
-                    label={filter.label}
-                    options={filter.options}
-                    value={filter.value}
-                    onChange={filter.onChange}
-                    variant={filter.variant}
-                    disabled={filter.disabled}
-                    maxSelections={filter.maxSelections}
-                    hideCounterChip={filter.hideCounterChip}
-                    hideClearAction={filter.hideClearAction}
-                    menuMinWidth={filter.menuMinWidth}
-                    clearLabel={filter.clearLabel}
-                  />
-                ))}
-
-                {onClearFilters ? (
-                  <Tooltip
-                    title={clearFiltersTooltip}
-                    placement="top"
-                    arrow
-                    slotProps={{
-                      transition: {
-                        timeout: 0
-                      },
-                      tooltip: {
-                        sx: {
-                          minWidth: '153px',
-                          height: '28px',
-                          px: '16px',
-                          py: '4px',
-                          borderRadius: '20px',
-                          bgcolor: '#3F444A',
-                          fontStyle: 'italic',
-                          fontSize: '14px',
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'center'
-                        }
-                      },
-                      arrow: {
-                        sx: {
-                          color: '#3F444A'
-                        }
-                      }
-                    }}
-                  >
-                    <span>
-                      {resolvedActiveFiltersCount > 0 ? (
-                        <IconButton
-                          aria-label="clear-filters"
-                          onClick={onClearFilters}
-                          sx={{
-                            width: '40px',
-                            height: '40px',
-                            borderRadius: '8px',
-                            bgcolor: '#fff',
-                            color: '#190D03',
-                            '&:hover': {
-                              bgcolor: '#fff'
-                            },
-                            '&.Mui-disabled': {
-                              opacity: 0.5,
-                              color: '#190D03'
-                            }
-                          }}
-                        >
-                          <Image src="/icons/close.svg" alt="clear" width={22} height={22} />
-                        </IconButton>
-                      ) : null}
-                    </span>
-                  </Tooltip>
-                ) : null}
-              </Box>
-
-              {bottomTrailingContent}
-            </Box>
-          </Box>
-        ) : undefined
-      }
+      bottomContent={bottomContent}
     />
   );
 }

--- a/app/shared/components/filtering-toolbar/SortSelect.test.tsx
+++ b/app/shared/components/filtering-toolbar/SortSelect.test.tsx
@@ -1,0 +1,100 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { SortSelect } from './SortSelect';
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => <img {...props} alt={props.alt ?? ''} />
+}));
+
+jest.mock('~/shared/components/dropdown-menu/DropdownMenu', () => ({
+  __esModule: true,
+  default: ({ open, menuList }: { open: boolean; menuList: React.ReactNode }) =>
+    open ? <div data-testid="dropdown-menu">{menuList}</div> : null
+}));
+
+jest.mock('~/shared/components/selector/FilterSelectItem/FilterSelectItem', () => ({
+  __esModule: true,
+  default: ({ label, onClick }: { label: string; onClick: () => void }) => (
+    <button type="button" data-testid={`sort-option-${label}`} onClick={onClick}>
+      {label}
+    </button>
+  )
+}));
+
+describe('SortSelect', () => {
+  const fieldOptions = [
+    { value: 'date', label: 'Дата додавання' },
+    { value: 'name', label: 'Назва файлу' }
+  ] as const;
+
+  const orderOptions = {
+    date: [
+      { value: 'date_desc', label: 'Новіші-старіші' },
+      { value: 'date_asc', label: 'Старіші-новіші' }
+    ],
+    name: [
+      { value: 'name_asc', label: 'А-Я' },
+      { value: 'name_desc', label: 'Я-А' }
+    ]
+  } as const;
+
+  it('renders trigger label', () => {
+    render(
+      <SortSelect
+        fieldOptions={fieldOptions}
+        orderOptions={orderOptions}
+        fieldValue="date"
+        value="date_desc"
+        triggerLabel="Нові спочатку"
+        onFieldChange={jest.fn()}
+        onValueChange={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('Нові спочатку')).toBeInTheDocument();
+  });
+
+  it('calls onFieldChange when a field option is selected', () => {
+    const onFieldChange = jest.fn();
+
+    render(
+      <SortSelect
+        fieldOptions={fieldOptions}
+        orderOptions={orderOptions}
+        fieldValue="date"
+        value="date_desc"
+        triggerLabel="Нові спочатку"
+        onFieldChange={onFieldChange}
+        onValueChange={jest.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('sort-select'));
+    fireEvent.click(screen.getByTestId('sort-option-Назва файлу'));
+
+    expect(onFieldChange).toHaveBeenCalledWith('name');
+  });
+
+  it('calls onValueChange when an order option is selected', () => {
+    const onValueChange = jest.fn();
+
+    render(
+      <SortSelect
+        fieldOptions={fieldOptions}
+        orderOptions={orderOptions}
+        fieldValue="name"
+        value="name_desc"
+        triggerLabel="Я-А"
+        onFieldChange={jest.fn()}
+        onValueChange={onValueChange}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('sort-select'));
+    fireEvent.click(screen.getByTestId('sort-option-А-Я'));
+
+    expect(onValueChange).toHaveBeenCalledWith('name_asc');
+  });
+});

--- a/app/shared/components/filtering-toolbar/SortSelect.tsx
+++ b/app/shared/components/filtering-toolbar/SortSelect.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { Box, Divider, Typography } from '@mui/material';
+import Image from 'next/image';
+import { useRef, useState } from 'react';
+
+import DropdownMenu from '~/shared/components/dropdown-menu/DropdownMenu';
+import { filterSelectStyles } from '~/shared/components/selector/FilterSelect.styles';
+import FilterSelectItem from '~/shared/components/selector/FilterSelectItem/FilterSelectItem';
+
+export type SortFieldOption<FieldValue extends string> = {
+  value: FieldValue;
+  label: string;
+};
+
+export type SortOrderOption<SortValue extends string> = {
+  value: SortValue;
+  label: string;
+};
+
+export type SortSelectProps<FieldValue extends string, SortValue extends string> = Readonly<{
+  fieldOptions: readonly SortFieldOption<FieldValue>[];
+  orderOptions: Readonly<Record<FieldValue, readonly SortOrderOption<SortValue>[]>>;
+  fieldValue: FieldValue;
+  value: SortValue;
+  triggerLabel: string;
+  onFieldChange: (value: FieldValue) => void;
+  onValueChange: (value: SortValue) => void;
+  disabled?: boolean;
+  minWidth?: number;
+  fieldSectionLabel?: string;
+  orderSectionLabel?: string;
+  dataTestId?: string;
+}>;
+
+export function SortSelect<FieldValue extends string, SortValue extends string>({
+  fieldOptions,
+  orderOptions,
+  fieldValue,
+  value,
+  triggerLabel,
+  onFieldChange,
+  onValueChange,
+  disabled = false,
+  minWidth = 208,
+  fieldSectionLabel = 'Сортувати за',
+  orderSectionLabel = 'Порядок',
+  dataTestId = 'sort-select'
+}: SortSelectProps<FieldValue, SortValue>) {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const triggerRef = useRef<HTMLDivElement | null>(null);
+
+  const handleToggleMenu = () => {
+    if (disabled) {
+      return;
+    }
+
+    setAnchorEl((previous) => (previous ? null : triggerRef.current));
+  };
+
+  const handleCloseMenu = () => {
+    setAnchorEl(null);
+    requestAnimationFrame(() => triggerRef.current?.focus());
+  };
+
+  return (
+    <>
+      <Box
+        ref={triggerRef}
+        onClick={handleToggleMenu}
+        role="button"
+        tabIndex={disabled ? -1 : 0}
+        aria-haspopup="dialog"
+        aria-expanded={Boolean(anchorEl)}
+        data-testid={dataTestId}
+        sx={{
+          ...filterSelectStyles.root('filled', disabled),
+          minWidth: `${minWidth}px`
+        }}
+      >
+        <Typography sx={filterSelectStyles.label(disabled)}>{triggerLabel}</Typography>
+        <Box sx={filterSelectStyles.dropdownIcon(disabled)}>
+          <Image
+            src="/icons/chevron-down-dark.svg"
+            alt="chevron-down"
+            width={12}
+            height={12}
+            style={{ transform: 'translateY(2px)' }}
+          />
+        </Box>
+      </Box>
+
+      <DropdownMenu
+        disableScrollLock
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleCloseMenu}
+        sx={{
+          '& .MuiPaper-root': {
+            minWidth: `${minWidth}px`
+          }
+        }}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+        menuList={
+          <Box sx={{ padding: '8px' }}>
+            <Typography
+              sx={{
+                color: '#4E5061',
+                fontSize: '12px',
+                textTransform: 'uppercase',
+                px: '12px',
+                py: '4px'
+              }}
+            >
+              {fieldSectionLabel}
+            </Typography>
+
+            {fieldOptions.map((option) => (
+              <FilterSelectItem
+                key={option.value}
+                label={option.label}
+                selected={fieldValue === option.value}
+                onClick={() => onFieldChange(option.value)}
+                sx={filterSelectStyles.menuItem}
+              />
+            ))}
+
+            <Divider sx={{ my: 1 }} />
+
+            <Typography
+              sx={{
+                color: '#4E5061',
+                fontSize: '12px',
+                textTransform: 'uppercase',
+                px: '12px',
+                py: '4px'
+              }}
+            >
+              {orderSectionLabel}
+            </Typography>
+
+            {orderOptions[fieldValue].map((option) => (
+              <FilterSelectItem
+                key={option.value}
+                label={option.label}
+                selected={value === option.value}
+                onClick={() => {
+                  onValueChange(option.value);
+                  handleCloseMenu();
+                }}
+                sx={filterSelectStyles.menuItem}
+              />
+            ))}
+          </Box>
+        }
+      />
+    </>
+  );
+}

--- a/app/shared/components/filtering-toolbar/index.ts
+++ b/app/shared/components/filtering-toolbar/index.ts
@@ -1,0 +1,2 @@
+export * from './FilteringToolbar';
+export * from './SortSelect';

--- a/app/shared/components/search/Search.tsx
+++ b/app/shared/components/search/Search.tsx
@@ -18,10 +18,14 @@ export type SearchOption = {
   title: string;
 };
 
-type SearchProps = Readonly<{
+export type SearchProps = Readonly<{
   search: string;
   setSearch: (value: string) => void;
   options: SearchOption[];
+  placeholder?: string;
+  maxWidth?: number | string;
+  noOptionsText?: string;
+  clearButtonAriaLabel?: string;
 }>;
 
 const filterAndSortOptions = (list: SearchOption[], inputValue: string): SearchOption[] => {
@@ -59,7 +63,15 @@ const filterAndSortOptions = (list: SearchOption[], inputValue: string): SearchO
   });
 };
 
-export function Search({ search, setSearch, options }: SearchProps) {
+export function Search({
+  search,
+  setSearch,
+  options,
+  placeholder = 'Пошук',
+  maxWidth = '300px',
+  noOptionsText = 'Нічого не знайдено',
+  clearButtonAriaLabel = 'Очистити пошук'
+}: SearchProps) {
   const selectedOption = useMemo(
     () => options.find((option) => option.title.toLowerCase() === search.toLowerCase()) ?? null,
     [options, search]
@@ -71,6 +83,7 @@ export function Search({ search, setSearch, options }: SearchProps) {
     <Autocomplete<SearchOption, false, false, true>
       freeSolo
       options={filteredOptions}
+      noOptionsText={noOptionsText}
       value={selectedOption}
       inputValue={search}
       onInputChange={(_, value) => setSearch(value)}
@@ -96,7 +109,7 @@ export function Search({ search, setSearch, options }: SearchProps) {
       }}
       sx={{
         width: '100%',
-        maxWidth: '300px',
+        maxWidth,
         '& .MuiAutocomplete-inputRoot[class*="MuiOutlinedInput-root"]': {
           paddingRight: '12px !important',
           paddingLeft: '16px !important'
@@ -106,7 +119,7 @@ export function Search({ search, setSearch, options }: SearchProps) {
         <OutlinedInput
           {...params.InputProps}
           inputProps={params.inputProps}
-          placeholder="Пошук"
+          placeholder={placeholder}
           fullWidth
           startAdornment={
             <InputAdornment position="start"
@@ -122,6 +135,7 @@ export function Search({ search, setSearch, options }: SearchProps) {
               <Box
                 component="button"
                 type="button"
+                aria-label={clearButtonAriaLabel}
                 onClick={() => setSearch('')}
                 sx={{
                   border: 'none',

--- a/app/shared/components/selector/FilterSelect.test.tsx
+++ b/app/shared/components/selector/FilterSelect.test.tsx
@@ -60,4 +60,15 @@ describe('FilterSelect', () => {
 
     expect(screen.queryByRole('menu')).not.toBeInTheDocument();
   });
+
+  it('should call onChange in controlled mode', () => {
+    const onChange = jest.fn();
+
+    render(<FilterSelect label="Controlled" options={mockOptions} value={[]} onChange={onChange} />);
+
+    fireEvent.click(screen.getByText('Controlled'));
+    fireEvent.click(screen.getByText('Second'));
+
+    expect(onChange).toHaveBeenCalledWith(['second']);
+  });
 });

--- a/app/shared/components/selector/FilterSelect.tsx
+++ b/app/shared/components/selector/FilterSelect.tsx
@@ -9,14 +9,16 @@ import FilterSelectItem from './FilterSelectItem/FilterSelectItem';
 import CloseIcon from '~/public/icons/close.svg';
 import DropdownMenu from '~/shared/components/dropdown-menu/DropdownMenu';
 
-interface FilterOption {
+export interface FilterOption {
   value: string;
   label: string;
 }
 
-interface FilterSelectProps {
+export interface FilterSelectProps {
   label: string;
   options: readonly FilterOption[];
+  value?: string[];
+  defaultValue?: string[];
   defaultValues?: string[];
   variant?: 'filled' | 'outlined';
   disabled?: boolean;
@@ -24,6 +26,8 @@ interface FilterSelectProps {
   hideCounterChip?: boolean;
   hideClearAction?: boolean;
   menuMinWidth?: number;
+  clearLabel?: string;
+  onChange?: (allSelected: string[]) => void;
   onAdd?: (value: string, label: string, allSelected: string[]) => void;
   onRemove?: (value: string, label: string, allSelected: string[]) => void;
 }
@@ -31,6 +35,8 @@ interface FilterSelectProps {
 export const FilterSelect: React.FC<FilterSelectProps> = ({
   label,
   options,
+  value,
+  defaultValue,
   defaultValues,
   variant = 'filled',
   disabled = false,
@@ -38,16 +44,31 @@ export const FilterSelect: React.FC<FilterSelectProps> = ({
   hideCounterChip = false,
   hideClearAction = false,
   menuMinWidth,
+  clearLabel = 'Очистити',
+  onChange,
   onAdd,
   onRemove
 }) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const [selectedValues, setSelectedValues] = useState<string[]>(() => defaultValues ?? []);
+  const [uncontrolledValues, setUncontrolledValues] = useState<string[]>(() => value ?? defaultValue ?? defaultValues ?? []);
   const triggerRef = useRef<HTMLDivElement | null>(null);
+  const selectedValues = value ?? uncontrolledValues;
 
   useEffect(() => {
-    setSelectedValues(defaultValues ?? []);
-  }, [defaultValues]);
+    if (value !== undefined) {
+      return;
+    }
+
+    setUncontrolledValues(defaultValue ?? defaultValues ?? []);
+  }, [defaultValue, defaultValues, value]);
+
+  const updateSelectedValues = (nextValues: string[]) => {
+    if (value === undefined) {
+      setUncontrolledValues(nextValues);
+    }
+
+    onChange?.(nextValues);
+  };
 
   const handleToggleMenu = () => {
     if (disabled) return;
@@ -82,7 +103,7 @@ export const FilterSelect: React.FC<FilterSelectProps> = ({
       return;
     }
 
-    setSelectedValues(newValues);
+    updateSelectedValues(newValues);
 
     if (maxSelections === 1) {
       handleCloseMenu();
@@ -91,7 +112,7 @@ export const FilterSelect: React.FC<FilterSelectProps> = ({
 
   const clearAll = () => {
     const removed = [...selectedValues];
-    setSelectedValues([]);
+    updateSelectedValues([]);
     removed.forEach((value) => {
       const option = options.find((item) => item.value === value);
       onRemove?.(value, option?.label ?? '', []);
@@ -179,7 +200,7 @@ export const FilterSelect: React.FC<FilterSelectProps> = ({
               <>
                 <Divider sx={{ my: 1 }} />
                 <Button variant="text" onClick={clearAll} sx={{ textTransform: 'none' }}>
-                  Очистити
+                  {clearLabel}
                 </Button>
               </>
             )}

--- a/app/shared/hooks/use-files/index.ts
+++ b/app/shared/hooks/use-files/index.ts
@@ -1,1 +1,2 @@
 export * from './useFiles';
+export * from './useFilesFiltering';

--- a/app/shared/hooks/use-files/useFilesFiltering.test.ts
+++ b/app/shared/hooks/use-files/useFilesFiltering.test.ts
@@ -1,0 +1,73 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useFilesFiltering } from './useFilesFiltering';
+
+const items = [
+  {
+    id: 'asset-image',
+    name: 'piano-studio.jpg',
+    type: 'image' as const,
+    dateAdded: '19.03.2026',
+    createdAtRaw: '2026-03-19T10:00:00.000Z',
+    format: 'jpg',
+    isStarred: true,
+    usage: [{ label: 'about-us' }]
+  },
+  {
+    id: 'asset-doc',
+    name: 'documents.zip',
+    type: 'pdf' as const,
+    dateAdded: '18.03.2026',
+    createdAtRaw: '2026-03-18T10:00:00.000Z',
+    format: 'zip',
+    isStarred: false,
+    usage: []
+  }
+];
+
+describe('useFilesFiltering', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('filters items by search query', () => {
+    const { result } = renderHook(() => useFilesFiltering(items));
+
+    expect(result.current.filteredFiles).toHaveLength(2);
+
+    act(() => {
+      result.current.toolbarProps.search?.setSearch('piano');
+    });
+
+    expect(result.current.filteredFiles).toHaveLength(1);
+    expect(result.current.filteredFiles[0]?.id).toBe('asset-image');
+  });
+
+  it('applies filter, tab and sort state outside the page component', () => {
+    const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
+    const { result } = renderHook(() => useFilesFiltering(items));
+
+    act(() => {
+      result.current.toolbarProps.filters?.[0]?.onChange(['zip']);
+    });
+
+    expect(result.current.filteredFiles).toHaveLength(1);
+    expect(result.current.filteredFiles[0]?.id).toBe('asset-doc');
+
+    act(() => {
+      result.current.toolbarProps.onClearFilters?.();
+      result.current.setActiveTab('favorites');
+    });
+
+    expect(result.current.filteredFiles).toHaveLength(1);
+    expect(result.current.filteredFiles[0]?.id).toBe('asset-image');
+
+    act(() => {
+      result.current.sortProps.onFieldChange('name');
+    });
+
+    expect(setItemSpy).toHaveBeenCalledWith('files_sort', 'name_asc');
+    expect(result.current.sortProps.triggerLabel).toBe('А→Я');
+  });
+});

--- a/app/shared/hooks/use-files/useFilesFiltering.ts
+++ b/app/shared/hooks/use-files/useFilesFiltering.ts
@@ -1,0 +1,289 @@
+import { type Dispatch, type SetStateAction, useCallback, useMemo, useState } from 'react';
+
+import { FORMAT_FILTER_OPTIONS } from '~/constants/file-formats';
+import {
+  type FilesSortValue,
+  type FilesTabValue,
+  SORT_FIELD_OPTIONS,
+  SORT_OPTIONS,
+  SORT_ORDER_OPTIONS,
+  type SortFieldValue,
+  USAGE_FILTER_OPTIONS
+} from '~/constants/files';
+import type { FilesCardsLayoutItem } from '~/shared/components/files-cards-layout';
+import type { FilteringToolbarFilterConfig, FilteringToolbarProps , SortSelectProps } from '~/shared/components/filtering-toolbar';
+import { normalizeSearch } from '~/shared/utils/normalizeSearch';
+
+type FilesFilteringUsageLink = Readonly<{
+  label: string;
+}>;
+
+export type UseFilesFilteringItem = Readonly<{
+  id: string;
+  name: string;
+  type: FilesCardsLayoutItem['type'];
+  dateAdded: string;
+  createdAtRaw?: string;
+  format?: string;
+  isStarred?: boolean;
+  usage: ReadonlyArray<FilesFilteringUsageLink>;
+}>;
+
+export type FilesFilteringToolbarProps = Pick<
+  FilteringToolbarProps,
+  'search' | 'filters' | 'isFiltersOpen' | 'onToggleFilters' | 'activeFiltersCount' | 'onClearFilters'
+>;
+
+export type FilesFilteringSortProps = Omit<
+  SortSelectProps<SortFieldValue, FilesSortValue>,
+  'minWidth' | 'dataTestId'
+>;
+
+export type UseFilesFilteringResult<Item extends UseFilesFilteringItem> = Readonly<{
+  activeTab: FilesTabValue;
+  setActiveTab: Dispatch<SetStateAction<FilesTabValue>>;
+  filteredFiles: Item[];
+  toolbarProps: FilesFilteringToolbarProps;
+  sortProps: FilesFilteringSortProps;
+}>;
+
+const normalizeFormatFilterValue = (value: string): string => {
+  if (value === 'jpeg') {
+    return 'jpg';
+  }
+
+  if (value === 'svg+xml') {
+    return 'svg';
+  }
+
+  if (value === 'msword') {
+    return 'doc';
+  }
+
+  if (value === 'vnd.openxmlformats-officedocument.wordprocessingml.document') {
+    return 'docx';
+  }
+
+  if (value === 'vnd.ms-excel') {
+    return 'xls';
+  }
+
+  if (value === 'vnd.openxmlformats-officedocument.spreadsheetml.sheet') {
+    return 'xlsx';
+  }
+
+  if (value === 'x-zip-compressed') {
+    return 'zip';
+  }
+
+  return value;
+};
+
+const DOCS_FORMAT_VALUES = new Set<string>(['pdf', 'zip', 'doc', 'docx', 'xls', 'xlsx']);
+
+const getUsageFilterValues = (usageLinks: ReadonlyArray<FilesFilteringUsageLink>): string[] => {
+  if (!usageLinks.length) {
+    return ['unused'];
+  }
+
+  const categories = new Set<string>();
+
+  usageLinks.forEach((usageLink) => {
+    const normalizedLabel = normalizeSearch(usageLink.label);
+
+    if (/новин|медіа|news|media/.test(normalizedLabel)) {
+      categories.add('news_media');
+      return;
+    }
+
+    if (/поді|event/.test(normalizedLabel)) {
+      categories.add('events');
+      return;
+    }
+
+    if (/творч|creative/.test(normalizedLabel)) {
+      categories.add('creativity');
+      return;
+    }
+
+    if (/файл|files/.test(normalizedLabel)) {
+      categories.add('files');
+      return;
+    }
+
+    if (/науков|scientific|research/.test(normalizedLabel)) {
+      categories.add('research');
+      return;
+    }
+
+    categories.add('main_pages');
+  });
+
+  return Array.from(categories);
+};
+
+export function useFilesFiltering<Item extends UseFilesFilteringItem>(allFiles: Item[]): UseFilesFilteringResult<Item> {
+  const [activeTab, setActiveTab] = useState<FilesTabValue>('all');
+  const [isFiltersOpen, setIsFiltersOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const [formatFilters, setFormatFilters] = useState<string[]>([]);
+  const [usageFilters, setUsageFilters] = useState<string[]>([]);
+  const [sortValue, setSortValue] = useState<FilesSortValue>(() => {
+    if (globalThis.window === undefined) {
+      return 'date_desc';
+    }
+
+    const saved = localStorage.getItem('files_sort');
+    return (SORT_OPTIONS.some((option) => option.value === saved) ? saved : 'date_desc') as FilesSortValue;
+  });
+
+  const titleOptions = useMemo(() => {
+    return Array.from(new Map(allFiles.map((file) => [file.id, { id: file.id, title: file.name }])).values());
+  }, [allFiles]);
+
+  const filesAfterBaseFiltering = useMemo(() => {
+    const normalizedSearch = normalizeSearch(search);
+
+    const filtered = allFiles.filter((file) => {
+      const matchesSearch = !normalizedSearch || file.name.toLowerCase().includes(normalizedSearch);
+      const normalizedFileFormat = normalizeFormatFilterValue(file.format?.toLowerCase() ?? '');
+      const matchesFormat =
+        !formatFilters.length ||
+        formatFilters.some((formatFilter) => normalizeFormatFilterValue(formatFilter) === normalizedFileFormat);
+      const fileUsageFilterValues = getUsageFilterValues(file.usage);
+      const matchesUsage =
+        !usageFilters.length || usageFilters.some((usageFilter) => fileUsageFilterValues.includes(usageFilter));
+
+      return matchesSearch && matchesFormat && matchesUsage;
+    });
+
+    return [...filtered].sort((left, right) => {
+      if (sortValue === 'name_asc') {
+        return left.name.localeCompare(right.name, 'uk');
+      }
+
+      if (sortValue === 'name_desc') {
+        return right.name.localeCompare(left.name, 'uk');
+      }
+
+      const leftDate = new Date(left.createdAtRaw ?? left.dateAdded).getTime();
+      const rightDate = new Date(right.createdAtRaw ?? right.dateAdded).getTime();
+
+      if (sortValue === 'date_asc') {
+        return leftDate - rightDate;
+      }
+
+      return rightDate - leftDate;
+    });
+  }, [allFiles, formatFilters, search, sortValue, usageFilters]);
+
+  const filteredFiles = useMemo(() => {
+    if (activeTab === 'all') {
+      return filesAfterBaseFiltering;
+    }
+
+    if (activeTab === 'favorites') {
+      return filesAfterBaseFiltering.filter((file) => file.isStarred);
+    }
+
+    if (activeTab === 'docs') {
+      return filesAfterBaseFiltering.filter((file) =>
+        DOCS_FORMAT_VALUES.has(normalizeFormatFilterValue(file.format?.toLowerCase() ?? ''))
+      );
+    }
+
+    return filesAfterBaseFiltering.filter((file) => file.type === activeTab);
+  }, [activeTab, filesAfterBaseFiltering]);
+
+  const activeFiltersCount = formatFilters.length + usageFilters.length;
+  const currentSortOption = SORT_OPTIONS.find((option) => option.value === sortValue) ?? SORT_OPTIONS[0];
+  const currentSortField: SortFieldValue = sortValue.startsWith('date') ? 'date' : 'name';
+
+  const toggleFilters = useCallback(() => {
+    setIsFiltersOpen((previous) => !previous);
+  }, []);
+
+  const clearFilters = useCallback(() => {
+    setFormatFilters([]);
+    setUsageFilters([]);
+  }, []);
+
+  const handleSortFieldChange = useCallback((field: SortFieldValue) => {
+    if (field === 'date') {
+      setSortValue((previous) => {
+        const next = previous.startsWith('date') ? previous : 'date_desc';
+        localStorage.setItem('files_sort', next);
+        return next;
+      });
+      return;
+    }
+
+    setSortValue((previous) => {
+      const next = previous.startsWith('name') ? previous : 'name_asc';
+      localStorage.setItem('files_sort', next);
+      return next;
+    });
+  }, []);
+
+  const handleSortValueChange = useCallback((nextValue: FilesSortValue) => {
+    setSortValue(nextValue);
+    localStorage.setItem('files_sort', nextValue);
+  }, []);
+
+  const filterConfigs = useMemo<FilteringToolbarFilterConfig[]>(
+    () => [
+      {
+        id: 'format',
+        label: 'Формат',
+        options: FORMAT_FILTER_OPTIONS,
+        value: formatFilters,
+        hideClearAction: true,
+        menuMinWidth: 116,
+        onChange: setFormatFilters
+      },
+      {
+        id: 'usage',
+        label: 'Використання',
+        options: USAGE_FILTER_OPTIONS,
+        value: usageFilters,
+        hideClearAction: true,
+        menuMinWidth: 190,
+        onChange: setUsageFilters
+      }
+    ],
+    [formatFilters, usageFilters]
+  );
+
+  const toolbarProps = useMemo<FilesFilteringToolbarProps>(
+    () => ({
+      search: { search, setSearch, options: titleOptions },
+      filters: filterConfigs,
+      isFiltersOpen,
+      onToggleFilters: toggleFilters,
+      activeFiltersCount,
+      onClearFilters: clearFilters
+    }),
+    [activeFiltersCount, clearFilters, filterConfigs, isFiltersOpen, search, titleOptions, toggleFilters]
+  );
+
+  const sortProps = useMemo<FilesFilteringSortProps>(
+    () => ({
+      fieldOptions: SORT_FIELD_OPTIONS,
+      orderOptions: SORT_ORDER_OPTIONS,
+      fieldValue: currentSortField,
+      value: sortValue,
+      triggerLabel: currentSortOption.label,
+      onFieldChange: handleSortFieldChange,
+      onValueChange: handleSortValueChange
+    }),
+    [currentSortField, currentSortOption.label, handleSortFieldChange, handleSortValueChange, sortValue]
+  );
+
+  return {
+    activeTab,
+    setActiveTab,
+    filteredFiles,
+    toolbarProps,
+    sortProps
+  };
+}


### PR DESCRIPTION
## Description

This PR implements unified and reusable **filtering and search components** for the application.

The goal is to standardize filtering and search functionality across different modules (e.g., Files and News & Events pages) by extracting the logic into reusable components.

The components:
- Support dynamic filter data (formats, statuses, categories, etc.)
- Provide consistent UI and behavior across the app
- Can be easily integrated into different pages
- Follow design specifications from Figma, including dropdown behavior and active states

These changes reduce code duplication and improve maintainability of filtering and search functionality across the project.

link:
https://github.com/Liatoshynsky-Foundation/lf-admin/issues/385

## Type of change

- [x] New feature

## How to test

1. Open the **Files page**.
2. Verify that filtering and search components are displayed.
3. Test search:
   - Enter a query and ensure results update correctly.
4. Test filters:
   - Apply different filters (e.g., format, usage).
   - Verify that results are filtered correctly.
5. Check UI behavior:
   - Dropdowns open/close correctly
   - Active filter states are displayed
