### PR TITLE
feat(ui): extend admin theme with Design System tokens

### DIFF
--- a/app/shared/theme/colors.ts
+++ b/app/shared/theme/colors.ts
@@ -1,10 +1,3 @@
-const hexToRgba = (hex: string, alpha: number) => {
-  const r = Number.parseInt(hex.slice(1, 3), 16);
-  const g = Number.parseInt(hex.slice(3, 5), 16);
-  const b = Number.parseInt(hex.slice(5, 7), 16);
-  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
-};
-
 export const mainHexPallete = {
   blue: {
     50: '#F9FAFB',
@@ -84,128 +77,102 @@ export const mainHexPallete = {
   black: '#190d03'
 };
 
-const commonStates = {
-  disabled: {
-    bg: mainHexPallete.blue[200],
-    text: mainHexPallete.blue[700],
-    border: mainHexPallete.blue[700],
-    icon: mainHexPallete.blue[700],
-
-    outline: {
-      text: mainHexPallete.blue[600],
-      border: mainHexPallete.blue[600],
-      icon: mainHexPallete.blue[600]
-    }
-  },
-
-  functional: {
-    error: 'rgba(230, 60, 20, 1)',
-    primaryBadge: 'rgba(95, 14, 15, 1)'
-  },
-
-  ripple: hexToRgba(mainHexPallete.brown[100], 0.4),
-
-  interaction: {
-    blackHover: '#342A21',
-    blackPressed: '#5D554E',
-    yellowHover: '#EEAF23',
-    yellowPressed: '#E5A922',
-    redHover: '#AC2F0F',
-    redFocused: '#9A2A0E',
-    redPressed: '#9A2A0D',
-    whiteHover: '#EEECEA',
-    whitePressed: '#D3CDC6'
-  },
-
-  blackAlpha: (opacity: number) => hexToRgba(mainHexPallete.black, opacity),
-  whiteAlpha: (opacity: number) => hexToRgba(mainHexPallete.white, opacity)
+const sharedTokens = {
+  error: 'rgba(230, 60, 20, 1)',
+  ripple: 'rgba(239, 233, 224, 0.4)',
+  primaryBadge: 'rgba(95, 14, 15, 1)'
 };
 
-const createButtonBase = (mainColor: string, hover: string, focused: string, pressed: string, isWhite?: boolean) => ({
-  filledEnabledBg: mainColor,
-  filledNormalText: isWhite ? mainHexPallete.black : mainHexPallete.white,
-  filledHoveredBg: hover,
-  filledFocusedBg: focused,
-  filledPressedBg: pressed,
-  filledDisabledBg: commonStates.disabled.bg,
-  outlinedEnabledBg: 'transparent',
-  outlinedNormalText: mainColor,
-  outlinedNormalBorder: mainColor,
-  outlinedHoveredBg: isWhite ? commonStates.whiteAlpha(0.08) : commonStates.blackAlpha(0.04),
-  outlinedFocusedBg: isWhite ? commonStates.whiteAlpha(0.16) : commonStates.blackAlpha(0.1),
-  outlinedPressedBg: isWhite ? commonStates.whiteAlpha(0.16) : commonStates.blackAlpha(0.1),
+const sharedButtonDisabled = {
+  filledDisabledBg: mainHexPallete.blue[200],
   outlinedDisabledBg: 'transparent',
-  outlinedDisabledBorder: commonStates.disabled.border,
-  disabledText: commonStates.disabled.text
-});
+  outlinedDisabledBorder: mainHexPallete.blue[700],
+  disabledText: mainHexPallete.blue[700]
+};
 
-const createInputBaseState = (isOutline: boolean) => {
-  const ds = isOutline ? commonStates.disabled.outline : commonStates.disabled;
-  const err = commonStates.functional.error;
-  return {
-    errorFirstIcon: err,
-    errorSecondIcon: err,
-    errorUnderline: err,
-    errorLabel: err,
-    errorIcon: err,
-    errorOutline: err,
-    errorTextInfo: err,
-    errorTextInfoIcon: err,
-    errorValue: mainHexPallete.black,
-    disabledFirstIcon: ds.icon,
-    disabledValue: ds.text,
-    disabledSecondIcon: ds.icon,
-    disabledUnderline: ds.border,
-    disabledLabel: ds.text,
-    disabledIcon: ds.icon,
-    disabledOutline: ds.border,
-    disabledTextInfo: ds.text
-  };
+const sharedInputErrorBase = {
+  errorValue: mainHexPallete.black
+};
+
+const standardInputError = {
+  ...sharedInputErrorBase,
+  errorFirstIcon: sharedTokens.error,
+  errorSecondIcon: sharedTokens.error,
+  errorUnderline: sharedTokens.error
+};
+
+const outlineInputError = {
+  ...sharedInputErrorBase,
+  errorLabel: sharedTokens.error,
+  errorIcon: sharedTokens.error,
+  errorOutline: sharedTokens.error,
+  errorTextInfo: sharedTokens.error,
+  errorTextInfoIcon: sharedTokens.error
 };
 
 export const badgeColors = {
-  standardDefaultValue: commonStates.blackAlpha(0.56),
+  standardDefaultValue: 'rgba(0, 0, 0, 0.56)',
   standardPrimaryValue: mainHexPallete.white,
-  standardPrimaryBg: commonStates.functional.primaryBadge,
+  standardPrimaryBg: sharedTokens.primaryBadge,
   standardSecondaryValue: mainHexPallete.black,
-  standardErrorBg: commonStates.functional.error,
+  standardErrorBg: 'rgba(230, 60, 20, 1)',
   standardErrorValue: mainHexPallete.white,
 
-  dotPrimaryBg: commonStates.functional.primaryBadge,
-  dotErrorBg: commonStates.functional.error
+  dotPrimaryBg: sharedTokens.primaryBadge,
+  dotErrorBg: 'rgba(230, 60, 20, 1)'
 };
 
 export const buttonColors = {
-  primary: createButtonBase(
-    mainHexPallete.black,
-    commonStates.interaction.blackHover,
-    commonStates.interaction.blackPressed,
-    commonStates.interaction.blackPressed
-  ),
-  secondary: createButtonBase(
-    mainHexPallete.white,
-    commonStates.interaction.whiteHover,
-    commonStates.interaction.whitePressed,
-    '#DAD5CF',
-    true
-  ),
+  primary: {
+    ...sharedButtonDisabled,
+    filledEnabledBg: mainHexPallete.black,
+    filledNormalText: mainHexPallete.white,
+    filledHoveredBg: 'rgb(52, 42, 33)',
+    filledFocusedBg: 'rgb(93, 85, 78)',
+    filledPressedBg: 'rgb(93, 85, 78)',
+
+    outlinedEnabledBg: 'transparent',
+    outlinedNormalText: mainHexPallete.black,
+    outlinedNormalBorder: mainHexPallete.black,
+    outlinedHoveredBg: 'rgba(25, 13, 3, 0.04)',
+    outlinedFocusedBg: 'rgba(25, 13, 3, 0.1)',
+    outlinedPressedBg: 'rgba(25, 13, 3, 0.1)'
+  },
+
+  secondary: {
+    ...sharedButtonDisabled,
+    filledEnabledBg: mainHexPallete.white,
+    filledNormalText: mainHexPallete.black,
+    filledHoveredBg: 'rgb(238, 236, 234)',
+    filledFocusedBg: 'rgb(211, 205, 198)',
+    filledPressedBg: 'rgb(218, 213, 207)',
+
+    outlinedEnabledBg: 'transparent',
+    outlinedNormalText: mainHexPallete.white,
+    outlinedNormalBorder: mainHexPallete.white,
+    outlinedHoveredBg: 'rgba(252, 252, 252, 0.08)',
+    outlinedFocusedBg: 'rgba(252, 252, 252, 0.16)',
+    outlinedPressedBg: 'rgba(252, 252, 252, 0.16)'
+  },
+
   tertiary: {
     enabledBg: mainHexPallete.yellow[500],
     normalText: mainHexPallete.black,
-    hoveredBg: commonStates.interaction.yellowHover,
-    focusedBg: commonStates.interaction.yellowPressed,
+    hoveredBg: 'rgb(238, 175, 35)',
+    focusedBg: 'rgb(229, 169, 34)',
     pressedBg: mainHexPallete.yellow[800],
-    disabledBg: commonStates.disabled.bg,
-    disabledText: commonStates.disabled.text
+    disabledBg: mainHexPallete.blue[200],
+    disabledText: mainHexPallete.blue[700]
   },
+
   error: {
     enabledBg: mainHexPallete.red[600],
     normalText: mainHexPallete.white,
-    hoveredBg: commonStates.interaction.redHover,
-    focusedBg: commonStates.interaction.redFocused,
-    pressedBg: commonStates.interaction.redPressed,
-    disabledBg: commonStates.disabled.bg,
-    disabledText: commonStates.disabled.text
+    hoveredBg: 'rgb(172, 47, 15)',
+    focusedBg: 'rgb(154, 42, 14)',
+    pressedBg: 'rgb(154, 42, 13)',
+    disabledBg: mainHexPallete.blue[200],
+    disabledText: mainHexPallete.blue[700]
   }
 };
 
@@ -234,12 +201,12 @@ export const checkboxColors = {
   defaultIcon: mainHexPallete.blue[500],
 
   hoveredIcon: mainHexPallete.blue[500],
-  hoveredRipple: commonStates.ripple,
+  hoveredRipple: sharedTokens.ripple,
 
   focusedIcon: mainHexPallete.brown[300],
-  focusedRipple: commonStates.ripple,
+  focusedRipple: sharedTokens.ripple,
 
-  disabledIcon: commonStates.disabled.bg,
+  disabledIcon: mainHexPallete.blue[200],
 
   selectedIcon: 'rgba(255, 188, 33, 1)'
 };
@@ -252,19 +219,19 @@ export const chipsColors = {
   filledPressedBg: mainHexPallete.brown[200],
   filledDisabledBg: mainHexPallete.blue[50],
 
-  outlineHoveredBg: commonStates.blackAlpha(0.08),
-  outlinePressedBg: commonStates.blackAlpha(0.24),
+  outlineHoveredBg: 'rgba(25, 13, 3, 0.08)',
+  outlinePressedBg: 'rgba(25, 13, 3, 0.24)',
   outlineNormalBorder: mainHexPallete.black,
-  outlineDisabledBorder: commonStates.disabled.border,
-  outlineDisabledText: commonStates.disabled.text
+  outlineDisabledBorder: mainHexPallete.blue[700],
+  outlineDisabledText: mainHexPallete.blue[700]
 };
 
 export const menuItemColors = {
-  hoveredBg: commonStates.blackAlpha(0.06),
-  activeBg: commonStates.blackAlpha(0.12),
+  hoveredBg: 'rgba(25, 13, 3, 0.06)',
+  activeBg: 'rgba(25, 13, 3, 0.12)',
 
   defaultText: mainHexPallete.black,
-  disabledText: commonStates.disabled.text
+  disabledText: mainHexPallete.blue[700]
 };
 
 export const selectorColors = {
@@ -281,37 +248,53 @@ export const selectorColors = {
 
 export const textFieldColors = {
   standard: {
-    ...createInputBaseState(false),
+    ...standardInputError,
     defaultFirstIcon: mainHexPallete.blue[800],
     defaultValue: mainHexPallete.blue[800],
     defaultSecondIcon: mainHexPallete.blue[700],
-    defaultUnderline: commonStates.blackAlpha(0.25),
+    defaultUnderline: 'rgba(25, 13, 3, 0.25)',
+
     hoveredFirstIcon: mainHexPallete.blue[800],
     hoveredValue: mainHexPallete.blue[800],
     hoveredSecondIcon: mainHexPallete.black,
-    hoveredUnderline: commonStates.blackAlpha(0.5),
+    hoveredUnderline: 'rgba(25, 13, 3, 0.5)',
+
     focusedFirstIcon: mainHexPallete.black,
     focusedValue: mainHexPallete.black,
     focusedSecondIcon: mainHexPallete.black,
-    focusedUnderline: mainHexPallete.black
+    focusedUnderline: mainHexPallete.black,
+
+    disabledFirstIcon: mainHexPallete.blue[700],
+    disabledValue: mainHexPallete.blue[700],
+    disabledSecondIcon: mainHexPallete.blue[700],
+    disabledUnderline: mainHexPallete.blue[700]
   },
+
   outline: {
-    ...createInputBaseState(true),
+    ...outlineInputError,
     defaultLabel: mainHexPallete.blue[800],
     defaultIcon: mainHexPallete.blue[700],
     defaultValue: mainHexPallete.black,
     defaultOutline: mainHexPallete.adminBlue[500],
     defaultTextInfo: mainHexPallete.blue[800],
+
     hoveredLabel: mainHexPallete.blue[800],
     hoveredIcon: mainHexPallete.black,
     hoveredValue: mainHexPallete.black,
-    hoveredOutline: commonStates.blackAlpha(0.5),
+    hoveredOutline: 'rgba(25, 13, 3, 0.5)',
     hoveredTextInfo: mainHexPallete.blue[800],
+
     focusedLabel: mainHexPallete.black,
     focusedIcon: mainHexPallete.black,
     focusedValue: mainHexPallete.black,
     focusedOutline: mainHexPallete.black,
-    focusedTextInfo: mainHexPallete.black
+    focusedTextInfo: mainHexPallete.black,
+
+    disabledLabel: mainHexPallete.blue[600],
+    disabledIcon: mainHexPallete.blue[600],
+    disabledValue: mainHexPallete.blue[600],
+    disabledOutline: mainHexPallete.blue[600],
+    disabledTextInfo: mainHexPallete.blue[600]
   }
 };
 
@@ -319,6 +302,6 @@ export const toolbarColors = {
   textColor: mainHexPallete.black,
   default: mainHexPallete.white,
   hovered: 'rgba(241, 242, 247, 1)',
-  focused: commonStates.blackAlpha(0.06),
+  focused: 'rgba(25, 13, 3, 0.06)',
   border: mainHexPallete.blue[200]
 };

--- a/app/shared/theme/colors.ts
+++ b/app/shared/theme/colors.ts
@@ -121,23 +121,46 @@ const commonStates = {
   whiteAlpha: (opacity: number) => hexToRgba(mainHexPallete.white, opacity)
 };
 
-const sharedErrorState = {
-  errorFirstIcon: commonStates.functional.error,
-  errorSecondIcon: commonStates.functional.error,
-  errorUnderline: commonStates.functional.error,
-  errorLabel: commonStates.functional.error,
-  errorIcon: commonStates.functional.error,
-  errorOutline: commonStates.functional.error,
-  errorTextInfo: commonStates.functional.error,
-  errorTextInfoIcon: commonStates.functional.error,
-  errorValue: mainHexPallete.black
-};
-
-const baseButtonDisabled = {
+const createButtonBase = (mainColor: string, hover: string, focused: string, pressed: string, isWhite?: boolean) => ({
+  filledEnabledBg: mainColor,
+  filledNormalText: isWhite ? mainHexPallete.black : mainHexPallete.white,
+  filledHoveredBg: hover,
+  filledFocusedBg: focused,
+  filledPressedBg: pressed,
   filledDisabledBg: commonStates.disabled.bg,
+  outlinedEnabledBg: 'transparent',
+  outlinedNormalText: mainColor,
+  outlinedNormalBorder: mainColor,
+  outlinedHoveredBg: isWhite ? commonStates.whiteAlpha(0.08) : commonStates.blackAlpha(0.04),
+  outlinedFocusedBg: isWhite ? commonStates.whiteAlpha(0.16) : commonStates.blackAlpha(0.1),
+  outlinedPressedBg: isWhite ? commonStates.whiteAlpha(0.16) : commonStates.blackAlpha(0.1),
   outlinedDisabledBg: 'transparent',
   outlinedDisabledBorder: commonStates.disabled.border,
   disabledText: commonStates.disabled.text
+});
+
+const createInputBaseState = (isOutline: boolean) => {
+  const ds = isOutline ? commonStates.disabled.outline : commonStates.disabled;
+  const err = commonStates.functional.error;
+  return {
+    errorFirstIcon: err,
+    errorSecondIcon: err,
+    errorUnderline: err,
+    errorLabel: err,
+    errorIcon: err,
+    errorOutline: err,
+    errorTextInfo: err,
+    errorTextInfoIcon: err,
+    errorValue: mainHexPallete.black,
+    disabledFirstIcon: ds.icon,
+    disabledValue: ds.text,
+    disabledSecondIcon: ds.icon,
+    disabledUnderline: ds.border,
+    disabledLabel: ds.text,
+    disabledIcon: ds.icon,
+    disabledOutline: ds.border,
+    disabledTextInfo: ds.text
+  };
 };
 
 export const badgeColors = {
@@ -153,38 +176,19 @@ export const badgeColors = {
 };
 
 export const buttonColors = {
-  primary: {
-    ...baseButtonDisabled,
-    filledEnabledBg: mainHexPallete.black,
-    filledNormalText: mainHexPallete.white,
-    filledHoveredBg: commonStates.interaction.blackHover,
-    filledFocusedBg: commonStates.interaction.blackPressed,
-    filledPressedBg: commonStates.interaction.blackPressed,
-
-    outlinedEnabledBg: 'transparent',
-    outlinedNormalText: mainHexPallete.black,
-    outlinedNormalBorder: mainHexPallete.black,
-    outlinedHoveredBg: commonStates.blackAlpha(0.04),
-    outlinedFocusedBg: commonStates.blackAlpha(0.1),
-    outlinedPressedBg: commonStates.blackAlpha(0.1)
-  },
-
-  secondary: {
-    ...baseButtonDisabled,
-    filledEnabledBg: mainHexPallete.white,
-    filledNormalText: mainHexPallete.black,
-    filledHoveredBg: commonStates.interaction.whiteHover,
-    filledFocusedBg: commonStates.interaction.whitePressed,
-    filledPressedBg: '#DAD5CF',
-
-    outlinedEnabledBg: 'transparent',
-    outlinedNormalText: mainHexPallete.white,
-    outlinedNormalBorder: mainHexPallete.white,
-    outlinedHoveredBg: commonStates.whiteAlpha(0.08),
-    outlinedFocusedBg: commonStates.whiteAlpha(0.16),
-    outlinedPressedBg: commonStates.whiteAlpha(0.16)
-  },
-
+  primary: createButtonBase(
+    mainHexPallete.black,
+    commonStates.interaction.blackHover,
+    commonStates.interaction.blackPressed,
+    commonStates.interaction.blackPressed
+  ),
+  secondary: createButtonBase(
+    mainHexPallete.white,
+    commonStates.interaction.whiteHover,
+    commonStates.interaction.whitePressed,
+    '#DAD5CF',
+    true
+  ),
   tertiary: {
     enabledBg: mainHexPallete.yellow[500],
     normalText: mainHexPallete.black,
@@ -194,7 +198,6 @@ export const buttonColors = {
     disabledBg: commonStates.disabled.bg,
     disabledText: commonStates.disabled.text
   },
-
   error: {
     enabledBg: mainHexPallete.red[600],
     normalText: mainHexPallete.white,
@@ -278,53 +281,37 @@ export const selectorColors = {
 
 export const textFieldColors = {
   standard: {
-    ...sharedErrorState,
+    ...createInputBaseState(false),
     defaultFirstIcon: mainHexPallete.blue[800],
     defaultValue: mainHexPallete.blue[800],
     defaultSecondIcon: mainHexPallete.blue[700],
     defaultUnderline: commonStates.blackAlpha(0.25),
-
     hoveredFirstIcon: mainHexPallete.blue[800],
     hoveredValue: mainHexPallete.blue[800],
     hoveredSecondIcon: mainHexPallete.black,
     hoveredUnderline: commonStates.blackAlpha(0.5),
-
     focusedFirstIcon: mainHexPallete.black,
     focusedValue: mainHexPallete.black,
     focusedSecondIcon: mainHexPallete.black,
-    focusedUnderline: mainHexPallete.black,
-
-    disabledFirstIcon: commonStates.disabled.icon,
-    disabledValue: commonStates.disabled.text,
-    disabledSecondIcon: commonStates.disabled.icon,
-    disabledUnderline: commonStates.disabled.border
+    focusedUnderline: mainHexPallete.black
   },
-
   outline: {
-    ...sharedErrorState,
+    ...createInputBaseState(true),
     defaultLabel: mainHexPallete.blue[800],
     defaultIcon: mainHexPallete.blue[700],
     defaultValue: mainHexPallete.black,
     defaultOutline: mainHexPallete.adminBlue[500],
     defaultTextInfo: mainHexPallete.blue[800],
-
     hoveredLabel: mainHexPallete.blue[800],
     hoveredIcon: mainHexPallete.black,
     hoveredValue: mainHexPallete.black,
     hoveredOutline: commonStates.blackAlpha(0.5),
     hoveredTextInfo: mainHexPallete.blue[800],
-
     focusedLabel: mainHexPallete.black,
     focusedIcon: mainHexPallete.black,
     focusedValue: mainHexPallete.black,
     focusedOutline: mainHexPallete.black,
-    focusedTextInfo: mainHexPallete.black,
-
-    disabledLabel: commonStates.disabled.outline.text,
-    disabledIcon: commonStates.disabled.outline.icon,
-    disabledValue: commonStates.disabled.outline.text,
-    disabledOutline: commonStates.disabled.outline.border,
-    disabledTextInfo: commonStates.disabled.outline.text
+    focusedTextInfo: mainHexPallete.black
   }
 };
 

--- a/app/shared/theme/colors.ts
+++ b/app/shared/theme/colors.ts
@@ -1,3 +1,10 @@
+const hexToRgba = (hex: string, alpha: number) => {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+};
+
 export const mainHexPallete = {
   blue: {
     50: '#F9FAFB',
@@ -77,77 +84,114 @@ export const mainHexPallete = {
   black: '#190d03'
 };
 
+const commonStates = {
+  disabled: {
+    bg: mainHexPallete.blue[200],
+    text: mainHexPallete.blue[700],
+    border: mainHexPallete.blue[700],
+    icon: mainHexPallete.blue[700],
+
+    outline: {
+      text: mainHexPallete.blue[600],
+      border: mainHexPallete.blue[600],
+      icon: mainHexPallete.blue[600]
+    }
+  },
+
+  functional: {
+    error: 'rgba(230, 60, 20, 1)',
+    primaryBadge: 'rgba(95, 14, 15, 1)'
+  },
+
+  ripple: hexToRgba(mainHexPallete.brown[100], 0.4),
+
+  interaction: {
+    blackHover: '#342A21',
+    blackPressed: '#5D554E',
+    yellowHover: '#EEAF23',
+    yellowPressed: '#E5A922',
+    redHover: '#AC2F0F',
+    redFocused: '#9A2A0E',
+    redPressed: '#9A2A0D',
+    whiteHover: '#EEECEA',
+    whitePressed: '#D3CDC6'
+  },
+
+  blackAlpha: (opacity: number) => hexToRgba(mainHexPallete.black, opacity),
+  whiteAlpha: (opacity: number) => hexToRgba(mainHexPallete.white, opacity)
+};
+
 export const badgeColors = {
-  standardDefaultValue: 'rgba(0, 0, 0, 0.56)',
+  standardDefaultValue: commonStates.blackAlpha(0.56),
   standardPrimaryValue: mainHexPallete.white,
-  standardPrimaryBg: 'rgba(95, 14, 15, 1)',
+  standardPrimaryBg: commonStates.functional.primaryBadge,
   standardSecondaryValue: mainHexPallete.black,
-  standardErrorBg: 'rgba(230, 60, 20, 1)',
+  standardErrorBg: commonStates.functional.error,
   standardErrorValue: mainHexPallete.white,
 
-  dotPrimaryBg: 'rgba(95, 14, 15, 1)',
-  dotErrorBg: 'rgba(230, 60, 20, 1)'
+  dotPrimaryBg: commonStates.functional.primaryBadge,
+  dotErrorBg: commonStates.functional.error
 };
 
 export const buttonColors = {
   primary: {
     filledEnabledBg: mainHexPallete.black,
     filledNormalText: mainHexPallete.white,
-    filledHoveredBg: 'rgb(52, 42, 33)',
-    filledFocusedBg: 'rgb(93, 85, 78)',
-    filledPressedBg: 'rgb(93, 85, 78)',
-    filledDisabledBg: mainHexPallete.blue[200],
+    filledHoveredBg: commonStates.interaction.blackHover,
+    filledFocusedBg: commonStates.interaction.blackPressed,
+    filledPressedBg: commonStates.interaction.blackPressed,
+    filledDisabledBg: commonStates.disabled.bg,
 
     outlinedEnabledBg: 'transparent',
     outlinedNormalText: mainHexPallete.black,
     outlinedNormalBorder: mainHexPallete.black,
-    outlinedHoveredBg: 'rgba(25, 13, 3, 0.04)',
-    outlinedFocusedBg: 'rgba(25, 13, 3, 0.1)',
-    outlinedPressedBg: 'rgba(25, 13, 3, 0.1)',
+    outlinedHoveredBg: commonStates.blackAlpha(0.04),
+    outlinedFocusedBg: commonStates.blackAlpha(0.1),
+    outlinedPressedBg: commonStates.blackAlpha(0.1),
     outlinedDisabledBg: 'transparent',
-    outlinedDisabledBorder: mainHexPallete.blue[700],
+    outlinedDisabledBorder: commonStates.disabled.border,
 
-    disabledText: mainHexPallete.blue[700]
+    disabledText: commonStates.disabled.text
   },
 
   secondary: {
     filledEnabledBg: mainHexPallete.white,
     filledNormalText: mainHexPallete.black,
-    filledHoveredBg: 'rgb(238, 236, 234)',
-    filledFocusedBg: 'rgb(211, 205, 198)',
-    filledPressedBg: 'rgb(218, 213, 207)',
-    filledDisabledBg: mainHexPallete.blue[200],
+    filledHoveredBg: commonStates.interaction.whiteHover,
+    filledFocusedBg: commonStates.interaction.whitePressed,
+    filledPressedBg: '#DAD5CF',
+    filledDisabledBg: commonStates.disabled.bg,
 
     outlinedEnabledBg: 'transparent',
     outlinedNormalText: mainHexPallete.white,
     outlinedNormalBorder: mainHexPallete.white,
-    outlinedHoveredBg: 'rgba(252, 252, 252, 0.08)',
-    outlinedFocusedBg: 'rgba(252, 252, 252, 0.16)',
-    outlinedPressedBg: 'rgba(252, 252, 252, 0.16)',
+    outlinedHoveredBg: commonStates.whiteAlpha(0.08),
+    outlinedFocusedBg: commonStates.whiteAlpha(0.16),
+    outlinedPressedBg: commonStates.whiteAlpha(0.16),
     outlinedDisabledBg: 'transparent',
-    outlinedDisabledBorder: mainHexPallete.blue[700],
+    outlinedDisabledBorder: commonStates.disabled.border,
 
-    disabledText: mainHexPallete.blue[700]
+    disabledText: commonStates.disabled.text
   },
 
   tertiary: {
     enabledBg: mainHexPallete.yellow[500],
     normalText: mainHexPallete.black,
-    hoveredBg: 'rgb(238, 175, 35)',
-    focusedBg: 'rgb(229, 169, 34)',
+    hoveredBg: commonStates.interaction.yellowHover,
+    focusedBg: commonStates.interaction.yellowPressed,
     pressedBg: mainHexPallete.yellow[800],
-    disabledBg: mainHexPallete.blue[200],
-    disabledText: mainHexPallete.blue[700]
+    disabledBg: commonStates.disabled.bg,
+    disabledText: commonStates.disabled.text
   },
 
   error: {
     enabledBg: mainHexPallete.red[600],
     normalText: mainHexPallete.white,
-    hoveredBg: 'rgb(172, 47, 15)',
-    focusedBg: 'rgb(154, 42, 14)',
-    pressedBg: 'rgb(154, 42, 13)',
-    disabledBg: mainHexPallete.blue[200],
-    disabledText: mainHexPallete.blue[700]
+    hoveredBg: commonStates.interaction.redHover,
+    focusedBg: commonStates.interaction.redFocused,
+    pressedBg: commonStates.interaction.redPressed,
+    disabledBg: commonStates.disabled.bg,
+    disabledText: commonStates.disabled.text
   }
 };
 
@@ -176,12 +220,12 @@ export const checkboxColors = {
   defaultIcon: mainHexPallete.blue[500],
 
   hoveredIcon: mainHexPallete.blue[500],
-  hoveredRipple: 'rgba(239, 233, 224, 0.4)',
+  hoveredRipple: commonStates.ripple,
 
   focusedIcon: mainHexPallete.brown[300],
-  focusedRipple: 'rgba(239, 233, 224, 0.4)',
+  focusedRipple: commonStates.ripple,
 
-  disabledIcon: mainHexPallete.blue[200],
+  disabledIcon: commonStates.disabled.bg,
 
   selectedIcon: 'rgba(255, 188, 33, 1)'
 };
@@ -194,19 +238,19 @@ export const chipsColors = {
   filledPressedBg: mainHexPallete.brown[200],
   filledDisabledBg: mainHexPallete.blue[50],
 
-  outlineHoveredBg: 'rgba(25, 13, 3, 0.08)',
-  outlinePressedBg: 'rgba(25, 13, 3, 0.24)',
+  outlineHoveredBg: commonStates.blackAlpha(0.08),
+  outlinePressedBg: commonStates.blackAlpha(0.24),
   outlineNormalBorder: mainHexPallete.black,
-  outlineDisabledBorder: mainHexPallete.blue[700],
-  outlineDisabledText: mainHexPallete.blue[700]
+  outlineDisabledBorder: commonStates.disabled.border,
+  outlineDisabledText: commonStates.disabled.text
 };
 
 export const menuItemColors = {
-  hoveredBg: 'rgba(25, 13, 3, 0.06)',
-  activeBg: 'rgba(25, 13, 3, 0.12)',
+  hoveredBg: commonStates.blackAlpha(0.06),
+  activeBg: commonStates.blackAlpha(0.12),
 
   defaultText: mainHexPallete.black,
-  disabledText: mainHexPallete.blue[700]
+  disabledText: commonStates.disabled.text
 };
 
 export const selectorColors = {
@@ -226,27 +270,27 @@ export const textFieldColors = {
     defaultFirstIcon: mainHexPallete.blue[800],
     defaultValue: mainHexPallete.blue[800],
     defaultSecondIcon: mainHexPallete.blue[700],
-    defaultUnderline: 'rgba(25, 13, 3, 0.25)',
+    defaultUnderline: commonStates.blackAlpha(0.25),
 
     hoveredFirstIcon: mainHexPallete.blue[800],
     hoveredValue: mainHexPallete.blue[800],
     hoveredSecondIcon: mainHexPallete.black,
-    hoveredUnderline: 'rgba(25, 13, 3, 0.5)',
+    hoveredUnderline: commonStates.blackAlpha(0.5),
 
     focusedFirstIcon: mainHexPallete.black,
     focusedValue: mainHexPallete.black,
     focusedSecondIcon: mainHexPallete.black,
     focusedUnderline: mainHexPallete.black,
 
-    disabledFirstIcon: mainHexPallete.blue[700],
-    disabledValue: mainHexPallete.blue[700],
-    disabledSecondIcon: mainHexPallete.blue[700],
-    disabledUnderline: mainHexPallete.blue[700],
+    disabledFirstIcon: commonStates.disabled.icon,
+    disabledValue: commonStates.disabled.text,
+    disabledSecondIcon: commonStates.disabled.icon,
+    disabledUnderline: commonStates.disabled.border,
 
-    errorFirstIcon: 'rgba(230, 60, 20, 1)',
+    errorFirstIcon: commonStates.functional.error,
     errorValue: mainHexPallete.black,
-    errorSecondIcon: 'rgba(230, 60, 20, 1)',
-    errorUnderline: 'rgba(230, 60, 20, 1)'
+    errorSecondIcon: commonStates.functional.error,
+    errorUnderline: commonStates.functional.error
   },
 
   outline: {
@@ -259,7 +303,7 @@ export const textFieldColors = {
     hoveredLabel: mainHexPallete.blue[800],
     hoveredIcon: mainHexPallete.black,
     hoveredValue: mainHexPallete.black,
-    hoveredOutline: 'rgba(25, 13, 3, 0.5)',
+    hoveredOutline: commonStates.blackAlpha(0.5),
     hoveredTextInfo: mainHexPallete.blue[800],
 
     focusedLabel: mainHexPallete.black,
@@ -268,18 +312,18 @@ export const textFieldColors = {
     focusedOutline: mainHexPallete.black,
     focusedTextInfo: mainHexPallete.black,
 
-    disabledLabel: mainHexPallete.blue[600],
-    disabledIcon: mainHexPallete.blue[600],
-    disabledValue: mainHexPallete.blue[600],
-    disabledOutline: mainHexPallete.blue[600],
-    disabledTextInfo: mainHexPallete.blue[600],
+    disabledLabel: commonStates.disabled.outline.text,
+    disabledIcon: commonStates.disabled.outline.icon,
+    disabledValue: commonStates.disabled.outline.text,
+    disabledOutline: commonStates.disabled.outline.border,
+    disabledTextInfo: commonStates.disabled.outline.text,
 
-    errorLabel: 'rgba(230, 60, 20, 1)',
-    errorIcon: 'rgba(230, 60, 20, 1)',
+    errorLabel: commonStates.functional.error,
+    errorIcon: commonStates.functional.error,
     errorValue: mainHexPallete.black,
-    errorOutline: 'rgba(230, 60, 20, 1)',
-    errorTextInfo: 'rgba(230, 60, 20, 1)',
-    errorTextInfoIcon: 'rgba(230, 60, 20, 1)'
+    errorOutline: commonStates.functional.error,
+    errorTextInfo: commonStates.functional.error,
+    errorTextInfoIcon: commonStates.functional.error
   }
 };
 
@@ -287,6 +331,6 @@ export const toolbarColors = {
   textColor: mainHexPallete.black,
   default: mainHexPallete.white,
   hovered: 'rgba(241, 242, 247, 1)',
-  focused: 'rgba(25, 13, 3, 0.06)',
+  focused: commonStates.blackAlpha(0.06),
   border: mainHexPallete.blue[200]
 };

--- a/app/shared/theme/colors.ts
+++ b/app/shared/theme/colors.ts
@@ -1,0 +1,292 @@
+export const mainHexPallete = {
+  blue: {
+    50: '#F9FAFB',
+    100: '#F0F2FB',
+    200: '#D9DCE8',
+    300: '#C6C8D3',
+    400: '#B2B3BE',
+    500: '#9D9FA9',
+    600: '#898C95',
+    700: '#63666E',
+    800: '#52545A',
+    900: '#3F444A'
+  },
+  yellow: {
+    100: '#FFF8E9',
+    200: '#FFEABA',
+    300: '#FFE099',
+    400: '#FFD26A',
+    500: '#FCBD28',
+    600: '#E0A01F',
+    700: '#BF7D13',
+    800: '#8A570C',
+    900: '#673E0F'
+  },
+  brown: {
+    50: '#F7F5F1',
+    100: '#EDE8DF',
+    200: '#D3CAC0',
+    300: '#B8AEA2',
+    400: '#9F9185',
+    500: '#87756B',
+    600: '#6E5A51',
+    700: '#574139',
+    800: '#412B21',
+    900: '#2D1611'
+  },
+  red: {
+    50: '#FCF0ED',
+    100: '#FAE2DC',
+    200: '#F7C3B6',
+    300: '#F4A593',
+    400: '#F7856A',
+    500: '#eb6343',
+    600: '#d13712',
+    700: '#A32B0E',
+    800: '#7F210B',
+    900: '#611908'
+  },
+  burgundy: {
+    50: '#F9F3F3',
+    100: '#E6D4D3',
+    200: '#D4B8B4',
+    300: '#C19C96',
+    400: '#AE7F79',
+    500: '#9B655E',
+    600: '#874943',
+    700: '#732E28',
+    800: '#600e0f',
+    900: '#3d0607'
+  },
+  adminBlue: {
+    50: '#F8F8FA',
+    100: '#F1F2F7',
+    200: '#E6E7ED',
+    300: '#DCDDE5',
+    400: '#C3C4CE',
+    500: '#ADAEBA',
+    600: '#989CAB',
+    700: '#868A9C',
+    800: '#696C7D',
+    900: '#4E5061'
+  },
+  green: {
+    100: '#E2F2DC'
+  },
+  white: '#FCFCFC',
+  black: '#190d03'
+};
+
+export const badgeColors = {
+  standardDefaultValue: 'rgba(0, 0, 0, 0.56)',
+  standardPrimaryValue: mainHexPallete.white,
+  standardPrimaryBg: 'rgba(95, 14, 15, 1)',
+  standardSecondaryValue: mainHexPallete.black,
+  standardErrorBg: 'rgba(230, 60, 20, 1)',
+  standardErrorValue: mainHexPallete.white,
+
+  dotPrimaryBg: 'rgba(95, 14, 15, 1)',
+  dotErrorBg: 'rgba(230, 60, 20, 1)'
+};
+
+export const buttonColors = {
+  primary: {
+    filledEnabledBg: mainHexPallete.black,
+    filledNormalText: mainHexPallete.white,
+    filledHoveredBg: 'rgb(52, 42, 33)',
+    filledFocusedBg: 'rgb(93, 85, 78)',
+    filledPressedBg: 'rgb(93, 85, 78)',
+    filledDisabledBg: mainHexPallete.blue[200],
+
+    outlinedEnabledBg: 'transparent',
+    outlinedNormalText: mainHexPallete.black,
+    outlinedNormalBorder: mainHexPallete.black,
+    outlinedHoveredBg: 'rgba(25, 13, 3, 0.04)',
+    outlinedFocusedBg: 'rgba(25, 13, 3, 0.1)',
+    outlinedPressedBg: 'rgba(25, 13, 3, 0.1)',
+    outlinedDisabledBg: 'transparent',
+    outlinedDisabledBorder: mainHexPallete.blue[700],
+
+    disabledText: mainHexPallete.blue[700]
+  },
+
+  secondary: {
+    filledEnabledBg: mainHexPallete.white,
+    filledNormalText: mainHexPallete.black,
+    filledHoveredBg: 'rgb(238, 236, 234)',
+    filledFocusedBg: 'rgb(211, 205, 198)',
+    filledPressedBg: 'rgb(218, 213, 207)',
+    filledDisabledBg: mainHexPallete.blue[200],
+
+    outlinedEnabledBg: 'transparent',
+    outlinedNormalText: mainHexPallete.white,
+    outlinedNormalBorder: mainHexPallete.white,
+    outlinedHoveredBg: 'rgba(252, 252, 252, 0.08)',
+    outlinedFocusedBg: 'rgba(252, 252, 252, 0.16)',
+    outlinedPressedBg: 'rgba(252, 252, 252, 0.16)',
+    outlinedDisabledBg: 'transparent',
+    outlinedDisabledBorder: mainHexPallete.blue[700],
+
+    disabledText: mainHexPallete.blue[700]
+  },
+
+  tertiary: {
+    enabledBg: mainHexPallete.yellow[500],
+    normalText: mainHexPallete.black,
+    hoveredBg: 'rgb(238, 175, 35)',
+    focusedBg: 'rgb(229, 169, 34)',
+    pressedBg: mainHexPallete.yellow[800],
+    disabledBg: mainHexPallete.blue[200],
+    disabledText: mainHexPallete.blue[700]
+  },
+
+  error: {
+    enabledBg: mainHexPallete.red[600],
+    normalText: mainHexPallete.white,
+    hoveredBg: 'rgb(172, 47, 15)',
+    focusedBg: 'rgb(154, 42, 14)',
+    pressedBg: 'rgb(154, 42, 13)',
+    disabledBg: mainHexPallete.blue[200],
+    disabledText: mainHexPallete.blue[700]
+  }
+};
+
+export const buttonGroupColors = {
+  primary: {
+    selectedButton: mainHexPallete.black,
+    selectedButtonText: mainHexPallete.white,
+    groupBackground: mainHexPallete.blue[50],
+    buttonText: mainHexPallete.black
+  },
+  secondary: {
+    selectedButton: mainHexPallete.white,
+    selectedButtonText: mainHexPallete.black,
+    groupBackground: mainHexPallete.yellow[500],
+    buttonText: mainHexPallete.black
+  },
+  tertiary: {
+    selectedButton: mainHexPallete.white,
+    selectedButtonText: mainHexPallete.black,
+    groupBackground: mainHexPallete.brown[200],
+    buttonText: mainHexPallete.black
+  }
+};
+
+export const checkboxColors = {
+  defaultIcon: mainHexPallete.blue[500],
+
+  hoveredIcon: mainHexPallete.blue[500],
+  hoveredRipple: 'rgba(239, 233, 224, 0.4)',
+
+  focusedIcon: mainHexPallete.brown[300],
+  focusedRipple: 'rgba(239, 233, 224, 0.4)',
+
+  disabledIcon: mainHexPallete.blue[200],
+
+  selectedIcon: 'rgba(255, 188, 33, 1)'
+};
+
+export const chipsColors = {
+  normalText: mainHexPallete.black,
+
+  filledDefaultBg: mainHexPallete.white,
+  filledHoveredBg: mainHexPallete.brown[100],
+  filledPressedBg: mainHexPallete.brown[200],
+  filledDisabledBg: mainHexPallete.blue[50],
+
+  outlineHoveredBg: 'rgba(25, 13, 3, 0.08)',
+  outlinePressedBg: 'rgba(25, 13, 3, 0.24)',
+  outlineNormalBorder: mainHexPallete.black,
+  outlineDisabledBorder: mainHexPallete.blue[700],
+  outlineDisabledText: mainHexPallete.blue[700]
+};
+
+export const menuItemColors = {
+  hoveredBg: 'rgba(25, 13, 3, 0.06)',
+  activeBg: 'rgba(25, 13, 3, 0.12)',
+
+  defaultText: mainHexPallete.black,
+  disabledText: mainHexPallete.blue[700]
+};
+
+export const selectorColors = {
+  standardTextColor: mainHexPallete.black,
+
+  filledBg: mainHexPallete.blue[200],
+  filledChipsBg: mainHexPallete.white,
+  filledChipsContent: mainHexPallete.black,
+
+  outlineBorder: mainHexPallete.black,
+  outlineDefaultChipsBg: mainHexPallete.black,
+  outlineDefaultTextColor: mainHexPallete.white
+};
+
+export const textFieldColors = {
+  standard: {
+    defaultFirstIcon: mainHexPallete.blue[800],
+    defaultValue: mainHexPallete.blue[800],
+    defaultSecondIcon: mainHexPallete.blue[700],
+    defaultUnderline: 'rgba(25, 13, 3, 0.25)',
+
+    hoveredFirstIcon: mainHexPallete.blue[800],
+    hoveredValue: mainHexPallete.blue[800],
+    hoveredSecondIcon: mainHexPallete.black,
+    hoveredUnderline: 'rgba(25, 13, 3, 0.5)',
+
+    focusedFirstIcon: mainHexPallete.black,
+    focusedValue: mainHexPallete.black,
+    focusedSecondIcon: mainHexPallete.black,
+    focusedUnderline: mainHexPallete.black,
+
+    disabledFirstIcon: mainHexPallete.blue[700],
+    disabledValue: mainHexPallete.blue[700],
+    disabledSecondIcon: mainHexPallete.blue[700],
+    disabledUnderline: mainHexPallete.blue[700],
+
+    errorFirstIcon: 'rgba(230, 60, 20, 1)',
+    errorValue: mainHexPallete.black,
+    errorSecondIcon: 'rgba(230, 60, 20, 1)',
+    errorUnderline: 'rgba(230, 60, 20, 1)'
+  },
+
+  outline: {
+    defaultLabel: mainHexPallete.blue[800],
+    defaultIcon: mainHexPallete.blue[700],
+    defaultValue: mainHexPallete.black,
+    defaultOutline: mainHexPallete.adminBlue[500],
+    defaultTextInfo: mainHexPallete.blue[800],
+
+    hoveredLabel: mainHexPallete.blue[800],
+    hoveredIcon: mainHexPallete.black,
+    hoveredValue: mainHexPallete.black,
+    hoveredOutline: 'rgba(25, 13, 3, 0.5)',
+    hoveredTextInfo: mainHexPallete.blue[800],
+
+    focusedLabel: mainHexPallete.black,
+    focusedIcon: mainHexPallete.black,
+    focusedValue: mainHexPallete.black,
+    focusedOutline: mainHexPallete.black,
+    focusedTextInfo: mainHexPallete.black,
+
+    disabledLabel: mainHexPallete.blue[600],
+    disabledIcon: mainHexPallete.blue[600],
+    disabledValue: mainHexPallete.blue[600],
+    disabledOutline: mainHexPallete.blue[600],
+    disabledTextInfo: mainHexPallete.blue[600],
+
+    errorLabel: 'rgba(230, 60, 20, 1)',
+    errorIcon: 'rgba(230, 60, 20, 1)',
+    errorValue: mainHexPallete.black,
+    errorOutline: 'rgba(230, 60, 20, 1)',
+    errorTextInfo: 'rgba(230, 60, 20, 1)',
+    errorTextInfoIcon: 'rgba(230, 60, 20, 1)'
+  }
+};
+
+export const toolbarColors = {
+  textColor: mainHexPallete.black,
+  default: mainHexPallete.white,
+  hovered: 'rgba(241, 242, 247, 1)',
+  focused: 'rgba(25, 13, 3, 0.06)',
+  border: mainHexPallete.blue[200]
+};

--- a/app/shared/theme/colors.ts
+++ b/app/shared/theme/colors.ts
@@ -1,7 +1,7 @@
 const hexToRgba = (hex: string, alpha: number) => {
-  const r = parseInt(hex.slice(1, 3), 16);
-  const g = parseInt(hex.slice(3, 5), 16);
-  const b = parseInt(hex.slice(5, 7), 16);
+  const r = Number.parseInt(hex.slice(1, 3), 16);
+  const g = Number.parseInt(hex.slice(3, 5), 16);
+  const b = Number.parseInt(hex.slice(5, 7), 16);
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 };
 
@@ -121,6 +121,25 @@ const commonStates = {
   whiteAlpha: (opacity: number) => hexToRgba(mainHexPallete.white, opacity)
 };
 
+const sharedErrorState = {
+  errorFirstIcon: commonStates.functional.error,
+  errorSecondIcon: commonStates.functional.error,
+  errorUnderline: commonStates.functional.error,
+  errorLabel: commonStates.functional.error,
+  errorIcon: commonStates.functional.error,
+  errorOutline: commonStates.functional.error,
+  errorTextInfo: commonStates.functional.error,
+  errorTextInfoIcon: commonStates.functional.error,
+  errorValue: mainHexPallete.black
+};
+
+const baseButtonDisabled = {
+  filledDisabledBg: commonStates.disabled.bg,
+  outlinedDisabledBg: 'transparent',
+  outlinedDisabledBorder: commonStates.disabled.border,
+  disabledText: commonStates.disabled.text
+};
+
 export const badgeColors = {
   standardDefaultValue: commonStates.blackAlpha(0.56),
   standardPrimaryValue: mainHexPallete.white,
@@ -135,43 +154,35 @@ export const badgeColors = {
 
 export const buttonColors = {
   primary: {
+    ...baseButtonDisabled,
     filledEnabledBg: mainHexPallete.black,
     filledNormalText: mainHexPallete.white,
     filledHoveredBg: commonStates.interaction.blackHover,
     filledFocusedBg: commonStates.interaction.blackPressed,
     filledPressedBg: commonStates.interaction.blackPressed,
-    filledDisabledBg: commonStates.disabled.bg,
 
     outlinedEnabledBg: 'transparent',
     outlinedNormalText: mainHexPallete.black,
     outlinedNormalBorder: mainHexPallete.black,
     outlinedHoveredBg: commonStates.blackAlpha(0.04),
     outlinedFocusedBg: commonStates.blackAlpha(0.1),
-    outlinedPressedBg: commonStates.blackAlpha(0.1),
-    outlinedDisabledBg: 'transparent',
-    outlinedDisabledBorder: commonStates.disabled.border,
-
-    disabledText: commonStates.disabled.text
+    outlinedPressedBg: commonStates.blackAlpha(0.1)
   },
 
   secondary: {
+    ...baseButtonDisabled,
     filledEnabledBg: mainHexPallete.white,
     filledNormalText: mainHexPallete.black,
     filledHoveredBg: commonStates.interaction.whiteHover,
     filledFocusedBg: commonStates.interaction.whitePressed,
     filledPressedBg: '#DAD5CF',
-    filledDisabledBg: commonStates.disabled.bg,
 
     outlinedEnabledBg: 'transparent',
     outlinedNormalText: mainHexPallete.white,
     outlinedNormalBorder: mainHexPallete.white,
     outlinedHoveredBg: commonStates.whiteAlpha(0.08),
     outlinedFocusedBg: commonStates.whiteAlpha(0.16),
-    outlinedPressedBg: commonStates.whiteAlpha(0.16),
-    outlinedDisabledBg: 'transparent',
-    outlinedDisabledBorder: commonStates.disabled.border,
-
-    disabledText: commonStates.disabled.text
+    outlinedPressedBg: commonStates.whiteAlpha(0.16)
   },
 
   tertiary: {
@@ -267,6 +278,7 @@ export const selectorColors = {
 
 export const textFieldColors = {
   standard: {
+    ...sharedErrorState,
     defaultFirstIcon: mainHexPallete.blue[800],
     defaultValue: mainHexPallete.blue[800],
     defaultSecondIcon: mainHexPallete.blue[700],
@@ -285,15 +297,11 @@ export const textFieldColors = {
     disabledFirstIcon: commonStates.disabled.icon,
     disabledValue: commonStates.disabled.text,
     disabledSecondIcon: commonStates.disabled.icon,
-    disabledUnderline: commonStates.disabled.border,
-
-    errorFirstIcon: commonStates.functional.error,
-    errorValue: mainHexPallete.black,
-    errorSecondIcon: commonStates.functional.error,
-    errorUnderline: commonStates.functional.error
+    disabledUnderline: commonStates.disabled.border
   },
 
   outline: {
+    ...sharedErrorState,
     defaultLabel: mainHexPallete.blue[800],
     defaultIcon: mainHexPallete.blue[700],
     defaultValue: mainHexPallete.black,
@@ -316,14 +324,7 @@ export const textFieldColors = {
     disabledIcon: commonStates.disabled.outline.icon,
     disabledValue: commonStates.disabled.outline.text,
     disabledOutline: commonStates.disabled.outline.border,
-    disabledTextInfo: commonStates.disabled.outline.text,
-
-    errorLabel: commonStates.functional.error,
-    errorIcon: commonStates.functional.error,
-    errorValue: mainHexPallete.black,
-    errorOutline: commonStates.functional.error,
-    errorTextInfo: commonStates.functional.error,
-    errorTextInfoIcon: commonStates.functional.error
+    disabledTextInfo: commonStates.disabled.outline.text
   }
 };
 

--- a/app/shared/theme/theme.ts
+++ b/app/shared/theme/theme.ts
@@ -1,8 +1,33 @@
 import { createTheme } from '@mui/material/styles';
 import { Mulish, Oswald } from 'next/font/google';
 
+import {
+  badgeColors,
+  buttonColors,
+  buttonGroupColors,
+  checkboxColors,
+  chipsColors,
+  mainHexPallete,
+  menuItemColors,
+  selectorColors,
+  textFieldColors,
+  toolbarColors
+} from './colors';
+
 const oswald = Oswald({ subsets: ['latin'] });
 const mulish = Mulish({ subsets: ['latin'] });
+
+declare module '@mui/material/styles' {
+  interface BreakpointOverrides {
+    xs: true;
+    sm: true;
+    md: true;
+    lg: true;
+    xl: true;
+    xxl: true;
+    ultra: true;
+  }
+}
 
 declare module '@mui/material/styles' {
   interface TypographyVariants {
@@ -49,8 +74,105 @@ declare module '@mui/material/Typography' {
   }
 }
 
+declare module '@mui/material/styles' {
+  interface Palette {
+    tertiary: Palette['primary'];
+  }
+
+  interface PaletteOptions {
+    tertiary?: PaletteOptions['primary'];
+  }
+}
+
+declare module '@mui/material/Button' {
+  interface ButtonPropsColorOverrides {
+    tertiary: true;
+  }
+}
+
+declare module '@mui/material/ButtonGroup' {
+  interface ButtonGroupPropsColorOverrides {
+    tertiary: true;
+  }
+}
+
+export const buttonSizeStyles = {
+  small: {
+    height: '32px',
+    padding: '4px 12px',
+    fontSize: '14px',
+    fontWeight: 400,
+    lineHeight: '140%'
+  },
+  medium: {
+    height: '40px',
+    padding: '8px 24px',
+    fontSize: '16px',
+    fontWeight: 500,
+    lineHeight: '150%'
+  },
+  large: {
+    height: '56px',
+    padding: '14px 32px',
+    fontSize: '18px',
+    fontWeight: 500,
+    lineHeight: '155%'
+  }
+};
+
+const baseTextStyles = {
+  fontSize: '16px',
+  fontWeight: 500,
+  lineHeight: '150%',
+  fontFamily: mulish.style.fontFamily
+};
+
 export const createAdminTheme = () =>
   createTheme({
+    breakpoints: {
+      values: {
+        ultra: 1920,
+        xxl: 1728,
+        xl: 1448,
+        lg: 1280,
+        md: 1024,
+        sm: 768,
+        xs: 0
+      }
+    },
+
+    palette: {
+      primary: {
+        main: buttonColors.primary.filledEnabledBg,
+        contrastText: buttonColors.primary.filledNormalText
+      },
+      secondary: {
+        main: buttonColors.secondary.filledEnabledBg,
+        contrastText: buttonColors.secondary.filledNormalText
+      },
+      tertiary: {
+        main: buttonColors.tertiary.enabledBg,
+        contrastText: buttonColors.tertiary.normalText
+      },
+      warning: {
+        main: mainHexPallete.yellow[500],
+        dark: mainHexPallete.burgundy[700]
+      },
+      error: {
+        main: buttonColors.error.enabledBg,
+        contrastText: buttonColors.error.normalText
+      },
+      text: {
+        primary: mainHexPallete.black,
+        secondary: mainHexPallete.blue[800],
+        disabled: mainHexPallete.blue[200]
+      },
+      background: {
+        default: mainHexPallete.white
+      },
+      ...mainHexPallete
+    },
+
     typography: {
       fontFamily: mulish.style.fontFamily,
       h1: {
@@ -145,6 +267,7 @@ export const createAdminTheme = () =>
         lineHeight: '140%'
       }
     },
+
     components: {
       MuiTypography: {
         defaultProps: {
@@ -162,6 +285,678 @@ export const createAdminTheme = () =>
             customItalic14: 'p'
           }
         }
+      },
+      MuiButton: {
+        styleOverrides: {
+          root: {
+            textTransform: 'none',
+            borderRadius: '28px',
+            boxShadow: 'none',
+            '&:hover': {
+              boxShadow: 'none'
+            },
+            whiteSpace: 'nowrap',
+            fontFamily: mulish.style.fontFamily
+          }
+        },
+        variants: [
+          {
+            props: { variant: 'contained', color: 'primary' },
+            style: {
+              backgroundColor: buttonColors.primary.filledEnabledBg,
+              color: buttonColors.primary.filledNormalText,
+              '&:hover': {
+                backgroundColor: buttonColors.primary.filledHoveredBg
+              },
+              '&:focus-visible': {
+                backgroundColor: buttonColors.primary.filledFocusedBg
+              },
+              '&:active': {
+                backgroundColor: buttonColors.primary.filledPressedBg
+              },
+              '&:disabled': {
+                backgroundColor: buttonColors.primary.filledDisabledBg,
+                color: buttonColors.primary.disabledText
+              }
+            }
+          },
+          {
+            props: { variant: 'outlined', color: 'primary' },
+            style: {
+              backgroundColor: buttonColors.primary.outlinedEnabledBg,
+              border: `1px solid ${buttonColors.primary.outlinedNormalBorder}`,
+              color: buttonColors.primary.outlinedNormalText,
+              '&:hover': {
+                backgroundColor: buttonColors.primary.outlinedHoveredBg
+              },
+              '&:focus-visible': {
+                backgroundColor: buttonColors.primary.outlinedFocusedBg
+              },
+              '&:active': {
+                backgroundColor: buttonColors.primary.outlinedPressedBg
+              },
+              '&:disabled': {
+                border: `1px solid ${buttonColors.primary.outlinedDisabledBorder}`,
+                color: buttonColors.primary.disabledText
+              }
+            }
+          },
+          {
+            props: { variant: 'text', color: 'primary' },
+            style: {
+              backgroundColor: 'transparent',
+              color: mainHexPallete.black,
+              '&:hover': {
+                backgroundColor: buttonColors.primary.outlinedHoveredBg
+              },
+              '&:focus-visible': {
+                backgroundColor: buttonColors.primary.outlinedFocusedBg
+              },
+              '&:active': {
+                backgroundColor: buttonColors.primary.outlinedPressedBg
+              },
+              '&:disabled': {
+                backgroundColor: 'transparent',
+                color: buttonColors.primary.disabledText
+              }
+            }
+          },
+          {
+            props: { variant: 'contained', color: 'secondary' },
+            style: {
+              backgroundColor: buttonColors.secondary.filledEnabledBg,
+              color: buttonColors.secondary.filledNormalText,
+              '&:hover': {
+                backgroundColor: buttonColors.secondary.filledHoveredBg
+              },
+              '&:focus-visible': {
+                backgroundColor: buttonColors.secondary.filledFocusedBg
+              },
+              '&:active': {
+                backgroundColor: buttonColors.secondary.filledPressedBg
+              },
+              '&:disabled': {
+                backgroundColor: buttonColors.secondary.filledDisabledBg,
+                color: buttonColors.secondary.disabledText
+              }
+            }
+          },
+          {
+            props: { variant: 'outlined', color: 'secondary' },
+            style: {
+              backgroundColor: buttonColors.secondary.outlinedEnabledBg,
+              border: `1px solid ${buttonColors.secondary.outlinedNormalBorder}`,
+              color: buttonColors.secondary.outlinedNormalText,
+              '&:hover': {
+                backgroundColor: buttonColors.secondary.outlinedHoveredBg
+              },
+              '&:focus-visible': {
+                backgroundColor: buttonColors.secondary.outlinedFocusedBg
+              },
+              '&:active': {
+                backgroundColor: buttonColors.secondary.outlinedPressedBg
+              },
+              '&:disabled': {
+                backgroundColor: buttonColors.secondary.outlinedDisabledBg,
+                border: `1px solid ${buttonColors.secondary.outlinedDisabledBorder}`,
+                color: buttonColors.secondary.disabledText
+              }
+            }
+          },
+          {
+            props: { variant: 'text', color: 'secondary' },
+            style: {
+              backgroundColor: 'transparent',
+              color: mainHexPallete.white,
+              '&:hover': {
+                backgroundColor: buttonColors.secondary.outlinedHoveredBg
+              },
+              '&:focus-visible': {
+                backgroundColor: buttonColors.secondary.outlinedFocusedBg
+              },
+              '&:active': {
+                backgroundColor: buttonColors.secondary.outlinedPressedBg
+              },
+              '&:disabled': {
+                backgroundColor: 'transparent',
+                color: buttonColors.secondary.disabledText
+              }
+            }
+          },
+          {
+            props: { variant: 'contained', color: 'tertiary' },
+            style: {
+              backgroundColor: buttonColors.tertiary.enabledBg,
+              color: buttonColors.tertiary.normalText,
+              '&:hover': {
+                backgroundColor: buttonColors.tertiary.hoveredBg
+              },
+              '&:focus-visible': {
+                backgroundColor: buttonColors.tertiary.focusedBg
+              },
+              '&:active': {
+                backgroundColor: buttonColors.tertiary.pressedBg
+              },
+              '&:disabled': {
+                backgroundColor: buttonColors.tertiary.disabledBg,
+                color: buttonColors.tertiary.disabledText
+              }
+            }
+          },
+          {
+            props: { variant: 'contained', color: 'error' },
+            style: {
+              backgroundColor: buttonColors.error.enabledBg,
+              color: buttonColors.error.normalText,
+              '&:hover': {
+                backgroundColor: buttonColors.error.hoveredBg
+              },
+              '&:focus-visible': {
+                backgroundColor: buttonColors.error.focusedBg
+              },
+              '&:active': {
+                backgroundColor: buttonColors.error.pressedBg
+              },
+              '&:disabled': {
+                backgroundColor: buttonColors.error.disabledBg,
+                color: buttonColors.error.disabledText
+              }
+            }
+          },
+          {
+            props: { size: 'small' },
+            style: buttonSizeStyles.small
+          },
+          {
+            props: { size: 'medium' },
+            style: buttonSizeStyles.medium
+          },
+          {
+            props: { size: 'large' },
+            style: buttonSizeStyles.large
+          }
+        ]
+      },
+      MuiInputBase: {
+        styleOverrides: {
+          root: {
+            height: '48px',
+            ...baseTextStyles,
+
+            '& .MuiInputBase-input:-webkit-autofill': {
+              WebkitBoxShadow: '0 0 0 100px white inset',
+              WebkitTextFillColor: textFieldColors.outline.defaultValue,
+              caretColor: textFieldColors.outline.defaultValue,
+              transition: 'background-color 5000s ease-in-out 0s'
+            },
+
+            '&.Mui-disabled .MuiInputBase-input': {
+              color: textFieldColors.outline.disabledValue,
+              WebkitTextFillColor: textFieldColors.outline.disabledValue
+            }
+          }
+        }
+      },
+      MuiInput: {
+        styleOverrides: {
+          root: {
+            color: textFieldColors.standard.defaultValue,
+
+            '&:before': {
+              borderBottom: `1px solid ${textFieldColors.standard.defaultUnderline}`
+            },
+            '&:hover:not(.Mui-disabled):before': {
+              borderBottom: `1px solid ${textFieldColors.standard.hoveredUnderline}`
+            },
+            '&.Mui-focused:after': {
+              borderBottom: `2px solid ${textFieldColors.standard.focusedUnderline}`
+            },
+            '&.Mui-error:before, &.Mui-error:after': {
+              borderBottom: `2px solid ${textFieldColors.standard.errorUnderline}`
+            },
+            '&.Mui-error:hover:not(.Mui-disabled):before': {
+              borderBottom: `2px solid ${textFieldColors.standard.errorUnderline}`
+            },
+            '&.Mui-disabled:before': {
+              borderBottom: `1px solid ${textFieldColors.standard.disabledUnderline}`,
+              borderBottomStyle: 'solid'
+            }
+          }
+        }
+      },
+      MuiOutlinedInput: {
+        styleOverrides: {
+          root: {
+            borderRadius: '8px',
+            padding: '0 16px',
+            color: textFieldColors.outline.defaultValue,
+
+            '& .MuiOutlinedInput-input': {
+              padding: 0
+            },
+
+            '& .MuiOutlinedInput-notchedOutline': {
+              borderColor: textFieldColors.outline.defaultOutline
+            },
+            '&:hover .MuiOutlinedInput-notchedOutline': {
+              borderColor: textFieldColors.outline.hoveredOutline
+            },
+            '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+              borderColor: textFieldColors.outline.focusedOutline,
+              borderWidth: '1px'
+            },
+            '&.Mui-error .MuiOutlinedInput-notchedOutline': {
+              borderColor: textFieldColors.outline.errorOutline
+            },
+            '&.Mui-disabled .MuiOutlinedInput-notchedOutline': {
+              borderColor: textFieldColors.outline.disabledOutline
+            },
+
+            '&.Mui-focused .MuiInputBase-input': {
+              color: textFieldColors.outline.focusedValue,
+              WebkitTextFillColor: textFieldColors.outline.focusedValue
+            },
+            '&.Mui-error .MuiInputBase-input': {
+              color: textFieldColors.outline.errorValue,
+              WebkitTextFillColor: textFieldColors.outline.errorValue
+            }
+          }
+        }
+      },
+      MuiInputLabel: {
+        styleOverrides: {
+          root: {
+            ...baseTextStyles,
+            color: textFieldColors.outline.defaultLabel,
+
+            '&:not(.Mui-disabled):hover': {
+              color: textFieldColors.outline.hoveredLabel
+            },
+            '&.Mui-focused': {
+              color: textFieldColors.outline.focusedLabel
+            },
+            '&.Mui-error': {
+              color: textFieldColors.outline.errorLabel
+            },
+            '&.Mui-disabled': {
+              color: textFieldColors.outline.disabledLabel
+            }
+          }
+        }
+      },
+      MuiFormHelperText: {
+        styleOverrides: {
+          root: {
+            margin: '4px 0 0',
+            fontSize: '14px',
+            fontFamily: baseTextStyles.fontFamily,
+
+            color: textFieldColors.outline.defaultTextInfo,
+
+            '&.Mui-error': {
+              color: textFieldColors.outline.errorTextInfo
+            },
+            '&.Mui-disabled': {
+              color: textFieldColors.outline.disabledTextInfo
+            }
+          }
+        }
+      },
+      MuiButtonGroup: {
+        styleOverrides: {
+          root: {
+            display: 'flex',
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'center',
+            borderRadius: '9999px',
+            padding: '2px',
+            fontFamily: mulish.style.fontFamily,
+            position: 'relative',
+            overflow: 'hidden',
+            width: 'fit-content',
+            border: 'none',
+            lineHeight: '150%',
+
+            '& .MuiButtonGroup-grouped': {
+              border: 'none',
+              borderRadius: '9999px',
+              minWidth: 'auto',
+              padding: '4px 22px',
+              '&:not(:last-of-type)': {
+                borderRight: 'none'
+              }
+            }
+          }
+        },
+        variants: [
+          {
+            props: { color: 'primary' },
+            style: {
+              backgroundColor: buttonGroupColors.primary.groupBackground,
+
+              '& .MuiButtonGroup-grouped': {
+                color: buttonGroupColors.primary.buttonText
+              },
+
+              '& .MuiButtonGroup-grouped.MuiButton-contained': {
+                backgroundColor: buttonGroupColors.primary.selectedButton,
+                color: buttonGroupColors.primary.selectedButtonText,
+                boxShadow: 'none',
+
+                '&:hover': {
+                  backgroundColor: buttonGroupColors.primary.selectedButton,
+                  boxShadow: 'none'
+                }
+              }
+            }
+          },
+          {
+            props: { color: 'secondary' },
+            style: {
+              backgroundColor: buttonGroupColors.secondary.groupBackground,
+
+              '& .MuiButtonGroup-grouped': {
+                color: buttonGroupColors.secondary.buttonText
+              },
+
+              '& .MuiButtonGroup-grouped.MuiButton-contained': {
+                backgroundColor: buttonGroupColors.secondary.selectedButton,
+                color: buttonGroupColors.secondary.selectedButtonText,
+                boxShadow: 'none',
+
+                '&:hover': {
+                  backgroundColor: buttonGroupColors.secondary.selectedButton,
+                  boxShadow: 'none'
+                }
+              }
+            }
+          },
+          {
+            props: { color: 'tertiary' },
+            style: {
+              backgroundColor: buttonGroupColors.tertiary.groupBackground,
+
+              '& .MuiButtonGroup-grouped': {
+                color: buttonGroupColors.tertiary.buttonText
+              },
+
+              '& .MuiButtonGroup-grouped.MuiButton-contained': {
+                backgroundColor: buttonGroupColors.tertiary.selectedButton,
+                color: buttonGroupColors.tertiary.selectedButtonText,
+                boxShadow: 'none',
+
+                '&:hover': {
+                  backgroundColor: buttonGroupColors.tertiary.selectedButton,
+                  boxShadow: 'none'
+                }
+              }
+            }
+          }
+        ]
+      },
+      MuiMenu: {
+        styleOverrides: {
+          paper: {
+            marginTop: '4px',
+            borderRadius: '8px',
+            boxShadow: `
+            0px 4px 8px rgba(0, 0, 0, 0.06),
+            0px 0px 4px rgba(0, 0, 0, 0.04)
+          `
+          }
+        }
+      },
+      MuiMenuItem: {
+        styleOverrides: {
+          root: {
+            ...baseTextStyles,
+            gap: '4px',
+
+            color: menuItemColors.defaultText,
+
+            '&.Mui-disabled': {
+              color: menuItemColors.disabledText,
+              backgroundColor: 'transparent',
+              pointerEvents: 'none'
+            },
+
+            '&:hover': {
+              backgroundColor: menuItemColors.hoveredBg
+            },
+
+            '&:active': {
+              backgroundColor: menuItemColors.activeBg
+            },
+
+            '&.Mui-selected': {
+              backgroundColor: 'transparent',
+              '&:hover': {
+                backgroundColor: menuItemColors.hoveredBg
+              }
+            }
+          }
+        }
+      },
+      MuiCheckbox: {
+        styleOverrides: {
+          root: {
+            color: checkboxColors.defaultIcon,
+
+            '&:hover': {
+              backgroundColor: checkboxColors.hoveredRipple,
+
+              '&:not(.Mui-checked)': {
+                color: checkboxColors.hoveredIcon
+              }
+            },
+
+            '&.Mui-focusVisible': {
+              backgroundColor: checkboxColors.focusedRipple,
+              color: checkboxColors.focusedIcon
+            },
+
+            '&.Mui-checked': {
+              color: checkboxColors.selectedIcon,
+
+              '&:hover': {
+                backgroundColor: checkboxColors.hoveredRipple
+              }
+            },
+
+            '&.Mui-disabled': {
+              color: checkboxColors.disabledIcon
+            }
+          }
+        }
+      },
+      MuiBadge: {
+        styleOverrides: {
+          badge: {
+            fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
+            fontSize: '12px',
+            fontWeight: 500
+          }
+        },
+        variants: [
+          {
+            props: { color: 'default', variant: 'standard' },
+            style: {
+              backgroundColor: 'transparent',
+              color: badgeColors.standardDefaultValue
+            }
+          },
+          {
+            props: { color: 'primary', variant: 'standard' },
+            style: {
+              backgroundColor: badgeColors.standardPrimaryBg,
+              color: badgeColors.standardPrimaryValue
+            }
+          },
+          {
+            props: { color: 'primary', variant: 'dot' },
+            style: {
+              backgroundColor: badgeColors.dotPrimaryBg
+            }
+          },
+          {
+            props: { color: 'secondary', variant: 'standard' },
+            style: {
+              backgroundColor: 'transparent',
+              color: badgeColors.standardSecondaryValue
+            }
+          },
+          {
+            props: { color: 'error', variant: 'standard' },
+            style: {
+              backgroundColor: badgeColors.standardErrorBg,
+              color: badgeColors.standardErrorValue
+            }
+          },
+          {
+            props: { color: 'error', variant: 'dot' },
+            style: {
+              backgroundColor: badgeColors.dotErrorBg
+            }
+          }
+        ]
+      },
+      MuiChip: {
+        styleOverrides: {
+          root: {
+            ...baseTextStyles,
+            color: chipsColors.normalText,
+            borderRadius: '20px'
+          },
+
+          deleteIcon: {
+            color: 'inherit',
+            '&:hover': {
+              color: 'inherit',
+              opacity: 0.7
+            }
+          }
+        },
+        variants: [
+          {
+            props: { variant: 'filled' },
+            style: {
+              backgroundColor: chipsColors.filledDefaultBg,
+              border: 'none',
+
+              '&:hover': {
+                backgroundColor: chipsColors.filledHoveredBg
+              },
+              '&:active': {
+                backgroundColor: chipsColors.filledPressedBg
+              },
+              '&.Mui-disabled': {
+                backgroundColor: chipsColors.filledDisabledBg,
+                opacity: 1
+              }
+            }
+          },
+          {
+            props: { variant: 'outlined' },
+            style: {
+              backgroundColor: 'transparent',
+              border: `1px solid ${chipsColors.outlineNormalBorder}`,
+
+              '&:hover': {
+                backgroundColor: chipsColors.outlineHoveredBg
+              },
+              '&:active': {
+                backgroundColor: chipsColors.outlinePressedBg
+              },
+              '&.Mui-disabled': {
+                borderColor: chipsColors.outlineDisabledBorder,
+                color: chipsColors.outlineDisabledText,
+                opacity: 1
+              }
+            }
+          }
+        ]
+      },
+      MuiToggleButtonGroup: {
+        styleOverrides: {
+          root: {
+            backgroundColor: toolbarColors.default,
+            borderRadius: '4px',
+            border: `1px solid ${toolbarColors.border}`,
+
+            '& .MuiToggleButtonGroup-grouped': {
+              border: 'none',
+              borderRadius: 0,
+
+              '&:not(:first-of-type)': {
+                borderLeft: `1px solid ${toolbarColors.border}`
+              },
+
+              '&:first-of-type': {
+                borderTopLeftRadius: 'inherit',
+                borderBottomLeftRadius: 'inherit'
+              },
+              '&:last-of-type': {
+                borderTopRightRadius: 'inherit',
+                borderBottomRightRadius: 'inherit'
+              }
+            }
+          }
+        }
+      },
+
+      MuiToggleButton: {
+        styleOverrides: {
+          root: {
+            color: toolbarColors.textColor,
+
+            '&:hover': {
+              backgroundColor: toolbarColors.hovered
+            },
+            '&.Mui-selected': {
+              backgroundColor: toolbarColors.focused,
+              color: 'inherit',
+              '&:hover': {
+                backgroundColor: toolbarColors.focused
+              }
+            }
+          }
+        }
+      },
+      MuiSelect: {
+        styleOverrides: {
+          root: {
+            color: selectorColors.standardTextColor
+          }
+        },
+        variants: [
+          {
+            props: { variant: 'filled' },
+            style: {
+              backgroundColor: selectorColors.filledBg,
+              borderRadius: '8px',
+              '&:before, &:after': { display: 'none' },
+
+              '& .MuiChip-root': {
+                backgroundColor: selectorColors.filledChipsBg,
+                color: selectorColors.filledChipsContent
+              }
+            }
+          },
+          {
+            props: { variant: 'outlined' },
+            style: {
+              '& .MuiChip-root': {
+                backgroundColor: selectorColors.outlineDefaultChipsBg,
+                color: selectorColors.outlineDefaultTextColor,
+
+                '& .MuiChip-deleteIcon': {
+                  color: selectorColors.outlineDefaultTextColor
+                }
+              }
+            }
+          }
+        ]
       }
     }
   });


### PR DESCRIPTION
## Description

This PR refactors and extends the existing theme to serve as a robust, centralized single source of truth for all UI styling in lf-admin. It aligns the implementation with the Figma Design System by introducing full color palettes, global component styles and semantic typography.

**Key changes and additions:**
- `colors.ts` file was created as a main color dictionary for the app;
- `BodyProvider.tsx` file was refactored to remove redundant fonts and configure the app for using only necessary typography;
- `body` selector in `globals.css` file was refactored to set base typography styles for the app;
- `theme.ts` file was refactored to reimagine overall typography usage approach and set up styles for the base app components.

**Please note, that the Sonar's warning about code duplication in `colors.ts` is permitted with the team's approval**

## Type of change

- [x] New feature
- [x] Refactoring / Tech debt

### Checklist

- [x] The theme includes all functional colors mapped to the palette (Success green, Primary yellow/gold, mainHexPallete, rgbButtonColors, etc.).
- [x] Custom colors (like tertiary) are properly typed using TypeScript module augmentation for MUI's Palette.
- [x] Border radius is systematically applied (e.g., 28px for buttons, consistent radiuses for cards and inputs).
- [x] Core design system components (starting with MuiButton) are refactored to use styleOverrides and variants inside the theme instead of localized styles.
- [x] adminTheme remains entirely type-safe.
- [x] All theme properties and component variants are covered by unit tests in theme.test.tsx.
- [x] All custom* variants are removed.
- [x] Typography uses semantic and scalable naming.
- [x] No duplicated styles across variants.
- [x] Font tokens (body, display) are used.
- [x] lineHeight uses unitless values, not %.
---
