### PR TITLE
fix: prevent cards layout shift on image preview modal

### DIFF
--- a/app/shared/components/file-info-sidebar/image-preview-modal/ImagePreviewModal.tsx
+++ b/app/shared/components/file-info-sidebar/image-preview-modal/ImagePreviewModal.tsx
@@ -47,6 +47,7 @@ export function ImagePreviewModal({ open, src, alt, onClose, padding = 40 }: Rea
     <Modal
       open={open}
       onClose={onClose}
+      disableScrollLock
       closeAfterTransition
       slotProps={{
         backdrop: { sx: { bgcolor: alpha(colors.blue[900], 0.4) } }


### PR DESCRIPTION
## Description

Fixed the background layout shift on the Files page when opening the full-screen image preview. Added disableScrollLock to the ImagePreviewModal component to prevent MUI from hiding the system scrollbar.

## Type of change

- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test
1. Open the Files page.
2. Click on any image card to open the sidebar.
3. Click the image thumbnail in the sidebar to open the full-screen preview.
3. Verify: The background file cards do not shift or jump to the right.

### Actual result: 
The grid of file cards in the background abruptly shifts/jumps to the right.
(Cause: MUI Modal applies overflow: hidden to the body, removing the system scrollbar and adding padding-right compensation, which conflicts with the responsive grid).

https://github.com/user-attachments/assets/27c6669d-a43c-4078-b329-3b45f3482e34



### Expected result: 
The image preview modal opens smoothly without causing any layout shifts to the background content.

Closes: https://github.com/Liatoshynsky-Foundation/lf-admin/issues/445
