### PR TITLE
feat: create publications edit page

### DIFF
--- a/app/(logged_in)/publications/[type]/[id]/edit/EditPublicationsView.styles.ts
+++ b/app/(logged_in)/publications/[type]/[id]/edit/EditPublicationsView.styles.ts
@@ -49,15 +49,6 @@ export const styles = {
     bgcolr: 'adminBlue.50',
     p: '16px 32px'
   },
-  // collapse: {
-  //   bgcolor: 'white',
-  //   border: '1px solid',
-  //   borderColor: 'blue.200',
-  //   px: '24px',
-  //   '& .MuiAccordionSummary-root, & .MuiAccordionDetails-root': {
-  //     p: '4px 0'
-  //   },
-  // },
   contentEditor: {
     p: '24px',
     bgcolor: 'white',

--- a/app/(logged_in)/publications/[type]/[id]/edit/EditPublicationsView.test.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/edit/EditPublicationsView.test.tsx
@@ -1,0 +1,169 @@
+import { Block } from '@blocknote/core';
+import { fireEvent,render, screen } from '@testing-library/react';
+import React, { MouseEvent } from 'react';
+
+import { EditPublicationsView, EditPublicationsViewProps } from './EditPublicationsView';
+import { EditorLanguage, MenuActionId } from '~/constants/publications';
+import { SerializedContent } from '~/shared/components/content-editor';
+
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(() => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+  })),
+  useParams: jest.fn(() => ({})),
+}));
+
+type MockContentEditorProps = {
+  persistence: { onChange: (val: SerializedContent) => void };
+  initialContent?: Block[];
+};
+
+jest.mock('~/shared/components/content-editor', () => ({
+  ContentEditor: ({ persistence, initialContent }: MockContentEditorProps) => (
+    <textarea
+      data-testid="mock-content-editor"
+      defaultValue={initialContent ? 'has-content' : ''}
+      onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        persistence.onChange({ 
+          blocks: [{ type: 'paragraph', content: e.target.value }] 
+        } as unknown as SerializedContent);
+      }}
+    />
+  ),
+  isContentEmpty: (blocks?: unknown[]) => !blocks || blocks.length === 0,
+}));
+
+type MockTitleDropdownProps = {
+  onMenuOpen: (e: MouseEvent<HTMLButtonElement>) => void;
+  title?: string;
+};
+
+jest.mock('~/shared/components/divided-header/title-dropdown/TitleDropdown', () => ({
+  TitleDropdown: ({ onMenuOpen, title }: MockTitleDropdownProps) => (
+    <button data-testid="mock-title-dropdown" onClick={onMenuOpen}>
+      {title ?? 'Empty Title'}
+    </button>
+  ),
+}));
+
+type MockHeaderRightActionsProps = {
+  onMenuOpen: (e: MouseEvent<HTMLButtonElement>) => void;
+  onPublish: () => void;
+};
+
+jest.mock('~/shared/components/divided-header/header-right-actions/HeaderRightActions', () => {
+  return function MockHeaderRightActions({ onMenuOpen, onPublish }: MockHeaderRightActionsProps) {
+    return (
+      <div data-testid="mock-header-actions">
+        <button data-testid="mock-publish-quick-btn" onClick={onPublish}>Quick Publish</button>
+        <button data-testid="mock-publish-menu-btn" onClick={onMenuOpen}>Open Publish Menu</button>
+      </div>
+    );
+  };
+});
+
+describe('EditPublicationsView Component', () => {
+  const mockOnLanguageChange = jest.fn();
+  const mockOnEditorChange = jest.fn();
+  const mockOnAction = jest.fn();
+  const mockOnSeoClick = jest.fn();
+
+  const defaultProps: EditPublicationsViewProps = {
+    type: 'news',
+    isLoading: false,
+    currentData: { adminTitle: 'Test News Title' },
+    editedContent: {
+      uk: { content: { blocks: [], version: '1', lastModified: '' } },
+      en: { content: { blocks: [], version: '1', lastModified: '' } },
+    },
+    editorResetKey: 0,
+    currentLanguage: 'UA',
+    onLanguageChange: mockOnLanguageChange,
+    onEditorChange: mockOnEditorChange,
+    onAction: mockOnAction,
+    onSeoClick: mockOnSeoClick,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render the loading state when isLoading is true', () => {
+    render(<EditPublicationsView {...defaultProps} isLoading={true} />);
+    expect(screen.getByText('Завантаження...')).toBeInTheDocument();
+  });
+
+  it('should render the loading state when editedContent is null', () => {
+    render(<EditPublicationsView {...defaultProps} editedContent={null} />);
+    expect(screen.getByText('Завантаження...')).toBeInTheDocument();
+  });
+
+  it('should render the layout correctly for news', () => {
+    render(<EditPublicationsView {...defaultProps} />);
+    
+    expect(screen.getByTestId('mock-title-dropdown')).toHaveTextContent('Test News Title');
+    expect(screen.getByTestId('mock-content-editor')).toBeInTheDocument();
+    expect(screen.getByText('Чернетка')).toBeInTheDocument();
+  });
+
+  it('should render the layout correctly for media (no editor)', () => {
+    render(<EditPublicationsView {...defaultProps} type="media" />);
+    
+    expect(screen.getByText('Редагування Ми у ЗМІ')).toBeInTheDocument();
+    expect(screen.queryByTestId('mock-content-editor')).not.toBeInTheDocument();
+  });
+
+  it('should trigger onEditorChange when the user types in the editor', () => {
+    render(<EditPublicationsView {...defaultProps} currentLanguage="EN" />);
+    
+    const editor = screen.getByTestId('mock-content-editor');
+    fireEvent.change(editor, { target: { value: 'New text' } });
+
+    expect(mockOnEditorChange).toHaveBeenCalledTimes(1);
+    expect(mockOnEditorChange).toHaveBeenCalledWith(
+      expect.objectContaining({ blocks: [{ type: 'paragraph', content: 'New text' }] }),
+      'en'
+    );
+  });
+
+  it('should trigger onLanguageChange when a new language is selected from the menu', () => {
+    render(<EditPublicationsView {...defaultProps} currentLanguage="UA" />);
+    
+    fireEvent.click(screen.getByTestId('mock-title-dropdown'));
+    fireEvent.click(screen.getByText('Англійська'));
+
+    expect(mockOnLanguageChange).toHaveBeenCalledTimes(1);
+    expect(mockOnLanguageChange).toHaveBeenCalledWith('EN' as EditorLanguage);
+  });
+
+  it('should trigger onSeoClick when the SEO option is selected from the menu', () => {
+    render(<EditPublicationsView {...defaultProps} />);
+    
+    fireEvent.click(screen.getByTestId('mock-title-dropdown'));
+    fireEvent.click(screen.getByText('SEO налаштування'));
+
+    expect(mockOnSeoClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('should trigger onAction when a publish menu item is clicked', () => {
+    render(<EditPublicationsView {...defaultProps} />);
+    
+    fireEvent.click(screen.getByTestId('mock-publish-menu-btn'));
+    fireEvent.click(screen.getByText('Зберегти зміни'));
+
+    expect(mockOnAction).toHaveBeenCalledTimes(1);
+    expect(mockOnAction).toHaveBeenCalledWith(MenuActionId.SAVE_DRAFT);
+  });
+
+  it('should handle the quick publish button from HeaderRightActions directly', () => {
+    render(<EditPublicationsView {...defaultProps} />);
+    
+    fireEvent.click(screen.getByTestId('mock-publish-quick-btn'));
+
+    expect(mockOnAction).toHaveBeenCalledTimes(1);
+    expect(mockOnAction).toHaveBeenCalledWith(MenuActionId.PUBLISH);
+  });
+});

--- a/app/(logged_in)/publications/[type]/[id]/edit/EditPublicationsView.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/edit/EditPublicationsView.tsx
@@ -1,0 +1,182 @@
+import { Box, Chip, Divider, ListSubheader, Menu, MenuItem, Typography } from '@mui/material';
+import { MouseEvent, useState } from 'react';
+
+import { styles } from './EditPublicationsView.styles';
+import {
+  ACTIONS_TYPE,
+  EditorLanguage,
+  HEADER_MENU_OPTIONS,
+  LANGUAGE_OPTIONS,
+  LocalizedEditorState,
+  MenuActionId,
+  PUBLICATIONS_BASE_PATH,
+  PublicationsChipLabels,
+  PublicationsItemType
+} from '~/constants/publications';
+import { ContentEditor, isContentEmpty, SerializedContent } from '~/shared/components/content-editor';
+import DividedHeader from '~/shared/components/divided-header/DividedHeader';
+import HeaderRightActions from '~/shared/components/divided-header/header-right-actions/HeaderRightActions';
+import { TitleDropdown } from '~/shared/components/divided-header/title-dropdown/TitleDropdown';
+
+type AnchorId = 'navigation' | 'publish';
+type MenuAnchor = Partial<Record<AnchorId, HTMLButtonElement>>;
+
+export type PublicationViewData = {
+  adminTitle?: string | null;
+};
+
+export type EditPublicationsViewProps = {
+  type: PublicationsItemType;
+  isLoading: boolean;
+  currentData: PublicationViewData | null | undefined;
+  editedContent: LocalizedEditorState | null;
+  editorResetKey: number;
+  currentLanguage: EditorLanguage; 
+  onLanguageChange: (lang: EditorLanguage) => void;
+  onEditorChange: (content: SerializedContent, localeKey: 'uk' | 'en') => void;
+  onAction: (actionId: MenuActionId) => void;
+  onSeoClick: () => void;
+};
+
+export function EditPublicationsView({
+  type,
+  isLoading,
+  currentData,
+  editedContent,
+  editorResetKey,
+  currentLanguage,
+  onLanguageChange,
+  onEditorChange,
+  onAction,
+  onSeoClick
+}: Readonly<EditPublicationsViewProps>) {
+  const [anchors, setAnchors] = useState<MenuAnchor>({});
+
+  const localeKey = currentLanguage === 'UA' ? 'uk' : 'en';
+
+  const handleOpen = (event: MouseEvent<HTMLElement>, id: AnchorId) =>
+    setAnchors((prev) => ({ ...prev, [id]: event.currentTarget as HTMLButtonElement }));
+  const handleClose = (id: AnchorId) => setAnchors((prev) => ({ ...prev, [id]: undefined }));
+
+  const handlePublishActionClick = (actionId: MenuActionId) => {
+    onAction(actionId);
+    handleClose('publish');
+  };
+
+  if (isLoading || editedContent === null) return <Box sx={{ p: 4 }}>{'Завантаження...'}</Box>;
+
+  const initialBlocks = editedContent[localeKey]?.content?.blocks;
+  const isContentValid = Array.isArray(initialBlocks) && initialBlocks.length;
+  const publishActions = (HEADER_MENU_OPTIONS.baseActions as ACTIONS_TYPE[]).filter(
+    (a) => a.id !== MenuActionId.PUBLISH
+  );
+
+  return (
+    <Box sx={styles.container}>
+      <DividedHeader
+        sx={styles.header}
+        originUrl={PUBLICATIONS_BASE_PATH}
+        rightActionsComponent={
+          <HeaderRightActions
+            mode={type === 'media' ? 'seo' : 'edit'}
+            onMenuOpen={(e) => handleOpen(e, 'publish')}
+            onPublish={() => handlePublishActionClick(MenuActionId.PUBLISH)}
+          />
+        }
+      >
+        {type === 'media' ? (
+          <Typography variant="customBold20Tight">{'Редагування Ми у ЗМІ'}</Typography>
+        ) : (
+          <TitleDropdown
+            type="multilingual"
+            language={currentLanguage}
+            title={currentData?.adminTitle ?? ''}
+            onMenuOpen={(e) => handleOpen(e, 'navigation')}
+          />
+        )}
+        <Chip sx={styles.chip(type)} label={PublicationsChipLabels[type]} />
+        <Chip sx={styles.chip('draft')} label="Чернетка" />
+      </DividedHeader>
+
+      <Box sx={styles.mainContent}>
+        {type !== 'media' && (
+          <ContentEditor
+            initialContent={isContentValid ? initialBlocks : undefined}
+            key={`${currentLanguage}-${editorResetKey}`}
+            persistence={{
+              onChange: (content) => onEditorChange(content, localeKey)
+            }}
+            sx={styles.contentEditor}
+            editorConfig={{ sideMenu: true }}
+          />
+        )}
+      </Box>
+
+      <Menu
+        anchorEl={anchors['navigation']}
+        open={Boolean(anchors['navigation'])}
+        onClose={() => handleClose('navigation')}
+        disableScrollLock
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+        slotProps={{ paper: { sx: { width: 205 } } }}
+        sx={styles.menu}
+      >
+        <ListSubheader sx={styles.menuSubheader}>
+          <Typography variant="customMedium14Tight">{'Мовні версії'}</Typography>
+        </ListSubheader>
+
+        {LANGUAGE_OPTIONS.map(({ locale, key, label }) => {
+          const blocks = editedContent?.[key]?.content?.blocks;
+          const isDraft = !isContentEmpty(blocks);
+
+          return (
+            <MenuItem
+              key={key}
+              onClick={() => {
+                onLanguageChange(locale);
+                handleClose('navigation');
+              }}
+              sx={styles.menuItem}
+            >
+              <Typography variant="customMedium16">{label}</Typography>
+              {isDraft && (
+                <Typography variant="customItalic14" sx={styles.draftCaption}>
+                  {'(чернетка)'}
+                </Typography>
+              )}
+            </MenuItem>
+          );
+        })}
+
+        <Divider sx={{ my: '7px' }} />
+        <MenuItem
+          onClick={() => {
+            onSeoClick();
+            handleClose('navigation');
+          }}
+          sx={styles.menuItem}
+        >
+          <Typography variant="customMedium16">{'SEO налаштування'}</Typography>
+        </MenuItem>
+      </Menu>
+
+      <Menu
+        anchorEl={anchors['publish']}
+        open={Boolean(anchors['publish'])}
+        onClose={() => handleClose('publish')}
+        disableScrollLock
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        slotProps={{ paper: { sx: { width: 260 } } }}
+        sx={styles.menu}
+      >
+        {publishActions.map((action) => (
+          <MenuItem sx={styles.menuItem} key={action.id} onClick={() => handlePublishActionClick(action.id)}>
+            <Typography variant="customMedium16">{action.label}</Typography>
+          </MenuItem>
+        ))}
+      </Menu>
+    </Box>
+  );
+}

--- a/app/(logged_in)/publications/[type]/[id]/edit/page.styles.ts
+++ b/app/(logged_in)/publications/[type]/[id]/edit/page.styles.ts
@@ -1,0 +1,85 @@
+
+import { publicationsChipsColors } from '~/shared/theme/colors';
+
+type ChipColorType = 'draft' | 'published' | 'news' | 'event' | 'media';
+
+const ChipsColorsMap: Record<ChipColorType, string> = {
+  draft: publicationsChipsColors.draftBg,
+  published: publicationsChipsColors.publishedBg,
+  news: publicationsChipsColors.newsBg,
+  event: publicationsChipsColors.eventBg,
+  media: publicationsChipsColors.mediaMentionBg
+};
+
+export const styles = {
+  container: {
+    width: '100%',
+    minHeight: '100vh',
+    bgcolor: 'adminBlue.50'
+  },
+  header: {
+    bgcolor: 'white'
+  },
+  menu: {
+    mt: 1,
+    '& .MuiPaper-root': {
+      '&::-webkit-scrollbar': {
+        display: 'none'
+      },
+      msOverflowStyle: 'none',
+      scrollbarWidth: 'none',
+
+      overflowY: 'auto'
+    }
+  },
+  menuItem: {
+    p: '10px 16px',
+    borderRadius: '8px',
+    height: 44
+  },
+  mainContent: {
+    bgcolor: 'adminBlue.50',
+    p: '16px 32px'
+  },
+  collapse: {
+    bgcolor: 'white',
+    border: '1px solid',
+    borderColor: 'blue.200',
+    px: '24px',
+    '& .MuiAccordionSummary-root, & .MuiAccordionDetails-root': {
+      p: '4px 0'
+    },
+    '& .MuiAccordionSummary-content': {}
+  },
+  contentEditor: {
+    border: 'none',
+    p: 0,
+    bgcolor: 'white',
+    '& .bn-editor': {
+      p: 0,
+      bgcolor: 'white'
+    }
+  },
+  chip: (color: ChipColorType) => ({
+    pointerEvents: 'none',
+    cursor: 'default',
+    userSelect: 'none',
+
+    '&:hover': {
+      bgcolor: 'inherit'
+    },
+    '&:active': {
+      boxShadow: 'none'
+    },
+
+    '& .MuiTouchRipple-root': {
+      display: 'none'
+    },
+
+    bgcolor: ChipsColorsMap[color],
+    height: 28,
+    '& .MuiChip-root': {
+      p: '4px 8px'
+    }
+  })
+};

--- a/app/(logged_in)/publications/[type]/[id]/edit/page.styles.ts
+++ b/app/(logged_in)/publications/[type]/[id]/edit/page.styles.ts
@@ -1,20 +1,19 @@
 
-import { publicationsChipsColors } from '~/shared/theme/colors';
 
-type ChipColorType = 'draft' | 'published' | 'news' | 'event' | 'media';
+type ChipColorType = 'draft' | 'published' | 'news' | 'events' | 'media';
 
-const ChipsColorsMap: Record<ChipColorType, string> = {
-  draft: publicationsChipsColors.draftBg,
-  published: publicationsChipsColors.publishedBg,
-  news: publicationsChipsColors.newsBg,
-  event: publicationsChipsColors.eventBg,
-  media: publicationsChipsColors.mediaMentionBg
+const publicationsChipsColors: Record<ChipColorType, string> = {
+  published: '#579A40',
+  draft: 'red.200',
+  news: '#B6D0F7',
+  events: '#F7B6E1',
+  media: '#B6F7CF'
 };
+
 
 export const styles = {
   container: {
     width: '100%',
-    minHeight: '100vh',
     bgcolor: 'adminBlue.50'
   },
   header: {
@@ -32,31 +31,40 @@ export const styles = {
       overflowY: 'auto'
     }
   },
+  menuSubheader: {
+    height: 26,
+    display: 'flex',
+    alignItems: 'center'
+  },
   menuItem: {
     p: '10px 16px',
     borderRadius: '8px',
     height: 44
   },
+  draftCaption: {
+    color: 'red.600',
+  },
   mainContent: {
-    bgcolor: 'adminBlue.50',
+    minHeight: '100vh',
+    bgcolr: 'adminBlue.50',
     p: '16px 32px'
   },
-  collapse: {
-    bgcolor: 'white',
-    border: '1px solid',
-    borderColor: 'blue.200',
-    px: '24px',
-    '& .MuiAccordionSummary-root, & .MuiAccordionDetails-root': {
-      p: '4px 0'
-    },
-    '& .MuiAccordionSummary-content': {}
-  },
+  // collapse: {
+  //   bgcolor: 'white',
+  //   border: '1px solid',
+  //   borderColor: 'blue.200',
+  //   px: '24px',
+  //   '& .MuiAccordionSummary-root, & .MuiAccordionDetails-root': {
+  //     p: '4px 0'
+  //   },
+  // },
   contentEditor: {
-    border: 'none',
-    p: 0,
+    p: '24px',
     bgcolor: 'white',
+    borderRadius: '20px',
+    borderColor: 'blue.200',
     '& .bn-editor': {
-      p: 0,
+      maxWidth: '1136px',
       bgcolor: 'white'
     }
   },
@@ -76,7 +84,7 @@ export const styles = {
       display: 'none'
     },
 
-    bgcolor: ChipsColorsMap[color],
+    bgcolor: publicationsChipsColors[color],
     height: 28,
     '& .MuiChip-root': {
       p: '4px 8px'

--- a/app/(logged_in)/publications/[type]/[id]/edit/page.test.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/edit/page.test.tsx
@@ -1,0 +1,194 @@
+import { act,fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { notFound,useParams, useRouter } from 'next/navigation';
+import toast from 'react-hot-toast';
+
+import { EditPublicationsViewProps } from './EditPublicationsView';
+import EditPublicationsPage from './page';
+import { CONTENT_MUTATION_RESULTS, LocalizedEditorState,MenuActionId } from '~/constants/publications';
+import { SerializedContent } from '~/shared/components/content-editor';
+import { usePublicationManager } from '~/shared/hooks/use-publications-manager/usePublicationsManager';
+import { BaseContentStatuses } from '~/types/enums/common.enums';
+
+jest.mock('next/navigation', () => ({
+  useParams: jest.fn(),
+  useRouter: jest.fn(),
+  notFound: jest.fn()
+}));
+
+jest.mock('react-hot-toast', () => ({
+  success: jest.fn(),
+  error: jest.fn()
+}));
+
+jest.mock('~/shared/hooks/use-publications-manager/usePublicationsManager', () => ({
+  usePublicationManager: jest.fn()
+}));
+
+const baseMockManager = {
+  isLoading: false,
+  currentData: { status: BaseContentStatuses.Draft, adminTitle: 'Test Data' },
+  hasError: false,
+  editedContent: {
+    uk: { content: { blocks: [], version: '1', lastModified: '' } },
+    en: { content: { blocks: [], version: '1', lastModified: '' } }
+  },
+  setEditedContent: jest.fn(),
+  currentLanguage: 'UA',
+  setCurrentLanguage: jest.fn(),
+  editorResetKey: 0,
+  resetEditorState: jest.fn(),
+  updateResource: jest.fn().mockResolvedValue({ data: { id: '1' } })
+};
+
+jest.mock('./EditPublicationsView', () => ({
+  EditPublicationsView: (props: EditPublicationsViewProps) => (
+    <div data-testid="mock-view">
+      <button
+        data-testid="trigger-editor-change"
+        onClick={() =>
+          props.onEditorChange(
+            { blocks: [{ type: 'paragraph', content: 'new' }] } as unknown as SerializedContent,
+            'uk'
+          )
+        }
+      />
+      <button data-testid="trigger-publish" onClick={() => props.onAction(MenuActionId.PUBLISH)} />
+      <button data-testid="trigger-save-exit" onClick={() => props.onAction(MenuActionId.SAVE_AND_EXIT)} />
+      <button data-testid="trigger-delete" onClick={() => props.onAction(MenuActionId.DELETE_DRAFT)} />
+      <button data-testid="trigger-seo" onClick={props.onSeoClick} />
+    </div>
+  )
+}));
+
+describe('EditPublicationsPage Container', () => {
+  const mockPush = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useParams as jest.Mock).mockReturnValue({ type: 'news', id: '123' });
+    (useRouter as jest.Mock).mockReturnValue({ push: mockPush });
+    (usePublicationManager as jest.Mock).mockReturnValue(baseMockManager);
+  });
+
+  it('should call notFound if loading is finished but data is null', () => {
+    (usePublicationManager as jest.Mock).mockReturnValue({
+      ...baseMockManager,
+      isLoading: false,
+      currentData: null,
+      hasError: false
+    });
+
+    render(<EditPublicationsPage />);
+    expect(notFound).toHaveBeenCalledTimes(1);
+  });
+
+  it('should redirect to SEO page when onSeoClick is triggered', () => {
+    render(<EditPublicationsPage />);
+
+    fireEvent.click(screen.getByTestId('trigger-seo'));
+
+    expect(mockPush).toHaveBeenCalledWith('/publications/news/123/seo');
+  });
+
+  it('should debounce editor changes and update state after 500ms', () => {
+    jest.useFakeTimers();
+    render(<EditPublicationsPage />);
+
+    fireEvent.click(screen.getByTestId('trigger-editor-change'));
+
+    expect(baseMockManager.setEditedContent).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(baseMockManager.setEditedContent).toHaveBeenCalledTimes(1);
+
+    const stateUpdater = baseMockManager.setEditedContent.mock.calls[0][0] as (
+      prev: LocalizedEditorState | null
+    ) => LocalizedEditorState | null;
+    const prevState = baseMockManager.editedContent;
+    const newState = stateUpdater(prevState);
+
+    expect(newState?.uk?.content.blocks[0].content).toBe('new');
+
+    jest.useRealTimers();
+  });
+
+  it('should handle PUBLISH action correctly', async () => {
+    render(<EditPublicationsPage />);
+
+    fireEvent.click(screen.getByTestId('trigger-publish'));
+
+    await waitFor(() => {
+      expect(baseMockManager.updateResource).toHaveBeenCalledWith(BaseContentStatuses.Published, {
+        content: baseMockManager.editedContent
+      });
+      expect(toast.success).toHaveBeenCalledWith(CONTENT_MUTATION_RESULTS.draftPublished);
+    });
+  });
+
+  it('should handle SAVE_AND_EXIT action and redirect router', async () => {
+    render(<EditPublicationsPage />);
+
+    fireEvent.click(screen.getByTestId('trigger-save-exit'));
+
+    await waitFor(() => {
+      expect(baseMockManager.updateResource).toHaveBeenCalledWith(BaseContentStatuses.Draft, {
+        content: baseMockManager.editedContent
+      });
+      expect(toast.success).toHaveBeenCalledWith(CONTENT_MUTATION_RESULTS.draftSaved);
+      expect(mockPush).toHaveBeenCalledWith('/publications');
+    });
+  });
+
+  it('should handle DELETE_DRAFT action correctly for the active language', async () => {
+    (usePublicationManager as jest.Mock).mockReturnValue({
+      ...baseMockManager,
+      currentLanguage: 'UA',
+      currentData: { status: BaseContentStatuses.Editing }
+    });
+
+    render(<EditPublicationsPage />);
+
+    fireEvent.click(screen.getByTestId('trigger-delete'));
+
+    await waitFor(() => {
+      expect(baseMockManager.updateResource).toHaveBeenCalledWith(
+        BaseContentStatuses.Editing,
+        expect.objectContaining({
+          content: expect.objectContaining({
+            uk: expect.objectContaining({
+              content: expect.objectContaining({ blocks: [] })
+            })
+          })
+        })
+      );
+
+      expect(toast.success).toHaveBeenCalledWith(CONTENT_MUTATION_RESULTS.draftDeleted);
+
+      expect(baseMockManager.resetEditorState).toHaveBeenCalled();
+    });
+  });
+
+  it('should catch mutation errors and trigger a toast.error', async () => {
+    const errorMessage = 'Network Failure';
+    (usePublicationManager as jest.Mock).mockReturnValue({
+      ...baseMockManager,
+      updateResource: jest.fn().mockRejectedValue(new Error(errorMessage))
+    });
+
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(<EditPublicationsPage />);
+
+    fireEvent.click(screen.getByTestId('trigger-publish'));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(`Помилка: ${errorMessage}`);
+      expect(consoleSpy).toHaveBeenCalled();
+    });
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/app/(logged_in)/publications/[type]/[id]/edit/page.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/edit/page.tsx
@@ -13,6 +13,7 @@ import {
   DEFAULT_EMPTY_DOCUMENT,
   EditorLanguage,
   HEADER_MENU_OPTIONS,
+  LANGUAGE_OPTIONS,
   LocalizedEditorState,
   MenuActionId,
   PUBLICATION_EDIT_ERROR_STATE,
@@ -21,20 +22,15 @@ import {
   PublicationsChipLabels,
   PublicationsItemType
 } from '~/constants/publications';
-import { ContentEditor, SerializedContent } from '~/shared/components/content-editor';
+import { ContentEditor, isContentEmpty, SerializedContent } from '~/shared/components/content-editor';
 import DividedHeader from '~/shared/components/divided-header/DividedHeader';
 import HeaderRightActions from '~/shared/components/divided-header/header-right-actions/HeaderRightActions';
-import ProgressStatus from '~/shared/components/divided-header/progress-status/ProgressStatus';
 import { TitleDropdown } from '~/shared/components/divided-header/title-dropdown/TitleDropdown';
-import { useDeleteEvent, useEventById, useUpdateEvent } from '~/shared/hooks/use-events/useEvents';
-import {
-  useDeleteMediaMention,
-  useMediaMentionById,
-  useUpdateMediaMention
-} from '~/shared/hooks/use-media-mentions/useMediaMentions';
-import { useDeleteNews, useNewsById, useUpdateNews } from '~/shared/hooks/use-news/useNews';
+import { useEventById, useUpdateEvent } from '~/shared/hooks/use-events/useEvents';
+import { useMediaMentionById, useUpdateMediaMention } from '~/shared/hooks/use-media-mentions/useMediaMentions';
+import { useNewsById, useUpdateNews } from '~/shared/hooks/use-news/useNews';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
-import { EventStatus, MediaStatus, NewsStatus } from '~/types/graphql/generated/graphql';
+import { type EventStatus, type MediaStatus, type NewsStatus } from '~/types/graphql/generated/graphql';
 
 type Params = {
   type: PublicationsItemType;
@@ -52,26 +48,15 @@ export default function EditPublicationsPage() {
   const event = useEventById(id, { skip: type !== 'events' });
   const media = useMediaMentionById(id, { skip: type !== 'media' });
 
-  const activeQuery = type === 'news' ? news : type === 'events' ? event : media;
+  const queryMap = {
+    news,
+    events: event,
+    media
+  };
+
+  const activeQuery = queryMap[type];
   const isLoading = activeQuery.loading;
   const hasError = activeQuery.error;
-
-  const [updateNews] = useUpdateNews();
-  const [updateEvent] = useUpdateEvent();
-  const [updateMedia] = useUpdateMediaMention();
-
-  const [deleteNews] = useDeleteNews();
-  const [deleteEvent] = useDeleteEvent();
-  const [deleteMedia] = useDeleteMediaMention();
-
-  const [anchors, setAnchors] = useState<MenuAnchor>({});
-  const [currentLanguage, setCurrentLanguage] = useState<EditorLanguage>('UA');
-  const [editedContent, setEditedContent] = useState<LocalizedEditorState | null>(null);
-
-  const latestBlocksRef = useRef<SerializedContent>(null);
-  const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
-
-  const localeKey = currentLanguage === 'UA' ? 'uk' : 'en';
 
   const currentData = useMemo(() => {
     switch (type) {
@@ -84,32 +69,43 @@ export default function EditPublicationsPage() {
     }
   }, [news.data, event.data, media.data]);
 
-  useEffect(() => {
-    const currentResourceData =
-      type === 'news' ? news.data?.newsById : type === 'events' ? event.data?.eventById : null;
+  const [updateNews] = useUpdateNews();
+  const [updateEvent] = useUpdateEvent();
+  const [updateMedia] = useUpdateMediaMention();
 
-    if (isLoading || activeQuery.data === undefined) return;
+  const [anchors, setAnchors] = useState<MenuAnchor>({});
+  const [currentLanguage, setCurrentLanguage] = useState<EditorLanguage>('UA');
+  const [editedContent, setEditedContent] = useState<LocalizedEditorState | null>(null);
+
+  const latestBlocksRef = useRef<SerializedContent>(null);
+  const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
+
+  const localeKey = currentLanguage === 'UA' ? 'uk' : 'en';
+
+  useEffect(() => {
+    if (type === 'media' || isLoading || activeQuery.data === undefined) return;
 
     if (editedContent === null) {
-      const getSafeBlocks = (langData: Record<'blocks', Block[] | undefined>): Block[] => {
-        const arr = langData?.blocks;
-        return Array.isArray(arr) && arr.length > 0 ? arr : DEFAULT_EMPTY_DOCUMENT.blocks;
-      };
+      const resourceData = type === 'news' ? news.data?.newsById?.content : event.data?.eventById?.content;
 
-      setEditedContent({
-        uk: {
-          blocks: getSafeBlocks(currentResourceData?.content?.uk),
-          version: DEFAULT_EMPTY_DOCUMENT.version,
-          lastModified: new Date().toISOString()
-        },
-        en: {
-          blocks: getSafeBlocks(currentResourceData?.content?.en),
-          version: DEFAULT_EMPTY_DOCUMENT.version,
-          lastModified: new Date().toISOString()
+      const hasUk = !isContentEmpty(resourceData?.uk?.content?.blocks);
+      const hasEn = !isContentEmpty(resourceData?.en?.content?.blocks);
+
+      setCurrentLanguage(!hasUk && hasEn ? 'EN' : 'UA');
+
+      const createSafeLangObj = (blocks: Block[] | undefined) => ({
+        content: {
+          ...DEFAULT_EMPTY_DOCUMENT,
+          blocks: !isContentEmpty(blocks) && blocks ? blocks : DEFAULT_EMPTY_DOCUMENT.blocks
         }
       });
+
+      setEditedContent({
+        uk: createSafeLangObj(resourceData?.uk?.content?.blocks),
+        en: createSafeLangObj(resourceData?.en?.content?.blocks)
+      });
     }
-  }, [isLoading, editedContent]);
+  }, [isLoading, editedContent, type, activeQuery.data, news.data, event.data]);
 
   useEffect(() => {
     return () => {
@@ -121,30 +117,16 @@ export default function EditPublicationsPage() {
 
   if (isNotFound) notFound();
 
-  const status = {
-    isReady: !hasError && !isLoading,
-    errorMessage: hasError ? PUBLICATION_EDIT_ERROR_STATE : null
-  };
-
   useEffect(() => {
-    if (status.errorMessage) toast.error(status.errorMessage);
-  }, [status.errorMessage]);
+    if (hasError && !isLoading) toast.error(PUBLICATION_EDIT_ERROR_STATE);
+  }, [hasError, isLoading]);
 
   const handleEditorChange = (content: SerializedContent) => {
     latestBlocksRef.current = content;
-
     if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
 
     debounceTimerRef.current = setTimeout(() => {
-      if (latestBlocksRef.current?.blocks) {
-        setEditedContent((prev) => {
-          if (!prev) return prev;
-          return {
-            ...prev,
-            [localeKey]: latestBlocksRef.current
-          };
-        });
-      }
+      setEditedContent((prev) => (prev ? { ...prev, [localeKey]: { content: latestBlocksRef.current } } : prev));
     }, 500);
   };
 
@@ -153,18 +135,14 @@ export default function EditPublicationsPage() {
 
     const resourceMap: Record<string, PublicationResource> = {
       news: {
-        update: (status, extra = {}) =>
-          updateNews({ id, input: { ...extra, status: status as unknown as NewsStatus } }),
-        remove: () => deleteNews({ id })
+        update: (status, extra = {}) => updateNews({ id, input: { ...extra, status: status as unknown as NewsStatus } })
       },
       events: {
         update: (status, extra = {}) =>
-          updateEvent({ id, input: { ...extra, status: status as unknown as EventStatus } }),
-        remove: () => deleteEvent({ id })
+          updateEvent({ id, input: { ...extra, status: status as unknown as EventStatus } })
       },
       media: {
-        update: (status, extra = {}) => updateMedia(id, { ...extra, status: status as unknown as MediaStatus }),
-        remove: () => deleteMedia(id)
+        update: (status, extra = {}) => updateMedia(id, { ...extra, status: status as unknown as MediaStatus })
       }
     };
 
@@ -187,11 +165,19 @@ export default function EditPublicationsPage() {
         }
       },
       [MenuActionId.DELETE_DRAFT]: async () => {
-        const { data } = await currentResource.remove();
-        if (data) {
-          toast.success(CONTENT_MUTATION_RESULTS.draftDeleted);
-          router.push(PUBLICATIONS_BASE_PATH);
-        }
+        const emptyContent = {
+          content: {
+            ...editedContent,
+            [localeKey]: {
+              content: { ...DEFAULT_EMPTY_DOCUMENT }
+            }
+          }
+        };
+        const { data } = await currentResource.update(
+          (currentData?.status as unknown as BaseContentStatuses) ?? BaseContentStatuses.Draft,
+          emptyContent
+        );
+        if (data) toast.success(CONTENT_MUTATION_RESULTS.draftDeleted);
       }
     };
 
@@ -209,10 +195,13 @@ export default function EditPublicationsPage() {
     setAnchors((prev) => ({ ...prev, [id]: event.currentTarget as HTMLButtonElement }));
   const handleClose = (id: AnchorId) => setAnchors((prev) => ({ ...prev, [id]: undefined }));
 
-  const baseActions = HEADER_MENU_OPTIONS.baseActions as ACTIONS_TYPE[];
-  const publishActions = [...baseActions].filter((action) => action.id !== MenuActionId.PUBLISH);
-
   if (isLoading || editedContent === null) return <Box sx={{ p: 4 }}>Завантаження...</Box>;
+
+  const initialBlocks = editedContent[localeKey]?.content?.blocks;
+  const isContentValid = Array.isArray(initialBlocks) && initialBlocks.length;
+  const publishActions = (HEADER_MENU_OPTIONS.baseActions as ACTIONS_TYPE[]).filter(
+    (a) => a.id !== MenuActionId.PUBLISH
+  );
 
   return (
     <Box sx={styles.container}>
@@ -239,13 +228,12 @@ export default function EditPublicationsPage() {
         )}
         <Chip sx={styles.chip(type)} label={PublicationsChipLabels[type]} />
         <Chip sx={styles.chip('draft')} label="Чернетка" />
-        {type !== 'media' && <ProgressStatus isSaved={false} />}
       </DividedHeader>
 
       <Box sx={styles.mainContent}>
         {type !== 'media' && (
           <ContentEditor
-            initialContent={editedContent[localeKey]?.blocks?.length ? editedContent[localeKey].blocks : undefined}
+            initialContent={isContentValid ? initialBlocks : undefined}
             key={currentLanguage}
             persistence={{
               onChange: handleEditorChange
@@ -270,35 +258,28 @@ export default function EditPublicationsPage() {
           <Typography variant="customMedium14Tight">Мовні версії</Typography>
         </ListSubheader>
 
-        <MenuItem
-          onClick={() => {
-            setCurrentLanguage('UA');
-            handleClose('navigation');
-          }}
-          sx={styles.menuItem}
-        >
-          <Typography variant="customMedium16">Українська</Typography>
-          {Array.isArray(editedContent?.uk?.blocks) && editedContent.uk.blocks.length > 1 && (
-            <Typography variant="customItalic14" sx={styles.draftCaption}>
-              (чернетка)
-            </Typography>
-          )}
-        </MenuItem>
+        {LANGUAGE_OPTIONS.map(({ locale, key, label }) => {
+          const blocks = editedContent?.[key]?.content?.blocks;
+          const isDraft = !isContentEmpty(blocks);
 
-        <MenuItem
-          onClick={() => {
-            setCurrentLanguage('EN');
-            handleClose('navigation');
-          }}
-          sx={styles.menuItem}
-        >
-          <Typography variant="customMedium16">Англійська</Typography>
-          {Array.isArray(editedContent?.en?.blocks) && editedContent.en.blocks.length > 1 && (
-            <Typography variant="customItalic14" sx={styles.draftCaption}>
-              (чернетка)
-            </Typography>
-          )}
-        </MenuItem>
+          return (
+            <MenuItem
+              key={key}
+              onClick={() => {
+                setCurrentLanguage(locale);
+                handleClose('navigation');
+              }}
+              sx={styles.menuItem}
+            >
+              <Typography variant="customMedium16">{label}</Typography>
+              {isDraft && (
+                <Typography variant="customItalic14" sx={styles.draftCaption}>
+                  (чернетка)
+                </Typography>
+              )}
+            </MenuItem>
+          );
+        })}
 
         <Divider sx={{ my: '7px' }} />
         <MenuItem onClick={() => handleClose('navigation')} sx={styles.menuItem}>
@@ -317,7 +298,7 @@ export default function EditPublicationsPage() {
         sx={styles.menu}
       >
         {publishActions.map((action) => (
-          <MenuItem sx={styles.menuItem} key={action.id} onClick={() => handleMenuAction(action.id as MenuActionId)}>
+          <MenuItem sx={styles.menuItem} key={action.id} onClick={() => handleMenuAction(action.id)}>
             <Typography variant="customMedium16">{action.label}</Typography>
           </MenuItem>
         ))}

--- a/app/(logged_in)/publications/[type]/[id]/edit/page.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/edit/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { Block } from '@blocknote/core';
-import { Box, Chip, Divider, ListSubheader,Menu, MenuItem, Typography } from '@mui/material';
+import { Box, Chip, Divider, ListSubheader, Menu, MenuItem, Typography } from '@mui/material';
 import { useParams, useRouter } from 'next/navigation';
-import { MouseEvent, useEffect, useMemo,useState } from 'react';
+import { MouseEvent, useEffect, useMemo, useState } from 'react';
 import toast from 'react-hot-toast';
 
 import { styles } from './page.styles';
@@ -34,6 +34,8 @@ type Params = {
   type: PublicationsItemType;
   id: string;
 };
+
+const DEFAULT_EMPTY_DOCUMENT: Block[] = [{ type: 'paragraph', content: [] } as unknown as Block];
 
 export type LocalizedEditorState = {
   en?: {
@@ -87,8 +89,6 @@ export default function EditPublicationsPage() {
   const [currentLanguage, setCurrentLanguage] = useState<EditorLanguage>('UA');
 
   const localeKey = currentLanguage === 'UA' ? 'uk' : 'en';
-
-  const DEFAULT_EMPTY_DOCUMENT: Block[] = [{ type: 'paragraph', content: [] } as unknown as Block];
 
   useEffect(() => {
     const currentResourceData =
@@ -176,6 +176,10 @@ export default function EditPublicationsPage() {
   const baseActions = HEADER_MENU_OPTIONS.baseActions as ACTIONS_TYPE[];
   const publishActions = [...baseActions].filter((action) => action.id !== MenuActionId.PUBLISH);
 
+  const currentBlocks = editedContent?.[localeKey]?.blocks;
+
+  const initialBlocksForEditor = currentBlocks && currentBlocks.length > 0 ? currentBlocks : undefined;
+
   const renderChips = (
     <>
       <Chip sx={styles.chip(type)} label={PublicationsChipLabels[type]} />
@@ -225,9 +229,13 @@ export default function EditPublicationsPage() {
         sx={styles.menuItem}
       >
         <Typography variant="customMedium16">Українська</Typography>
-        <Typography variant="customItalic14" sx={styles.draftCaption}>
-          (чернетка)
-        </Typography>
+        {Array.isArray(editedContent?.uk?.blocks) && editedContent.uk.blocks.length > 1 && (
+          <>
+            <Typography variant="customItalic14" sx={styles.draftCaption}>
+              (чернетка)
+            </Typography>
+          </>
+        )}
       </MenuItem>
 
       <MenuItem
@@ -238,6 +246,14 @@ export default function EditPublicationsPage() {
         sx={styles.menuItem}
       >
         <Typography variant="customMedium16">Англійська</Typography>
+
+        {Array.isArray(editedContent?.en?.blocks) && editedContent.en.blocks.length > 1 && (
+          <>
+            <Typography variant="customItalic14" sx={styles.draftCaption}>
+              (чернетка)
+            </Typography>
+          </>
+        )}
       </MenuItem>
 
       <Divider sx={{ my: '7px' }} />
@@ -265,10 +281,6 @@ export default function EditPublicationsPage() {
       ))}
     </Menu>
   );
-
-  const currentBlocks = editedContent?.[localeKey]?.blocks;
-
-  const initialBlocksForEditor = currentBlocks && currentBlocks.length > 0 ? currentBlocks : undefined;
 
   if (isLoading) return <Box sx={{ p: 4 }}>Завантаження...</Box>;
 

--- a/app/(logged_in)/publications/[type]/[id]/edit/page.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/edit/page.tsx
@@ -2,20 +2,26 @@
 
 import { Block } from '@blocknote/core';
 import { Box, Chip, Divider, ListSubheader, Menu, MenuItem, Typography } from '@mui/material';
-import { useParams, useRouter } from 'next/navigation';
-import { MouseEvent, useEffect, useMemo, useState } from 'react';
+import { notFound, useParams, useRouter } from 'next/navigation';
+import { MouseEvent, useEffect, useMemo, useRef, useState } from 'react';
 import toast from 'react-hot-toast';
 
 import { styles } from './page.styles';
 import {
   ACTIONS_TYPE,
+  CONTENT_MUTATION_RESULTS,
+  DEFAULT_EMPTY_DOCUMENT,
+  EditorLanguage,
   HEADER_MENU_OPTIONS,
+  LocalizedEditorState,
   MenuActionId,
+  PUBLICATION_EDIT_ERROR_STATE,
+  PublicationResource,
   PUBLICATIONS_BASE_PATH,
   PublicationsChipLabels,
   PublicationsItemType
 } from '~/constants/publications';
-import { ContentEditor } from '~/shared/components/content-editor';
+import { ContentEditor, SerializedContent } from '~/shared/components/content-editor';
 import DividedHeader from '~/shared/components/divided-header/DividedHeader';
 import HeaderRightActions from '~/shared/components/divided-header/header-right-actions/HeaderRightActions';
 import ProgressStatus from '~/shared/components/divided-header/progress-status/ProgressStatus';
@@ -35,25 +41,6 @@ type Params = {
   id: string;
 };
 
-const DEFAULT_EMPTY_DOCUMENT: Block[] = [{ type: 'paragraph', content: [] } as unknown as Block];
-
-export type LocalizedEditorState = {
-  en?: {
-    blocks: Block[] | null | undefined;
-  };
-  uk?: {
-    blocks: Block[] | null | undefined;
-  };
-  __typename?: string;
-};
-
-type EditorLanguage = 'EN' | 'UA';
-
-type PublicationResource = {
-  update: (status: BaseContentStatuses, extra?: Record<string, unknown>) => Promise<unknown>;
-  remove: () => Promise<unknown>;
-};
-
 type AnchorId = 'navigation' | 'publish';
 type MenuAnchor = Partial<Record<AnchorId, HTMLButtonElement>>;
 
@@ -65,16 +52,9 @@ export default function EditPublicationsPage() {
   const event = useEventById(id, { skip: type !== 'events' });
   const media = useMediaMentionById(id, { skip: type !== 'media' });
 
-  const currentData = useMemo(() => {
-    switch (type) {
-    case 'news':
-      return news.data?.newsById;
-    case 'events':
-      return event.data?.eventById;
-    case 'media':
-      return media.data?.mediaMentionById;
-    }
-  }, [type, news, event, media]);
+  const activeQuery = type === 'news' ? news : type === 'events' ? event : media;
+  const isLoading = activeQuery.loading;
+  const hasError = activeQuery.error;
 
   const [updateNews] = useUpdateNews();
   const [updateEvent] = useUpdateEvent();
@@ -85,44 +65,91 @@ export default function EditPublicationsPage() {
   const [deleteMedia] = useDeleteMediaMention();
 
   const [anchors, setAnchors] = useState<MenuAnchor>({});
-  const [editedContent, setEditedContent] = useState<LocalizedEditorState | null>(null);
   const [currentLanguage, setCurrentLanguage] = useState<EditorLanguage>('UA');
+  const [editedContent, setEditedContent] = useState<LocalizedEditorState | null>(null);
+
+  const latestBlocksRef = useRef<SerializedContent>(null);
+  const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   const localeKey = currentLanguage === 'UA' ? 'uk' : 'en';
+
+  const currentData = useMemo(() => {
+    switch (type) {
+    case 'news':
+      return news.data?.newsById;
+    case 'events':
+      return event.data?.eventById;
+    case 'media':
+      return media.data?.mediaMentionById;
+    }
+  }, [news.data, event.data, media.data]);
 
   useEffect(() => {
     const currentResourceData =
       type === 'news' ? news.data?.newsById : type === 'events' ? event.data?.eventById : null;
 
-    if (editedContent === null && currentResourceData?.content) {
+    if (isLoading || activeQuery.data === undefined) return;
+
+    if (editedContent === null) {
       const getSafeBlocks = (langData: Record<'blocks', Block[] | undefined>): Block[] => {
         const arr = langData?.blocks;
-        return Array.isArray(arr) && arr.length > 0 ? arr : DEFAULT_EMPTY_DOCUMENT;
+        return Array.isArray(arr) && arr.length > 0 ? arr : DEFAULT_EMPTY_DOCUMENT.blocks;
       };
 
       setEditedContent({
-        uk: { blocks: getSafeBlocks(currentResourceData?.content?.uk) },
-        en: { blocks: getSafeBlocks(currentResourceData?.content?.en) }
+        uk: {
+          blocks: getSafeBlocks(currentResourceData?.content?.uk),
+          version: DEFAULT_EMPTY_DOCUMENT.version,
+          lastModified: new Date().toISOString()
+        },
+        en: {
+          blocks: getSafeBlocks(currentResourceData?.content?.en),
+          version: DEFAULT_EMPTY_DOCUMENT.version,
+          lastModified: new Date().toISOString()
+        }
       });
     }
-  }, [event.data, currentLanguage]);
+  }, [isLoading, editedContent]);
 
-  const isLoading = event.loading || news.loading || media.loading;
-  const hasError = event.error || news.error || media.error;
+  useEffect(() => {
+    return () => {
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+    };
+  }, []);
+
+  const isNotFound = !isLoading && activeQuery.data !== undefined && currentData === null;
+
+  if (isNotFound) notFound();
 
   const status = {
     isReady: !hasError && !isLoading,
-    errorMessage: hasError ? 'Помилка серверу' : null
+    errorMessage: hasError ? PUBLICATION_EDIT_ERROR_STATE : null
   };
 
   useEffect(() => {
     if (status.errorMessage) toast.error(status.errorMessage);
   }, [status.errorMessage]);
 
+  const handleEditorChange = (content: SerializedContent) => {
+    latestBlocksRef.current = content;
+
+    if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+
+    debounceTimerRef.current = setTimeout(() => {
+      if (latestBlocksRef.current?.blocks) {
+        setEditedContent((prev) => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            [localeKey]: latestBlocksRef.current
+          };
+        });
+      }
+    }, 500);
+  };
+
   const handleMenuAction = async (actionId: MenuActionId) => {
-    const contentPayload = {
-      content: editedContent
-    };
+    const contentPayload = { content: editedContent };
 
     const resourceMap: Record<string, PublicationResource> = {
       news: {
@@ -144,19 +171,32 @@ export default function EditPublicationsPage() {
     const currentResource = resourceMap[type as keyof typeof resourceMap];
 
     const actions: Record<MenuActionId | string, () => Promise<unknown> | void> = {
-      [MenuActionId.PUBLISH]: () => currentResource.update(BaseContentStatuses.Published, contentPayload),
-      [MenuActionId.SAVE_DRAFT]: () => currentResource.update(BaseContentStatuses.Draft, contentPayload),
-      [MenuActionId.SAVE_AND_EXIT]: async () => {
-        await currentResource.update(BaseContentStatuses.Draft, contentPayload);
-        router.push(PUBLICATIONS_BASE_PATH);
+      [MenuActionId.PUBLISH]: async () => {
+        const { data } = await currentResource.update(BaseContentStatuses.Published, contentPayload);
+        if (data) toast.success(CONTENT_MUTATION_RESULTS.draftPublished);
       },
-      [MenuActionId.DELETE_DRAFT]: () => currentResource.remove()
+      [MenuActionId.SAVE_DRAFT]: async () => {
+        const { data } = await currentResource.update(BaseContentStatuses.Draft, contentPayload);
+        if (data) toast.success(CONTENT_MUTATION_RESULTS.draftSaved);
+      },
+      [MenuActionId.SAVE_AND_EXIT]: async () => {
+        const { data } = await currentResource.update(BaseContentStatuses.Draft, contentPayload);
+        if (data) {
+          toast.success(CONTENT_MUTATION_RESULTS.draftSaved);
+          router.push(PUBLICATIONS_BASE_PATH);
+        }
+      },
+      [MenuActionId.DELETE_DRAFT]: async () => {
+        const { data } = await currentResource.remove();
+        if (data) {
+          toast.success(CONTENT_MUTATION_RESULTS.draftDeleted);
+          router.push(PUBLICATIONS_BASE_PATH);
+        }
+      }
     };
 
     try {
-      if (actions[actionId]) {
-        await actions[actionId]();
-      }
+      if (actions[actionId]) await actions[actionId]();
     } catch (err) {
       toast.error(`Помилка ${err}`);
       console.error(`Action ${actionId} failed`, err);
@@ -165,131 +205,20 @@ export default function EditPublicationsPage() {
     handleClose('publish');
   };
 
-  const handleOpen = (event: MouseEvent<HTMLElement>, id: AnchorId) => {
+  const handleOpen = (event: MouseEvent<HTMLElement>, id: AnchorId) =>
     setAnchors((prev) => ({ ...prev, [id]: event.currentTarget as HTMLButtonElement }));
-  };
-
-  const handleClose = (id: AnchorId) => {
-    setAnchors((prev) => ({ ...prev, [id]: undefined }));
-  };
+  const handleClose = (id: AnchorId) => setAnchors((prev) => ({ ...prev, [id]: undefined }));
 
   const baseActions = HEADER_MENU_OPTIONS.baseActions as ACTIONS_TYPE[];
   const publishActions = [...baseActions].filter((action) => action.id !== MenuActionId.PUBLISH);
 
-  const currentBlocks = editedContent?.[localeKey]?.blocks;
-
-  const initialBlocksForEditor = currentBlocks && currentBlocks.length > 0 ? currentBlocks : undefined;
-
-  const renderChips = (
-    <>
-      <Chip sx={styles.chip(type)} label={PublicationsChipLabels[type]} />
-      <Chip sx={styles.chip('draft')} label="Чернетка" />
-    </>
-  );
-
-  const renderHeaderChild = (
-    <>
-      {type === 'media' ? (
-        <Typography variant="customBold20Tight">Редагування Ми у ЗМІ</Typography>
-      ) : (
-        <TitleDropdown
-          type="multilingual"
-          language={currentLanguage}
-          title={currentData?.adminTitle ?? ''}
-          onMenuOpen={(e) => handleOpen(e, 'navigation')}
-        />
-      )}
-      {renderChips}
-      {type !== 'media' && <ProgressStatus isSaved={false} />}
-    </>
-  );
-
-  const renderNavigationMenu = (
-    <Menu
-      anchorEl={anchors['navigation']}
-      open={Boolean(anchors['navigation'])}
-      onClose={() => handleClose('navigation')}
-      disableScrollLock
-      anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-      transformOrigin={{ vertical: 'top', horizontal: 'left' }}
-      slotProps={{
-        paper: { sx: { width: 205 } }
-      }}
-      sx={styles.menu}
-    >
-      <ListSubheader sx={styles.menuSubheader}>
-        <Typography variant="customMedium14Tight">Мовні версії</Typography>
-      </ListSubheader>
-
-      <MenuItem
-        onClick={() => {
-          setCurrentLanguage('UA');
-          handleClose('navigation');
-        }}
-        sx={styles.menuItem}
-      >
-        <Typography variant="customMedium16">Українська</Typography>
-        {Array.isArray(editedContent?.uk?.blocks) && editedContent.uk.blocks.length > 1 && (
-          <>
-            <Typography variant="customItalic14" sx={styles.draftCaption}>
-              (чернетка)
-            </Typography>
-          </>
-        )}
-      </MenuItem>
-
-      <MenuItem
-        onClick={() => {
-          setCurrentLanguage('EN');
-          handleClose('navigation');
-        }}
-        sx={styles.menuItem}
-      >
-        <Typography variant="customMedium16">Англійська</Typography>
-
-        {Array.isArray(editedContent?.en?.blocks) && editedContent.en.blocks.length > 1 && (
-          <>
-            <Typography variant="customItalic14" sx={styles.draftCaption}>
-              (чернетка)
-            </Typography>
-          </>
-        )}
-      </MenuItem>
-
-      <Divider sx={{ my: '7px' }} />
-      <MenuItem onClick={() => handleClose('navigation')} sx={styles.menuItem}>
-        <Typography variant="customMedium16">SEO налаштування</Typography>
-      </MenuItem>
-    </Menu>
-  );
-
-  const renderPublishMenu = (
-    <Menu
-      anchorEl={anchors['publish']}
-      open={Boolean(anchors['publish'])}
-      onClose={() => handleClose('publish')}
-      disableScrollLock
-      anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-      transformOrigin={{ vertical: 'top', horizontal: 'right' }}
-      slotProps={{ paper: { sx: { width: 260 } } }}
-      sx={styles.menu}
-    >
-      {publishActions.map((action) => (
-        <MenuItem sx={styles.menuItem} key={action.id} onClick={() => handleMenuAction(action.id as MenuActionId)}>
-          <Typography variant="customMedium16">{action.label}</Typography>
-        </MenuItem>
-      ))}
-    </Menu>
-  );
-
-  if (isLoading) return <Box sx={{ p: 4 }}>Завантаження...</Box>;
-
-  console.log(editedContent?.[localeKey]?.blocks);
+  if (isLoading || editedContent === null) return <Box sx={{ p: 4 }}>Завантаження...</Box>;
 
   return (
     <Box sx={styles.container}>
       <DividedHeader
         sx={styles.header}
+        originUrl={PUBLICATIONS_BASE_PATH}
         rightActionsComponent={
           <HeaderRightActions
             mode={type === 'media' ? 'seo' : 'edit'}
@@ -298,30 +227,101 @@ export default function EditPublicationsPage() {
           />
         }
       >
-        {renderHeaderChild}
+        {type === 'media' ? (
+          <Typography variant="customBold20Tight">Редагування Ми у ЗМІ</Typography>
+        ) : (
+          <TitleDropdown
+            type="multilingual"
+            language={currentLanguage}
+            title={currentData?.adminTitle ?? ''}
+            onMenuOpen={(e) => handleOpen(e, 'navigation')}
+          />
+        )}
+        <Chip sx={styles.chip(type)} label={PublicationsChipLabels[type]} />
+        <Chip sx={styles.chip('draft')} label="Чернетка" />
+        {type !== 'media' && <ProgressStatus isSaved={false} />}
       </DividedHeader>
 
       <Box sx={styles.mainContent}>
-        {type !== 'media' && editedContent && (
+        {type !== 'media' && (
           <ContentEditor
-            persistence={{
-              onChange: (newBlocks) => {
-                setEditedContent((prev) => ({
-                  ...prev,
-                  [localeKey]: newBlocks
-                }));
-              }
-            }}
-            initialContent={initialBlocksForEditor}
+            initialContent={editedContent[localeKey]?.blocks?.length ? editedContent[localeKey].blocks : undefined}
             key={currentLanguage}
+            persistence={{
+              onChange: handleEditorChange
+            }}
             sx={styles.contentEditor}
             editorConfig={{ sideMenu: true }}
           />
         )}
       </Box>
 
-      {renderNavigationMenu}
-      {renderPublishMenu}
+      <Menu
+        anchorEl={anchors['navigation']}
+        open={Boolean(anchors['navigation'])}
+        onClose={() => handleClose('navigation')}
+        disableScrollLock
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+        slotProps={{ paper: { sx: { width: 205 } } }}
+        sx={styles.menu}
+      >
+        <ListSubheader sx={styles.menuSubheader}>
+          <Typography variant="customMedium14Tight">Мовні версії</Typography>
+        </ListSubheader>
+
+        <MenuItem
+          onClick={() => {
+            setCurrentLanguage('UA');
+            handleClose('navigation');
+          }}
+          sx={styles.menuItem}
+        >
+          <Typography variant="customMedium16">Українська</Typography>
+          {Array.isArray(editedContent?.uk?.blocks) && editedContent.uk.blocks.length > 1 && (
+            <Typography variant="customItalic14" sx={styles.draftCaption}>
+              (чернетка)
+            </Typography>
+          )}
+        </MenuItem>
+
+        <MenuItem
+          onClick={() => {
+            setCurrentLanguage('EN');
+            handleClose('navigation');
+          }}
+          sx={styles.menuItem}
+        >
+          <Typography variant="customMedium16">Англійська</Typography>
+          {Array.isArray(editedContent?.en?.blocks) && editedContent.en.blocks.length > 1 && (
+            <Typography variant="customItalic14" sx={styles.draftCaption}>
+              (чернетка)
+            </Typography>
+          )}
+        </MenuItem>
+
+        <Divider sx={{ my: '7px' }} />
+        <MenuItem onClick={() => handleClose('navigation')} sx={styles.menuItem}>
+          <Typography variant="customMedium16">SEO налаштування</Typography>
+        </MenuItem>
+      </Menu>
+
+      <Menu
+        anchorEl={anchors['publish']}
+        open={Boolean(anchors['publish'])}
+        onClose={() => handleClose('publish')}
+        disableScrollLock
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        slotProps={{ paper: { sx: { width: 260 } } }}
+        sx={styles.menu}
+      >
+        {publishActions.map((action) => (
+          <MenuItem sx={styles.menuItem} key={action.id} onClick={() => handleMenuAction(action.id as MenuActionId)}>
+            <Typography variant="customMedium16">{action.label}</Typography>
+          </MenuItem>
+        ))}
+      </Menu>
     </Box>
   );
 }

--- a/app/(logged_in)/publications/[type]/[id]/edit/page.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/edit/page.tsx
@@ -76,6 +76,7 @@ export default function EditPublicationsPage() {
   const [anchors, setAnchors] = useState<MenuAnchor>({});
   const [currentLanguage, setCurrentLanguage] = useState<EditorLanguage>('UA');
   const [editedContent, setEditedContent] = useState<LocalizedEditorState | null>(null);
+  const [editorResetKey, setEditorResetKey] = useState<number>(0);
 
   const latestBlocksRef = useRef<SerializedContent>(null);
   const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
@@ -177,7 +178,12 @@ export default function EditPublicationsPage() {
           (currentData?.status as unknown as BaseContentStatuses) ?? BaseContentStatuses.Draft,
           emptyContent
         );
-        if (data) toast.success(CONTENT_MUTATION_RESULTS.draftDeleted);
+        if (data) {
+          toast.success(CONTENT_MUTATION_RESULTS.draftDeleted);
+          latestBlocksRef.current = null;
+          setEditedContent(emptyContent.content);
+          setEditorResetKey((prev) => prev + 1);
+        }
       }
     };
 
@@ -195,7 +201,7 @@ export default function EditPublicationsPage() {
     setAnchors((prev) => ({ ...prev, [id]: event.currentTarget as HTMLButtonElement }));
   const handleClose = (id: AnchorId) => setAnchors((prev) => ({ ...prev, [id]: undefined }));
 
-  if (isLoading || editedContent === null) return <Box sx={{ p: 4 }}>Завантаження...</Box>;
+  if (isLoading || editedContent === null) return <Box sx={{ p: 4 }}>{'Завантаження...'}</Box>;
 
   const initialBlocks = editedContent[localeKey]?.content?.blocks;
   const isContentValid = Array.isArray(initialBlocks) && initialBlocks.length;
@@ -210,14 +216,14 @@ export default function EditPublicationsPage() {
         originUrl={PUBLICATIONS_BASE_PATH}
         rightActionsComponent={
           <HeaderRightActions
-            mode={type === 'media' ? 'seo' : 'edit'}
+            mode={'edit'}
             onMenuOpen={(e) => handleOpen(e, 'publish')}
             onPublish={() => handleMenuAction(MenuActionId.PUBLISH)}
           />
         }
       >
         {type === 'media' ? (
-          <Typography variant="customBold20Tight">Редагування Ми у ЗМІ</Typography>
+          <Typography variant="customBold20Tight">{'Редагування Ми у ЗМІ'}</Typography>
         ) : (
           <TitleDropdown
             type="multilingual"
@@ -234,7 +240,7 @@ export default function EditPublicationsPage() {
         {type !== 'media' && (
           <ContentEditor
             initialContent={isContentValid ? initialBlocks : undefined}
-            key={currentLanguage}
+            key={`${currentLanguage}-${editorResetKey}`}
             persistence={{
               onChange: handleEditorChange
             }}
@@ -255,7 +261,7 @@ export default function EditPublicationsPage() {
         sx={styles.menu}
       >
         <ListSubheader sx={styles.menuSubheader}>
-          <Typography variant="customMedium14Tight">Мовні версії</Typography>
+          <Typography variant="customMedium14Tight">{'Мовні версії'}</Typography>
         </ListSubheader>
 
         {LANGUAGE_OPTIONS.map(({ locale, key, label }) => {
@@ -274,7 +280,7 @@ export default function EditPublicationsPage() {
               <Typography variant="customMedium16">{label}</Typography>
               {isDraft && (
                 <Typography variant="customItalic14" sx={styles.draftCaption}>
-                  (чернетка)
+                  {'(чернетка)'}
                 </Typography>
               )}
             </MenuItem>
@@ -282,8 +288,8 @@ export default function EditPublicationsPage() {
         })}
 
         <Divider sx={{ my: '7px' }} />
-        <MenuItem onClick={() => handleClose('navigation')} sx={styles.menuItem}>
-          <Typography variant="customMedium16">SEO налаштування</Typography>
+        <MenuItem onClick={() => router.push(`${PUBLICATIONS_BASE_PATH}/${type}/${id}/seo`)} sx={styles.menuItem}>
+          <Typography variant="customMedium16">{'SEO налаштування'}</Typography>
         </MenuItem>
       </Menu>
 

--- a/app/(logged_in)/publications/[type]/[id]/edit/page.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/edit/page.tsx
@@ -1,9 +1,315 @@
-import { Box } from '@mui/material';
+'use client';
 
-export default function EditPublicationPage() {
+import { Block } from '@blocknote/core';
+import { Box, Chip, Divider, ListSubheader,Menu, MenuItem, Typography } from '@mui/material';
+import { useParams, useRouter } from 'next/navigation';
+import { MouseEvent, useEffect, useMemo,useState } from 'react';
+import toast from 'react-hot-toast';
+
+import { styles } from './page.styles';
+import {
+  ACTIONS_TYPE,
+  HEADER_MENU_OPTIONS,
+  MenuActionId,
+  PUBLICATIONS_BASE_PATH,
+  PublicationsChipLabels,
+  PublicationsItemType
+} from '~/constants/publications';
+import { ContentEditor } from '~/shared/components/content-editor';
+import DividedHeader from '~/shared/components/divided-header/DividedHeader';
+import HeaderRightActions from '~/shared/components/divided-header/header-right-actions/HeaderRightActions';
+import ProgressStatus from '~/shared/components/divided-header/progress-status/ProgressStatus';
+import { TitleDropdown } from '~/shared/components/divided-header/title-dropdown/TitleDropdown';
+import { useDeleteEvent, useEventById, useUpdateEvent } from '~/shared/hooks/use-events/useEvents';
+import {
+  useDeleteMediaMention,
+  useMediaMentionById,
+  useUpdateMediaMention
+} from '~/shared/hooks/use-media-mentions/useMediaMentions';
+import { useDeleteNews, useNewsById, useUpdateNews } from '~/shared/hooks/use-news/useNews';
+import { BaseContentStatuses } from '~/types/enums/common.enums';
+import { EventStatus, MediaStatus, NewsStatus } from '~/types/graphql/generated/graphql';
+
+type Params = {
+  type: PublicationsItemType;
+  id: string;
+};
+
+export type LocalizedEditorState = {
+  en?: {
+    blocks: Block[] | null | undefined;
+  };
+  uk?: {
+    blocks: Block[] | null | undefined;
+  };
+  __typename?: string;
+};
+
+type EditorLanguage = 'EN' | 'UA';
+
+type PublicationResource = {
+  update: (status: BaseContentStatuses, extra?: Record<string, unknown>) => Promise<unknown>;
+  remove: () => Promise<unknown>;
+};
+
+type AnchorId = 'navigation' | 'publish';
+type MenuAnchor = Partial<Record<AnchorId, HTMLButtonElement>>;
+
+export default function EditPublicationsPage() {
+  const { type, id } = useParams<Params>();
+  const router = useRouter();
+
+  const news = useNewsById(id, { skip: type !== 'news' });
+  const event = useEventById(id, { skip: type !== 'events' });
+  const media = useMediaMentionById(id, { skip: type !== 'media' });
+
+  const currentData = useMemo(() => {
+    switch (type) {
+    case 'news':
+      return news.data?.newsById;
+    case 'events':
+      return event.data?.eventById;
+    case 'media':
+      return media.data?.mediaMentionById;
+    }
+  }, [type, news, event, media]);
+
+  const [updateNews] = useUpdateNews();
+  const [updateEvent] = useUpdateEvent();
+  const [updateMedia] = useUpdateMediaMention();
+
+  const [deleteNews] = useDeleteNews();
+  const [deleteEvent] = useDeleteEvent();
+  const [deleteMedia] = useDeleteMediaMention();
+
+  const [anchors, setAnchors] = useState<MenuAnchor>({});
+  const [editedContent, setEditedContent] = useState<LocalizedEditorState | null>(null);
+  const [currentLanguage, setCurrentLanguage] = useState<EditorLanguage>('UA');
+
+  const localeKey = currentLanguage === 'UA' ? 'uk' : 'en';
+
+  const DEFAULT_EMPTY_DOCUMENT: Block[] = [{ type: 'paragraph', content: [] } as unknown as Block];
+
+  useEffect(() => {
+    const currentResourceData =
+      type === 'news' ? news.data?.newsById : type === 'events' ? event.data?.eventById : null;
+
+    if (editedContent === null && currentResourceData?.content) {
+      const getSafeBlocks = (langData: Record<'blocks', Block[] | undefined>): Block[] => {
+        const arr = langData?.blocks;
+        return Array.isArray(arr) && arr.length > 0 ? arr : DEFAULT_EMPTY_DOCUMENT;
+      };
+
+      setEditedContent({
+        uk: { blocks: getSafeBlocks(currentResourceData?.content?.uk) },
+        en: { blocks: getSafeBlocks(currentResourceData?.content?.en) }
+      });
+    }
+  }, [event.data, currentLanguage]);
+
+  const isLoading = event.loading || news.loading || media.loading;
+  const hasError = event.error || news.error || media.error;
+
+  const status = {
+    isReady: !hasError && !isLoading,
+    errorMessage: hasError ? 'Помилка серверу' : null
+  };
+
+  useEffect(() => {
+    if (status.errorMessage) toast.error(status.errorMessage);
+  }, [status.errorMessage]);
+
+  const handleMenuAction = async (actionId: MenuActionId) => {
+    const contentPayload = {
+      content: editedContent
+    };
+
+    const resourceMap: Record<string, PublicationResource> = {
+      news: {
+        update: (status, extra = {}) =>
+          updateNews({ id, input: { ...extra, status: status as unknown as NewsStatus } }),
+        remove: () => deleteNews({ id })
+      },
+      events: {
+        update: (status, extra = {}) =>
+          updateEvent({ id, input: { ...extra, status: status as unknown as EventStatus } }),
+        remove: () => deleteEvent({ id })
+      },
+      media: {
+        update: (status, extra = {}) => updateMedia(id, { ...extra, status: status as unknown as MediaStatus }),
+        remove: () => deleteMedia(id)
+      }
+    };
+
+    const currentResource = resourceMap[type as keyof typeof resourceMap];
+
+    const actions: Record<MenuActionId | string, () => Promise<unknown> | void> = {
+      [MenuActionId.PUBLISH]: () => currentResource.update(BaseContentStatuses.Published, contentPayload),
+      [MenuActionId.SAVE_DRAFT]: () => currentResource.update(BaseContentStatuses.Draft, contentPayload),
+      [MenuActionId.SAVE_AND_EXIT]: async () => {
+        await currentResource.update(BaseContentStatuses.Draft, contentPayload);
+        router.push(PUBLICATIONS_BASE_PATH);
+      },
+      [MenuActionId.DELETE_DRAFT]: () => currentResource.remove()
+    };
+
+    try {
+      if (actions[actionId]) {
+        await actions[actionId]();
+      }
+    } catch (err) {
+      toast.error(`Помилка ${err}`);
+      console.error(`Action ${actionId} failed`, err);
+    }
+
+    handleClose('publish');
+  };
+
+  const handleOpen = (event: MouseEvent<HTMLElement>, id: AnchorId) => {
+    setAnchors((prev) => ({ ...prev, [id]: event.currentTarget as HTMLButtonElement }));
+  };
+
+  const handleClose = (id: AnchorId) => {
+    setAnchors((prev) => ({ ...prev, [id]: undefined }));
+  };
+
+  const baseActions = HEADER_MENU_OPTIONS.baseActions as ACTIONS_TYPE[];
+  const publishActions = [...baseActions].filter((action) => action.id !== MenuActionId.PUBLISH);
+
+  const renderChips = (
+    <>
+      <Chip sx={styles.chip(type)} label={PublicationsChipLabels[type]} />
+      <Chip sx={styles.chip('draft')} label="Чернетка" />
+    </>
+  );
+
+  const renderHeaderChild = (
+    <>
+      {type === 'media' ? (
+        <Typography variant="customBold20Tight">Редагування Ми у ЗМІ</Typography>
+      ) : (
+        <TitleDropdown
+          type="multilingual"
+          language={currentLanguage}
+          title={currentData?.adminTitle ?? ''}
+          onMenuOpen={(e) => handleOpen(e, 'navigation')}
+        />
+      )}
+      {renderChips}
+      {type !== 'media' && <ProgressStatus isSaved={false} />}
+    </>
+  );
+
+  const renderNavigationMenu = (
+    <Menu
+      anchorEl={anchors['navigation']}
+      open={Boolean(anchors['navigation'])}
+      onClose={() => handleClose('navigation')}
+      disableScrollLock
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+      transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+      slotProps={{
+        paper: { sx: { width: 205 } }
+      }}
+      sx={styles.menu}
+    >
+      <ListSubheader sx={styles.menuSubheader}>
+        <Typography variant="customMedium14Tight">Мовні версії</Typography>
+      </ListSubheader>
+
+      <MenuItem
+        onClick={() => {
+          setCurrentLanguage('UA');
+          handleClose('navigation');
+        }}
+        sx={styles.menuItem}
+      >
+        <Typography variant="customMedium16">Українська</Typography>
+        <Typography variant="customItalic14" sx={styles.draftCaption}>
+          (чернетка)
+        </Typography>
+      </MenuItem>
+
+      <MenuItem
+        onClick={() => {
+          setCurrentLanguage('EN');
+          handleClose('navigation');
+        }}
+        sx={styles.menuItem}
+      >
+        <Typography variant="customMedium16">Англійська</Typography>
+      </MenuItem>
+
+      <Divider sx={{ my: '7px' }} />
+      <MenuItem onClick={() => handleClose('navigation')} sx={styles.menuItem}>
+        <Typography variant="customMedium16">SEO налаштування</Typography>
+      </MenuItem>
+    </Menu>
+  );
+
+  const renderPublishMenu = (
+    <Menu
+      anchorEl={anchors['publish']}
+      open={Boolean(anchors['publish'])}
+      onClose={() => handleClose('publish')}
+      disableScrollLock
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+      slotProps={{ paper: { sx: { width: 260 } } }}
+      sx={styles.menu}
+    >
+      {publishActions.map((action) => (
+        <MenuItem sx={styles.menuItem} key={action.id} onClick={() => handleMenuAction(action.id as MenuActionId)}>
+          <Typography variant="customMedium16">{action.label}</Typography>
+        </MenuItem>
+      ))}
+    </Menu>
+  );
+
+  const currentBlocks = editedContent?.[localeKey]?.blocks;
+
+  const initialBlocksForEditor = currentBlocks && currentBlocks.length > 0 ? currentBlocks : undefined;
+
+  if (isLoading) return <Box sx={{ p: 4 }}>Завантаження...</Box>;
+
+  console.log(editedContent?.[localeKey]?.blocks);
+
   return (
-    <Box>
+    <Box sx={styles.container}>
+      <DividedHeader
+        sx={styles.header}
+        rightActionsComponent={
+          <HeaderRightActions
+            mode={type === 'media' ? 'seo' : 'edit'}
+            onMenuOpen={(e) => handleOpen(e, 'publish')}
+            onPublish={() => handleMenuAction(MenuActionId.PUBLISH)}
+          />
+        }
+      >
+        {renderHeaderChild}
+      </DividedHeader>
 
+      <Box sx={styles.mainContent}>
+        {type !== 'media' && editedContent && (
+          <ContentEditor
+            persistence={{
+              onChange: (newBlocks) => {
+                setEditedContent((prev) => ({
+                  ...prev,
+                  [localeKey]: newBlocks
+                }));
+              }
+            }}
+            initialContent={initialBlocksForEditor}
+            key={currentLanguage}
+            sx={styles.contentEditor}
+            editorConfig={{ sideMenu: true }}
+          />
+        )}
+      </Box>
+
+      {renderNavigationMenu}
+      {renderPublishMenu}
     </Box>
   );
 }

--- a/app/(logged_in)/publications/[type]/[id]/edit/page.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/edit/page.tsx
@@ -1,112 +1,34 @@
 'use client';
 
-import { Block } from '@blocknote/core';
-import { Box, Chip, Divider, ListSubheader, Menu, MenuItem, Typography } from '@mui/material';
 import { notFound, useParams, useRouter } from 'next/navigation';
-import { MouseEvent, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import toast from 'react-hot-toast';
 
-import { styles } from './page.styles';
+import { EditPublicationsView } from './EditPublicationsView';
 import {
-  ACTIONS_TYPE,
   CONTENT_MUTATION_RESULTS,
   DEFAULT_EMPTY_DOCUMENT,
-  EditorLanguage,
-  HEADER_MENU_OPTIONS,
-  LANGUAGE_OPTIONS,
-  LocalizedEditorState,
   MenuActionId,
-  PUBLICATION_EDIT_ERROR_STATE,
-  PublicationResource,
   PUBLICATIONS_BASE_PATH,
-  PublicationsChipLabels,
   PublicationsItemType
 } from '~/constants/publications';
-import { ContentEditor, isContentEmpty, SerializedContent } from '~/shared/components/content-editor';
-import DividedHeader from '~/shared/components/divided-header/DividedHeader';
-import HeaderRightActions from '~/shared/components/divided-header/header-right-actions/HeaderRightActions';
-import { TitleDropdown } from '~/shared/components/divided-header/title-dropdown/TitleDropdown';
-import { useEventById, useUpdateEvent } from '~/shared/hooks/use-events/useEvents';
-import { useMediaMentionById, useUpdateMediaMention } from '~/shared/hooks/use-media-mentions/useMediaMentions';
-import { useNewsById, useUpdateNews } from '~/shared/hooks/use-news/useNews';
+import { SerializedContent } from '~/shared/components/content-editor';
+import { usePublicationManager } from '~/shared/hooks/use-publications-manager/usePublicationsManager';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
-import { type EventStatus, type MediaStatus, type NewsStatus } from '~/types/graphql/generated/graphql';
 
 type Params = {
   type: PublicationsItemType;
   id: string;
 };
 
-type AnchorId = 'navigation' | 'publish';
-type MenuAnchor = Partial<Record<AnchorId, HTMLButtonElement>>;
-
 export default function EditPublicationsPage() {
   const { type, id } = useParams<Params>();
   const router = useRouter();
 
-  const news = useNewsById(id, { skip: type !== 'news' });
-  const event = useEventById(id, { skip: type !== 'events' });
-  const media = useMediaMentionById(id, { skip: type !== 'media' });
+  const manager = usePublicationManager(type, id);
 
-  const queryMap = {
-    news,
-    events: event,
-    media
-  };
-
-  const activeQuery = queryMap[type];
-  const isLoading = activeQuery.loading;
-  const hasError = activeQuery.error;
-
-  const currentData = useMemo(() => {
-    switch (type) {
-    case 'news':
-      return news.data?.newsById;
-    case 'events':
-      return event.data?.eventById;
-    case 'media':
-      return media.data?.mediaMentionById;
-    }
-  }, [news.data, event.data, media.data]);
-
-  const [updateNews] = useUpdateNews();
-  const [updateEvent] = useUpdateEvent();
-  const [updateMedia] = useUpdateMediaMention();
-
-  const [anchors, setAnchors] = useState<MenuAnchor>({});
-  const [currentLanguage, setCurrentLanguage] = useState<EditorLanguage>('UA');
-  const [editedContent, setEditedContent] = useState<LocalizedEditorState | null>(null);
-  const [editorResetKey, setEditorResetKey] = useState<number>(0);
-
-  const latestBlocksRef = useRef<SerializedContent>(null);
+  const latestBlocksRef = useRef<SerializedContent | null>(null);
   const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
-
-  const localeKey = currentLanguage === 'UA' ? 'uk' : 'en';
-
-  useEffect(() => {
-    if (type === 'media' || isLoading || activeQuery.data === undefined) return;
-
-    if (editedContent === null) {
-      const resourceData = type === 'news' ? news.data?.newsById?.content : event.data?.eventById?.content;
-
-      const hasUk = !isContentEmpty(resourceData?.uk?.content?.blocks);
-      const hasEn = !isContentEmpty(resourceData?.en?.content?.blocks);
-
-      setCurrentLanguage(!hasUk && hasEn ? 'EN' : 'UA');
-
-      const createSafeLangObj = (blocks: Block[] | undefined) => ({
-        content: {
-          ...DEFAULT_EMPTY_DOCUMENT,
-          blocks: !isContentEmpty(blocks) && blocks ? blocks : DEFAULT_EMPTY_DOCUMENT.blocks
-        }
-      });
-
-      setEditedContent({
-        uk: createSafeLangObj(resourceData?.uk?.content?.blocks),
-        en: createSafeLangObj(resourceData?.en?.content?.blocks)
-      });
-    }
-  }, [isLoading, editedContent, type, activeQuery.data, news.data, event.data]);
 
   useEffect(() => {
     return () => {
@@ -114,201 +36,91 @@ export default function EditPublicationsPage() {
     };
   }, []);
 
-  const isNotFound = !isLoading && activeQuery.data !== undefined && currentData === null;
+  if (!manager.isLoading && manager.currentData === null && !manager.hasError) {
+    notFound();
+  }
 
-  if (isNotFound) notFound();
-
-  useEffect(() => {
-    if (hasError && !isLoading) toast.error(PUBLICATION_EDIT_ERROR_STATE);
-  }, [hasError, isLoading]);
-
-  const handleEditorChange = (content: SerializedContent) => {
+  const handleEditorChange = (content: SerializedContent, localeKey: 'uk' | 'en') => {
     latestBlocksRef.current = content;
+
     if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
 
     debounceTimerRef.current = setTimeout(() => {
-      setEditedContent((prev) => (prev ? { ...prev, [localeKey]: { content: latestBlocksRef.current } } : prev));
+      if (latestBlocksRef.current) {
+        manager.setEditedContent((prev) =>
+          prev ? { ...prev, [localeKey]: { content: latestBlocksRef.current! } } : prev
+        );
+      }
     }, 500);
   };
 
   const handleMenuAction = async (actionId: MenuActionId) => {
-    const contentPayload = { content: editedContent };
+    const contentPayload = { content: manager.editedContent };
 
-    const resourceMap: Record<string, PublicationResource> = {
-      news: {
-        update: (status, extra = {}) => updateNews({ id, input: { ...extra, status: status as unknown as NewsStatus } })
-      },
-      events: {
-        update: (status, extra = {}) =>
-          updateEvent({ id, input: { ...extra, status: status as unknown as EventStatus } })
-      },
-      media: {
-        update: (status, extra = {}) => updateMedia(id, { ...extra, status: status as unknown as MediaStatus })
-      }
-    };
-
-    const currentResource = resourceMap[type as keyof typeof resourceMap];
-
-    const actions: Record<MenuActionId | string, () => Promise<unknown> | void> = {
-      [MenuActionId.PUBLISH]: async () => {
-        const { data } = await currentResource.update(BaseContentStatuses.Published, contentPayload);
+    try {
+      switch (actionId) {
+      case MenuActionId.PUBLISH: {
+        const { data } = await manager.updateResource(BaseContentStatuses.Published, contentPayload);
         if (data) toast.success(CONTENT_MUTATION_RESULTS.draftPublished);
-      },
-      [MenuActionId.SAVE_DRAFT]: async () => {
-        const { data } = await currentResource.update(BaseContentStatuses.Draft, contentPayload);
+        break;
+      }
+
+      case MenuActionId.SAVE_DRAFT: {
+        const { data } = await manager.updateResource(BaseContentStatuses.Draft, contentPayload);
         if (data) toast.success(CONTENT_MUTATION_RESULTS.draftSaved);
-      },
-      [MenuActionId.SAVE_AND_EXIT]: async () => {
-        const { data } = await currentResource.update(BaseContentStatuses.Draft, contentPayload);
+        break;
+      }
+
+      case MenuActionId.SAVE_AND_EXIT: {
+        const { data } = await manager.updateResource(BaseContentStatuses.Draft, contentPayload);
         if (data) {
           toast.success(CONTENT_MUTATION_RESULTS.draftSaved);
           router.push(PUBLICATIONS_BASE_PATH);
         }
-      },
-      [MenuActionId.DELETE_DRAFT]: async () => {
+        break;
+      }
+
+      case MenuActionId.DELETE_DRAFT: {
+        const localeKey = manager.currentLanguage === 'UA' ? 'uk' : 'en';
+
         const emptyContent = {
           content: {
-            ...editedContent,
-            [localeKey]: {
-              content: { ...DEFAULT_EMPTY_DOCUMENT }
-            }
+            ...manager.editedContent,
+            [localeKey]: { content: { ...DEFAULT_EMPTY_DOCUMENT } }
           }
         };
-        const { data } = await currentResource.update(
-          (currentData?.status as unknown as BaseContentStatuses) ?? BaseContentStatuses.Draft,
-          emptyContent
-        );
+
+        const currentStatus =
+            (manager.currentData?.status as unknown as BaseContentStatuses) ?? BaseContentStatuses.Draft;
+
+        const { data } = await manager.updateResource(currentStatus, emptyContent);
+
         if (data) {
           toast.success(CONTENT_MUTATION_RESULTS.draftDeleted);
           latestBlocksRef.current = null;
-          setEditedContent(emptyContent.content);
-          setEditorResetKey((prev) => prev + 1);
+          manager.resetEditorState(emptyContent.content);
         }
+        break;
       }
-    };
-
-    try {
-      if (actions[actionId]) await actions[actionId]();
+      }
     } catch (err) {
-      toast.error(`Помилка ${err}`);
+      toast.error(`Помилка: ${err instanceof Error ? err.message : String(err)}`);
       console.error(`Action ${actionId} failed`, err);
     }
-
-    handleClose('publish');
   };
 
-  const handleOpen = (event: MouseEvent<HTMLElement>, id: AnchorId) =>
-    setAnchors((prev) => ({ ...prev, [id]: event.currentTarget as HTMLButtonElement }));
-  const handleClose = (id: AnchorId) => setAnchors((prev) => ({ ...prev, [id]: undefined }));
-
-  if (isLoading || editedContent === null) return <Box sx={{ p: 4 }}>{'Завантаження...'}</Box>;
-
-  const initialBlocks = editedContent[localeKey]?.content?.blocks;
-  const isContentValid = Array.isArray(initialBlocks) && initialBlocks.length;
-  const publishActions = (HEADER_MENU_OPTIONS.baseActions as ACTIONS_TYPE[]).filter(
-    (a) => a.id !== MenuActionId.PUBLISH
-  );
-
   return (
-    <Box sx={styles.container}>
-      <DividedHeader
-        sx={styles.header}
-        originUrl={PUBLICATIONS_BASE_PATH}
-        rightActionsComponent={
-          <HeaderRightActions
-            mode={'edit'}
-            onMenuOpen={(e) => handleOpen(e, 'publish')}
-            onPublish={() => handleMenuAction(MenuActionId.PUBLISH)}
-          />
-        }
-      >
-        {type === 'media' ? (
-          <Typography variant="customBold20Tight">{'Редагування Ми у ЗМІ'}</Typography>
-        ) : (
-          <TitleDropdown
-            type="multilingual"
-            language={currentLanguage}
-            title={currentData?.adminTitle ?? ''}
-            onMenuOpen={(e) => handleOpen(e, 'navigation')}
-          />
-        )}
-        <Chip sx={styles.chip(type)} label={PublicationsChipLabels[type]} />
-        <Chip sx={styles.chip('draft')} label="Чернетка" />
-      </DividedHeader>
-
-      <Box sx={styles.mainContent}>
-        {type !== 'media' && (
-          <ContentEditor
-            initialContent={isContentValid ? initialBlocks : undefined}
-            key={`${currentLanguage}-${editorResetKey}`}
-            persistence={{
-              onChange: handleEditorChange
-            }}
-            sx={styles.contentEditor}
-            editorConfig={{ sideMenu: true }}
-          />
-        )}
-      </Box>
-
-      <Menu
-        anchorEl={anchors['navigation']}
-        open={Boolean(anchors['navigation'])}
-        onClose={() => handleClose('navigation')}
-        disableScrollLock
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
-        slotProps={{ paper: { sx: { width: 205 } } }}
-        sx={styles.menu}
-      >
-        <ListSubheader sx={styles.menuSubheader}>
-          <Typography variant="customMedium14Tight">{'Мовні версії'}</Typography>
-        </ListSubheader>
-
-        {LANGUAGE_OPTIONS.map(({ locale, key, label }) => {
-          const blocks = editedContent?.[key]?.content?.blocks;
-          const isDraft = !isContentEmpty(blocks);
-
-          return (
-            <MenuItem
-              key={key}
-              onClick={() => {
-                setCurrentLanguage(locale);
-                handleClose('navigation');
-              }}
-              sx={styles.menuItem}
-            >
-              <Typography variant="customMedium16">{label}</Typography>
-              {isDraft && (
-                <Typography variant="customItalic14" sx={styles.draftCaption}>
-                  {'(чернетка)'}
-                </Typography>
-              )}
-            </MenuItem>
-          );
-        })}
-
-        <Divider sx={{ my: '7px' }} />
-        <MenuItem onClick={() => router.push(`${PUBLICATIONS_BASE_PATH}/${type}/${id}/seo`)} sx={styles.menuItem}>
-          <Typography variant="customMedium16">{'SEO налаштування'}</Typography>
-        </MenuItem>
-      </Menu>
-
-      <Menu
-        anchorEl={anchors['publish']}
-        open={Boolean(anchors['publish'])}
-        onClose={() => handleClose('publish')}
-        disableScrollLock
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
-        slotProps={{ paper: { sx: { width: 260 } } }}
-        sx={styles.menu}
-      >
-        {publishActions.map((action) => (
-          <MenuItem sx={styles.menuItem} key={action.id} onClick={() => handleMenuAction(action.id)}>
-            <Typography variant="customMedium16">{action.label}</Typography>
-          </MenuItem>
-        ))}
-      </Menu>
-    </Box>
+    <EditPublicationsView
+      type={type}
+      isLoading={manager.isLoading}
+      currentData={manager.currentData}
+      editedContent={manager.editedContent}
+      editorResetKey={manager.editorResetKey}
+      currentLanguage={manager.currentLanguage}
+      onLanguageChange={manager.setCurrentLanguage}
+      onEditorChange={handleEditorChange}
+      onAction={handleMenuAction}
+      onSeoClick={() => router.push(`${PUBLICATIONS_BASE_PATH}/${type}/${id}/seo`)}
+    />
   );
 }

--- a/app/(logged_in)/publications/[type]/create/page.tsx
+++ b/app/(logged_in)/publications/[type]/create/page.tsx
@@ -141,7 +141,7 @@ export default function CreatePublicationPage() {
         const result = await createEvent({
           ...commonInput,
           eventLink: adminTitle,
-          content: { uk: {}, en: {} },
+          content: { uk: { content: { blocks: [] } }, en: { content: { blocks: [] } } },
           eventDateTimeStart: ukMeta.startDateTime ?? undefined,
           eventDateTimeEnd: ukMeta.endDateTime ?? undefined,
           ticketUrl: seoValue.ticketUrl ?? undefined,
@@ -152,7 +152,7 @@ export default function CreatePublicationPage() {
       } else if (publicationType === 'news') {
         const result = await createNews({
           ...commonInput,
-          content: { uk: {}, en: {} },
+          content: { uk: {content: {blocks: []}}, en: {content: {blocks: []}} },
           newsDate: publishDate?.toISOString() ?? undefined,
           status: NewsStatus.Draft
         });

--- a/app/constants/publications.ts
+++ b/app/constants/publications.ts
@@ -17,7 +17,6 @@ export type PublicationsStatusValue = (typeof PUBLICATIONS_STATUSES)[number];
 export type PublicationsLanguageValue = 'uk' | 'en' | 'bilingual';
 export type PublicationsFilterId = 'status' | 'language';
 
-
 export type PublicationsTabConfig = Readonly<{
   value: PublicationsTabValue;
   label: string;
@@ -202,8 +201,7 @@ export type MutationResponse<TData = unknown> = {
   data?: TData | null;
 };
 
-export type PublicationResource = {
-  update: (status: BaseContentStatuses, extra?: Record<string, unknown>) => Promise<MutationResponse>;
-};
-
-
+export type PublicationResource = (
+  status: BaseContentStatuses,
+  extra?: Record<string, unknown>
+) => Promise<MutationResponse>;

--- a/app/constants/publications.ts
+++ b/app/constants/publications.ts
@@ -17,6 +17,12 @@ export type PublicationsStatusValue = (typeof PUBLICATIONS_STATUSES)[number];
 export type PublicationsLanguageValue = 'uk' | 'en' | 'bilingual';
 export type PublicationsFilterId = 'status' | 'language';
 
+export type PublicationLanguageOption = Readonly<{
+  locale: EditorLanguage;
+  key: 'uk' | 'en';
+  label: 'Українська' | 'Англійська';
+}>;
+
 export type PublicationsTabConfig = Readonly<{
   value: PublicationsTabValue;
   label: string;
@@ -49,9 +55,11 @@ type PublicationsCategoryConfig = Readonly<{
 export const PUBLICATIONS_PAGE_TITLE = 'Новини та події';
 export const PUBLICATIONS_EMPTY_STATE_TITLE = 'Матеріали відсутні';
 export const PUBLICATIONS_EMPTY_STATE_DESCRIPTION = 'Матеріали для цієї вкладки поки відсутні.';
-export const PUBLICATIONS_EVENTS_EMPTY_STATE_DESCRIPTION = 'Матеріали для вкладки "Події" з’являться після підключення джерела даних.';
+export const PUBLICATIONS_EVENTS_EMPTY_STATE_DESCRIPTION =
+  'Матеріали для вкладки "Події" з’являться після підключення джерела даних.';
 export const PUBLICATIONS_EMPTY_STATE_NO_RESULTS_TITLE = 'Результатів немає';
-export const PUBLICATIONS_EMPTY_STATE_NO_RESULTS_DESCRIPTION = 'За цими критеріями нічого не знайдено.\nСпробуйте змінити параметри фільтрів або пошуку.';
+export const PUBLICATIONS_EMPTY_STATE_NO_RESULTS_DESCRIPTION =
+  'За цими критеріями нічого не знайдено.\nСпробуйте змінити параметри фільтрів або пошуку.';
 export const PUBLICATIONS_LOADING_STATE_TITLE = 'Завантаження матеріалів';
 export const PUBLICATIONS_LOADING_STATE_DESCRIPTION = 'Зачекайте, поки завершиться запит.';
 export const PUBLICATIONS_ERROR_STATE_TITLE = 'Не вдалося завантажити матеріали';
@@ -129,7 +137,10 @@ export const PUBLICATIONS_FILTERS: ReadonlyArray<PublicationsFilterConfig> = [
   }
 ];
 
-export const PublicationsEditorPlaceholder = 'H';
+export const LANGUAGE_OPTIONS: ReadonlyArray<PublicationLanguageOption> = [
+  { locale: 'UA', key: 'uk', label: 'Українська' },
+  { locale: 'EN', key: 'en', label: 'Англійська' }
+] as const;
 
 export const PublicationsChipLabels: Record<PublicationsItemType, string> = {
   news: 'Новина',
@@ -175,8 +186,12 @@ export const DEFAULT_EMPTY_DOCUMENT: SerializedContent = {
 };
 
 export type LocalizedEditorState = {
-  en?: SerializedContent;
-  uk?: SerializedContent;
+  en?: {
+    content: SerializedContent;
+  };
+  uk?: {
+    content: SerializedContent;
+  };
   __typename?: string;
 };
 
@@ -188,5 +203,4 @@ export type MutationResponse<TData = unknown> = {
 
 export type PublicationResource = {
   update: (status: BaseContentStatuses, extra?: Record<string, unknown>) => Promise<MutationResponse>;
-  remove: () => Promise<MutationResponse>;
 };

--- a/app/constants/publications.ts
+++ b/app/constants/publications.ts
@@ -17,11 +17,6 @@ export type PublicationsStatusValue = (typeof PUBLICATIONS_STATUSES)[number];
 export type PublicationsLanguageValue = 'uk' | 'en' | 'bilingual';
 export type PublicationsFilterId = 'status' | 'language';
 
-export type PublicationLanguageOption = Readonly<{
-  locale: EditorLanguage;
-  key: 'uk' | 'en';
-  label: 'Українська' | 'Англійська';
-}>;
 
 export type PublicationsTabConfig = Readonly<{
   value: PublicationsTabValue;
@@ -137,6 +132,12 @@ export const PUBLICATIONS_FILTERS: ReadonlyArray<PublicationsFilterConfig> = [
   }
 ];
 
+export type PublicationLanguageOption = Readonly<{
+  locale: EditorLanguage;
+  key: 'uk' | 'en';
+  label: 'Українська' | 'Англійська';
+}>;
+
 export const LANGUAGE_OPTIONS: ReadonlyArray<PublicationLanguageOption> = [
   { locale: 'UA', key: 'uk', label: 'Українська' },
   { locale: 'EN', key: 'en', label: 'Англійська' }
@@ -204,3 +205,5 @@ export type MutationResponse<TData = unknown> = {
 export type PublicationResource = {
   update: (status: BaseContentStatuses, extra?: Record<string, unknown>) => Promise<MutationResponse>;
 };
+
+

--- a/app/constants/publications.ts
+++ b/app/constants/publications.ts
@@ -1,3 +1,4 @@
+import { CONTENT_VERSION, SerializedContent } from '~/shared/components/content-editor/types';
 import type { FilterOption } from '~/shared/components/selector/FilterSelect';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
 
@@ -55,6 +56,7 @@ export const PUBLICATIONS_LOADING_STATE_TITLE = 'Завантаження мат
 export const PUBLICATIONS_LOADING_STATE_DESCRIPTION = 'Зачекайте, поки завершиться запит.';
 export const PUBLICATIONS_ERROR_STATE_TITLE = 'Не вдалося завантажити матеріали';
 export const PUBLICATIONS_ERROR_STATE_DESCRIPTION = 'Спробуйте оновити сторінку або повторити пізніше.';
+export const PUBLICATION_EDIT_ERROR_STATE = 'Щось пішло не так';
 
 export const PUBLICATIONS_BASE_PATH = '/publications';
 
@@ -157,3 +159,34 @@ export const HEADER_MENU_OPTIONS: HEADER_MENU_OPTIONS_TYPE = {
     { id: MenuActionId.DELETE_DRAFT, label: 'Видалити чернетку' }
   ]
 } as const;
+
+export type MUTATION_RESULT = Record<string, string>;
+
+export const CONTENT_MUTATION_RESULTS: MUTATION_RESULT = {
+  draftPublished: 'Чернетку опубліковано успішно',
+  draftSaved: 'Чернетку збережено успішно',
+  draftDeleted: 'Чернетку видалено успішно'
+};
+
+export const DEFAULT_EMPTY_DOCUMENT: SerializedContent = {
+  blocks: [],
+  version: CONTENT_VERSION,
+  lastModified: new Date().toISOString()
+};
+
+export type LocalizedEditorState = {
+  en?: SerializedContent;
+  uk?: SerializedContent;
+  __typename?: string;
+};
+
+export type EditorLanguage = 'EN' | 'UA';
+
+export type MutationResponse<TData = unknown> = {
+  data?: TData | null;
+};
+
+export type PublicationResource = {
+  update: (status: BaseContentStatuses, extra?: Record<string, unknown>) => Promise<MutationResponse>;
+  remove: () => Promise<MutationResponse>;
+};

--- a/app/constants/publications.ts
+++ b/app/constants/publications.ts
@@ -1,6 +1,9 @@
 import type { FilterOption } from '~/shared/components/selector/FilterSelect';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
 
+export const PUBLICATIONS_TYPES = ['event', 'news', 'media'] as const;
+export type PublicationsType = (typeof PUBLICATIONS_TYPES)[number];
+
 export type PublicationsTabValue = 'all' | 'events' | 'news' | 'media';
 export type PublicationsItemType = Exclude<PublicationsTabValue, 'all'>;
 export const PUBLICATIONS_STATUSES = [
@@ -53,7 +56,7 @@ export const PUBLICATIONS_LOADING_STATE_DESCRIPTION = 'Зачекайте, по�
 export const PUBLICATIONS_ERROR_STATE_TITLE = 'Не вдалося завантажити матеріали';
 export const PUBLICATIONS_ERROR_STATE_DESCRIPTION = 'Спробуйте оновити сторінку або повторити пізніше.';
 
-const PUBLICATIONS_BASE_PATH = '/publications';
+export const PUBLICATIONS_BASE_PATH = '/publications';
 
 const PUBLICATIONS_CATEGORIES: ReadonlyArray<PublicationsCategoryConfig> = [
   {
@@ -123,3 +126,34 @@ export const PUBLICATIONS_FILTERS: ReadonlyArray<PublicationsFilterConfig> = [
     menuMinWidth: 205
   }
 ];
+
+export const PublicationsEditorPlaceholder = 'H';
+
+export const PublicationsChipLabels: Record<PublicationsItemType, string> = {
+  news: 'Новина',
+  events: 'Подія',
+  media: 'Ми у ЗМІ'
+} as const;
+
+export enum MenuActionId {
+  PUBLISH = 'PUBLISH',
+  SAVE_DRAFT = 'SAVE_DRAFT',
+  SAVE_AND_EXIT = 'SAVE_AND_EXIT',
+  DELETE_DRAFT = 'DELETE_DRAFT'
+}
+
+export type ACTIONS_TYPE = {
+  id: MenuActionId;
+  label: string;
+};
+
+export type HEADER_MENU_OPTIONS_TYPE = Record<string, ReadonlyArray<ACTIONS_TYPE>>;
+
+export const HEADER_MENU_OPTIONS: HEADER_MENU_OPTIONS_TYPE = {
+  baseActions: [
+    { id: MenuActionId.PUBLISH, label: 'Опублікувати' },
+    { id: MenuActionId.SAVE_DRAFT, label: 'Зберегти зміни' },
+    { id: MenuActionId.SAVE_AND_EXIT, label: 'Зберегти зміни і вийти' },
+    { id: MenuActionId.DELETE_DRAFT, label: 'Видалити чернетку' }
+  ]
+} as const;

--- a/app/shared/components/content-editor/BlockNoteEditor.styles.ts
+++ b/app/shared/components/content-editor/BlockNoteEditor.styles.ts
@@ -1,6 +1,6 @@
-import { SxProps } from '@mui/material';
+import { SxProps, Theme } from '@mui/material';
 
-export const styles: Record<string, SxProps> = {
+export const styles: Record<string, SxProps<Theme>> = {
   container: {
     width: '100%',
     backgroundColor: '#fff',
@@ -9,10 +9,10 @@ export const styles: Record<string, SxProps> = {
     padding: '24px',
     fontFamily: 'Mulish, sans-serif',
     '& .bn-container': {
-      width: '100%'
+      width: '100%',
     },
     '& .bn-editor': {
-      minHeight: '400px'
+      minHeight: '400px',
     },
     // Hide native file input when using custom file picker
     '&.custom-file-picker-enabled': {

--- a/app/shared/components/content-editor/BlockNoteEditor.tsx
+++ b/app/shared/components/content-editor/BlockNoteEditor.tsx
@@ -94,7 +94,7 @@ export const BlockNoteEditor = ({
       uploadFile: handleFileUpload,
       initialContent: initialContent || undefined,
       dropCursor: multiColumnDropCursor,
-      placeholderText: placeholder
+      placeholders: { default: placeholder, }
     },
     [isMounted]
   );
@@ -212,11 +212,7 @@ export const BlockNoteEditor = ({
   }
 
   return (
-    <Box sx={[
-      styles.container,
-      ...sxToArray(sx),
-      {minHeight},
-    ]}>
+    <Box sx={[styles.container, ...sxToArray(sx), { minHeight }]}>
       <BlockNoteView
         editor={editor}
         editable={editable}

--- a/app/shared/components/content-editor/BlockNoteEditor.tsx
+++ b/app/shared/components/content-editor/BlockNoteEditor.tsx
@@ -18,6 +18,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { styles } from './BlockNoteEditor.styles';
 import { BlockNoteEditorProps } from './types';
 import { useFilePickerUpload } from './useFilePickerUpload';
+import { sxToArray } from '~/lib/utils/sxToArray';
 
 const defaultFileUploadHandler = async (file: File): Promise<string> => {
   return new Promise((resolve, reject) => {
@@ -42,9 +43,11 @@ export const BlockNoteEditor = ({
   onChange,
   placeholder = 'Почніть вводити текст або використайте "/" для команд...',
   editable = true,
+  sideMenu = false,
   minHeight = '800px',
   fileUpload,
-  keyboardShortcuts
+  keyboardShortcuts,
+  sx
 }: BlockNoteEditorProps) => {
   const [isMounted, setIsMounted] = useState(false);
 
@@ -209,14 +212,18 @@ export const BlockNoteEditor = ({
   }
 
   return (
-    <Box sx={{ ...styles.container, minHeight }}>
+    <Box sx={[
+      styles.container,
+      ...sxToArray(sx),
+      {minHeight},
+    ]}>
       <BlockNoteView
         editor={editor}
         editable={editable}
         onChange={handleEditorChange}
         theme="light"
         data-theming-css-variables-demo
-        sideMenu={true}
+        sideMenu={sideMenu}
       />
 
       {modalProps && fileUpload?.customModal?.(modalProps)}

--- a/app/shared/components/content-editor/ContentEditor.tsx
+++ b/app/shared/components/content-editor/ContentEditor.tsx
@@ -12,7 +12,8 @@ export const ContentEditor = ({
   persistence,
   editorConfig,
   renderSaveButton,
-  onSaveComplete
+  onSaveComplete,
+  sx
 }: ContentEditorProps) => {
   const [content, setContent] = useState<Block[] | null>(() => deserializeContent(initialContent));
 
@@ -96,11 +97,13 @@ export const ContentEditor = ({
         onChange={handleContentChange}
         placeholder={editorConfig?.placeholder}
         editable={editorConfig?.editable}
+        sideMenu={editorConfig?.sideMenu}
         minHeight={editorConfig?.minHeight}
         fileUpload={editorConfig?.fileUpload}
         keyboardShortcuts={{
           onSave: () => void handleSave()
         }}
+        sx={sx}
       />
 
       {renderSaveButton?.({ onSave: () => void handleSave(), isSaving })}

--- a/app/shared/components/content-editor/types.ts
+++ b/app/shared/components/content-editor/types.ts
@@ -1,4 +1,5 @@
 import { Block } from '@blocknote/core';
+import { SxProps, Theme } from '@mui/material';
 import { ReactElement } from 'react';
 
 export interface FilePickerModalProps {
@@ -20,11 +21,13 @@ export interface BlockNoteEditorProps {
   onChange?: (content: Block[]) => void;
   placeholder?: string;
   editable?: boolean;
+  sideMenu?: boolean;
   minHeight?: string;
   fileUpload?: FileUploadConfig;
   keyboardShortcuts?: {
     onSave?: () => void;
   };
+  sx?: SxProps<Theme>
 }
 
 export interface SerializedContent {
@@ -45,6 +48,7 @@ export interface ContentEditorProps {
 
   editorConfig?: {
     placeholder?: string;
+    sideMenu?: boolean;
     editable?: boolean;
     minHeight?: string;
     fileUpload?: FileUploadConfig;
@@ -53,6 +57,7 @@ export interface ContentEditorProps {
   renderSaveButton?: (props: { onSave: () => void; isSaving: boolean }) => ReactElement;
 
   onSaveComplete?: (success: boolean) => void;
+  sx?: SxProps<Theme>
 }
 
 export const CONTENT_VERSION = '1.0.0';

--- a/app/shared/components/divided-header/header-right-actions/HeaderRightActions.style.ts
+++ b/app/shared/components/divided-header/header-right-actions/HeaderRightActions.style.ts
@@ -47,22 +47,23 @@ export const styles = {
   },
 
   group: {
+    display: 'flex',
     gap: '2px',
-    '& .MuiButtonGroup-grouped,  & .MuiIconButton-root': {
+    textTransform: 'none',
+    fontSize: '16px',
+    fontWeight: 500,
+    lineHeight: '150%',
+    border: 'none',
+    '& .MuiButton-root, & .MuiIconButton-root': {
       bgcolor: COLORS.yellow,
       color: COLORS.textBlack,
-      textTransform: 'none',
-      fontSize: '16px',
-      fontWeight: 500,
-      lineHeight: '150%',
-      border: 'none',
-      '&.Mui-disabled': {
-        border: 'none',
-        bgcolor: COLORS.grayBg,
-        color: COLORS.textGray
-      },
       '&:hover': { bgcolor: COLORS.yellowHover }
-    }
+    },
+    '&.Mui-disabled': {
+      border: 'none',
+      bgcolor: COLORS.grayBg,
+      color: COLORS.textGray
+    },
   } as SxProps<Theme>,
 
   groupLeft: { borderRadius: '28px 0 0 28px', px: 3 } as SxProps<Theme>,

--- a/app/shared/components/divided-header/header-right-actions/HeaderRightActions.tsx
+++ b/app/shared/components/divided-header/header-right-actions/HeaderRightActions.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, ButtonGroup, IconButton, Stack, SxProps, Theme } from '@mui/material';
+import { Box, Button, IconButton, Stack, SxProps, Theme } from '@mui/material';
 import { ChevronDown, EyeIcon } from 'lucide-react';
 import React, { MouseEvent } from 'react';
 
@@ -61,9 +61,7 @@ export default function HeaderRightActions(props: HeaderRightActionsProps) {
             <EyeIcon size={24} strokeWidth={1.5} />
           </IconButton>
 
-          <ButtonGroup
-            variant="contained"
-            disableElevation
+          <Box
             sx={styles.group}
             role="group"
             aria-label="Дії публікації"
@@ -74,7 +72,7 @@ export default function HeaderRightActions(props: HeaderRightActionsProps) {
             <IconButton aria-label="Відкрити меню параметрів" onClick={props.onMenuOpen} sx={styles.groupRight}>
               <ChevronDown size={20} />
             </IconButton>
-          </ButtonGroup>
+          </Box>
         </>
       );
 

--- a/app/shared/components/divided-header/title-dropdown/TitleDropdown.tsx
+++ b/app/shared/components/divided-header/title-dropdown/TitleDropdown.tsx
@@ -31,7 +31,7 @@ export const TitleDropdown = (props: TitleDropdownProps) => {
 
   return (
     <Box sx={[styles.container, ...sxToArray(props.sx)]}>
-      <Typography sx={{ width: 320 }} noWrap variant="customBold20Tight" title={title}>
+      <Typography sx={{ maxWidth: 320 }} noWrap variant="customBold20Tight" title={title}>
         {title}
       </Typography>
 

--- a/app/shared/components/divided-header/title-dropdown/TitleDropdown.tsx
+++ b/app/shared/components/divided-header/title-dropdown/TitleDropdown.tsx
@@ -14,12 +14,12 @@ type BaseTitleDropdownProps = {
 };
 
 type MultilingualProps = BaseTitleDropdownProps & {
-  type?: 'multilingual';
+  type: 'multilingual';
   language?: 'UA' | 'EN';
 };
 
 type SeoProps = BaseTitleDropdownProps & {
-  type?: 'SEO';
+  type: 'SEO';
 };
 
 export type TitleDropdownProps = MultilingualProps | SeoProps;

--- a/app/shared/hooks/use-events/useEvents.tsx
+++ b/app/shared/hooks/use-events/useEvents.tsx
@@ -17,16 +17,19 @@ import {
   useAllEventsQuery,
   useCreateEventMutation,
   useDeleteEventMutation,
+  useEventByIdQuery,
   useEventsCountQuery,
   useIncrementEventViewsMutation,
   usePaginatedEventsQuery,
   usePublishedEventsQuery,
-  useUpdateEventMutation
-} from '~/types/graphql/generated/graphql';
+  useUpdateEventMutation} from '~/types/graphql/generated/graphql';
 
 type QueryHookOptions = Readonly<{
   skip?: boolean;
 }>;
+
+export const useEventById = (id: string, options: QueryHookOptions = {}) =>
+  useEventByIdQuery({ variables: { id }, fetchPolicy: 'network-only', skip: options.skip || !id });
 
 export const useAllEvents = (filters?: EventFiltersInput, options: QueryHookOptions = {}) =>
   useAllEventsQuery({ variables: { filters }, fetchPolicy: 'network-only', skip: options.skip });

--- a/app/shared/hooks/use-events/useEvents.tsx
+++ b/app/shared/hooks/use-events/useEvents.tsx
@@ -24,11 +24,15 @@ import {
   useUpdateEventMutation
 } from '~/types/graphql/generated/graphql';
 
-export const useAllEvents = (filters?: EventFiltersInput) =>
-  useAllEventsQuery({ variables: { filters }, fetchPolicy: 'network-only' });
+type QueryHookOptions = Readonly<{
+  skip?: boolean;
+}>;
 
-export const usePublishedEvents = (filters?: EventFiltersInput) =>
-  usePublishedEventsQuery({ variables: { filters }, fetchPolicy: 'cache-first' });
+export const useAllEvents = (filters?: EventFiltersInput, options: QueryHookOptions = {}) =>
+  useAllEventsQuery({ variables: { filters }, fetchPolicy: 'network-only', skip: options.skip });
+
+export const usePublishedEvents = (filters?: EventFiltersInput, options: QueryHookOptions = {}) =>
+  usePublishedEventsQuery({ variables: { filters }, fetchPolicy: 'cache-first', skip: options.skip });
 
 export const usePaginatedEvents = (page = 1, limit = 10, filters?: EventFiltersInput) =>
   usePaginatedEventsQuery({ variables: { page, limit, filters }, fetchPolicy: 'network-only' });

--- a/app/shared/hooks/use-media-mentions/useMediaMentions.tsx
+++ b/app/shared/hooks/use-media-mentions/useMediaMentions.tsx
@@ -13,6 +13,7 @@ import {
   useAllMediaMentionsQuery,
   useCreateMediaMentionMutation,
   useDeleteMediaMentionMutation,
+  useMediaMentionByIdQuery,
   useMediaMentionsCountQuery,
   usePaginatedMediaMentionsQuery,
   usePublishedMediaMentionsQuery,
@@ -22,6 +23,9 @@ import {
 type QueryHookOptions = Readonly<{
   skip?: boolean;
 }>;
+
+export const useMediaMentionById = (id: string, options: QueryHookOptions = {}) =>
+  useMediaMentionByIdQuery({ variables: { id }, fetchPolicy: 'network-only', skip: options.skip || !id });
 
 // We should discuss on cache policy
 export const useAllMediaMentions = (filters?: MediaMentionsFiltersInput, options: QueryHookOptions = {}) => {

--- a/app/shared/hooks/use-news/useNews.tsx
+++ b/app/shared/hooks/use-news/useNews.tsx
@@ -18,15 +18,18 @@ import {
   useCreateNewsMutation,
   useDeleteNewsMutation,
   useIncrementNewsViewsMutation,
+  useNewsByIdQuery,
   useNewsCountQuery,
   usePaginatedNewsQuery,
   usePublishedNewsQuery,
-  useUpdateNewsMutation
-} from '~/types/graphql/generated/graphql';
+  useUpdateNewsMutation} from '~/types/graphql/generated/graphql';
 
 type QueryHookOptions = Readonly<{
   skip?: boolean;
 }>;
+
+export const useNewsById = (id: string, options: QueryHookOptions = {}) =>
+  useNewsByIdQuery({ variables: { id }, fetchPolicy: 'network-only', skip: options.skip || !id });
 
 export const useAllNews = (filters?: NewsFiltersInput, options: QueryHookOptions = {}) =>
   useAllNewsQuery({ variables: { filters }, fetchPolicy: 'network-only', skip: options.skip });

--- a/app/shared/hooks/use-publications-manager/usePublicationsManager.test.ts
+++ b/app/shared/hooks/use-publications-manager/usePublicationsManager.test.ts
@@ -1,0 +1,185 @@
+import { act,renderHook } from '@testing-library/react';
+
+import { usePublicationManager } from './usePublicationsManager';
+import { LocalizedEditorState } from '~/constants/publications';
+import { BaseContentStatuses } from '~/types/enums/common.enums';
+
+jest.mock('~/shared/components/content-editor', () => ({
+  isContentEmpty: jest.fn((blocks: unknown[]) => !blocks || blocks.length === 0)
+}));
+
+jest.mock('~/constants/publications', () => ({
+  DEFAULT_EMPTY_DOCUMENT: { blocks: [] },
+}));
+
+const mockUpdateNews = jest.fn();
+const mockUpdateEvent = jest.fn();
+const mockUpdateMedia = jest.fn();
+
+jest.mock('~/shared/hooks/use-news/useNews', () => ({
+  useNewsById: jest.fn(),
+  useUpdateNews: () => [mockUpdateNews]
+}));
+
+jest.mock('~/shared/hooks/use-events/useEvents', () => ({
+  useEventById: jest.fn(),
+  useUpdateEvent: () => [mockUpdateEvent]
+}));
+
+jest.mock('~/shared/hooks/use-media-mentions/useMediaMentions', () => ({
+  useMediaMentionById: jest.fn(),
+  useUpdateMediaMention: () => [mockUpdateMedia]
+}));
+
+import { useEventById } from '~/shared/hooks/use-events/useEvents';
+import { useMediaMentionById } from '~/shared/hooks/use-media-mentions/useMediaMentions';
+import { useNewsById } from '~/shared/hooks/use-news/useNews';
+
+const resetQueryMocks = () => {
+  (useNewsById as jest.Mock).mockReturnValue({ data: undefined, loading: false, error: undefined });
+  (useEventById as jest.Mock).mockReturnValue({ data: undefined, loading: false, error: undefined });
+  (useMediaMentionById as jest.Mock).mockReturnValue({ data: undefined, loading: false, error: undefined });
+};
+
+describe('usePublicationManager Hook', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetQueryMocks();
+  });
+
+  describe('Data Fetching', () => {
+    it('should correctly return news data and skip others', () => {
+      const mockNewsData = { newsById: { adminTitle: 'News Title' } };
+      (useNewsById as jest.Mock).mockReturnValue({ data: mockNewsData, loading: false });
+
+      const { result } = renderHook(() => usePublicationManager('news', '1'));
+
+      expect(result.current.currentData).toEqual(mockNewsData.newsById);
+      expect(result.current.isLoading).toBe(false);
+      
+      expect(useNewsById).toHaveBeenCalledWith('1', { skip: false });
+      expect(useEventById).toHaveBeenCalledWith('1', { skip: true });
+      expect(useMediaMentionById).toHaveBeenCalledWith('1', { skip: true });
+    });
+
+    it('should correctly return events data', () => {
+      const mockEventData = { eventById: { adminTitle: 'Event Title' } };
+      (useEventById as jest.Mock).mockReturnValue({ data: mockEventData, loading: false });
+
+      const { result } = renderHook(() => usePublicationManager('events', '2'));
+
+      expect(result.current.currentData).toEqual(mockEventData.eventById);
+    });
+  });
+
+  describe('Content Initialization', () => {
+    it('should initialize content and default to UA if UK content exists', () => {
+      (useNewsById as jest.Mock).mockReturnValue({
+        loading: false,
+        data: {
+          newsById: {
+            content: {
+              uk: { content: { blocks: [{ type: 'paragraph' }] } },
+              en: { content: { blocks: [] } }
+            }
+          }
+        }
+      });
+
+      const { result } = renderHook(() => usePublicationManager('news', '1'));
+
+      expect(result.current.currentLanguage).toBe('UA');
+      expect(result.current.editedContent?.uk?.content?.blocks.length).toBe(1);
+    });
+
+    it('should initialize content and fallback to EN if UK is empty but EN exists', () => {
+      (useNewsById as jest.Mock).mockReturnValue({
+        loading: false,
+        data: {
+          newsById: {
+            content: {
+              uk: { content: { blocks: [] } },
+              en: { content: { blocks: [{ type: 'paragraph' }] } }
+            }
+          }
+        }
+      });
+
+      const { result } = renderHook(() => usePublicationManager('news', '1'));
+
+      expect(result.current.currentLanguage).toBe('EN');
+    });
+
+    it('should completely skip initialization for media type', () => {
+      (useMediaMentionById as jest.Mock).mockReturnValue({
+        loading: false,
+        data: { mediaMentionById: { adminTitle: 'Media' } }
+      });
+
+      const { result } = renderHook(() => usePublicationManager('media', '1'));
+
+      expect(result.current.editedContent).toBeNull();
+    });
+  });
+
+  describe('updateResource Mutation Logic', () => {
+    it('should call updateNews for news type', async () => {
+      const { result } = renderHook(() => usePublicationManager('news', '1'));
+
+      await act(async () => {
+        await result.current.updateResource(BaseContentStatuses.Published, { extraProp: true });
+      });
+
+      expect(mockUpdateNews).toHaveBeenCalledWith({
+        id: '1',
+        input: { extraProp: true, status: BaseContentStatuses.Published }
+      });
+    });
+
+    it('should call updateEvent for events type', async () => {
+      const { result } = renderHook(() => usePublicationManager('events', '2'));
+
+      await act(async () => {
+        await result.current.updateResource(BaseContentStatuses.Draft, { customVal: 'test' });
+      });
+
+      expect(mockUpdateEvent).toHaveBeenCalledWith({
+        id: '2',
+        input: { customVal: 'test', status: BaseContentStatuses.Draft }
+      });
+    });
+
+    it('should call updateMedia for media type with correct argument structure', async () => {
+      const { result } = renderHook(() => usePublicationManager('media', '3'));
+
+      await act(async () => {
+        await result.current.updateResource(BaseContentStatuses.Published, { url: 'abc' });
+      });
+
+      expect(mockUpdateMedia).toHaveBeenCalledWith('3', {
+        url: 'abc',
+        status: BaseContentStatuses.Published
+      });
+    });
+  });
+
+  describe('State Reset Logic', () => {
+    it('should overwrite editedContent and increment editorResetKey', () => {
+      const { result } = renderHook(() => usePublicationManager('news', '1'));
+
+      expect(result.current.editorResetKey).toBe(0);
+
+      const emptyPayload: LocalizedEditorState = {
+        uk: { content: { blocks: [], version: '1', lastModified: '' } },
+        en: { content: { blocks: [], version: '1', lastModified: '' } }
+      };
+
+      act(() => {
+        result.current.resetEditorState(emptyPayload);
+      });
+
+      expect(result.current.editedContent).toEqual(emptyPayload);
+      expect(result.current.editorResetKey).toBe(1); 
+    });
+  });
+});

--- a/app/shared/hooks/use-publications-manager/usePublicationsManager.ts
+++ b/app/shared/hooks/use-publications-manager/usePublicationsManager.ts
@@ -1,0 +1,115 @@
+import { Block } from '@blocknote/core';
+import { useEffect, useMemo,useState } from 'react';
+
+import {
+  DEFAULT_EMPTY_DOCUMENT,
+  EditorLanguage,
+  LocalizedEditorState,
+  PublicationResource,
+  PublicationsItemType
+} from '~/constants/publications';
+import { isContentEmpty } from '~/shared/components/content-editor';
+import { useEventById, useUpdateEvent } from '~/shared/hooks/use-events/useEvents';
+import { useMediaMentionById, useUpdateMediaMention } from '~/shared/hooks/use-media-mentions/useMediaMentions';
+import { useNewsById, useUpdateNews } from '~/shared/hooks/use-news/useNews';
+import { type EventStatus, type MediaStatus, type NewsStatus } from '~/types/graphql/generated/graphql';
+
+export function usePublicationManager(type: PublicationsItemType, id: string) {
+  const news = useNewsById(id, { skip: type !== 'news' });
+  const event = useEventById(id, { skip: type !== 'events' });
+  const media = useMediaMentionById(id, { skip: type !== 'media' });
+
+  const [updateNews] = useUpdateNews();
+  const [updateEvent] = useUpdateEvent();
+  const [updateMedia] = useUpdateMediaMention();
+
+  const queryMap = useMemo(() => ({ news, events: event, media }), [news, event, media]);
+  const activeQuery = queryMap[type];
+
+  const isLoading = activeQuery.loading;
+  const hasError = activeQuery.error;
+
+  const currentData = useMemo(() => {
+    switch (type) {
+    case 'news':
+      return news.data?.newsById;
+    case 'events':
+      return event.data?.eventById;
+    case 'media':
+      return media.data?.mediaMentionById;
+    default:
+      return null;
+    }
+  }, [type, news.data, event.data, media.data]);
+
+  const [editedContent, setEditedContent] = useState<LocalizedEditorState | null>(null);
+  const [currentLanguage, setCurrentLanguage] = useState<EditorLanguage>('UA');
+  const [editorResetKey, setEditorResetKey] = useState<number>(0);
+
+  useEffect(() => {
+    if (type === 'media' || isLoading || activeQuery.data === undefined) return;
+
+    if (editedContent === null) {
+      const resourceData = type === 'news' ? news.data?.newsById?.content : event.data?.eventById?.content;
+
+      const hasUk = !isContentEmpty(resourceData?.uk?.content?.blocks);
+      const hasEn = !isContentEmpty(resourceData?.en?.content?.blocks);
+
+      setCurrentLanguage(!hasUk && hasEn ? 'EN' : 'UA');
+
+      const createSafeLangObj = (blocks: Block[] | undefined) => ({
+        content: {
+          ...DEFAULT_EMPTY_DOCUMENT,
+          blocks: !isContentEmpty(blocks) && blocks ? blocks : DEFAULT_EMPTY_DOCUMENT.blocks
+        }
+      });
+
+      setEditedContent({
+        uk: createSafeLangObj(resourceData?.uk?.content?.blocks),
+        en: createSafeLangObj(resourceData?.en?.content?.blocks)
+      });
+    }
+  }, [isLoading, editedContent, type, activeQuery.data, news.data, event.data]);
+
+  const updateResource: PublicationResource = async (status, extra = {}) => {
+    switch (type) {
+    case 'news':
+      return updateNews({
+        id,
+        input: { ...extra, status: status as unknown as NewsStatus }
+      });
+    case 'events':
+      return updateEvent({
+        id,
+        input: { ...extra, status: status as unknown as EventStatus }
+      });
+    case 'media':
+      return updateMedia(id, {
+        ...extra,
+        status: status as unknown as MediaStatus
+      });
+    default:
+      throw new Error(`Unsupported publication type for mutation: ${type}`);
+    }
+  };
+
+  const resetEditorState = (emptyContent: LocalizedEditorState) => {
+    setEditedContent(emptyContent);
+    setEditorResetKey((prev) => prev + 1);
+  };
+
+  return {
+    currentData,
+    isLoading,
+    hasError,
+
+    editedContent,
+    setEditedContent,
+    currentLanguage,
+    setCurrentLanguage,
+    editorResetKey,
+    resetEditorState,
+
+    updateResource
+  };
+}


### PR DESCRIPTION

## Description

Implemented page that effectively utilizes `DividedHeader` and required components, GraphQL hooks to create and clear publication's content, separates logic and UI into components and glues them into container component(`page.tsx`), increasing the page testability.

## Key changes
1. Separated page by 3 parts:
     - Hook `usePublicationsManager.ts` that manages the state, lifecycle and resources(hooks) sharing.
     - View `EditPublicationsView` that holds UI logic and stays reusable.
     - Container `page.tsx`.
2. Supplemented custom publication hooks with skip ability and with hook `useNewsById`, `useEventById`, `useMediaMentionById`.
3. Fixed several UI bugs in `HeaderRightActions.tsx`, `TitleDropdown.tsx`.
4. ContentEditor now given ability of conditionally render the sideMenu, and of taking custom `sx` prop. Also corrected the placeholder output.
5. Provided all necessary types within file `publications.ts`.

## Type of change

- [x] New feature

## How to test

>[!IMPORTANT]
> Perform your check only on `events` type of publication, because DB doesn't hold correct document structure for others, thus, fetching e.g. `news` will crash with appolo error.

1. Go to [URL](https://lf-admin-stage-dzfpbxeuauh7fad2.polandcentral-01.azurewebsites.net/publications/events/69e360d1891a01b605321f33/edit).
2. Ensure required functionality works as intended by editing or entering text in editor, perform following operations on page and refresh the page, ensuring the data persisted or removed:
     - Saving -> database now holds updated content and status 'draft'.
     - Saving and exiting -> database now holds updated content and status 'draft'.
     - Publishing -> database now holds updated content and status 'published'.
     - Content deleting  -> database now holds empty array in `content/[locale]`. 
>[!NOTE] 
>Publishing and saving the content save two locales, but content deleting deletes content only on chosen locale.
3. Change the language and try to perform same scenario.

## Video / Screenshots

https://github.com/user-attachments/assets/e167b18d-17f3-4468-b769-2bbb971ef613

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board
