### PR TITLE
fix(ui): apply crop coordinates to image preview in PhotoBlock

### DIFF
--- a/app/shared/components/design-system/photo-block/PhotoBlock.styles.ts
+++ b/app/shared/components/design-system/photo-block/PhotoBlock.styles.ts
@@ -1,3 +1,6 @@
+export const PREVIEW_W = 196;
+export const PREVIEW_H = 120;
+
 export const styles = {
   container: {
     width: '100%',
@@ -19,8 +22,8 @@ export const styles = {
   },
 
   imagePreview: {
-    width: '196px',
-    height: '120px',
+    width: `${PREVIEW_W}px`,
+    height: `${PREVIEW_H}px`,
     objectFit: 'cover',
     flexShrink: 0,
     border: '1px solid #B2B3BE',

--- a/app/shared/components/design-system/photo-block/PhotoBlock.test.tsx
+++ b/app/shared/components/design-system/photo-block/PhotoBlock.test.tsx
@@ -237,9 +237,11 @@ describe('ImagePreviewBlock', () => {
   it('renders placeholder when no image', () => {
     renderComponent({ imageUrl: '' });
 
-    const img = screen.queryByRole('img');
-    expect(img).toBeInTheDocument();
-    expect(img).toHaveAttribute('src', '/icons/cloud-upload.svg');
+    const icon = screen.getByTestId('cloud-upload-icon');
+
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveAttribute('width', '76');
+    expect(icon).toHaveAttribute('height', '76');
   });
 
   it('updates preview when imageUrl changes', async () => {

--- a/app/shared/components/design-system/photo-block/PhotoBlock.tsx
+++ b/app/shared/components/design-system/photo-block/PhotoBlock.tsx
@@ -6,12 +6,16 @@ import toast from 'react-hot-toast';
 
 import Button from '../button/Button';
 import { styles } from './PhotoBlock.styles';
+import { useCroppedImage } from '~/hooks/use-cropped-image/use-cropped-image';
 import { readFileAsDataURL } from '~/lib/utils/readFileAsDataURL';
 import ImageIcon from '~/public/icons/image.svg';
 import PencilIcon from '~/public/icons/pencil.svg';
 import { MediaModal } from '~/shared/components/media-modal/MediaModal';
 import type { MediaModalOpenState, MediaModalResult } from '~/shared/components/media-modal/MediaModal.types';
 import { useImageMetadata } from '~/shared/hooks/use-image-metadata/useImageMetadata';
+
+const PREVIEW_W = 196;
+const PREVIEW_H = 120;
 
 interface ImagePreviewBlockProps extends StackProps {
   imageUrl: string;
@@ -48,18 +52,23 @@ export const ImagePreviewBlock = ({
 
   const [isMediaModalOpen, setIsMediaModalOpen] = useState(false);
   const [mediaInitial, setMediaInitial] = useState<MediaModalOpenState | undefined>(undefined);
-
-  const [savedCrop, setSavedCrop] = useState<MediaModalResult['crop']>(initialCrop || null);
+  const [savedCrop, setSavedCrop] = useState<MediaModalResult['crop']>(initialCrop ?? null);
 
   useEffect(() => {
     setPreviewImage(imageUrl);
   }, [imageUrl]);
 
   useEffect(() => {
-    setSavedCrop(initialCrop || null);
+    setSavedCrop(initialCrop ?? null);
   }, [initialCrop]);
 
   const { dimensions, fileName: finalFileName } = useImageMetadata(previewImage, fileName);
+
+  const { styles: cropStyles, onLoad: onImgLoad } = useCroppedImage(
+    savedCrop,
+    PREVIEW_W,
+    PREVIEW_H
+  );
 
   const openEditCrop = () => {
     setMediaInitial({
@@ -125,12 +134,24 @@ export const ImagePreviewBlock = ({
 
       <Box sx={styles.imageBlock}>
         {previewImage ? (
-          <Box
-            component="img"
-            src={previewImage}
-            alt={title || 'Selected'}
-            sx={oval ? styles.imageOvalPreview : styles.imagePreview}
-          />
+          oval ? (
+            <Box
+              component="img"
+              src={previewImage}
+              alt={title || 'Selected'}
+              sx={styles.imageOvalPreview}
+            />
+          ) : (
+            <Box sx={cropStyles.container}>
+              <Box
+                component="img"
+                src={previewImage}
+                alt={title || 'Selected'}
+                onLoad={onImgLoad}
+                sx={cropStyles.image}
+              />
+            </Box>
+          )
         ) : (
           <Box sx={styles.imagePreview}>
             <Box

--- a/app/shared/components/design-system/photo-block/PhotoBlock.tsx
+++ b/app/shared/components/design-system/photo-block/PhotoBlock.tsx
@@ -6,7 +6,7 @@ import { useEffect, useMemo, useState } from 'react';
 import toast from 'react-hot-toast';
 
 import Button from '../button/Button';
-import { styles } from './PhotoBlock.styles';
+import {PREVIEW_H, PREVIEW_W, styles} from './PhotoBlock.styles';
 import { useCroppedImage } from '~/hooks/use-cropped-image/use-cropped-image';
 import { readFileAsDataURL } from '~/lib/utils/readFileAsDataURL';
 import ImageIcon from '~/public/icons/image.svg';
@@ -14,9 +14,6 @@ import PencilIcon from '~/public/icons/pencil.svg';
 import { MediaModal } from '~/shared/components/media-modal/MediaModal';
 import type { MediaModalOpenState, MediaModalResult } from '~/shared/components/media-modal/MediaModal.types';
 import { useImageMetadata } from '~/shared/hooks/use-image-metadata/useImageMetadata';
-
-const PREVIEW_W = 196;
-const PREVIEW_H = 120;
 
 interface ImagePreviewBlockProps extends StackProps {
   imageUrl: string;

--- a/app/shared/components/design-system/photo-block/PhotoBlock.tsx
+++ b/app/shared/components/design-system/photo-block/PhotoBlock.tsx
@@ -130,6 +130,7 @@ export const ImagePreviewBlock = ({
       return (
         <Box sx={styles.imagePreview}>
           <CloudUpload
+            data-testid="cloud-upload-icon"
             size={76}
             strokeWidth={1.5}
             style={{ opacity: 0.3 }}

--- a/app/shared/components/design-system/photo-block/PhotoBlock.tsx
+++ b/app/shared/components/design-system/photo-block/PhotoBlock.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Box, Stack, type StackProps, TextField, Typography } from '@mui/material';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import toast from 'react-hot-toast';
 
 import Button from '../button/Button';
@@ -124,6 +124,44 @@ export const ImagePreviewBlock = ({
     }
   };
 
+  const renderPreviewContent = useMemo(() => {
+    if (!previewImage) {
+      return (
+        <Box sx={styles.imagePreview}>
+          <Box
+            component="img"
+            src="/icons/cloud-upload.svg"
+            alt="cloud upload"
+            sx={{ width: 76, height: 76, opacity: 0.3 }}
+          />
+        </Box>
+      );
+    }
+
+    if (oval) {
+      return (
+        <Box
+          component="img"
+          src={previewImage}
+          alt={title || 'Selected'}
+          sx={styles.imageOvalPreview}
+        />
+      );
+    }
+
+    return (
+      <Box sx={cropStyles.container}>
+        <Box
+          component="img"
+          src={previewImage}
+          alt={title || 'Selected'}
+          onLoad={onImgLoad}
+          sx={cropStyles.image}
+        />
+      </Box>
+    );
+  }, [previewImage, oval, title, cropStyles, onImgLoad]);
+
   return (
     <Box sx={styles.container}>
       {title ? (
@@ -133,35 +171,7 @@ export const ImagePreviewBlock = ({
       ) : null}
 
       <Box sx={styles.imageBlock}>
-        {previewImage ? (
-          oval ? (
-            <Box
-              component="img"
-              src={previewImage}
-              alt={title || 'Selected'}
-              sx={styles.imageOvalPreview}
-            />
-          ) : (
-            <Box sx={cropStyles.container}>
-              <Box
-                component="img"
-                src={previewImage}
-                alt={title || 'Selected'}
-                onLoad={onImgLoad}
-                sx={cropStyles.image}
-              />
-            </Box>
-          )
-        ) : (
-          <Box sx={styles.imagePreview}>
-            <Box
-              component="img"
-              src="/icons/cloud-upload.svg"
-              alt="cloud upload"
-              sx={{ width: 76, height: 76, opacity: 0.3 }}
-            />
-          </Box>
-        )}
+        {renderPreviewContent}
 
         <Stack spacing={stackSpacing} sx={styles.rightBlock}>
           <Stack spacing={typographySpacing}>

--- a/app/shared/components/design-system/photo-block/PhotoBlock.tsx
+++ b/app/shared/components/design-system/photo-block/PhotoBlock.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Box, Stack, type StackProps, TextField, Typography } from '@mui/material';
+import { CloudUpload } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import toast from 'react-hot-toast';
 
@@ -128,11 +129,10 @@ export const ImagePreviewBlock = ({
     if (!previewImage) {
       return (
         <Box sx={styles.imagePreview}>
-          <Box
-            component="img"
-            src="/icons/cloud-upload.svg"
-            alt="cloud upload"
-            sx={{ width: 76, height: 76, opacity: 0.3 }}
+          <CloudUpload
+            size={76}
+            strokeWidth={1.5}
+            style={{ opacity: 0.3 }}
           />
         </Box>
       );

--- a/app/shared/components/media-modal/MediaModal.renderers.ts
+++ b/app/shared/components/media-modal/MediaModal.renderers.ts
@@ -1,7 +1,8 @@
 import type { ReactNode } from 'react';
 
 import type { GalleryFilters, UsedFilters } from './flow/MediaModalFlowState';
-import type { CropResult, GalleryMedia, SelectedMedia, UploadMedia, UsedMedia } from './MediaModal.types';
+import type { GalleryMedia, SelectedMedia, UploadMedia, UsedMedia } from './MediaModal.types';
+import type { CropResult } from '~/types/common';
 
 export type GalleryRendererProps = {
   selected: GalleryMedia | null;

--- a/app/shared/components/media-modal/MediaModal.types.ts
+++ b/app/shared/components/media-modal/MediaModal.types.ts
@@ -1,3 +1,5 @@
+import {CropResult} from '~/types/common';
+
 export type MediaModalTab = 'GALLERY' | 'UPLOAD' | 'USED';
 export type MediaModalStep = 'SELECT' | 'CROP';
 
@@ -27,17 +29,6 @@ export type UploadMedia = {
 };
 
 export type SelectedMedia = GalleryMedia | UsedMedia | UploadMedia;
-
-export type CropRect = {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-};
-
-export type CropResult = {
-  rect: CropRect;
-};
 
 export type MediaModalResult = {
   selected: SelectedMedia;

--- a/app/shared/components/media-modal/flow/MediaModalFlow.test.tsx
+++ b/app/shared/components/media-modal/flow/MediaModalFlow.test.tsx
@@ -10,7 +10,6 @@ import type {
   UsedRendererProps
 } from '../MediaModal.renderers';
 import type {
-  CropResult,
   MediaModalOpenState,
   MediaModalResult,
   MediaModalTab,
@@ -18,6 +17,7 @@ import type {
 } from '../MediaModal.types';
 import { MockDsButton } from '../test-utils/mockDsButton';
 import { MediaModalFlow } from './MediaModalFlow';
+import type { CropResult } from '~/types/common';
 
 jest.mock('~/public/icons/iteration.svg', () => ({
   __esModule: true,

--- a/app/shared/components/media-modal/flow/MediaModalFlow.tsx
+++ b/app/shared/components/media-modal/flow/MediaModalFlow.tsx
@@ -8,7 +8,6 @@ import { MediaModalSwitcher } from '../components/switcher/MediaModalSwitcher';
 import type { MediaModalRenderers } from '../MediaModal.renderers';
 import { styles } from '../MediaModal.styles';
 import type {
-  CropResult,
   MediaModalOpenState,
   MediaModalResult,
   MediaModalTab,
@@ -20,6 +19,7 @@ import { useMediaModalApply } from './useMediaModalApply';
 import ArrowLeftIcon from '~/public/icons/arrowLeft.svg';
 import IterationIcon from '~/public/icons/iteration.svg';
 import Button from '~/shared/components/design-system/button/Button';
+import type { CropResult } from '~/types/common';
 
 export type MediaModalFlowProps = {
   open: boolean;

--- a/app/shared/components/media-modal/flow/MediaModalFlowState.test.ts
+++ b/app/shared/components/media-modal/flow/MediaModalFlowState.test.ts
@@ -1,5 +1,6 @@
-import type { CropResult, MediaModalOpenState, SelectedMedia } from '../MediaModal.types';
+import type { MediaModalOpenState, SelectedMedia } from '../MediaModal.types';
 import { buildInitialState, reducer } from './MediaModalFlowState';
+import type { CropResult } from '~/types/common';
 
 const initialCrop: CropResult = { rect: { x: 0, y: 0, width: 200, height: 200 } };
 const resizedCrop: CropResult = { rect: { x: 10, y: 12, width: 180, height: 160 } };

--- a/app/shared/components/media-modal/flow/MediaModalFlowState.ts
+++ b/app/shared/components/media-modal/flow/MediaModalFlowState.ts
@@ -1,11 +1,11 @@
 import type {
-  CropResult,
   MediaModalOpenState,
   MediaModalStep,
   MediaModalTab,
   SelectedMedia
 } from '../MediaModal.types';
 import { isImageUploadFile } from '../MediaModal.utils';
+import type { CropResult } from '~/types/common';
 
 export type GalleryFilters = {
   search: string;

--- a/app/shared/hooks/use-cropped-image/use-cropped-image.test.ts
+++ b/app/shared/hooks/use-cropped-image/use-cropped-image.test.ts
@@ -1,0 +1,133 @@
+import { act, renderHook } from '@testing-library/react';
+import React from 'react';
+
+import { useCroppedImage } from './use-cropped-image';
+import type { CropResult } from '~/types/common';
+
+describe('useCroppedImage hook', () => {
+  const containerW = 100;
+  const containerH = 100;
+
+  const mockCrop: CropResult = {
+    rect: {
+      x: 10,
+      y: 20,
+      width: 50,
+      height: 50,
+    },
+  };
+
+  it('should return default styles when crop is missing or natural size is 0', () => {
+    const { result } = renderHook(() =>
+      useCroppedImage(null, containerW, containerH)
+    );
+
+    expect(result.current.styles.container).toEqual({
+      width: containerW,
+      height: containerH,
+      overflow: 'hidden',
+      position: 'relative',
+      flexShrink: 0,
+    });
+
+    expect(result.current.styles.image).toEqual({
+      width: '100%',
+      height: '100%',
+      objectFit: 'cover',
+      objectPosition: 'center',
+      display: 'block',
+    });
+  });
+
+  it('should update natural size and calculate styles on image load', () => {
+    const { result } = renderHook(() =>
+      useCroppedImage(mockCrop, containerW, containerH)
+    );
+
+    const mockEvent = {
+      currentTarget: {
+        naturalWidth: 500,
+        naturalHeight: 300,
+      },
+    } as unknown as React.SyntheticEvent<HTMLImageElement>;
+
+    act(() => {
+      result.current.onLoad(mockEvent);
+    });
+
+    const { image } = result.current.styles;
+    expect(image.width).toBe(500);
+    expect(image.height).toBe(300);
+    expect(image.transform).toContain('scale(2)');
+    expect(image.transform).toContain('translate(-20px, -40px)');
+  });
+
+  it('should handle different aspect ratios and center the crop (Math.max scale)', () => {
+    const narrowCrop: CropResult = {
+      rect: { x: 0, y: 0, width: 50, height: 25 }
+    };
+
+    const { result } = renderHook(() =>
+      useCroppedImage(narrowCrop, containerW, containerH)
+    );
+
+    const mockEvent = {
+      currentTarget: { naturalWidth: 1000, naturalHeight: 1000 },
+    } as unknown as React.SyntheticEvent<HTMLImageElement>;
+
+    act(() => {
+      result.current.onLoad(mockEvent);
+    });
+
+    expect(result.current.styles.image.transform).toContain('scale(4)');
+    expect(result.current.styles.image.transform).toContain('translate(-50px, 0px)');
+  });
+
+  it('should return default styles if crop rect width or height is zero', () => {
+    const brokenCrop: CropResult = {
+      rect: { x: 10, y: 10, width: 0, height: 50 }
+    };
+
+    const { result } = renderHook(() =>
+      useCroppedImage(brokenCrop, containerW, containerH)
+    );
+
+    const mockEvent = {
+      currentTarget: { naturalWidth: 500, naturalHeight: 500 },
+    } as unknown as React.SyntheticEvent<HTMLImageElement>;
+
+    act(() => {
+      result.current.onLoad(mockEvent);
+    });
+
+    expect(result.current.styles.image).toEqual({
+      width: '100%',
+      height: '100%',
+      objectFit: 'cover',
+      objectPosition: 'center',
+      display: 'block',
+    });
+  });
+
+  it('should return default styles if crop rect is missing', () => {
+    const incompleteCrop = { someOtherData: {} } as unknown as CropResult;
+
+    const { result } = renderHook(() =>
+      useCroppedImage(incompleteCrop, containerW, containerH)
+    );
+
+    expect(result.current.styles.image.objectFit).toBe('cover');
+  });
+
+  it('should memoize styles when dependencies do not change', () => {
+    const { result, rerender } = renderHook(
+      ({ crop }) => useCroppedImage(crop, containerW, containerH),
+      { initialProps: { crop: mockCrop } }
+    );
+
+    const firstStyles = result.current.styles;
+
+    rerender({ crop: mockCrop });
+    expect(result.current.styles).toBe(firstStyles);
+  });
+});

--- a/app/shared/hooks/use-cropped-image/use-cropped-image.ts
+++ b/app/shared/hooks/use-cropped-image/use-cropped-image.ts
@@ -1,0 +1,87 @@
+import { useCallback, useMemo, useState } from 'react';
+
+import type { CropResult } from '~/shared/components/media-modal/MediaModal.types';
+
+export type CroppedImageStyles = {
+  container: React.CSSProperties;
+  image: React.CSSProperties;
+};
+
+function buildCroppedStyles(
+  crop: CropResult | null | undefined,
+  natW: number,
+  natH: number,
+  containerW: number,
+  containerH: number
+): CroppedImageStyles {
+  const containerBase: React.CSSProperties = {
+    width: containerW,
+    height: containerH,
+    overflow: 'hidden',
+    position: 'relative',
+    flexShrink: 0,
+    border: '1px solid #B2B3BE',
+  };
+
+  if (!crop?.rect || natW === 0 || natH === 0) {
+    return {
+      container: containerBase,
+      image: {
+        width: '100%',
+        height: '100%',
+        objectFit: 'cover',
+        objectPosition: 'center',
+        display: 'block',
+      },
+    };
+  }
+
+  const { x, y, width: cropW, height: cropH } = crop.rect;
+
+  const scaleX = containerW / cropW;
+  const scaleY = containerH / cropH;
+  const scale = Math.max(scaleX, scaleY);
+
+  const renderedCropW = cropW * scale;
+  const renderedCropH = cropH * scale;
+  const centerOffsetX = (containerW - renderedCropW) / 2;
+  const centerOffsetY = (containerH - renderedCropH) / 2;
+
+  const translateX = -(x * scale) + centerOffsetX;
+  const translateY = -(y * scale) + centerOffsetY;
+
+  return {
+    container: containerBase,
+    image: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: natW,
+      height: natH,
+      maxWidth: 'none',
+      transformOrigin: '0 0',
+      transform: `translate(${translateX}px, ${translateY}px) scale(${scale})`,
+      display: 'block',
+    },
+  };
+}
+
+export function useCroppedImage(
+  crop: CropResult | null | undefined,
+  containerW: number,
+  containerH: number
+) {
+  const [naturalSize, setNaturalSize] = useState<{ w: number; h: number }>({ w: 0, h: 0 });
+
+  const onLoad = useCallback((e: React.SyntheticEvent<HTMLImageElement>) => {
+    const img = e.currentTarget;
+    setNaturalSize({ w: img.naturalWidth, h: img.naturalHeight });
+  }, []);
+
+  const styles = useMemo(
+    () => buildCroppedStyles(crop, naturalSize.w, naturalSize.h, containerW, containerH),
+    [crop, naturalSize.w, naturalSize.h, containerW, containerH]
+  );
+
+  return { styles, onLoad };
+}

--- a/app/shared/hooks/use-cropped-image/use-cropped-image.ts
+++ b/app/shared/hooks/use-cropped-image/use-cropped-image.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
 
-import type { CropResult } from '~/shared/components/media-modal/MediaModal.types';
+import type { CropResult } from '~/types/common';
 
 export type CroppedImageStyles = {
   container: React.CSSProperties;
@@ -20,10 +20,15 @@ function buildCroppedStyles(
     overflow: 'hidden',
     position: 'relative',
     flexShrink: 0,
-    border: '1px solid #B2B3BE',
   };
 
-  if (!crop?.rect || natW === 0 || natH === 0) {
+  if (
+    !crop?.rect ||
+      crop.rect.width === 0 ||
+      crop.rect.height === 0 ||
+      natW === 0 ||
+      natH === 0
+  ) {
     return {
       container: containerBase,
       image: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7390,6 +7390,111 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.14.tgz",
+      "integrity": "sha512-Y9K6SPzobnZvrRDPO2s0grgzC+Egf0CqfbdvYmQVaztV890zicw8Z8+4Vqw8oPck8r1TjUHxVh8299Cg4TrxXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.14.tgz",
+      "integrity": "sha512-aNnkSMjSFRTOmkd7qoNI2/rETQm/vKD6c/Ac9BZGa9CtoOzy3c2njgz7LvebQJ8iPxdeTuGnAjagyis8a9ifBw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.14.tgz",
+      "integrity": "sha512-tjlpia+yStPRS//6sdmlVwuO1Rioern4u2onafa5n+h2hCS9MAvMXqpVbSrjgiEOoCs0nJy7oPOmWgtRRNSM5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.14.tgz",
+      "integrity": "sha512-8B8cngBaLadl5lbDRdxGCP1Lef8ipD6KlxS3v0ElDAGil6lafrAM3B258p1KJOglInCVFUjk751IXMr2ixeQOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.14.tgz",
+      "integrity": "sha512-bAS6tIAg8u4Gn3Nz7fCPpSoKAexEt2d5vn1mzokcqdqyov6ZJ6gu6GdF9l8ORFrBuRHgv3go/RfzYz5BkZ6YSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.14.tgz",
+      "integrity": "sha512-mMxv/FcrT7Gfaq4tsR22l17oKWXZmH/lVqcvjX0kfp5I0lKodHYLICKPoX1KRnnE+ci6oIUdriUhuA3rBCDiSw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.14.tgz",
+      "integrity": "sha512-OTmiBlYThppnvnsqx0rBqjDRemlmIeZ8/o4zI7veaXoeO1PVHoyj2lfTfXTiiGjCyRDhA10y4h6ZvZvBiynr2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@next/swc-win32-x64-msvc": {
       "version": "15.5.14",
       "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.14.tgz",
@@ -26485,111 +26590,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.14.tgz",
-      "integrity": "sha512-Y9K6SPzobnZvrRDPO2s0grgzC+Egf0CqfbdvYmQVaztV890zicw8Z8+4Vqw8oPck8r1TjUHxVh8299Cg4TrxXg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.14.tgz",
-      "integrity": "sha512-aNnkSMjSFRTOmkd7qoNI2/rETQm/vKD6c/Ac9BZGa9CtoOzy3c2njgz7LvebQJ8iPxdeTuGnAjagyis8a9ifBw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.14.tgz",
-      "integrity": "sha512-tjlpia+yStPRS//6sdmlVwuO1Rioern4u2onafa5n+h2hCS9MAvMXqpVbSrjgiEOoCs0nJy7oPOmWgtRRNSM5Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.14.tgz",
-      "integrity": "sha512-8B8cngBaLadl5lbDRdxGCP1Lef8ipD6KlxS3v0ElDAGil6lafrAM3B258p1KJOglInCVFUjk751IXMr2ixeQOQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.14.tgz",
-      "integrity": "sha512-bAS6tIAg8u4Gn3Nz7fCPpSoKAexEt2d5vn1mzokcqdqyov6ZJ6gu6GdF9l8ORFrBuRHgv3go/RfzYz5BkZ6YSQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.14.tgz",
-      "integrity": "sha512-mMxv/FcrT7Gfaq4tsR22l17oKWXZmH/lVqcvjX0kfp5I0lKodHYLICKPoX1KRnnE+ci6oIUdriUhuA3rBCDiSw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.14.tgz",
-      "integrity": "sha512-OTmiBlYThppnvnsqx0rBqjDRemlmIeZ8/o4zI7veaXoeO1PVHoyj2lfTfXTiiGjCyRDhA10y4h6ZvZvBiynr2g==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     }
   }


### PR DESCRIPTION
## Description

This PR fixes an issue where images in the `PhotoBlock` component ignored the crop metadata stored in the database. I implemented the `useCroppedImage` hook to calculate the correct CSS transformations (scale and translate) based on the saved crop coordinates (x, y, width, height). This ensures that the preview in the admin panel matches the framing selected by the user in the MediaModal.

Summary of changes:
- Integrated `useCroppedImage` hook into `ImagePreviewBlock`.
- Updated `PhotoBlock.tsx` to apply calculated styles to the image preview.
- Ensured images are no longer stretched or displayed in full scale when a crop is present.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: ## How to test

1. Open the admin panel and navigate to a section containing a `PhotoBlock` (about-us page).
2. Upload an image or select an existing one.
3. Open the "Edit" (Редагувати) mode and set a specific crop area.
4. Save the changes and verify that the preview image in the `PhotoBlock` accurately displays only the cropped area.

## Video / Screenshots
### Before

https://github.com/user-attachments/assets/b6f34cfa-5137-45a5-84a2-5e54e5984450


### After

https://github.com/user-attachments/assets/fe6f0ffa-3d91-475d-80f5-4f2dadc7a442


Closes #455