### PR TITLE
fix: events arent shown in publications

### DIFF
--- a/app/(logged_in)/publications/PublicationsPageContent.tsx
+++ b/app/(logged_in)/publications/PublicationsPageContent.tsx
@@ -33,14 +33,12 @@ import { EmptyState } from '~/shared/components/empty-state';
 import { FilteringToolbar, SortSelect } from '~/shared/components/filtering-toolbar';
 import { PageHeader } from '~/shared/components/page-header/PageHeader';
 import { filterSelectStyles } from '~/shared/components/selector/FilterSelect.styles';
+import { useAllEvents } from '~/shared/hooks/use-events/useEvents';
 import { useAllMediaMentions } from '~/shared/hooks/use-media-mentions/useMediaMentions';
 import { useAllNews } from '~/shared/hooks/use-news/useNews';
 import { usePublicationsFiltering } from '~/shared/hooks/use-publications';
 import type { LocalizedString } from '~/types/common';
-import {
-  type AllMediaMentionsQuery,
-  type AllNewsQuery
-} from '~/types/graphql/generated/graphql';
+import { type AllEventsQuery, type AllMediaMentionsQuery, type AllNewsQuery } from '~/types/graphql/generated/graphql';
 import { normalizeSearch } from '~/utils/normalizeSearch';
 
 type PublicationsPageContentProps = Readonly<{
@@ -71,6 +69,7 @@ type PublicationCardItem = {
 };
 
 type NewsItem = AllNewsQuery['allNews'][number];
+type EventItem = AllEventsQuery['allEvents'][number];
 type MediaMentionItem = AllMediaMentionsQuery['allMediaMentions'][number];
 type PublicationsTabStateMap<T> = {
   news: T;
@@ -85,7 +84,11 @@ const DEFAULT_COVER_IMAGE = '/images/image.png';
 const DEFAULT_COVER_ALT = 'Обкладинка матеріалу';
 const SORT_FALLBACK_DATE = '1970-01-01T00:00:00.000Z';
 
-const comparePublicationItems = (left: PublicationCardItem, right: PublicationCardItem, sortValue: FilesSortValue): number => {
+const comparePublicationItems = (
+  left: PublicationCardItem,
+  right: PublicationCardItem,
+  sortValue: FilesSortValue
+): number => {
   if (sortValue === 'name_asc') {
     return left.sortTitle.localeCompare(right.sortTitle, 'uk');
   }
@@ -250,6 +253,43 @@ const mapNewsItem = (item: NewsItem): PublicationCardItem | null => {
   };
 };
 
+const mapEventItem = (item: EventItem): PublicationCardItem | null => {
+  if (!isPublicationCardStatus(item.status)) {
+    return null;
+  }
+
+  const publicationStatus = item.status;
+
+  const fallbackTitle = item.adminTitle;
+  const title = toLocalizedCardValue(item.title, fallbackTitle);
+  const titleText = getPrimaryText(item.title, fallbackTitle);
+  const sortTitle = fallbackTitle || titleText;
+  const sortableDate = getSortableDate(item.publishedAt, item.eventDateTimeStart, item.eventDateTimeEnd);
+
+  const coverImage = (item as any).coverImage;
+
+  return {
+    id: item.id,
+    title: titleText,
+    sortTitle,
+    titleData: title,
+    type: 'events',
+    cardType: mapCardType('events'),
+    dateAdded: sortableDate,
+    createdAtRaw: sortableDate,
+    createdAt: (item as any).createdAt,
+    updatedAt: (item as any).updatedAt,
+    publishedAt: item.publishedAt ?? undefined,
+    status: publicationStatus,
+    cardStatus: publicationStatus,
+    language: getLanguageFromLocalizedValue(title),
+    coverImage: {
+      src: coverImage?.src || DEFAULT_COVER_IMAGE,
+      alt: toLocalizedString(coverImage?.alt, titleText || DEFAULT_COVER_ALT)
+    }
+  };
+};
+
 const mapMediaMentionItem = (item: MediaMentionItem): PublicationCardItem | null => {
   if (!isPublicationCardStatus(item.status)) {
     return null;
@@ -399,16 +439,36 @@ function PublicationsCreateAction() {
 export function PublicationsPageContent({ activeTab }: PublicationsPageContentProps) {
   const { requestFilters, sortValue, toolbarProps, sortProps } = usePublicationsFiltering();
   const shouldFetchNews = activeTab === 'all' || activeTab === 'news';
+  const shouldFetchEvents = activeTab === 'all' || activeTab === 'events';
   const shouldFetchMedia = activeTab === 'all' || activeTab === 'media';
-  const { data: newsData, loading: isNewsLoading, error: newsError } = useAllNews(requestFilters.news, { skip: !shouldFetchNews });
-  const { data: mediaData, loading: isMediaLoading, error: mediaError } = useAllMediaMentions(requestFilters.media, { skip: !shouldFetchMedia });
+  const {
+    data: newsData,
+    loading: isNewsLoading,
+    error: newsError
+  } = useAllNews(requestFilters.news, { skip: !shouldFetchNews });
+  const {
+    data: eventsData,
+    loading: isEventsLoading,
+    error: eventsError
+  } = useAllEvents(requestFilters.events, { skip: !shouldFetchEvents });
+  const {
+    data: mediaData,
+    loading: isMediaLoading,
+    error: mediaError
+  } = useAllMediaMentions(requestFilters.media, { skip: !shouldFetchMedia });
 
   const newsItems = useMemo<PublicationCardItem[]>(() => {
     return (newsData?.allNews ?? []).map(mapNewsItem).filter((item): item is PublicationCardItem => Boolean(item));
   }, [newsData?.allNews]);
 
+  const eventItems = useMemo<PublicationCardItem[]>(() => {
+    return (eventsData?.allEvents ?? []).map(mapEventItem).filter((item): item is PublicationCardItem => Boolean(item));
+  }, [eventsData?.allEvents]);
+
   const mediaItems = useMemo<PublicationCardItem[]>(() => {
-    return (mediaData?.allMediaMentions ?? []).map(mapMediaMentionItem).filter((item): item is PublicationCardItem => Boolean(item));
+    return (mediaData?.allMediaMentions ?? [])
+      .map(mapMediaMentionItem)
+      .filter((item): item is PublicationCardItem => Boolean(item));
   }, [mediaData?.allMediaMentions]);
 
   const visibleItems = useMemo<PublicationCardItem[]>(() => {
@@ -416,16 +476,17 @@ export function PublicationsPageContent({ activeTab }: PublicationsPageContentPr
       return newsItems;
     }
 
+    if (activeTab === 'events') {
+      return eventItems;
+    }
+
     if (activeTab === 'media') {
       return mediaItems;
     }
 
-    if (activeTab === 'events') {
-      return [];
-    }
-
-    return mergeSortedPublicationItems(newsItems, mediaItems, sortValue);
-  }, [activeTab, mediaItems, newsItems, sortValue]);
+    const mergedNewsMedia = mergeSortedPublicationItems(newsItems, mediaItems, sortValue);
+    return mergeSortedPublicationItems(mergedNewsMedia, eventItems, sortValue);
+  }, [activeTab, mediaItems, eventItems, newsItems, sortValue]);
 
   const titleOptions = useMemo(() => getPublicationSearchOptions(visibleItems), [visibleItems]);
   const resolvedToolbarProps = useMemo(
@@ -442,13 +503,23 @@ export function PublicationsPageContent({ activeTab }: PublicationsPageContentPr
   );
   const hasActiveCriteria = Boolean(toolbarProps.search?.search.trim()) || Boolean(toolbarProps.activeFiltersCount);
   const hasBaseItems = visibleItems.length > 0;
-  const isLoading = getActiveTabState(activeTab, { news: shouldFetchNews ? isNewsLoading : false, media: shouldFetchMedia ? isMediaLoading : false, events: false }, (states) =>
-    states.news || states.media || states.events
+  const isLoading = getActiveTabState(
+    activeTab,
+    {
+      news: shouldFetchNews ? isNewsLoading : false,
+      events: shouldFetchEvents ? isEventsLoading : false,
+      media: shouldFetchMedia ? isMediaLoading : false
+    },
+    (states) => states.news || states.media || states.events
   );
   const activeError = getActiveTabState(
     activeTab,
-    { news: shouldFetchNews ? newsError : undefined, media: shouldFetchMedia ? mediaError : undefined, events: undefined },
-    (states) => states.news ?? states.media ?? states.events
+    {
+      news: shouldFetchNews ? newsError : undefined,
+      events: shouldFetchEvents ? eventsError : undefined,
+      media: shouldFetchMedia ? mediaError : undefined
+    },
+    (states) => states.news ?? states.events ?? states.media
   );
   const shouldShowLoadingState = activeTab === 'all' ? !hasBaseItems && isLoading : isLoading;
   const shouldShowErrorState = activeTab === 'all' ? !hasBaseItems && Boolean(activeError) : Boolean(activeError);
@@ -466,30 +537,19 @@ export function PublicationsPageContent({ activeTab }: PublicationsPageContentPr
   const content = (() => {
     if (shouldShowLoadingState) {
       return (
-        <EmptyState
-          title={PUBLICATIONS_LOADING_STATE_TITLE}
-          description={PUBLICATIONS_LOADING_STATE_DESCRIPTION}
-        />
+        <EmptyState title={PUBLICATIONS_LOADING_STATE_TITLE} description={PUBLICATIONS_LOADING_STATE_DESCRIPTION} />
       );
     }
 
     if (shouldShowErrorState) {
-      return (
-        <EmptyState
-          title={PUBLICATIONS_ERROR_STATE_TITLE}
-          description={PUBLICATIONS_ERROR_STATE_DESCRIPTION}
-        />
-      );
+      return <EmptyState title={PUBLICATIONS_ERROR_STATE_TITLE} description={PUBLICATIONS_ERROR_STATE_DESCRIPTION} />;
     }
 
     if (visibleItems.length) {
       return (
         <Box sx={styles.cardGrid}>
           {visibleItems.map((item) => (
-            <Box
-              key={item.id}
-              sx={styles.cardWrapper}
-            >
+            <Box key={item.id} sx={styles.cardWrapper}>
               <ContentCard
                 type={item.cardType}
                 coverImage={item.coverImage}
@@ -507,12 +567,7 @@ export function PublicationsPageContent({ activeTab }: PublicationsPageContentPr
       );
     }
 
-    return (
-      <EmptyState
-        title={emptyStateTitle}
-        description={emptyStateDescription}
-      />
-    );
+    return <EmptyState title={emptyStateTitle} description={emptyStateDescription} />;
   })();
 
   return (
@@ -536,13 +591,7 @@ export function PublicationsPageContent({ activeTab }: PublicationsPageContentPr
       <FilteringToolbar
         {...resolvedToolbarProps}
         dataTestId="publications-control-panel"
-        bottomTrailingContent={
-          <SortSelect
-            {...sortProps}
-            minWidth={208}
-            dataTestId="publications-sort-select"
-          />
-        }
+        bottomTrailingContent={<SortSelect {...sortProps} minWidth={208} dataTestId="publications-sort-select" />}
       />
 
       {content}

--- a/app/(logged_in)/publications/PublicationsPageContent.tsx
+++ b/app/(logged_in)/publications/PublicationsPageContent.tsx
@@ -266,7 +266,7 @@ const mapEventItem = (item: EventItem): PublicationCardItem | null => {
   const sortTitle = fallbackTitle || titleText;
   const sortableDate = getSortableDate(item.publishedAt, item.eventDateTimeStart, item.eventDateTimeEnd);
 
-  const coverImage = (item as any).coverImage;
+  const coverImage = item.coverImage;
 
   return {
     id: item.id,
@@ -277,8 +277,8 @@ const mapEventItem = (item: EventItem): PublicationCardItem | null => {
     cardType: mapCardType('events'),
     dateAdded: sortableDate,
     createdAtRaw: sortableDate,
-    createdAt: (item as any).createdAt,
-    updatedAt: (item as any).updatedAt,
+    createdAt: item.createdAt,
+    updatedAt: item.updatedAt,
     publishedAt: item.publishedAt ?? undefined,
     status: publicationStatus,
     cardStatus: publicationStatus,

--- a/app/(logged_in)/publications/page.test.tsx
+++ b/app/(logged_in)/publications/page.test.tsx
@@ -2,10 +2,11 @@ import { fireEvent, render, screen, within } from '@testing-library/react';
 import React from 'react';
 
 import Page from './page';
-import { MediaStatus, NewsStatus } from '~/types/graphql/generated/graphql';
+import { EventStatus, MediaStatus, NewsStatus } from '~/types/graphql/generated/graphql';
 
 const mockUseAllNews = jest.fn();
 const mockUseAllMediaMentions = jest.fn();
+const mockUseAllEvents = jest.fn();
 
 type QuerySortOption = {
   field: 'adminTitle' | 'createdAt';
@@ -68,6 +69,29 @@ const NEWS_ITEMS = [
   }
 ];
 
+const EVENT_ITEMS = [
+  {
+    id: 'event-1',
+    slug: 'main-event',
+    adminTitle: 'Головна подія сезону',
+    language: 'uk',
+    title: { uk: 'Головна подія сезону', en: '' },
+    status: EventStatus.Published,
+    createdAt: '2026-03-17T10:00:00.000Z', 
+    updatedAt: '2026-03-17T10:00:00.000Z',
+    publishedAt: '2026-03-18T10:00:00.000Z',
+    eventDateTimeStart: '2026-04-01T10:00:00.000Z',
+    eventDateTimeEnd: '2026-04-01T12:00:00.000Z',
+    description: null,
+    coverImage: {
+      src: '/event-1.png',
+      alt: { uk: 'Подія', en: '' }
+    },
+    meta: { views: 20 },
+    __typename: 'Event'
+  }
+];
+
 const MEDIA_ITEMS = [
   {
     id: 'media-1',
@@ -106,19 +130,16 @@ const MEDIA_ITEMS = [
   }
 ];
 
+
 const getSearchText = (title: string | { uk?: string; en?: string }, adminTitle?: string) => {
   if (typeof title === 'string') {
     return `${title} ${adminTitle ?? ''}`.trim().toLowerCase();
   }
-
   return [title.uk, title.en, adminTitle].filter(Boolean).join(' ').toLowerCase();
 };
 
 const getSortTitle = (item: { adminTitle?: string; title: string | { uk?: string; en?: string } }) => {
-  if (item.adminTitle) {
-    return item.adminTitle;
-  }
-
+  if (item.adminTitle) return item.adminTitle;
   return typeof item.title === 'string' ? item.title : item.title.uk || item.title.en || '';
 };
 
@@ -141,10 +162,7 @@ const getFieldComparison = (
   right: SortablePublicationItem,
   field: QuerySortOption['field']
 ): number => {
-  if (field === 'adminTitle') {
-    return compareByAdminTitle(left, right);
-  }
-
+  if (field === 'adminTitle') return compareByAdminTitle(left, right);
   return compareByCreatedAt(left, right);
 };
 
@@ -159,12 +177,10 @@ const compareBySort = (
 ) => {
   for (const criterion of sort) {
     const comparison = getFieldComparison(left, right, criterion.field);
-
     if (comparison !== 0) {
       return applySortOrder(comparison, criterion.order);
     }
   }
-
   return 0;
 };
 
@@ -190,28 +206,27 @@ const applyFilters = <T extends { createdAt: string; adminTitle?: string; title:
 };
 
 const buildNewsResponse = (filters?: PublicationsQueryFilters, options?: QueryHookOptions) => {
-  if (options?.skip) {
-    return { data: undefined, loading: false, error: undefined };
-  }
-
+  if (options?.skip) return { data: undefined, loading: false, error: undefined };
   return {
-    data: {
-      allNews: applyFilters(NEWS_ITEMS, filters)
-    },
+    data: { allNews: applyFilters(NEWS_ITEMS, filters) },
     loading: false,
     error: undefined
   };
 };
 
 const buildMediaResponse = (filters?: PublicationsQueryFilters, options?: QueryHookOptions) => {
-  if (options?.skip) {
-    return { data: undefined, loading: false, error: undefined };
-  }
-
+  if (options?.skip) return { data: undefined, loading: false, error: undefined };
   return {
-    data: {
-      allMediaMentions: applyFilters(MEDIA_ITEMS, filters)
-    },
+    data: { allMediaMentions: applyFilters(MEDIA_ITEMS, filters) },
+    loading: false,
+    error: undefined
+  };
+};
+
+const buildEventsResponse = (filters?: PublicationsQueryFilters, options?: QueryHookOptions) => {
+  if (options?.skip) return { data: undefined, loading: false, error: undefined };
+  return {
+    data: { allEvents: applyFilters(EVENT_ITEMS, filters) },
     loading: false,
     error: undefined
   };
@@ -224,6 +239,11 @@ jest.mock('~/shared/hooks/use-news/useNews', () => ({
 jest.mock('~/shared/hooks/use-media-mentions/useMediaMentions', () => ({
   useAllMediaMentions: (filters?: PublicationsQueryFilters, options?: QueryHookOptions) =>
     mockUseAllMediaMentions(filters, options)
+}));
+
+jest.mock('~/shared/hooks/use-events/useEvents', () => ({
+  useAllEvents: (filters?: PublicationsQueryFilters, options?: QueryHookOptions) =>
+    mockUseAllEvents(filters, options)
 }));
 
 jest.mock('~/shared/components/content-card/ContentCard', () => ({
@@ -242,7 +262,7 @@ jest.mock('~/shared/components/content-card/ContentCard', () => ({
     <div data-testid="publication-card">
       <span data-testid="publication-card-title">{title.uk || title.en}</span>
       <span>{status}</span>
-      <span>{type}</span>
+      <span data-testid="publication-card-type">{type}</span>
       {editHref ? <a href={editHref}>Редагувати</a> : null}
     </div>
   )
@@ -346,6 +366,10 @@ describe('Publications page', () => {
     mockUseAllMediaMentions.mockImplementation((filters?: PublicationsQueryFilters, options?: QueryHookOptions) =>
       buildMediaResponse(filters, options)
     );
+
+    mockUseAllEvents.mockImplementation((filters?: PublicationsQueryFilters, options?: QueryHookOptions) =>
+      buildEventsResponse(filters, options)
+    );
   });
 
   it('renders the configured page header and filtering controls', () => {
@@ -358,7 +382,9 @@ describe('Publications page', () => {
     expect(screen.getByRole('tab', { name: 'Ми у ЗМІ' })).toHaveAttribute('href', '/publications/media');
     expect(screen.getByRole('button', { name: 'Створити' })).toBeInTheDocument();
     expect(screen.getByTestId('publications-control-panel')).toBeInTheDocument();
-    expect(screen.getAllByTestId('publication-card')).toHaveLength(4);
+    
+    expect(screen.getAllByTestId('publication-card')).toHaveLength(5);
+    expect(screen.getByText('Головна подія сезону')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Фільтри' }));
 
@@ -399,15 +425,16 @@ describe('Publications page', () => {
     );
   });
 
-  it('filters cards by search value', () => {
+  it('filters cards by search value (across all types)', () => {
     render(<Page />);
 
-    fireEvent.change(screen.getByTestId('search'), { target: { value: 'фестиваль' } });
+    fireEvent.change(screen.getByTestId('search'), { target: { value: 'головна' } });
 
     expect(screen.getAllByTestId('publication-card')).toHaveLength(1);
-    expect(screen.getByText('Новина про фестиваль')).toBeInTheDocument();
-    expect(mockUseAllNews).toHaveBeenLastCalledWith(
-      expect.objectContaining({ search: 'фестиваль' }),
+    expect(screen.getByText('Головна подія сезону')).toBeInTheDocument();
+    
+    expect(mockUseAllEvents).toHaveBeenLastCalledWith(
+      expect.objectContaining({ search: 'головна' }),
       expect.objectContaining({ skip: false })
     );
   });
@@ -427,7 +454,7 @@ describe('Publications page', () => {
     render(<Page />);
 
     const beforeSort = screen.getAllByTestId('publication-card-title').map((element) => element.textContent);
-
+    
     expect(beforeSort[0]).toBe('Новина про фестиваль');
 
     fireEvent.click(screen.getByRole('button', { name: 'Фільтри' }));
@@ -436,7 +463,8 @@ describe('Publications page', () => {
     const afterSort = screen.getAllByTestId('publication-card-title').map((element) => element.textContent);
 
     expect(afterSort[0]).toBe('Вечір камерної музики');
-    expect(mockUseAllNews).toHaveBeenLastCalledWith(
+    
+    expect(mockUseAllEvents).toHaveBeenLastCalledWith(
       expect.objectContaining({
         sort: [
           { field: 'adminTitle', order: 'asc' },
@@ -447,7 +475,7 @@ describe('Publications page', () => {
     );
   });
 
-  it('keeps rendering news on the all tab when media request fails', () => {
+  it('keeps rendering remaining data on the all tab when one request fails', () => {
     mockUseAllMediaMentions.mockReturnValue({
       data: undefined,
       loading: false,
@@ -457,7 +485,10 @@ describe('Publications page', () => {
     render(<Page />);
 
     expect(screen.queryByText('Не вдалося завантажити матеріали')).not.toBeInTheDocument();
+    
     expect(screen.getByText('Новина про фестиваль')).toBeInTheDocument();
-    expect(screen.getByText('Вечір камерної музики')).toBeInTheDocument();
+    expect(screen.getByText('Головна подія сезону')).toBeInTheDocument();
+    
+    expect(screen.queryByText('Інтерв’ю про нову постановку')).not.toBeInTheDocument();
   });
 });

--- a/app/shared/hooks/use-publications/usePublicationsFiltering.test.ts
+++ b/app/shared/hooks/use-publications/usePublicationsFiltering.test.ts
@@ -1,7 +1,7 @@
 import { act, renderHook } from '@testing-library/react';
 
 import { usePublicationsFiltering } from './usePublicationsFiltering';
-import { MediaMentionsSortBy, NewsSortBy } from '~/types/graphql/generated/graphql';
+import { EventSortBy, MediaMentionsSortBy, NewsSortBy } from '~/types/graphql/generated/graphql';
 
 describe('usePublicationsFiltering', () => {
   beforeEach(() => {
@@ -14,6 +14,7 @@ describe('usePublicationsFiltering', () => {
 
     expect(result.current.requestFilters.news.sort).toEqual([{ field: NewsSortBy.CreatedAt, order: 'desc' }]);
     expect(result.current.requestFilters.media.sort).toEqual([{ field: MediaMentionsSortBy.CreatedAt, order: 'desc' }]);
+    expect(result.current.requestFilters.events.sort).toEqual([{ field: EventSortBy.CreatedAt, order: 'desc' }]);
 
     act(() => {
       result.current.toolbarProps.search?.setSearch(' фестиваль ');
@@ -32,6 +33,12 @@ describe('usePublicationsFiltering', () => {
       languages: ['bilingual'],
       statuses: ['editing'],
       sort: [{ field: MediaMentionsSortBy.CreatedAt, order: 'desc' }]
+    });
+    expect(result.current.requestFilters.events).toEqual({
+      search: 'фестиваль',
+      languages: ['bilingual'],
+      statuses: ['editing'],
+      sort: [{ field: EventSortBy.CreatedAt, order: 'desc' }]
     });
   });
 
@@ -52,6 +59,10 @@ describe('usePublicationsFiltering', () => {
     expect(result.current.requestFilters.media.sort).toEqual([
       { field: MediaMentionsSortBy.AdminTitle, order: 'asc' },
       { field: MediaMentionsSortBy.CreatedAt, order: 'desc' }
+    ]);
+    expect(result.current.requestFilters.events.sort).toEqual([
+      { field: EventSortBy.AdminTitle, order: 'asc' },
+      { field: EventSortBy.CreatedAt, order: 'desc' }
     ]);
     expect(result.current.toolbarProps.search?.options).toEqual([]);
   });

--- a/app/shared/hooks/use-publications/usePublicationsFiltering.ts
+++ b/app/shared/hooks/use-publications/usePublicationsFiltering.ts
@@ -16,14 +16,16 @@ import type { FilteringToolbarProps, SortSelectProps } from '~/shared/components
 import { BaseContentStatuses } from '~/types/enums/common.enums';
 import {
   ContentLanguage,
+  EventFiltersInput,
+  EventSortBy,
+  EventStatus,
   type MediaMentionsFiltersInput,
   MediaMentionsSortBy,
   MediaStatus,
   type NewsFiltersInput,
   NewsSortBy,
   NewsStatus,
-  SortOrder
-} from '~/types/graphql/generated/graphql';
+  SortOrder} from '~/types/graphql/generated/graphql';
 
 const SORT_STORAGE_KEY = 'publications_sort';
 
@@ -39,6 +41,7 @@ export type PublicationsFilteringSortProps = Omit<
 
 export type PublicationsRequestFilters = Readonly<{
   news: NewsFiltersInput;
+  events: EventFiltersInput;
   media: MediaMentionsFiltersInput;
 }>;
 
@@ -141,6 +144,12 @@ export function usePublicationsFiltering(): Readonly<{
         languages: languageFilters.length ? languageFilters.map(mapPublicationLanguageToApiLanguage) : undefined,
         statuses: statusFilters.length ? statusFilters.map((status) => mapPublicationStatus(status, NewsStatus)) : undefined,
         sort: getBaseContentSortOptions(sortValue, NewsSortBy) as NonNullable<NewsFiltersInput['sort']>
+      },
+      events: {
+        search: normalizedSearch || undefined,
+        languages: languageFilters.length ? languageFilters.map(mapPublicationLanguageToApiLanguage) : undefined,
+        statuses: statusFilters.length ? statusFilters.map((status) => mapPublicationStatus(status, EventStatus)) : undefined,
+        sort: getBaseContentSortOptions(sortValue, EventSortBy) as NonNullable<EventFiltersInput['sort']>
       },
       media: {
         search: normalizedSearch || undefined,

--- a/app/types/graphql/queries/events.graphql
+++ b/app/types/graphql/queries/events.graphql
@@ -74,10 +74,16 @@ query AllEvents($filters: EventFiltersInput) {
     }
     slug
     status
+    createdAt
+    updatedAt
     eventLink
     eventDateTimeStart
     eventDateTimeEnd
     publishedAt
+    coverImage {
+      src 
+      alt { uk en }
+    }
     meta {
       views
     }

--- a/src/interfaces/graphql/schemas/events.graphql
+++ b/src/interfaces/graphql/schemas/events.graphql
@@ -83,6 +83,7 @@ input EventFiltersInput {
   skip: Int
   statuses: [EventStatus!]
   slug: String
+  search: String
   eventDateTimeStart: String
   eventDateTimeEnd: String
   sort: [EventSortOptions!]


### PR DESCRIPTION
## Description

Expanded the main publications dashboard to support the fetching and rendering of Events alongside the existing News and Media Mentions. 

Key implementations include:
- **Data Fetching & Mapping:** Integrated the `useEvents` hook into `PublicationsPageContent.tsx` to fetch event data. Successfully mapped the event properties to the unified card component interface for consistent display in the grid.
- **Filtering Logic:** Updated the `usePublicationsFiltering.ts` hook to include 'events' as a valid filter category, allowing users to toggle event visibility on the dashboard.

## Type of change

- [x] New feature

## How to test

1. Go to [Publications](http://localhost:3000/publications).
2. Verify that Event cards are now fetched and rendered correctly in the grid alongside other publication types.
3. Interact with the publication type filters: toggle the 'Events' filter on and off to ensure the grid updates dynamically without errors.
4. Run the test suite to confirm that the newly added tests for the component and filtering hook pass successfully.

## Video / Screenshots

**Publications Dashboard (Events Included):**
<img width="1557" height="627" alt="image" src="https://github.com/user-attachments/assets/8623d8e5-5beb-4c57-a14b-aa9c578ca5b8" />

**Filter Functionality:**
<img width="583" height="610" alt="image" src="https://github.com/user-attachments/assets/677ab3d4-a56b-432a-b64e-9d7bd6632a9f" />


## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board