### PR TITLE
fix(ui): remove extra right padding on files grid when sidebar is open

### DIFF
--- a/app/(logged_in)/files/FilesPageContent.tsx
+++ b/app/(logged_in)/files/FilesPageContent.tsx
@@ -256,7 +256,7 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
         display: 'flex',
         flexDirection: 'column',
         gap: '20px',
-        pr: { xs: 0, md: sidebarFile ? `${SIDEBAR_WIDTH + 12}px` : 0 },
+        pr: { xs: 0, md: sidebarFile ? `${SIDEBAR_WIDTH}px` : 0 },
         transition: 'padding-right 0.2s ease'
       }}
     >


### PR DESCRIPTION
## Description

Fixed a bug causing uneven padding on the files grid when the right sidebar is open. Removed the extra 12px from the main container's (FilesPageContent) padding-right that was creating a visual imbalance. Now, the left and right padding of the card grid remain perfectly symmetrical, matching the Figma design.

## Type of change

- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Navigate to the "Files" page.
2. Observe the left and right padding of the file cards grid—they should be visually equal.
3. Click on any file to open the right side panel (FileInfoSidebar).
4. Ensure that after the sidebar appears, the right padding of the grid itself does not become larger than the left padding, and the overall balance (alignment) of the cards is maintained.

**Actual result:**
When the FileInfoSidebar is opened, the padding on the right side of the main grid container (between the file cards and the sidebar) becomes noticeably larger than the padding on the left side, creating a visual imbalance in the layout.

<img width="947" height="652" alt="Image" src="https://github.com/user-attachments/assets/98dccd8b-a8dc-481b-94f8-cfb4f6f91926" />


**Expected result:**
The left and right paddings of the main grid container should remain equal and match the Figma design, regardless of whether the sidebar is open or closed.

<img width="959" height="665" alt="image" src="https://github.com/user-attachments/assets/32f5e7d4-637e-43ee-9279-94ba31b4a55a" />


Closes: https://github.com/Liatoshynsky-Foundation/lf-admin/issues/460