### PR TITLE
fix: replace outlined star with filled and make it clickable in list view

### DIFF
--- a/app/shared/components/files-cards-layout/FilesCardsLayout.tsx
+++ b/app/shared/components/files-cards-layout/FilesCardsLayout.tsx
@@ -40,6 +40,7 @@ export function FilesCardsLayout({ view, items, onItemClick }: FilesCardsLayoutP
           {items.map((item) => (
             <Box key={item.id} sx={styles.listItem}>
               <MinimizedFileCard
+                id={item.id}
                 fileType={minimizedTypeMap[item.type]}
                 starred={!!item.isStarred}
                 linked={!!item.usageLinks && item.usageLinks > 0}

--- a/app/shared/components/minimized-file-card/MinimizedFileCard.styles.ts
+++ b/app/shared/components/minimized-file-card/MinimizedFileCard.styles.ts
@@ -19,5 +19,15 @@ export const styles = {
   },
   content: {
     gap: '8px'
+  },
+  iconWrapper: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    cursor: 'pointer',
+    transition: 'opacity 0.2s',
+    '&:hover': {
+      opacity: 0.7
+    }
   }
 };

--- a/app/shared/components/minimized-file-card/MinimizedFileCard.test.tsx
+++ b/app/shared/components/minimized-file-card/MinimizedFileCard.test.tsx
@@ -3,8 +3,14 @@ import userEvent from '@testing-library/user-event';
 
 import MinimizedFileCard from './MinimizedFileCard';
 
+jest.mock('~/types/graphql/generated/graphql', () => ({
+  ...jest.requireActual('~/types/graphql/generated/graphql'),
+  useUpdateAssetMutation: () => [jest.fn(), { loading: false }]
+}));
+
 describe('MinimizedFileCard', () => {
   const defaultProps = {
+    id: 'test-id-123',
     name: 'Test File',
     date: '10.10.2025'
   };

--- a/app/shared/components/minimized-file-card/MinimizedFileCard.tsx
+++ b/app/shared/components/minimized-file-card/MinimizedFileCard.tsx
@@ -1,8 +1,9 @@
-import { IconButton, Paper, Stack, Typography } from '@mui/material';
+import { Box, IconButton, Paper, Stack, Typography } from '@mui/material';
 import Image from 'next/image';
 import { MouseEvent } from 'react';
 
 import { styles } from '~/components/minimized-file-card/MinimizedFileCard.styles';
+import { useUpdateAssetMutation } from '~/types/graphql/generated/graphql';
 
 const ICON_SIZE = 21;
 
@@ -19,6 +20,7 @@ const FILE_TYPES = {
 type FileType = keyof typeof FILE_TYPES;
 
 interface MinimizedFileCardProps {
+  id: string;
   fileType?: FileType;
   starred?: boolean;
   linked?: boolean;
@@ -29,6 +31,7 @@ interface MinimizedFileCardProps {
 }
 
 const MinimizedFileCard = ({
+  id,
   fileType = FILE_TYPES.img,
   starred = false,
   linked = false,
@@ -37,9 +40,23 @@ const MinimizedFileCard = ({
   onClick,
   onMenuClick
 }: MinimizedFileCardProps) => {
+  const [updateAsset, { loading: isUpdatingStar }] = useUpdateAssetMutation();
+
   const handleMenuClick = (e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
     onMenuClick?.(e);
+  };
+
+  const handleStarClick = async (e: MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+    try {
+      await updateAsset({
+        variables: {
+          id,
+          input: { isStarred: !starred }
+        }
+      });
+    } catch {}
   };
 
   return (
@@ -56,8 +73,18 @@ const MinimizedFileCard = ({
           {name}
         </Typography>
 
-        <Stack direction="row" gap={'10px'}>
-          {starred && <Image src="/icons/star.svg" width={ICON_SIZE} height={ICON_SIZE} alt="Starred file" />}
+        <Stack direction="row" gap={'10px'} alignItems="center">
+          {starred && (
+            <Box
+              onClick={handleStarClick}
+              sx={{
+                ...styles.iconWrapper,
+                cursor: isUpdatingStar ? 'wait' : 'pointer'
+              }}
+            >
+              <Image src="/icons/star-1.svg" width={ICON_SIZE} height={ICON_SIZE} alt="Starred file" />
+            </Box>
+          )}
           {linked && <Image src="/icons/link.svg" width={ICON_SIZE} height={ICON_SIZE} alt="Linked file" />}
         </Stack>
       </Stack>


### PR DESCRIPTION
## Description

Added functionality for adding to favorites and removing which was not added for other file displays, also changed the star icon

## Type of change

- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Open the files page.
2. Switch the view mode to "List View". Try clicking the star icon next to the file name, make sure the file is removed from the favorites

### Actual result:
In the List View, the star icon for favorited files was outlined (transparent) instead of filled. Additionally, clicking the star icon did not trigger any action (the onClick handler was missing).

### Expected result:
In the List View, favorited files now correctly display a solid (filled) star icon. Clicking the icon successfully triggers the mutation to update the file's favorite status, and the UI updates immediate

https://github.com/user-attachments/assets/418c5403-45d6-475f-8e74-9374050fa49b


Closes: https://github.com/Liatoshynsky-Foundation/lf-admin/issues/476