### PR TITLE
feature: create media mentions editing within the edit page

### DIFF
--- a/app/(logged_in)/publications/[type]/[id]/edit/page.test.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/edit/page.test.tsx
@@ -1,12 +1,14 @@
-import { act,fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { notFound,useParams, useRouter } from 'next/navigation';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { notFound, useParams, useRouter } from 'next/navigation';
+import React from 'react';
 import toast from 'react-hot-toast';
 
 import { EditPublicationsViewProps } from './EditPublicationsView';
 import EditPublicationsPage from './page';
-import { CONTENT_MUTATION_RESULTS, LocalizedEditorState,MenuActionId } from '~/constants/publications';
+import { CONTENT_MUTATION_RESULTS, LocalizedEditorState, MenuActionId } from '~/constants/publications';
 import { SerializedContent } from '~/shared/components/content-editor';
 import { usePublicationManager } from '~/shared/hooks/use-publications-manager/usePublicationsManager';
+import { useUpsertPublication } from '~/shared/hooks/use-upsert-publication/useUpsertPublication';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
 
 jest.mock('next/navigation', () => ({
@@ -22,6 +24,10 @@ jest.mock('react-hot-toast', () => ({
 
 jest.mock('~/shared/hooks/use-publications-manager/usePublicationsManager', () => ({
   usePublicationManager: jest.fn()
+}));
+
+jest.mock('~/shared/hooks/use-upsert-publication/useUpsertPublication', () => ({
+  useUpsertPublication: jest.fn()
 }));
 
 const baseMockManager = {
@@ -42,7 +48,7 @@ const baseMockManager = {
 
 jest.mock('./EditPublicationsView', () => ({
   EditPublicationsView: (props: EditPublicationsViewProps) => (
-    <div data-testid="mock-view">
+    <div data-testid="mock-edit-view">
       <button
         data-testid="trigger-editor-change"
         onClick={() =>
@@ -60,14 +66,33 @@ jest.mock('./EditPublicationsView', () => ({
   )
 }));
 
+jest.mock('../../create/CreatePublicationsView', () => ({
+  __esModule: true,
+  default: () => <div data-testid="mock-create-view" />
+}));
+
 describe('EditPublicationsPage Container', () => {
   const mockPush = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
+    
     (useParams as jest.Mock).mockReturnValue({ type: 'news', id: '123' });
     (useRouter as jest.Mock).mockReturnValue({ push: mockPush });
     (usePublicationManager as jest.Mock).mockReturnValue(baseMockManager);
+    (useUpsertPublication as jest.Mock).mockReturnValue({ mockUpsertData: true });
+  });
+
+  it('should render CreatePublicationsView if type is media', () => {
+    (useParams as jest.Mock).mockReturnValue({ type: 'media', id: '456' });
+
+    render(<EditPublicationsPage />);
+
+    expect(useUpsertPublication).toHaveBeenCalledWith({ type: 'media', id: '456' });
+    
+    expect(screen.getByTestId('mock-create-view')).toBeInTheDocument();
+    
+    expect(screen.queryByTestId('mock-edit-view')).not.toBeInTheDocument();
   });
 
   it('should call notFound if loading is finished but data is null', () => {

--- a/app/(logged_in)/publications/[type]/[id]/edit/page.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/edit/page.tsx
@@ -4,6 +4,7 @@ import { notFound, useParams, useRouter } from 'next/navigation';
 import { useEffect, useRef } from 'react';
 import toast from 'react-hot-toast';
 
+import CreatePublicationsView from '../../create/CreatePublicationsView';
 import { EditPublicationsView } from './EditPublicationsView';
 import {
   CONTENT_MUTATION_RESULTS,
@@ -14,6 +15,7 @@ import {
 } from '~/constants/publications';
 import { SerializedContent } from '~/shared/components/content-editor';
 import { usePublicationManager } from '~/shared/hooks/use-publications-manager/usePublicationsManager';
+import { useUpsertPublication } from '~/shared/hooks/use-upsert-publication/useUpsertPublication';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
 
 type Params = {
@@ -26,6 +28,7 @@ export default function EditPublicationsPage() {
   const router = useRouter();
 
   const manager = usePublicationManager(type, id);
+  const publicationData = useUpsertPublication({ type, id });
 
   const latestBlocksRef = useRef<SerializedContent | null>(null);
   const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
@@ -109,7 +112,9 @@ export default function EditPublicationsPage() {
     }
   };
 
-  return (
+  return type === 'media' ? (
+    <CreatePublicationsView data={publicationData} />
+  ) : (
     <EditPublicationsView
       type={type}
       isLoading={manager.isLoading}

--- a/app/(logged_in)/publications/[type]/[id]/edit/page.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/edit/page.tsx
@@ -113,7 +113,7 @@ export default function EditPublicationsPage() {
   };
 
   return type === 'media' ? (
-    <CreatePublicationsView data={publicationData} />
+    <CreatePublicationsView data={publicationData}  mode='edit'/>
   ) : (
     <EditPublicationsView
       type={type}

--- a/app/(logged_in)/publications/[type]/create/CreatePublicationsView.test.tsx
+++ b/app/(logged_in)/publications/[type]/create/CreatePublicationsView.test.tsx
@@ -87,7 +87,7 @@ describe('CreatePublicationsView Component', () => {
   });
 
   describe('Rendering by Publication Type', () => {
-    it('renders correctly for News (no extra SEO fields)', () => {
+    it('should render correctly for News (no extra SEO fields)', () => {
       const mockData = createMockData({ publicationType: 'news' });
       render(<CreatePublicationsView data={mockData} />);
 
@@ -99,7 +99,7 @@ describe('CreatePublicationsView Component', () => {
       expect(screen.queryByTestId('mock-seo-canonical-url-field')).not.toBeInTheDocument();
     });
 
-    it('renders correctly for Events (includes DateTime fields)', () => {
+    it('should render correctly for Events (includes DateTime fields)', () => {
       const mockData = createMockData({ publicationType: 'events' });
       render(<CreatePublicationsView data={mockData} />);
 
@@ -107,7 +107,7 @@ describe('CreatePublicationsView Component', () => {
       expect(screen.getByTestId('mock-seo-datetime-fields')).toBeInTheDocument();
     });
 
-    it('renders correctly for Media (includes Canonical URL field)', () => {
+    it('should render correctly for Media (includes Canonical URL field)', () => {
       const mockData = createMockData({ publicationType: 'media' });
       render(<CreatePublicationsView data={mockData} />);
 
@@ -117,7 +117,7 @@ describe('CreatePublicationsView Component', () => {
   });
 
   describe('User Interactions', () => {
-    it('calls setAdminTitle when the admin title input changes', () => {
+    it('should call setAdminTitle when the admin title input changes', () => {
       const mockSetAdminTitle = jest.fn();
       const mockData = createMockData({
         publicationType: 'news',
@@ -133,7 +133,7 @@ describe('CreatePublicationsView Component', () => {
       expect(mockSetAdminTitle).toHaveBeenCalledWith('New Test Title');
     });
 
-    it('displays an error message on the admin title field if adminTitleError is present', () => {
+    it('should display an error message on the admin title field if adminTitleError is present', () => {
       const mockData = createMockData({
         publicationType: 'news',
         adminTitleError: 'Обов\'язкове поле'
@@ -143,7 +143,7 @@ describe('CreatePublicationsView Component', () => {
       expect(screen.getByText('Обов\'язкове поле')).toBeInTheDocument();
     });
 
-    it('calls setPublishDate when the date picker value changes', () => {
+    it('should call setPublishDate when the date picker value changes', () => {
       const mockSetPublishDate = jest.fn();
       const mockData = createMockData({
         publicationType: 'news',

--- a/app/(logged_in)/publications/[type]/create/CreatePublicationsView.tsx
+++ b/app/(logged_in)/publications/[type]/create/CreatePublicationsView.tsx
@@ -28,9 +28,12 @@ import { BaseContentStatuses } from '~/types/enums/common.enums';
 
 interface PublicationViewProps {
   data: ReturnType<typeof useUpsertPublication>;
+  mode?: 'edit' | 'create';
 }
 
-export default function CreatePublicationsView({ data }: Readonly<PublicationViewProps>) {
+
+
+export default function CreatePublicationsView({ data, mode = 'create' }: Readonly<PublicationViewProps>) {
   const {
     publicationType,
     adminTitle,
@@ -144,7 +147,7 @@ export default function CreatePublicationsView({ data }: Readonly<PublicationVie
           )
         }
       >
-        <Typography variant="customBold20Tight">{`Створення ${PAGE_TITLES[publicationType]}`}</Typography>
+        <Typography variant="customBold20Tight">{`${mode === 'edit' ? 'Редагування' : 'Створення'} ${PAGE_TITLES[publicationType]}`}</Typography>
       </DividedHeader>
       <Box sx={styles.contentWrapper}>
         <SeoCollapsibleBlock


### PR DESCRIPTION
## Description

Updated the main publication edit page to conditionally render the appropriate layout based on the publication type. 

Since Media items primarily consist of metadata, external URLs, and dates rather than long-form text, the full rich-text block editor is unnecessary for them. The edit container now checks the publication type and directly renders the `CreatePublicationView` form when editing a `media` item. News and Events remain unaffected and will continue to load the standard block content editor.

## Type of change

- [x] New feature

## How to test

1. Pull the branch locally and start the application.
2. **Test Media Edit:** Navigate to edit an existing Media publication.
3. Verify that the rich-text block editor is completely hidden and the metadata-focused `CreatePublicationView` form is rendered in its place.
4. **Test Other Types:** Navigate to edit an existing News or Event publication.
5. Verify that the standard block editor loads correctly and the form view is not rendered, ensuring no regressions for existing content workflows.
6. Verify that the previously implemented media-specific header actions (Publish, Save, etc.) still function correctly alongside this new view.

## Video / Screenshots

**Media Edit View (Form Layout):**
**News/Event Edit View (Block Editor Layout):**

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board