### PR TITLE
feat: implement seo page

### DIFF
--- a/app/(logged_in)/publications/[type]/[id]/seo/page.test.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/seo/page.test.tsx
@@ -16,57 +16,36 @@ jest.mock('~/shared/hooks/use-upsert-publication/useUpsertPublication', () => ({
   useUpsertPublication: jest.fn()
 }));
 
-jest.mock('~/(logged_in)/publications/[type]/create/CreatePublicationsView', () => {
-  return function MockCreatePublicationView() {
-    return <div data-testid="mock-create-view" />;
-  };
-});
+jest.mock('~/(logged_in)/publications/[type]/create/CreatePublicationsView', () => ({
+  __esModule: true,
+  default: () => <div data-testid="mock-create-view" />
+}));
 
-type MockDividedHeaderProps = {
-  children: ReactNode;
-  rightActionsComponent: ReactNode;
-  originUrl?: string;
-};
+jest.mock('~/shared/components/divided-header/DividedHeader', () => ({
+  __esModule: true,
+  default: ({ children, rightActionsComponent }: { children: ReactNode; rightActionsComponent: ReactNode }) => (
+    <div>
+      {children}
+      {rightActionsComponent}
+    </div>
+  )
+}));
 
-jest.mock('~/shared/components/divided-header/DividedHeader', () => {
-  return function MockDividedHeader({ children, rightActionsComponent }: MockDividedHeaderProps) {
-    return (
-      <header data-testid="mock-divided-header">
-        <div data-testid="header-children">{children}</div>
-        <div data-testid="header-actions">{rightActionsComponent}</div>
-      </header>
-    );
-  };
-});
-
-type MockHeaderRightActionsProps = {
-  onSave: () => void;
-  onCancel: () => void;
-  mode: string;
-};
-
-jest.mock('~/shared/components/divided-header/header-right-actions/HeaderRightActions', () => {
-  return function MockHeaderRightActions({ onSave, onCancel, mode }: MockHeaderRightActionsProps) {
-    return (
-      <div data-testid="mock-header-right-actions">
-        <span>Mode: {mode}</span>
-        <button data-testid="btn-save" onClick={onSave}>Save</button>
-        <button data-testid="btn-cancel" onClick={onCancel}>Cancel</button>
-      </div>
-    );
-  };
-});
-
-type MockTitleDropdownProps = {
-  type: string;
-  title: string;
-  renderMenuOpen: boolean;
-};
+jest.mock('~/shared/components/divided-header/header-right-actions/HeaderRightActions', () => ({
+  __esModule: true,
+  default: ({ onSave, onCancel }: { onSave: () => void; onCancel: () => void; mode: string }) => (
+    <>
+      <button data-testid="btn-save" onClick={onSave} />
+      <button data-testid="btn-cancel" onClick={onCancel} />
+    </>
+  )
+}));
 
 jest.mock('~/shared/components/divided-header/title-dropdown/TitleDropdown', () => ({
-  TitleDropdown: ({ type, title, renderMenuOpen }: MockTitleDropdownProps) => (
+  TitleDropdown: ({ type, title, renderMenuOpen }: { type: string; title: string; renderMenuOpen: boolean }) => (
     <div data-testid="mock-title-dropdown">
-      {type} - {title} - {renderMenuOpen ? 'Open' : 'Closed'}
+      <span data-type={type} data-open={renderMenuOpen} />
+      {title}
     </div>
   )
 }));
@@ -75,64 +54,44 @@ describe('PublicatiosSeoPage Container', () => {
   const mockHandleSave = jest.fn();
   const mockPush = jest.fn();
 
+  const setup = (type = 'news') => {
+    (useParams as jest.Mock).mockReturnValue({ type, id: '123' });
+    return render(<PublicatiosSeoPage />);
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
-
     (useRouter as jest.Mock).mockReturnValue({ push: mockPush });
-
     (useUpsertPublication as jest.Mock).mockReturnValue({
       handleSave: mockHandleSave
     } as unknown as ReturnType<typeof useUpsertPublication>);
   });
 
   it('should call notFound() if the type parameter is invalid', () => {
-    (useParams as jest.Mock).mockReturnValue({ type: 'invalid-type', id: '123' });
-
-    render(<PublicatiosSeoPage />);
-
+    setup('invalid-type');
     expect(notFound).toHaveBeenCalledTimes(1);
   });
 
-  it('should render the page successfully if the type is valid', () => {
-    (useParams as jest.Mock).mockReturnValue({ type: 'news', id: '123' });
+  describe('with valid publication type', () => {
+    beforeEach(() => {
+      setup('news');
+    });
 
-    render(<PublicatiosSeoPage />);
+    it('should render successfully with correct SEO title', () => {
+      expect(notFound).not.toHaveBeenCalled();
+      expect(useUpsertPublication).toHaveBeenCalledWith({ type: 'news', id: '123' });
+      expect(screen.getByTestId('mock-create-view')).toBeInTheDocument();
+      expect(screen.getByTestId('mock-title-dropdown')).toHaveTextContent('Редагування Новини');
+    });
 
-    expect(notFound).not.toHaveBeenCalled();
+    it('should handle save and cancel actions by routing to base path', () => {
+      fireEvent.click(screen.getByTestId('btn-save'));
+      expect(mockHandleSave).toHaveBeenCalledTimes(1);
 
-    expect(useUpsertPublication).toHaveBeenCalledWith({ type: 'news', id: '123' });
-    expect(screen.getByTestId('mock-create-view')).toBeInTheDocument();
-  });
+      fireEvent.click(screen.getByTestId('btn-cancel'));
 
-  it('should render the correct SEO title based on the publication type', () => {
-    (useParams as jest.Mock).mockReturnValue({ type: 'news', id: '123' });
-
-    render(<PublicatiosSeoPage />);
-
-    const titleDropdown = screen.getByTestId('mock-title-dropdown');
-    expect(titleDropdown).toHaveTextContent('SEO - Редагування Новини - Closed');
-  });
-
-  it('should navigate to the base path when the cancel button is clicked', () => {
-    (useParams as jest.Mock).mockReturnValue({ type: 'news', id: '123' });
-
-    render(<PublicatiosSeoPage />);
-
-    fireEvent.click(screen.getByTestId('btn-cancel'));
-
-    expect(mockPush).toHaveBeenCalledTimes(1);
-    expect(mockPush).toHaveBeenCalledWith(PUBLICATIONS_BASE_PATH);
-  });
-
-  it('should call publicationData.handleSave and navigate to the base path when save is clicked', () => {
-    (useParams as jest.Mock).mockReturnValue({ type: 'news', id: '123' });
-
-    render(<PublicatiosSeoPage />);
-
-    fireEvent.click(screen.getByTestId('btn-save'));
-
-    expect(mockHandleSave).toHaveBeenCalledTimes(1);
-    expect(mockPush).toHaveBeenCalledTimes(1);
-    expect(mockPush).toHaveBeenCalledWith(PUBLICATIONS_BASE_PATH);
+      expect(mockPush).toHaveBeenCalledTimes(2);
+      expect(mockPush).toHaveBeenCalledWith(PUBLICATIONS_BASE_PATH);
+    });
   });
 });

--- a/app/(logged_in)/publications/[type]/[id]/seo/page.test.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/seo/page.test.tsx
@@ -1,0 +1,138 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { notFound, useParams, useRouter } from 'next/navigation';
+import React, { ReactNode } from 'react';
+
+import PublicatiosSeoPage from './page';
+import { PUBLICATIONS_BASE_PATH } from '~/constants/publications';
+import { useUpsertPublication } from '~/shared/hooks/use-upsert-publication/useUpsertPublication';
+
+jest.mock('next/navigation', () => ({
+  useParams: jest.fn(),
+  useRouter: jest.fn(),
+  notFound: jest.fn()
+}));
+
+jest.mock('~/shared/hooks/use-upsert-publication/useUpsertPublication', () => ({
+  useUpsertPublication: jest.fn()
+}));
+
+jest.mock('~/(logged_in)/publications/[type]/create/CreatePublicationsView', () => {
+  return function MockCreatePublicationView() {
+    return <div data-testid="mock-create-view" />;
+  };
+});
+
+type MockDividedHeaderProps = {
+  children: ReactNode;
+  rightActionsComponent: ReactNode;
+  originUrl?: string;
+};
+
+jest.mock('~/shared/components/divided-header/DividedHeader', () => {
+  return function MockDividedHeader({ children, rightActionsComponent }: MockDividedHeaderProps) {
+    return (
+      <header data-testid="mock-divided-header">
+        <div data-testid="header-children">{children}</div>
+        <div data-testid="header-actions">{rightActionsComponent}</div>
+      </header>
+    );
+  };
+});
+
+type MockHeaderRightActionsProps = {
+  onSave: () => void;
+  onCancel: () => void;
+  mode: string;
+};
+
+jest.mock('~/shared/components/divided-header/header-right-actions/HeaderRightActions', () => {
+  return function MockHeaderRightActions({ onSave, onCancel, mode }: MockHeaderRightActionsProps) {
+    return (
+      <div data-testid="mock-header-right-actions">
+        <span>Mode: {mode}</span>
+        <button data-testid="btn-save" onClick={onSave}>Save</button>
+        <button data-testid="btn-cancel" onClick={onCancel}>Cancel</button>
+      </div>
+    );
+  };
+});
+
+type MockTitleDropdownProps = {
+  type: string;
+  title: string;
+  renderMenuOpen: boolean;
+};
+
+jest.mock('~/shared/components/divided-header/title-dropdown/TitleDropdown', () => ({
+  TitleDropdown: ({ type, title, renderMenuOpen }: MockTitleDropdownProps) => (
+    <div data-testid="mock-title-dropdown">
+      {type} - {title} - {renderMenuOpen ? 'Open' : 'Closed'}
+    </div>
+  )
+}));
+
+describe('PublicatiosSeoPage Container', () => {
+  const mockHandleSave = jest.fn();
+  const mockPush = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (useRouter as jest.Mock).mockReturnValue({ push: mockPush });
+
+    (useUpsertPublication as jest.Mock).mockReturnValue({
+      handleSave: mockHandleSave
+    } as unknown as ReturnType<typeof useUpsertPublication>);
+  });
+
+  it('should call notFound() if the type parameter is invalid', () => {
+    (useParams as jest.Mock).mockReturnValue({ type: 'invalid-type', id: '123' });
+
+    render(<PublicatiosSeoPage />);
+
+    expect(notFound).toHaveBeenCalledTimes(1);
+  });
+
+  it('should render the page successfully if the type is valid', () => {
+    (useParams as jest.Mock).mockReturnValue({ type: 'news', id: '123' });
+
+    render(<PublicatiosSeoPage />);
+
+    expect(notFound).not.toHaveBeenCalled();
+
+    expect(useUpsertPublication).toHaveBeenCalledWith({ type: 'news', id: '123' });
+    expect(screen.getByTestId('mock-create-view')).toBeInTheDocument();
+  });
+
+  it('should render the correct SEO title based on the publication type', () => {
+    (useParams as jest.Mock).mockReturnValue({ type: 'news', id: '123' });
+
+    render(<PublicatiosSeoPage />);
+
+    const titleDropdown = screen.getByTestId('mock-title-dropdown');
+    expect(titleDropdown).toHaveTextContent('SEO - Редагування Новини - Closed');
+  });
+
+  it('should navigate to the base path when the cancel button is clicked', () => {
+    (useParams as jest.Mock).mockReturnValue({ type: 'news', id: '123' });
+
+    render(<PublicatiosSeoPage />);
+
+    fireEvent.click(screen.getByTestId('btn-cancel'));
+
+    expect(mockPush).toHaveBeenCalledTimes(1);
+    expect(mockPush).toHaveBeenCalledWith(PUBLICATIONS_BASE_PATH);
+  });
+
+  it('should call publicationData.handleSave and navigate to the base path when save is clicked', () => {
+    (useParams as jest.Mock).mockReturnValue({ type: 'news', id: '123' });
+
+    render(<PublicatiosSeoPage />);
+
+    fireEvent.click(screen.getByTestId('btn-save'));
+
+    expect(mockHandleSave).toHaveBeenCalledTimes(1);
+    expect(mockPush).toHaveBeenCalledTimes(1);
+    expect(mockPush).toHaveBeenCalledWith(PUBLICATIONS_BASE_PATH);
+  });
+});

--- a/app/(logged_in)/publications/[type]/[id]/seo/page.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/seo/page.tsx
@@ -1,9 +1,41 @@
-import { Box } from '@mui/material';
+'use client';
 
-export default function PublicationSeoPage() {
+import { Box } from '@mui/material';
+import { useParams, useRouter } from 'next/navigation';
+
+import CreatePublicationView from '~/(logged_in)/publications/[type]/create/CreatePublicationsView';
+import { PAGE_TITLES, PUBLICATIONS_BASE_PATH, PublicationsItemType } from '~/constants/publications';
+import DividedHeader from '~/shared/components/divided-header/DividedHeader';
+import HeaderRightActions from '~/shared/components/divided-header/header-right-actions/HeaderRightActions';
+import { TitleDropdown } from '~/shared/components/divided-header/title-dropdown/TitleDropdown';
+import { useUpsertPublication } from '~/shared/hooks/use-upsert-publication/useUpsertPublication';
+
+type Params = {
+  type: PublicationsItemType;
+  id: string;
+};
+
+export default function PublicatiosSeoPage() {
+  const { type, id } = useParams<Params>();
+  const router = useRouter();
+
+  const publicationData = useUpsertPublication({ type, id });
+
+  const handleCancel = () => router.push(PUBLICATIONS_BASE_PATH);
+  const handleSave = () => {
+    publicationData?.handleSave();
+    router.push(PUBLICATIONS_BASE_PATH);
+  };
+
   return (
     <Box>
+      <DividedHeader
+        rightActionsComponent={<HeaderRightActions mode="seo" onSave={handleSave} onCancel={handleCancel} />}
+      >
+        <TitleDropdown type="SEO" title={`Редагування ${PAGE_TITLES[type]}`} renderMenuOpen={false} />
+      </DividedHeader>
 
+      <CreatePublicationView data={publicationData} />
     </Box>
   );
 }

--- a/app/(logged_in)/publications/[type]/[id]/seo/page.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/seo/page.tsx
@@ -1,10 +1,15 @@
 'use client';
 
 import { Box } from '@mui/material';
-import { useParams, useRouter } from 'next/navigation';
+import { notFound, useParams, useRouter } from 'next/navigation';
 
 import CreatePublicationView from '~/(logged_in)/publications/[type]/create/CreatePublicationsView';
-import { PAGE_TITLES, PUBLICATIONS_BASE_PATH, PublicationsItemType } from '~/constants/publications';
+import {
+  PAGE_TITLES,
+  PUBLICATIONS_BASE_PATH,
+  PUBLICATIONS_TYPES,
+  PublicationsItemType
+} from '~/constants/publications';
 import DividedHeader from '~/shared/components/divided-header/DividedHeader';
 import HeaderRightActions from '~/shared/components/divided-header/header-right-actions/HeaderRightActions';
 import { TitleDropdown } from '~/shared/components/divided-header/title-dropdown/TitleDropdown';
@@ -21,6 +26,8 @@ export default function PublicatiosSeoPage() {
 
   const publicationData = useUpsertPublication({ type, id });
 
+  if (!PUBLICATIONS_TYPES.includes(type)) notFound();
+
   const handleCancel = () => router.push(PUBLICATIONS_BASE_PATH);
   const handleSave = () => {
     publicationData?.handleSave();
@@ -30,6 +37,7 @@ export default function PublicatiosSeoPage() {
   return (
     <Box>
       <DividedHeader
+        originUrl={PUBLICATIONS_BASE_PATH}
         rightActionsComponent={<HeaderRightActions mode="seo" onSave={handleSave} onCancel={handleCancel} />}
       >
         <TitleDropdown type="SEO" title={`Редагування ${PAGE_TITLES[type]}`} renderMenuOpen={false} />

--- a/app/(logged_in)/publications/[type]/create/page.tsx
+++ b/app/(logged_in)/publications/[type]/create/page.tsx
@@ -15,9 +15,9 @@ export default function CreatePublicationPage() {
   const params = useParams();
   const type = params?.type as PublicationsItemType;
 
-  if (!PUBLICATIONS_TYPES.includes(type)) notFound();
-  
   const publicationData = useUpsertPublication({ type });
+
+  if (!PUBLICATIONS_TYPES.includes(type)) notFound();
 
   return (
     <Box sx={styles.container}>

--- a/app/shared/components/divided-header/title-dropdown/TitleDropdown.tsx
+++ b/app/shared/components/divided-header/title-dropdown/TitleDropdown.tsx
@@ -10,7 +10,8 @@ import { sxToArray } from '~/lib/utils/sxToArray';
 type BaseTitleDropdownProps = {
   title: string;
   sx?: SxProps<Theme>;
-  onMenuOpen: (event: MouseEvent<HTMLElement>) => void;
+  renderMenuOpen?: boolean;
+  onMenuOpen?: (event: MouseEvent<HTMLElement>) => void;
 };
 
 type MultilingualProps = BaseTitleDropdownProps & {
@@ -25,7 +26,7 @@ type SeoProps = BaseTitleDropdownProps & {
 export type TitleDropdownProps = MultilingualProps | SeoProps;
 
 export const TitleDropdown = (props: TitleDropdownProps) => {
-  const { title, type, onMenuOpen } = props;
+  const { title, type, renderMenuOpen = true, onMenuOpen } = props;
 
   const contextLabel = type === 'multilingual' ? (props.language ?? 'UA') : 'SEO';
 
@@ -40,9 +41,11 @@ export const TitleDropdown = (props: TitleDropdownProps) => {
       </Typography>
 
       <Typography variant="customBold20Tight">{contextLabel}</Typography>
-      <IconButton aria-label="Відкрити меню" sx={{ ml: '-4px' }} onClick={onMenuOpen}>
-        <ChevronDown size="20px" color="#190D03" strokeWidth="1.5px" />
-      </IconButton>
+      {renderMenuOpen && (
+        <IconButton aria-label="Відкрити меню" sx={{ ml: '-4px' }} onClick={onMenuOpen}>
+          <ChevronDown size="20px" color="#190D03" strokeWidth="1.5px" />
+        </IconButton>
+      )}
     </Box>
   );
 };


### PR DESCRIPTION
## Description

Implemented the dedicated SEO editing page for publications at the newly created `/publications/[type]/[id]/seo` route. This allows users to efficiently modify metadata, canonical URLs, and publication dates for existing content without having to load the full visual block editor.

The page was built as a "smart container" that seamlessly connects our shared logic and UI components:
- **Routing & Validation:** Extracts and validates the `type` and `id` parameters from the URL.
- **Data Hook Integration:** Initializes the `useUpsertPublication` hook to automatically fetch the existing publication data and manage the form state.
- **Header Configuration:** Integrates the `DividedHeader` with the `HeaderRightActions` in `seo` mode. The "Save" button connects directly to the hook's upsert mutation, while "Cancel" safely routes the user back to the main publications dashboard.
- **View Integration:** Renders the shared `CreatePublicationView` to display the pre-filled metadata fields.

## Type of change

- [x] New feature

## How to test

1. Pull the branch locally and start the application.
2. Navigate to the SEO editing route for an existing publication (e.g., `/publications/news/123/seo`).
3. **Verify UI:** Ensure the `CreatePublicationView` renders correctly and is pre-filled with the existing metadata for that publication. Verify the header displays the "Cancel" and "Save" buttons.
4. **Test Cancel:** Click the "Cancel" button and verify it redirects you safely back to `/publications` without saving any changes.
5. **Test Save:** Make a modification to one of the SEO fields (e.g., canonical URL or publication date). Click "Save" and verify that the update mutation triggers successfully and the new data persists.

## Video / Screenshots

**SEO Editing Page (Pre-filled):**
<img width="1206" height="888" alt="image" src="https://github.com/user-attachments/assets/f21a0cae-3aa3-41b7-8f26-708eed8a5ade" />

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board