### PR TITLE
feat: add rename file modal to sidebar

### DIFF
--- a/app/(logged_in)/files/FilesPageContent.tsx
+++ b/app/(logged_in)/files/FilesPageContent.tsx
@@ -49,6 +49,7 @@ import type { MediaModalRenderers } from '~/shared/components/media-modal/MediaM
 import type { MediaModalOpenState, MediaModalResult } from '~/shared/components/media-modal/MediaModal.types';
 import { UploadView } from '~/shared/components/media-modal/views/upload-view/UploadView';
 import { PageHeader } from '~/shared/components/page-header/PageHeader';
+import { RenameFileModal } from '~/shared/components/rename-file-modal/RenameFileModal';
 import { ViewToggle } from '~/shared/components/view-toggle';
 import { useAllAssets } from '~/shared/hooks/use-assets/useAssets';
 import { useFilesFiltering } from '~/shared/hooks/use-files';
@@ -151,6 +152,11 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
   const [hasInitializedSelection, setHasInitializedSelection] = useState(false);
   const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
   const [uploadModalInitial, setUploadModalInitial] = useState<MediaModalOpenState | undefined>(undefined);
+  const [renameModalState, setRenameModalState] = useState<{ open: boolean; fileId: string; currentFilename: string }>({
+    open: false,
+    fileId: '',
+    currentFilename: ''
+  });
   const { data, loading, error, refetch } = useAllAssets();
   const [uploadBlob] = useUploadBlobMutation();
 
@@ -354,14 +360,33 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
         />
       )}
 
-      {sidebarFile && <FileInfoSidebar file={sidebarFile} onClose={() => setSelectedFileId(null)} />}
-
+      {sidebarFile && (
+        <FileInfoSidebar
+          file={sidebarFile}
+          onClose={() => setSelectedFileId(null)}
+          onRequestAction={(action) => {
+            if (action.type === 'rename') {
+              setRenameModalState({
+                open: true,
+                fileId: action.fileId,
+                currentFilename: sidebarFile.filename
+              });
+            }
+          }}
+        />
+      )}
       <MediaModal
         open={isUploadModalOpen}
         initial={uploadModalInitial}
         onClose={handleCloseUploadFlow}
         onApply={handleUploadApply}
         renderers={{ upload: renderFilesUpload }}
+      />
+      <RenameFileModal
+        open={renameModalState.open}
+        fileId={renameModalState.fileId}
+        currentFilename={renameModalState.currentFilename}
+        onClose={() => setRenameModalState((prev) => ({ ...prev, open: false }))}
       />
     </Box>
   );

--- a/app/(logged_in)/files/page.test.tsx
+++ b/app/(logged_in)/files/page.test.tsx
@@ -28,7 +28,8 @@ jest.mock('~/types/graphql/generated/graphql', () => ({
     Document: 'Document',
     Spreadsheet: 'Spreadsheet'
   },
-  useUploadBlobMutation: () => [mockUploadBlob]
+  useUploadBlobMutation: () => [mockUploadBlob],
+  useUpdateAssetMutation: () => [jest.fn(), { loading: false }]
 }));
 
 jest.mock('~/shared/components/file-info-sidebar/FileInfoSidebar', () => ({

--- a/app/shared/components/rename-file-modal/RenameFileModal.test.tsx
+++ b/app/shared/components/rename-file-modal/RenameFileModal.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import toast from 'react-hot-toast';
+
+import { RenameFileModal } from './RenameFileModal';
+import { useUpdateAssetMutation } from '~/types/graphql/generated/graphql';
+
+jest.mock('react-hot-toast', () => ({
+  success: jest.fn(),
+  error: jest.fn()
+}));
+
+jest.mock('~/types/graphql/generated/graphql', () => ({
+  useUpdateAssetMutation: jest.fn()
+}));
+
+describe('RenameFileModal', () => {
+  const mockOnClose = jest.fn();
+  const mockUpdateAsset = jest.fn();
+
+  const defaultProps = {
+    open: true,
+    onClose: mockOnClose,
+    fileId: 'file-123',
+    currentFilename: 'old_name.jpg'
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useUpdateAssetMutation as jest.Mock).mockReturnValue([mockUpdateAsset, { loading: false }]);
+  });
+
+  it('renders modal with correct initial values', () => {
+    render(<RenameFileModal {...defaultProps} />);
+
+    expect(screen.getByText('Перейменувати файл')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('old_name.jpg')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /зберегти/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /скасувати/i })).toBeInTheDocument();
+  });
+
+  it('calls onClose when "Скасувати" is clicked', async () => {
+    const user = userEvent.setup();
+    render(<RenameFileModal {...defaultProps} />);
+
+    const cancelButton = screen.getByRole('button', { name: /скасувати/i });
+    await user.click(cancelButton);
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+    expect(mockUpdateAsset).not.toHaveBeenCalled();
+  });
+
+  it('closes modal without calling API if filename is unchanged', async () => {
+    const user = userEvent.setup();
+    render(<RenameFileModal {...defaultProps} />);
+
+    const saveButton = screen.getByRole('button', { name: /зберегти/i });
+    await user.click(saveButton);
+
+    expect(mockUpdateAsset).not.toHaveBeenCalled();
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes modal without calling API if filename is empty (only spaces)', async () => {
+    const user = userEvent.setup();
+    render(<RenameFileModal {...defaultProps} />);
+
+    const input = screen.getByDisplayValue('old_name.jpg');
+    await user.clear(input);
+    await user.type(input, '   ');
+
+    const saveButton = screen.getByRole('button', { name: /зберегти/i });
+    await user.click(saveButton);
+
+    expect(mockUpdateAsset).not.toHaveBeenCalled();
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls API and shows success toast on valid submit', async () => {
+    const user = userEvent.setup();
+    mockUpdateAsset.mockResolvedValueOnce({ data: {} });
+
+    render(<RenameFileModal {...defaultProps} />);
+
+    const input = screen.getByDisplayValue('old_name.jpg');
+    await user.clear(input);
+    await user.type(input, 'new_name.jpg');
+
+    const saveButton = screen.getByRole('button', { name: /зберегти/i });
+    await user.click(saveButton);
+
+    expect(mockUpdateAsset).toHaveBeenCalledWith({
+      variables: {
+        id: 'file-123',
+        input: { filename: 'new_name.jpg' }
+      }
+    });
+
+    await waitFor(() => {
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+      expect(toast.success).toHaveBeenCalledWith('Файл успішно перейменовано');
+    });
+  });
+
+  it('shows error toast on API failure', async () => {
+    const user = userEvent.setup();
+    mockUpdateAsset.mockRejectedValueOnce(new Error('API Error'));
+
+    render(<RenameFileModal {...defaultProps} />);
+
+    const input = screen.getByDisplayValue('old_name.jpg');
+    await user.clear(input);
+    await user.type(input, 'new_name.jpg');
+
+    const saveButton = screen.getByRole('button', { name: /зберегти/i });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Помилка при перейменуванні файлу');
+      expect(mockOnClose).not.toHaveBeenCalled();
+    });
+  });
+
+  it('disables input and buttons while loading', () => {
+    (useUpdateAssetMutation as jest.Mock).mockReturnValue([mockUpdateAsset, { loading: true }]);
+    render(<RenameFileModal {...defaultProps} />);
+
+    const input = screen.getByDisplayValue('old_name.jpg');
+    const saveButton = screen.getByRole('button', { name: /зберегти/i });
+    const cancelButton = screen.getByRole('button', { name: /скасувати/i });
+
+    expect(input).toBeDisabled();
+    expect(saveButton).toBeDisabled();
+    expect(cancelButton).toBeDisabled();
+  });
+});

--- a/app/shared/components/rename-file-modal/RenameFileModal.tsx
+++ b/app/shared/components/rename-file-modal/RenameFileModal.tsx
@@ -1,0 +1,102 @@
+import CloseIcon from '@mui/icons-material/Close';
+import { Box, Button, Dialog, IconButton,Typography } from '@mui/material';
+import React, { useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
+
+import { renameFileModalStyles as styles } from './RenameFileModalStyles';
+import { CustomTextField } from '~/shared/components/design-system/text-field/TextField';
+import { useUpdateAssetMutation } from '~/types/graphql/generated/graphql';
+
+export type RenameFileModalProps = {
+  open: boolean;
+  onClose: () => void;
+  fileId: string;
+  currentFilename: string;
+};
+
+export function RenameFileModal({ open, onClose, fileId, currentFilename }: Readonly<RenameFileModalProps>) {
+  const [filename, setFilename] = useState(currentFilename);
+  const [updateAsset, { loading }] = useUpdateAssetMutation();
+
+  useEffect(() => {
+    if (open) {
+      setFilename(currentFilename);
+    }
+  }, [open, currentFilename]);
+
+  const handleSave = async () => {
+    const trimmedName = filename.trim();
+
+    if (!trimmedName || trimmedName === currentFilename) {
+      onClose();
+      return;
+    }
+
+    try {
+      await updateAsset({
+        variables: {
+          id: fileId,
+          input: { filename: trimmedName }
+        }
+      });
+
+      onClose();
+      toast.success('Файл успішно перейменовано');
+    } catch {
+      toast.error('Помилка при перейменуванні файлу');
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={!loading ? onClose : undefined}
+      disableScrollLock
+      slotProps={{
+        paper: {
+          sx: styles.paper
+        }
+      }}
+    >
+      <Box sx={styles.header}>
+        <Typography sx={styles.title}>Перейменувати файл</Typography>
+        <IconButton onClick={onClose} disabled={loading} sx={{ color: 'text.primary', p: 0 }}>
+          <CloseIcon />
+        </IconButton>
+      </Box>
+
+      <Box sx={styles.inputContainer}>
+        <CustomTextField
+          fullWidth
+          autoFocus
+          value={filename}
+          onChange={(e) => setFilename(e.target.value)}
+          disabled={loading}
+        />
+      </Box>
+
+      <Box sx={styles.actions}>
+        <Button
+          onClick={handleSave}
+          disabled={loading}
+          variant="contained"
+          color="tertiary"
+          size="medium"
+          sx={styles.saveButton}
+        >
+          Зберегти
+        </Button>
+        <Button
+          onClick={onClose}
+          disabled={loading}
+          variant="outlined"
+          color="primary"
+          size="medium"
+          sx={styles.cancelButton}
+        >
+          Скасувати
+        </Button>
+      </Box>
+    </Dialog>
+  );
+}

--- a/app/shared/components/rename-file-modal/RenameFileModal.tsx
+++ b/app/shared/components/rename-file-modal/RenameFileModal.tsx
@@ -1,5 +1,5 @@
 import CloseIcon from '@mui/icons-material/Close';
-import { Box, Button, Dialog, IconButton,Typography } from '@mui/material';
+import { Box, Button, Dialog, IconButton, Typography } from '@mui/material';
 import React, { useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
 
@@ -50,7 +50,7 @@ export function RenameFileModal({ open, onClose, fileId, currentFilename }: Read
   return (
     <Dialog
       open={open}
-      onClose={!loading ? onClose : undefined}
+      onClose={loading ? undefined : onClose}
       disableScrollLock
       slotProps={{
         paper: {

--- a/app/shared/components/rename-file-modal/RenameFileModalStyles.ts
+++ b/app/shared/components/rename-file-modal/RenameFileModalStyles.ts
@@ -1,0 +1,48 @@
+import { SxProps, Theme } from '@mui/material/styles';
+
+export const renameFileModalStyles: Record<string, SxProps<Theme>> = {
+  paper: {
+    width: '572px',
+    maxWidth: '100%',
+    borderRadius: '24px',
+    padding: '28px 24px 28px 32px',
+    backgroundColor: 'background.default',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '40px',
+    boxSizing: 'border-box'
+  },
+
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    width: '100%'
+  },
+
+  title: {
+    fontSize: '28px',
+    fontWeight: 700,
+    lineHeight: 1.4,
+    color: 'text.primary',
+    margin: 0
+  },
+
+  inputContainer: {
+    width: '452px',
+    maxWidth: '100%'
+  },
+
+  actions: {
+    display: 'flex',
+    gap: '16px'
+  },
+
+  saveButton: {
+    width: '120px'
+  },
+
+  cancelButton: {
+    width: '131px'
+  }
+};


### PR DESCRIPTION
## Description

This PR introduces the ability to rename files directly from the FileInfoSidebar. It implements the RenameFileModal component and integrates it with the existing useUpdateAssetMutation via Apollo Client. The state is managed within FilesPageContent.

## Type of change

- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

Go to the Files page.

1. Click on any file card to open the right-hand FileInfoSidebar.
2. Click the Rename (pencil) icon in the sidebar actions.
3. In the opened modal, enter a new filename.
4. Click Save.
5. Verify that the success toast notification appears ("Файл успішно перейменовано").
6. Try opening the modal again and clicking Cancel (or changing the name to empty) to ensure no request is sent.

## Video / Screenshots


https://github.com/user-attachments/assets/ed5e56e5-5ce8-4c69-81b5-38a19e1f97e9



Closes: https://github.com/Liatoshynsky-Foundation/lf-admin/issues/469
