### PR TITLE
Fix sidebar toggle button position and logo behavior

### DIFF
--- a/app/shared/components/side-navigation/SideNavigation.styles.ts
+++ b/app/shared/components/side-navigation/SideNavigation.styles.ts
@@ -3,12 +3,23 @@ export const styles = {
     backgroundColor: '#F1F2F7',
     borderRight: '1px solid #DCDDE5',
     position: 'fixed',
+    display: 'flex',
+    flexDirection: 'column',
     maxWidth: '280px',
     padding: '32px 0',
-    scrollbarWidth: 'none',
     height: '100vh',
+    overflow: 'visible',
+    boxSizing: 'border-box',
+    '&::-webkit-scrollbar': {
+      display: 'none'
+    }
+  },
+  navigationContent: {
+    flex: 1,
+    minHeight: 0,
     overflowY: 'scroll',
     overflowX: 'visible',
+    scrollbarWidth: 'none',
     '&::-webkit-scrollbar': {
       display: 'none'
     }
@@ -24,7 +35,7 @@ export const styles = {
     height: 32,
     backgroundColor: '#F1F2F7',
     position: 'absolute',
-    top: '60px',
+    top: '90px',
     border: '1px solid #DCDDE5',
     transform: 'translateY(-50%)',
     zIndex: 1,
@@ -51,6 +62,7 @@ export const styles = {
     gap: '8px',
     flexDirection: 'column',
     borderRadius: '8px',
-    padding: 0
+    padding: 0,
+    cursor: 'pointer'
   }
 };

--- a/app/shared/components/side-navigation/SideNavigation.test.tsx
+++ b/app/shared/components/side-navigation/SideNavigation.test.tsx
@@ -7,23 +7,23 @@ describe('Side Navigation', () => {
     render(<SideBarNavigation />);
   });
 
-  it('should work with togging logo', () => {
-    const logoBtn = screen.getByRole('button', { name: /logo/i });
-    const closeBtn = screen.getByRole('button', { name: /close button/i });
+  it('toggles the sidebar only from the toggle button', () => {
+    const toggleBtn = screen.getByRole('button', { name: /toggle sidebar/i });
 
-    expect(logoBtn).toBeInTheDocument();
-    expect(closeBtn).toBeInTheDocument();
+    expect(toggleBtn).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /go to home page/i })).toHaveAttribute('href', '/');
 
-    fireEvent.click(closeBtn);
+    fireEvent.click(toggleBtn);
     expect(screen.queryByText('Контент')).not.toBeInTheDocument();
     expect(screen.queryByText('Інше')).not.toBeInTheDocument();
 
-    fireEvent.click(logoBtn);
+    fireEvent.click(toggleBtn);
     expect(screen.queryByText('Контент')).toBeInTheDocument();
     expect(screen.queryByText('Інше')).toBeInTheDocument();
+  });
 
-    fireEvent.click(logoBtn);
-    expect(screen.queryByText('Контент')).not.toBeInTheDocument();
-    expect(screen.queryByText('Інше')).not.toBeInTheDocument();
+  it('renders the logo as a home link instead of a button', () => {
+    expect(screen.getByRole('link', { name: /go to home page/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /logo/i })).not.toBeInTheDocument();
   });
 });

--- a/app/shared/components/side-navigation/SideNavigation.tsx
+++ b/app/shared/components/side-navigation/SideNavigation.tsx
@@ -3,6 +3,7 @@ import { Box, Divider, IconButton, List } from '@mui/material';
 import ListSubheader from '@mui/material/ListSubheader';
 import { AdditionalElement, ListElementType } from 'app/types/sideNavigation';
 import Image from 'next/image';
+import Link from 'next/link';
 import { useCallback, useState } from 'react';
 
 import { CollapseListNavigation } from './collapse-list-navigation/CollapseListNavigation';
@@ -60,30 +61,34 @@ export const SideBarNavigation = () => {
 
   return (
     <Box sx={{ height: '100vh', width: w, flexShrink: 0 }}>
-      <IconButton onClick={handleToggle} sx={{ ...styles.hideBtn, left: l }}>
-        <Image src={`/icons/chevron${open ? 'Left' : 'Right'}.svg`} alt="close button" width={24} height={24} />
-      </IconButton>
       <Box component="nav" sx={{ ...styles.drawerPaper, width: w, pt: open ? '32px' : '40px' }}>
+        <IconButton aria-label="toggle sidebar" onClick={handleToggle} sx={{ ...styles.hideBtn, left: l }}>
+          <Image src={`/icons/chevron${open ? 'Left' : 'Right'}.svg`} alt="" width={24} height={24} />
+        </IconButton>
         <Box sx={styles.topSection}>
-          <IconButton onClick={handleToggle} size="small" sx={styles.logoBlock}>
-            <Image src="/icons/logo.svg" alt="logo" width={open ? 63.85 : 80} height={open ? 24.22 : 32} />
-            {open && (
-              <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-                <Image src="/icons/Liatoshinsky-text.svg" alt="Liatoshinsky" width={146.28} height={17.97} />
-                <Image src="/icons/foundation-text.svg" alt="Foundation" width={63.85} height={24.22} />
-              </Box>
-            )}
-          </IconButton>
+          <Link href="/" aria-label="go to home page" style={{ textDecoration: 'none' }}>
+            <Box sx={styles.logoBlock}>
+              <Image src="/icons/logo.svg" alt="logo" width={open ? 63.85 : 80} height={open ? 24.22 : 32} />
+              {open && (
+                <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+                  <Image src="/icons/Liatoshinsky-text.svg" alt="Liatoshinsky" width={146.28} height={17.97} />
+                  <Image src="/icons/foundation-text.svg" alt="Foundation" width={63.85} height={24.22} />
+                </Box>
+              )}
+            </Box>
+          </Link>
         </Box>
-        <Box sx={{ height: open ? 40 : 64 }} />
-        <List sx={{ p: 0 }}>
-          {renderItems(NAVIGATION_DATA.main)}
-          {open && <ListSubheader sx={{ ...styles.subheader, ...styles.divider }}>Контент</ListSubheader>}
-          {renderItems(NAVIGATION_DATA.content)}
-          <Divider sx={styles.divider} />
-          {open && <ListSubheader sx={{ ...styles.subheader, ...styles.divider }}>Інше</ListSubheader>}
-          {renderItems(NAVIGATION_DATA.other)}
-        </List>
+        <Box sx={styles.navigationContent}>
+          <Box sx={{ height: open ? 40 : 64 }} />
+          <List sx={{ p: 0 }}>
+            {renderItems(NAVIGATION_DATA.main)}
+            {open && <ListSubheader sx={{ ...styles.subheader, ...styles.divider }}>Контент</ListSubheader>}
+            {renderItems(NAVIGATION_DATA.content)}
+            <Divider sx={styles.divider} />
+            {open && <ListSubheader sx={{ ...styles.subheader, ...styles.divider }}>Інше</ListSubheader>}
+            {renderItems(NAVIGATION_DATA.other)}
+          </List>
+        </Box>
       </Box>
     </Box>
   );


### PR DESCRIPTION
## Description

This PR fixes multiple issues related to the **sidebar behavior**.

Previously:
- The **toggle button** scrolled with the page instead of staying fixed relative to the sidebar
- The **logo** had incorrect behavior:
  - Acted as a toggle button
  - Had an unwanted hover background effect
  - Did not navigate to the home page
  - Was wrapped in a `<button>` instead of a link

Now:
- The toggle button is fixed relative to the sidebar and does not scroll with page content
- The logo:
  - Navigates to the home page (`/`)
  - Is wrapped in a proper `<a>` / `Link`
  - Has no hover background effect
  - Does not control sidebar toggle

The toggle logic is now isolated to the toggle button only, ensuring predictable sidebar behavior and improved UX.

link:
https://github.com/Liatoshynsky-Foundation/lf-admin/issues/416

## Type of change

- [x] Bug fix

## How to test

1. Open any page with the **sidebar**.
2. Scroll the page:
   - Verify that the **toggle button stays fixed** relative to the sidebar
3. Hover over the **logo**:
   - Ensure no background hover effect is applied
4. Click the **logo**:
   - Verify it navigates to the **home page (`/`)**
   - Ensure it does NOT toggle the sidebar
5. Use the **toggle button**:
   - Verify it correctly collapses/expands the sidebar
6. Ensure no visual or functional regressions in the sidebar.

## Video / Screenshots

Before:
<img width="306" height="602" alt="Screenshot 2026-03-31 at 00 44 59" src="https://github.com/user-attachments/assets/a3b9453f-d0ba-4d66-bae8-6800a122f247" />

After:
<img width="470" height="792" alt="Screenshot 2026-03-31 at 00 44 29" src="https://github.com/user-attachments/assets/94c032b6-39ed-4eab-a194-2b453bd673b9" />
