### PR TITLE
chore: remove the imports and usage of SeoMetadataBlock from publicat…

### DIFF
--- a/app/(logged_in)/publications/page.tsx
+++ b/app/(logged_in)/publications/page.tsx
@@ -1,67 +1,9 @@
-'use client';
 import { Box } from '@mui/material';
-import { useCallback, useState } from 'react';
-
-import { SeoCanonicalUrlField } from '~/shared/components/forms/seo-metadata-form/seo-canonicalurl-field/SeoCanonicalUrlField';
-import { SeoDateTimeFields } from '~/shared/components/forms/seo-metadata-form/seo-datetime-fields/SeoDateTimeFields';
-import type { SeoBlockValue } from '~/shared/components/forms/seo-metadata-form/seo-metadata-block/SeoMetadataBlock';
-import SeoMetadataBlock from '~/shared/components/forms/seo-metadata-form/seo-metadata-block/SeoMetadataBlock';
-
-const defaultSeoValue: SeoBlockValue = {
-  meta: {
-    uk: { title: '', description: '', keywords: '' },
-    en: { title: '', description: '', keywords: '' }
-  },
-  ogImage: null,
-  allowIndexing: { uk: true, en: true }
-};
-
-interface MediaMentionExtraFieldsProps {
-  readonly locale: 'uk' | 'en';
-  readonly seoData: SeoBlockValue;
-  readonly onChange: (val: SeoBlockValue) => void;
-}
-
-function MediaMentionExtraFields({ locale, seoData, onChange }: MediaMentionExtraFieldsProps) {
-  return (
-    <>
-      <SeoCanonicalUrlField
-        value={seoData.meta[locale].canonicalUrl ?? ''}
-        onChange={(val) =>
-          onChange({ ...seoData, meta: { ...seoData.meta, [locale]: { ...seoData.meta[locale], canonicalUrl: val } } })
-        }
-        onBlur={() => {}}
-      />
-      <SeoDateTimeFields
-        startDateTime={seoData.meta[locale].startDateTime}
-        endDateTime={seoData.meta[locale].endDateTime}
-        onChange={(start, end) =>
-          onChange({
-            ...seoData,
-            meta: { ...seoData.meta, [locale]: { ...seoData.meta[locale], startDateTime: start, endDateTime: end } }
-          })
-        }
-      />
-    </>
-  );
-}
 
 export default function PublicationsPage() {
-  const [seoData, setSeoData] = useState<SeoBlockValue>(defaultSeoValue);
-
-  const renderExtraFields = useCallback(
-    (locale: 'uk' | 'en') => <MediaMentionExtraFields locale={locale} seoData={seoData} onChange={setSeoData} />,
-    [seoData]
-  );
-
   return (
     <Box>
-      <SeoMetadataBlock
-        value={seoData}
-        onChange={setSeoData}
-        showAlternativeText={true}
-        extraFields={renderExtraFields}
-      />
+
     </Box>
   );
 }


### PR DESCRIPTION
## Description

Removed the `SeoMetadataBlock` component from the main publications dashboard (`/publications/page.tsx`). The `/publications` route is intended to serve as a listing and management interface, and the presence of a standalone SEO metadata form was out of context for this view. This cleanup ensures the dashboard remains focused on its primary responsibility.

## Type of change
    
- [x] Refactoring / Tech debt    

## How to test

1. Pull the branch locally and start the application    
2. Navigate to the main publications dashboard at `/publications`. 
3. Verify that the SEO metadata form block is no longer rendered on the page.
4. Ensure that the `/publications/page.tsx`  is completely empty excepting basic Box component in return block.

## Video / Screenshots

<img width="1920" height="384" alt="image" src="https://github.com/user-attachments/assets/eadb9692-ff34-4ba5-91a1-a08c9f0bdb5c" />

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues   
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board