### PR TITLE
fix(ui): fix layout and image distortion in ImagePreviewBlock

### DIFF
--- a/app/shared/components/about-us/Intro-section/IntroSection.tsx
+++ b/app/shared/components/about-us/Intro-section/IntroSection.tsx
@@ -41,7 +41,7 @@ export const IntroSection = () => {
         }
       />
 
-      <Box sx={{ marginLeft: '-16px', marginTop: '15px' }}>
+      <Box sx={{ marginTop: '15px' }}>
         <ImagePreviewBlock
           imageUrl={getImageUrl(block.image)}
           fileName={block.image.src || ''}

--- a/app/shared/components/design-system/photo-block/PhotoBlock.styles.ts
+++ b/app/shared/components/design-system/photo-block/PhotoBlock.styles.ts
@@ -1,7 +1,6 @@
 export const styles = {
   container: {
     width: '100%',
-    maxWidth: '496px'
   },
 
   sectionTitle: {
@@ -22,6 +21,7 @@ export const styles = {
   imagePreview: {
     width: '196px',
     height: '120px',
+    objectFit: 'cover',
     flexShrink: 0,
     border: '1px solid #B2B3BE',
     display: 'grid',


### PR DESCRIPTION
## Description

This PR fixes a layout issue in the Admin panel's page-editor cards where the image preview was distorted and action buttons were overlapping with metadata. 

Key changes include:
- Removed `maxWidth` constraint from the `ImagePreviewBlock` component to allow it to occupy the full container width.
- Removed a negative margin that caused the block to overflow outside its parent card.
- Applied `objectFit: 'cover'` to the image to ensure it maintains its aspect ratio without compression or distortion.

## Type of change
- [x] Bug fix

1. Log in to the Admin dashboard and navigate to about-us page.
2. Open the "Intro Section" (Вступна секція) accordion.
3. Verify that the image preview is no longer squashed and displays correctly with `object-fit: cover`.
4. Ensure the action buttons ("Edit", "Change Image") are properly aligned and do not overlap with any text or the image itself.

## Video / Screenshots
### Before
<img width="1643" height="597" alt="image" src="https://github.com/user-attachments/assets/aa61db0e-5206-4052-a3f7-d8bd4ffba085" />

### After
<img width="1564" height="732" alt="image" src="https://github.com/user-attachments/assets/ddbf57bb-4331-4b77-b1fb-ff4e8242db88" />


Closes #449