### PR TITLE
fix(files): add custom icons for media formats and update asset schemas

### DIFF
--- a/app/(logged_in)/files/FilesPageContent.tsx
+++ b/app/(logged_in)/files/FilesPageContent.tsx
@@ -32,10 +32,7 @@ import {
   type FilesCardsLayoutItem,
   type FilesCardsLayoutView
 } from '~/shared/components/files-cards-layout';
-import {
-  FilteringToolbar,
-  SortSelect
-} from '~/shared/components/filtering-toolbar';
+import { FilteringToolbar, SortSelect } from '~/shared/components/filtering-toolbar';
 import { MediaModal } from '~/shared/components/media-modal/MediaModal';
 import type { MediaModalRenderers } from '~/shared/components/media-modal/MediaModal.renderers';
 import type { MediaModalOpenState, MediaModalResult } from '~/shared/components/media-modal/MediaModal.types';
@@ -63,7 +60,11 @@ type FilesPageContentProps = Readonly<{
 const assetCardTypeMap: Record<AssetType, FilesCardsLayoutItem['type']> = {
   [AssetType.Image]: 'image',
   [AssetType.Pdf]: 'pdf',
-  [AssetType.Audio]: 'audio'
+  [AssetType.Audio]: 'audio',
+  [AssetType.Document]: 'document',
+  [AssetType.Spreadsheet]: 'spreadsheet',
+  [AssetType.Video]: 'video',
+  [AssetType.Archive]: 'archive'
 };
 
 const supportedUploadMimeTypes = new Set<string>(FILES_UPLOAD_ALLOWED_MIME_TYPES);
@@ -294,13 +295,7 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
         {...toolbarProps}
         dataTestId="control-panel"
         rightSlot={<ViewToggle value={view} onChange={setView} />}
-        bottomTrailingContent={
-          <SortSelect
-            {...sortProps}
-            minWidth={208}
-            dataTestId="files-sort-select"
-          />
-        }
+        bottomTrailingContent={<SortSelect {...sortProps} minWidth={208} dataTestId="files-sort-select" />}
       />
 
       <FilesCardsLayout view={view} items={filteredFiles} onItemClick={(item) => setSelectedFileId(item.id)} />
@@ -308,12 +303,7 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
       {loading && <Typography>{FILES_LOADING_STATE_TEXT}</Typography>}
       {error && <Typography color="error">{FILES_ERROR_STATE_TEXT}</Typography>}
 
-      {sidebarFile && (
-        <FileInfoSidebar
-          file={sidebarFile}
-          onClose={() => setSelectedFileId(null)}
-        />
-      )}
+      {sidebarFile && <FileInfoSidebar file={sidebarFile} onClose={() => setSelectedFileId(null)} />}
 
       <MediaModal
         open={isUploadModalOpen}

--- a/app/(logged_in)/files/page.test.tsx
+++ b/app/(logged_in)/files/page.test.tsx
@@ -22,7 +22,11 @@ jest.mock('~/types/graphql/generated/graphql', () => ({
   AssetType: {
     Image: 'Image',
     Pdf: 'Pdf',
-    Audio: 'Audio'
+    Audio: 'Audio',
+    Archive: 'Archive',
+    Video: 'Video',
+    Document: 'Document',
+    Spreadsheet: 'Spreadsheet'
   },
   useUploadBlobMutation: () => [mockUploadBlob]
 }));
@@ -83,11 +87,7 @@ jest.mock('~/shared/components/filtering-toolbar', () => ({
   }) => (
     <div data-testid="control-panel">
       {search ? (
-        <input
-          data-testid="search"
-          value={search.search}
-          onChange={(event) => search.setSearch(event.target.value)}
-        />
+        <input data-testid="search" value={search.search} onChange={(event) => search.setSearch(event.target.value)} />
       ) : null}
       {onToggleFilters ? (
         <button type="button" onClick={onToggleFilters}>
@@ -167,7 +167,7 @@ describe('Files page', () => {
       },
       {
         id: 'asset-doc',
-        type: 'Pdf',
+        type: 'Archive',
         filename: 'documents.zip',
         createdAt: '2026-03-18T10:00:00.000Z',
         isStarred: false,

--- a/app/constants/file-formats.ts
+++ b/app/constants/file-formats.ts
@@ -13,7 +13,9 @@ export const ALL_FORMAT_FILTER_OPTIONS: ReadonlyArray<{ value: string; label: st
   { value: 'mp4', label: 'mp4' },
   { value: 'mpeg', label: 'mpeg' },
   { value: 'wav', label: 'wav' },
-  { value: 'mp3', label: 'mp3' }
+  { value: 'mp3', label: 'mp3' },
+  { value: 'zip', label: 'zip' },
+  { value: 'x-zip-compressed', label: 'zip' }
 ];
 
 export const VISIBLE_FORMAT_FILTER_VALUES = new Set<string>(['jpg', 'png', 'bmp', 'gif', 'webp', 'svg']);

--- a/app/shared/components/file-card/FileCard.test.tsx
+++ b/app/shared/components/file-card/FileCard.test.tsx
@@ -93,7 +93,7 @@ describe('FileCard', () => {
   });
 
   it('should render correct file type icon for different file types', () => {
-    const fileTypes: FileType[] = ['image', 'audio', 'pdf'];
+    const fileTypes: FileType[] = ['image', 'audio', 'pdf', 'document', 'spreadsheet', 'video', 'archive'];
 
     fileTypes.forEach((type) => {
       const { unmount } = render(<FileCard fileType={type} fileData={defaultFileData} />);

--- a/app/shared/components/file-card/FileCard.tsx
+++ b/app/shared/components/file-card/FileCard.tsx
@@ -13,7 +13,11 @@ const ICON_SIZE_2 = 32;
 const FILE_TYPES = {
   image: 'img',
   audio: 'audio',
-  pdf: 'pdf'
+  pdf: 'pdf',
+  document: 'doc',
+  spreadsheet: 'xls',
+  video: 'video-file',
+  archive: 'zip'
 } as const;
 
 export type FileType = keyof typeof FILE_TYPES;

--- a/app/shared/components/file-info-sidebar/FileInfoSidebar.test.tsx
+++ b/app/shared/components/file-info-sidebar/FileInfoSidebar.test.tsx
@@ -42,6 +42,14 @@ jest.mock('~/public/icons/type-audio.svg', () => ({
 jest.mock('~/public/icons/type-pdf.svg', () => ({ __esModule: true, default: () => <svg data-testid="PdfIcon" /> }));
 jest.mock('~/public/icons/zoom-in.svg', () => ({ __esModule: true, default: () => <svg data-testid="ZoomInIcon" /> }));
 
+jest.mock('~/public/icons/doc.svg', () => ({ __esModule: true, default: () => <svg data-testid="DocIcon" /> }));
+jest.mock('~/public/icons/xls.svg', () => ({ __esModule: true, default: () => <svg data-testid="XlsIcon" /> }));
+jest.mock('~/public/icons/video-file.svg', () => ({
+  __esModule: true,
+  default: () => <svg data-testid="VideoIcon" />
+}));
+jest.mock('~/public/icons/zip.svg', () => ({ __esModule: true, default: () => <svg data-testid="ArchiveIcon" /> }));
+
 const commitMock = jest.fn();
 const setDraftMock = jest.fn();
 jest.mock('./useAutosavedDescription', () => ({
@@ -103,6 +111,14 @@ describe('FileInfoSidebar', () => {
 
     fireEvent.click(screen.getByLabelText('Close sidebar'));
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should render ArchiveIcon when file type is archive', () => {
+    const archiveFile: FileDetailsSidebarFile = { ...baseFile, type: 'archive' };
+    render(<FileInfoSidebar file={archiveFile} onClose={jest.fn()} />);
+
+    const archiveIcons = screen.getAllByTestId('ArchiveIcon');
+    expect(archiveIcons.length).toBeGreaterThan(0);
   });
 
   it('should disable actions when file is missing id', () => {

--- a/app/shared/components/file-info-sidebar/FileInfoSidebar.tsx
+++ b/app/shared/components/file-info-sidebar/FileInfoSidebar.tsx
@@ -7,6 +7,7 @@ import { ImagePreviewModal } from './image-preview-modal/ImagePreviewModal';
 import { useAutosavedDescription } from './useAutosavedDescription';
 import { formatUsageCount } from '~/lib/utils/formatUsageCount';
 import CloseIcon from '~/public/icons/close.svg';
+import DocIcon from '~/public/icons/doc.svg';
 import DownloadOutlinedIcon from '~/public/icons/download.svg';
 import DeleteOutlineIcon from '~/public/icons/empty-trash.svg';
 import EditOutlinedIcon from '~/public/icons/pen-line.svg';
@@ -14,6 +15,9 @@ import PictureIcon from '~/public/icons/picture.svg';
 import StarBorderIcon from '~/public/icons/small-star.svg';
 import AudioIcon from '~/public/icons/type-audio.svg';
 import PdfIcon from '~/public/icons/type-pdf.svg';
+import VideoFileIcon from '~/public/icons/video-file.svg';
+import XlsIcon from '~/public/icons/xls.svg';
+import ArchiveIcon from '~/public/icons/zip.svg';
 import ZoomIn from '~/public/icons/zoom-in.svg';
 import { CustomTextField } from '~/shared/components/design-system/text-field/TextField';
 
@@ -25,7 +29,7 @@ export type FileUsageLink = {
 
 export type FileDetailsSidebarFile = {
   id: string;
-  type: 'image' | 'pdf' | 'audio';
+  type: 'image' | 'pdf' | 'audio' | 'document' | 'spreadsheet' | 'video' | 'archive';
   filename: string;
   previewUrl?: string;
 
@@ -61,7 +65,11 @@ const AUTOSAVE_DEBOUNCE_MS = 1800;
 const TYPE_ICON: Record<FileDetailsSidebarFile['type'], React.ComponentType> = {
   image: PictureIcon,
   pdf: PdfIcon,
-  audio: AudioIcon
+  audio: AudioIcon,
+  document: DocIcon,
+  spreadsheet: XlsIcon,
+  video: VideoFileIcon,
+  archive: ArchiveIcon
 };
 
 const Section = ({ title, children }: { title: string; children: React.ReactNode }) => (

--- a/app/shared/components/files-cards-layout/FilesCardsLayout.tsx
+++ b/app/shared/components/files-cards-layout/FilesCardsLayout.tsx
@@ -22,10 +22,14 @@ type FilesCardsLayoutProps = Readonly<{
   onItemClick?: (item: FilesCardsLayoutItem) => void;
 }>;
 
-const minimizedTypeMap: Record<FileType, 'img' | 'audio' | 'pdf'> = {
+const minimizedTypeMap: Record<FileType, 'img' | 'audio' | 'pdf' | 'doc' | 'xls' | 'video-file' | 'archive'> = {
   image: 'img',
   audio: 'audio',
-  pdf: 'pdf'
+  pdf: 'pdf',
+  document: 'doc',
+  spreadsheet: 'xls',
+  video: 'video-file',
+  archive: 'archive'
 };
 
 export function FilesCardsLayout({ view, items, onItemClick }: FilesCardsLayoutProps) {

--- a/app/shared/components/minimized-file-card/MinimizedFileCard.test.tsx
+++ b/app/shared/components/minimized-file-card/MinimizedFileCard.test.tsx
@@ -29,6 +29,26 @@ describe('MinimizedFileCard', () => {
     expect(screen.getByAltText('pdf file icon')).toBeInTheDocument();
   });
 
+  it('should render document icon when fileType is doc', () => {
+    render(<MinimizedFileCard {...defaultProps} fileType="doc" />);
+    expect(screen.getByAltText('doc file icon')).toBeInTheDocument();
+  });
+
+  it('should render spreadsheet icon when fileType is xls', () => {
+    render(<MinimizedFileCard {...defaultProps} fileType="xls" />);
+    expect(screen.getByAltText('xls file icon')).toBeInTheDocument();
+  });
+
+  it('should render video icon when fileType is video-file', () => {
+    render(<MinimizedFileCard {...defaultProps} fileType="video-file" />);
+    expect(screen.getByAltText('video-file file icon')).toBeInTheDocument();
+  });
+
+  it('should render archive icon when fileType is archive', () => {
+    render(<MinimizedFileCard {...defaultProps} fileType="archive" />);
+    expect(screen.getByAltText('archive file icon')).toBeInTheDocument();
+  });
+
   it('should render star icon when starred prop is true', () => {
     render(<MinimizedFileCard {...defaultProps} starred={true} />);
 

--- a/app/shared/components/minimized-file-card/MinimizedFileCard.tsx
+++ b/app/shared/components/minimized-file-card/MinimizedFileCard.tsx
@@ -9,10 +9,14 @@ const ICON_SIZE = 21;
 const FILE_TYPES = {
   img: 'img',
   audio: 'audio',
-  pdf: 'pdf'
+  pdf: 'pdf',
+  doc: 'doc',
+  xls: 'xls',
+  'video-file': 'video-file',
+  archive: 'zip'
 } as const;
 
-type FileType = (typeof FILE_TYPES)[keyof typeof FILE_TYPES];
+type FileType = keyof typeof FILE_TYPES;
 
 interface MinimizedFileCardProps {
   fileType?: FileType;

--- a/public/icons/doc.svg
+++ b/public/icons/doc.svg
@@ -1,0 +1,9 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <mask id="mask-doc">
+      <rect width="32" height="32" fill="white" />
+      <text x="16" y="16.5" text-anchor="middle" dominant-baseline="middle" fill="black" font-family="Verdana, sans-serif" font-size="6.5" font-weight="900" style="letter-spacing: -0.2px;">DOC</text>
+    </mask>
+  </defs>
+  <rect x="6" y="6" width="20" height="20" rx="3" fill="#190D03" mask="url(#mask-doc)"/>
+</svg>

--- a/public/icons/video-file.svg
+++ b/public/icons/video-file.svg
@@ -1,0 +1,9 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <mask id="mask-vid-icon">
+      <rect width="32" height="32" fill="white" />
+      <path d="M12 10l9 6-9 6V10z" fill="black"/>
+    </mask>
+  </defs>
+  <rect x="6" y="6" width="20" height="20" rx="3" fill="#190D03" mask="url(#mask-vid-icon)"/>
+</svg>

--- a/public/icons/xls.svg
+++ b/public/icons/xls.svg
@@ -1,0 +1,9 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <mask id="mask-xls">
+      <rect width="32" height="32" fill="white" />
+      <text x="16" y="16.5" text-anchor="middle" dominant-baseline="middle" fill="black" font-family="Verdana, sans-serif" font-size="6.5" font-weight="900" style="letter-spacing: -0.2px;">XLS</text>
+    </mask>
+  </defs>
+  <rect x="6" y="6" width="20" height="20" rx="3" fill="#190D03" mask="url(#mask-xls)"/>
+</svg>

--- a/public/icons/zip.svg
+++ b/public/icons/zip.svg
@@ -1,0 +1,9 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <mask id="mask-zip">
+      <rect width="32" height="32" fill="white" />
+      <text x="16" y="16.5" text-anchor="middle" dominant-baseline="middle" fill="black" font-family="Verdana, sans-serif" font-size="6.5" font-weight="900" style="letter-spacing: -0.2px;">ZIP</text>
+    </mask>
+  </defs>
+  <rect x="6" y="6" width="20" height="20" rx="3" fill="#190D03" mask="url(#mask-zip)"/>
+</svg>

--- a/src/infrastructure/repositories/assetRepository/assetRepository.ts
+++ b/src/infrastructure/repositories/assetRepository/assetRepository.ts
@@ -2,7 +2,7 @@ import { FilterQuery, Model, Types } from 'mongoose';
 
 import { createBaseRepository } from '../baseRepository/baseRepository';
 
-type AssetType = 'image' | 'pdf' | 'audio' | 'document' | 'spreadsheet' | 'video';
+type AssetType = 'image' | 'pdf' | 'audio' | 'document' | 'spreadsheet' | 'video' | 'archive';
 
 type AssetUsageRef = {
   pageId?: string;

--- a/src/infrastructure/repositories/assetRepository/assetRepository.ts
+++ b/src/infrastructure/repositories/assetRepository/assetRepository.ts
@@ -2,7 +2,7 @@ import { FilterQuery, Model, Types } from 'mongoose';
 
 import { createBaseRepository } from '../baseRepository/baseRepository';
 
-type AssetType = 'image' | 'pdf' | 'audio';
+type AssetType = 'image' | 'pdf' | 'audio' | 'document' | 'spreadsheet' | 'video';
 
 type AssetUsageRef = {
   pageId?: string;
@@ -80,7 +80,9 @@ const toEntity = (doc: DbAsset): AssetEntity => ({
   updatedAt: dateToIso(doc.updatedAt)
 });
 
-const buildAssetQuery = (filters?: Omit<AssetFilters, 'limit' | 'skip' | 'sortBy' | 'sortOrder'>): FilterQuery<DbAsset> => {
+const buildAssetQuery = (
+  filters?: Omit<AssetFilters, 'limit' | 'skip' | 'sortBy' | 'sortOrder'>
+): FilterQuery<DbAsset> => {
   const query: FilterQuery<DbAsset> = {};
 
   if (!filters) {

--- a/src/interfaces/graphql/schemas/assets.graphql
+++ b/src/interfaces/graphql/schemas/assets.graphql
@@ -5,6 +5,7 @@ enum AssetType {
   document
   spreadsheet
   video
+  archive
 }
 
 enum AssetSortBy {

--- a/src/interfaces/graphql/schemas/assets.graphql
+++ b/src/interfaces/graphql/schemas/assets.graphql
@@ -2,6 +2,9 @@ enum AssetType {
   image
   pdf
   audio
+  document
+  spreadsheet
+  video
 }
 
 enum AssetSortBy {


### PR DESCRIPTION
## Description

Added custom icons for various media formats (documents, spreadsheets, videos, archives) and implemented their correct frontend mapping. To support these new formats, the GraphQL schema and database models were updated, including the addition of an Archive type specifically for .zip files.
## Type of change

- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Navigate to the "Files" page.
2. Note: Uploading these specific file types via UI is not supported yet. Please review the existing (or mocked) files in the list.
3. Verify that the icons on the file cards and inside the right sidebar correctly match their file extensions.
4. Open the "Format" filter and ensure there are no duplicate entries and the filtering works correctly.

### Actual result: 
Currently, files like .docx, .xlsx, or .zip display a default 'PDF' icon. This happens because the frontend strictly relies on the backend AssetType (which only returns image, pdf, or audio) to determine the icon.

### Expected result: 
The system correctly recognizes and displays specific, distinct icons for various media types (documents, spreadsheets, videos, archives) on both the file cards and the right sidebar. The "Format" filter accurately groups these new types without duplicates.
<img width="1579" height="657" alt="image" src="https://github.com/user-attachments/assets/f23ebbeb-c504-4721-b7c4-f3693b507a43" />


mongodb changes:
pdf => document
<img width="802" height="321" alt="image" src="https://github.com/user-attachments/assets/ce0b46fd-0bb8-4e87-a746-72822265a4ce" />



## Checklist

- [X] Code compiles and runs correctly
- [X] Tests pass successfully
- [X] Linting checks are clean
- [X] No Sonar issues
- [ ] Documentation updated (if applicable)
- [X] All comments and requested changes addressed
- [X] Branch is up to date with the target branch
- [X] Linked issue/task included
- [X] Task moved to the review column on the board

Closes: https://github.com/Liatoshynsky-Foundation/lf-admin/issues/448
