### PR TITLE
feat(files): implement star and unstar functionality for assets

### DIFF
--- a/app/shared/components/file-card/FileCard.test.tsx
+++ b/app/shared/components/file-card/FileCard.test.tsx
@@ -2,10 +2,16 @@ import { fireEvent, render, screen } from '@testing-library/react';
 
 import FileCard, { FileCardData, FileType } from './FileCard';
 
+jest.mock('~/types/graphql/generated/graphql', () => ({
+  ...jest.requireActual('~/types/graphql/generated/graphql'),
+  useUpdateAssetMutation: () => [jest.fn(), { loading: false }]
+}));
+
 describe('FileCard', () => {
   const mockOnClick = jest.fn();
 
   const defaultFileData: FileCardData = {
+    id: 'test-file-123',
     name: 'Test Image.jpg',
     dateAdded: '2026-01-10',
     isStarred: false,

--- a/app/shared/components/file-card/FileCard.tsx
+++ b/app/shared/components/file-card/FileCard.tsx
@@ -6,6 +6,7 @@ import { MouseEvent, useState } from 'react';
 import { styles } from './FileCard.styles';
 import TooltipCustom from '~/ds-components/tooltip/Tooltip';
 import { formatUsageCount } from '~/lib/utils/formatUsageCount';
+import { useUpdateAssetMutation } from '~/types/graphql/generated/graphql';
 
 const ICON_SIZE = 21;
 const ICON_SIZE_2 = 32;
@@ -23,6 +24,7 @@ const FILE_TYPES = {
 export type FileType = keyof typeof FILE_TYPES;
 
 export interface FileCardData {
+  id: string;
   name: string;
   dateAdded: string;
   isStarred?: boolean;
@@ -38,10 +40,24 @@ export interface FileCardProps {
 
 const FileCard = ({ fileType, fileData, onClick }: FileCardProps) => {
   const [isTooltipOpen, setIsTooltipOpen] = useState(false);
-  const { name, dateAdded, isStarred = false, usageLinks, imageSrc } = fileData;
+  const { id, name, dateAdded, isStarred = false, usageLinks, imageSrc } = fileData;
+
+  const [updateAsset, { loading: isUpdatingStar }] = useUpdateAssetMutation();
 
   const handleMenuClick = (e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
+  };
+
+  const handleStarClick = async (e: MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+    try {
+      await updateAsset({
+        variables: {
+          id,
+          input: { isStarred: !isStarred }
+        }
+      });
+    } catch {}
   };
 
   const fileTypeIcon = FILE_TYPES[fileType] || FILE_TYPES.image;
@@ -84,7 +100,7 @@ const FileCard = ({ fileType, fileData, onClick }: FileCardProps) => {
 
         <Stack direction="row" gap="8px" alignItems="center">
           {isStarred && (
-            <Box sx={styles.iconWrapper}>
+            <Box sx={{ ...styles.iconWrapper, cursor: isUpdatingStar ? 'wait' : 'pointer' }} onClick={handleStarClick}>
               <Image src="/icons/star-1.svg" width={ICON_SIZE} height={ICON_SIZE} alt="Starred file" />
             </Box>
           )}

--- a/app/shared/components/file-info-sidebar/FileInfoSidebar.test.tsx
+++ b/app/shared/components/file-info-sidebar/FileInfoSidebar.test.tsx
@@ -3,6 +3,11 @@ import React from 'react';
 
 import { type FileDetailsSidebarFile, FileInfoSidebar } from './FileInfoSidebar';
 
+jest.mock('~/types/graphql/generated/graphql', () => ({
+  ...jest.requireActual('~/types/graphql/generated/graphql'),
+  useUpdateAssetMutation: () => [jest.fn(), { loading: false }]
+}));
+
 jest.mock('../design-system/tooltip/Tooltip', () => ({
   __esModule: true,
   default: ({ children }: { children: React.ReactNode }) => <>{children}</>
@@ -83,13 +88,7 @@ describe('FileInfoSidebar', () => {
 
   it('should render filename, meta, links, and description field', () => {
     render(
-      <FileInfoSidebar
-        file={baseFile}
-        onClose={jest.fn()}
-        onToggleStar={jest.fn()}
-        onDescriptionSave={jest.fn()}
-        onRequestAction={jest.fn()}
-      />
+      <FileInfoSidebar file={baseFile} onClose={jest.fn()} onDescriptionSave={jest.fn()} onRequestAction={jest.fn()} />
     );
 
     expect(screen.getByText('cat.png')).toBeInTheDocument();
@@ -125,12 +124,7 @@ describe('FileInfoSidebar', () => {
     const fileNoId = { ...baseFile, id: '' };
 
     render(
-      <FileInfoSidebar
-        file={fileNoId as FileDetailsSidebarFile}
-        onClose={jest.fn()}
-        onToggleStar={jest.fn()}
-        onRequestAction={jest.fn()}
-      />
+      <FileInfoSidebar file={fileNoId as FileDetailsSidebarFile} onClose={jest.fn()} onRequestAction={jest.fn()} />
     );
 
     expect(screen.getByLabelText('Додати в обрані')).toBeDisabled();
@@ -154,15 +148,6 @@ describe('FileInfoSidebar', () => {
     expect(onRequestAction).toHaveBeenCalledWith({ type: 'download', fileId: 'f1' });
 
     expect(onRequestAction).toHaveBeenCalledTimes(3);
-  });
-
-  it('should toggle star with correct next state', () => {
-    const onToggleStar = jest.fn();
-
-    render(<FileInfoSidebar file={baseFile} onClose={jest.fn()} onToggleStar={onToggleStar} />);
-
-    fireEvent.click(screen.getByLabelText('Додати в обрані'));
-    expect(onToggleStar).toHaveBeenCalledWith('f1', true);
   });
 
   it('should render preview image when previewUrl exists', () => {

--- a/app/shared/components/file-info-sidebar/FileInfoSidebar.tsx
+++ b/app/shared/components/file-info-sidebar/FileInfoSidebar.tsx
@@ -20,6 +20,7 @@ import XlsIcon from '~/public/icons/xls.svg';
 import ArchiveIcon from '~/public/icons/zip.svg';
 import ZoomIn from '~/public/icons/zoom-in.svg';
 import { CustomTextField } from '~/shared/components/design-system/text-field/TextField';
+import { useUpdateAssetMutation } from '~/types/graphql/generated/graphql';
 
 export type FileUsageLink = {
   id: string;
@@ -83,13 +84,7 @@ const RowText = ({ children }: { children: React.ReactNode }) => (
   <Typography sx={styles.rowText}>{children}</Typography>
 );
 
-export function FileInfoSidebar({
-  file,
-  onClose,
-  onToggleStar,
-  onDescriptionSave,
-  onRequestAction
-}: Readonly<FileInfoSidebarProps>) {
+export function FileInfoSidebar({ file, onClose, onDescriptionSave, onRequestAction }: Readonly<FileInfoSidebarProps>) {
   const fileId = file?.id;
   const filename = file?.filename ?? '—';
   const usageLinks = file?.usageLinks ?? [];
@@ -126,6 +121,21 @@ export function FileInfoSidebar({
     [fileId, onRequestAction]
   );
 
+  const [updateAsset, { loading: isUpdatingStar }] = useUpdateAssetMutation();
+
+  const handleStarToggle = async () => {
+    if (!file?.id) return;
+
+    try {
+      await updateAsset({
+        variables: {
+          id: file.id,
+          input: { isStarred: !isStarred }
+        }
+      });
+    } catch {}
+  };
+
   return (
     <Box sx={styles.root}>
       <Box sx={styles.header}>
@@ -146,9 +156,9 @@ export function FileInfoSidebar({
         <TooltipCustom title={isStarred ? 'Забрати з обраних' : 'Додати в обрані'} showArrow>
           <IconButton
             sx={{ ...styles.actionBtn, ...(isStarred ? styles.starFilled : {}) }}
-            onClick={() => fileId && onToggleStar?.(fileId, !isStarred)}
+            onClick={handleStarToggle}
             aria-label={isStarred ? 'Забрати з обраних' : 'Додати в обрані'}
-            disabled={!canEdit}
+            disabled={!canEdit || isUpdatingStar}
           >
             <StarBorderIcon />
           </IconButton>

--- a/app/shared/components/files-cards-layout/FilesCardsLayout.test.tsx
+++ b/app/shared/components/files-cards-layout/FilesCardsLayout.test.tsx
@@ -2,6 +2,11 @@ import { fireEvent, render, screen } from '@testing-library/react';
 
 import { FilesCardsLayout, type FilesCardsLayoutItem } from './FilesCardsLayout';
 
+jest.mock('~/types/graphql/generated/graphql', () => ({
+  ...jest.requireActual('~/types/graphql/generated/graphql'),
+  useUpdateAssetMutation: () => [jest.fn(), { loading: false }]
+}));
+
 jest.mock('~/shared/components/file-card', () => ({
   __esModule: true,
   default: ({ onClick }: { onClick?: () => void }) => (

--- a/app/shared/components/files-cards-layout/FilesCardsLayout.tsx
+++ b/app/shared/components/files-cards-layout/FilesCardsLayout.tsx
@@ -62,6 +62,7 @@ export function FilesCardsLayout({ view, items, onItemClick }: FilesCardsLayoutP
             <FileCard
               fileType={item.type}
               fileData={{
+                id: item.id,
                 name: item.name,
                 dateAdded: item.dateAdded,
                 isStarred: item.isStarred,

--- a/app/types/graphql/mutations/assets.graphql
+++ b/app/types/graphql/mutations/assets.graphql
@@ -1,0 +1,9 @@
+mutation UpdateAsset($id: ID!, $input: UpdateAssetInput!) {
+  updateAsset(id: $id, input: $input) {
+    id
+    isStarred
+    filename
+    description
+    updatedAt
+  }
+}

--- a/src/infrastructure/repositories/assetRepository/assetRepository.ts
+++ b/src/infrastructure/repositories/assetRepository/assetRepository.ts
@@ -117,10 +117,24 @@ const getAssetSort = (filters?: AssetFilters): Record<string, 1 | -1> => {
   };
 };
 
-export const AssetRepository = ({ AssetModel }: AssetRepoDeps) =>
-  createBaseRepository<AssetEntity, DbAsset, AssetFilters>({
+export type UpdateAssetData = Partial<Pick<AssetEntity, 'isStarred' | 'filename' | 'description'>>;
+
+export const AssetRepository = ({ AssetModel }: AssetRepoDeps) => {
+  const baseRepo = createBaseRepository<AssetEntity, DbAsset, AssetFilters>({
     model: AssetModel,
     toEntity,
     buildQuery: buildAssetQuery,
     getDefaultSort: getAssetSort
   });
+
+  const updateAsset = async (id: string, data: UpdateAssetData): Promise<AssetEntity | null> => {
+    const updatedDoc = await AssetModel.findByIdAndUpdate(id, { $set: data }, { new: true });
+
+    return updatedDoc ? toEntity(updatedDoc) : null;
+  };
+
+  return {
+    ...baseRepo,
+    updateAsset
+  };
+};

--- a/src/interfaces/graphql/resolvers/assets/Query.ts
+++ b/src/interfaces/graphql/resolvers/assets/Query.ts
@@ -14,11 +14,23 @@ export interface AllAssetsArgs {
     skip?: number;
   };
 }
+export interface UpdateAssetArgs {
+  id: string;
+  input: {
+    isStarred?: boolean;
+    filename?: string;
+    description?: string;
+  };
+}
 
 const endpointHandler = endpointRepositoryHandler('assetsRepository');
 
 export const AssetsQuery = {
-  allAssets: endpointHandler<AllAssetsArgs, unknown>(
-    async ({ args: { filters }, repo }) => repo.findAll(filters)
-  )
+  allAssets: endpointHandler<AllAssetsArgs, unknown>(async ({ args: { filters }, repo }) => repo.findAll(filters))
+};
+
+export const AssetsMutation = {
+  updateAsset: endpointHandler<UpdateAssetArgs, unknown>(async ({ args: { id, input }, repo }) => {
+    return repo.updateAsset(id, input);
+  })
 };

--- a/src/interfaces/graphql/resolvers/index.ts
+++ b/src/interfaces/graphql/resolvers/index.ts
@@ -1,5 +1,5 @@
 import { authMutation as AdminMutation } from './admin/AuthMutation';
-import { AssetsQuery } from './assets/Query';
+import { AssetsMutation,AssetsQuery } from './assets/Query';
 import { blobMutations as BlobMutation } from './blobStorage/blobMutation';
 import { EventsMutation } from './events/eventsMutation';
 import { EventsQuery } from './events/eventsQuery';
@@ -17,13 +17,14 @@ export const resolvers = {
     ...PageMutation,
     ...NewsMutation,
     ...MediaMentionsMutation,
-    ...EventsMutation
+    ...EventsMutation,
+    ...AssetsMutation
   },
   Query: {
     ...AdminQuery,
     ...NewsQuery,
     ...MediaMentionsQuery,
     ...EventsQuery,
-    ...AssetsQuery,
+    ...AssetsQuery
   }
 };

--- a/src/interfaces/graphql/schemas/assets.graphql
+++ b/src/interfaces/graphql/schemas/assets.graphql
@@ -49,3 +49,13 @@ input AssetsFiltersInput {
 extend type Query {
   allAssets(filters: AssetsFiltersInput): [Asset!]!
 }
+
+input UpdateAssetInput {
+  isStarred: Boolean
+  filename: String
+  description: String
+}
+
+extend type Mutation {
+  updateAsset(id: ID!, input: UpdateAssetInput!): Asset!
+}


### PR DESCRIPTION
## Description

Implemented star/unstar (favorite) functionality for assets. 
Added the `updateAsset` GraphQL mutation on the backend and integrated the star toggle action on the file card (`FileCard`) and the file details sidebar (`FileInfoSidebar`).

## Type of change

- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Navigate to the "Files" page.
2. Click the star icon on any file card to toggle its status.
3. Open the file details (right sidebar) and toggle the star status there — it should immediately sync with the card.
4. Switch to the "Favorites" tab and ensure only starred files are displayed.

### Expected Result
Users can toggle the favorite status of any file from the card or the sidebar. Starred files are successfully saved in the database and correctly displayed in the "Favorites" tab.



https://github.com/user-attachments/assets/1b9fd78e-baa1-4213-bd74-bd9449fdf948


Closes: https://github.com/Liatoshynsky-Foundation/lf-admin/issues/466
