### PR TITLE
bugfix: change cards to made fixed size

### DIFF
--- a/app/(logged_in)/publications/PublicationsPageContent.styles.ts
+++ b/app/(logged_in)/publications/PublicationsPageContent.styles.ts
@@ -10,11 +10,10 @@ export const styles: Record<string, SxProps<Theme>> = {
       xl: 'repeat(4, minmax(0, 1fr))'
     },
     gap: '16px',
-    width: '100%'
+    width: '100%',
   },
   cardWrapper: {
     minWidth: 0,
     display: 'flex',
-    height: '100%'
   }
 };

--- a/app/login/Liatoshynsky-Foundation.code-workspace
+++ b/app/login/Liatoshynsky-Foundation.code-workspace
@@ -1,0 +1,11 @@
+{
+	"folders": [
+		{
+			"path": "../../.."
+		},
+		{
+			"path": "../../../../../../../../Program Files/MongoDB"
+		}
+	],
+	"settings": {}
+}

--- a/app/shared/components/content-card/ContentCard.styles.ts
+++ b/app/shared/components/content-card/ContentCard.styles.ts
@@ -4,8 +4,9 @@ const styles: Record<string, SxProps<Theme>> = {
   card: {
     display: 'flex',
     flexDirection: 'column',
-    width: '366px',
-    height: '344px',          
+    minHeight: '266px',
+    width: '100%',
+    height: '100%',          
     borderRadius: '12px',
     boxShadow: '0px 1px 4px rgba(0, 0, 0, 0.08)',
     overflow: 'hidden',
@@ -34,7 +35,7 @@ const styles: Record<string, SxProps<Theme>> = {
     fontWeight: 700,
     fontFamily: 'Mulish, sans-serif',
     fontStyle: 'normal',
-    lineHeight: 1.5,            // 150%
+    lineHeight: 1.5,           
     letterSpacing: '0px',
     display: '-webkit-box',
     WebkitLineClamp: 2,

--- a/app/shared/components/content-card/ContentCard.styles.ts
+++ b/app/shared/components/content-card/ContentCard.styles.ts
@@ -1,33 +1,56 @@
-const styles = {
+import { SxProps, Theme } from '@mui/material';
+
+const styles: Record<string, SxProps<Theme>> = {
   card: {
     display: 'flex',
     flexDirection: 'column',
-    width: '100%',
-    maxWidth: '100%',
-    borderRadius: '16px',
-    border: '1px solid #D9DCE8'
+    width: '366px',
+    height: '344px',          
+    borderRadius: '12px',
+    boxShadow: '0px 1px 4px rgba(0, 0, 0, 0.08)',
+    overflow: 'hidden',
+    border: '1px solid rgba(0, 0, 0, 0.08)',
   },
   cardContent: {
     display: 'flex',
     flexDirection: 'column',
+    flex: 1,
     gap: '8px',
-    flexGrow: '1'
+    p: '12px',
+    overflow: 'hidden',
+    '&:last-child': {
+      pb: '12px',
+    },
+  },
+  mainInfo: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    gap: '4px',
+    overflow: 'hidden',
   },
   title: {
     fontSize: '18px',
     fontWeight: 700,
+    fontFamily: 'Mulish, sans-serif',
+    fontStyle: 'normal',
+    lineHeight: 1.5,            // 150%
+    letterSpacing: '0px',
+    display: '-webkit-box',
+    WebkitLineClamp: 2,
+    WebkitBoxOrient: 'vertical',
+    overflow: 'hidden',
     flex: 1,
-    color: '#190D03'
+    minWidth: 0,
   },
   date: {
-    color: '#898C95',
-    fontStyle: 'italic'
+    fontSize: '12px',
+    color: 'rgba(0, 0, 0, 0.45)',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    mt: 'auto',
   },
-  mainInfo: {
-    display: 'flex',
-    gap: '15px',
-    alignItems: 'baseline'
-  }
 };
 
 export default styles;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
         "name": "next"
       }
     ],
-    "baseUrl": ".", // Base URL for module resolution
+    "baseUrl": ".",
     "paths": {
       "~/*": ["./app/*"],
       "~/src/*": ["./src/*"],


### PR DESCRIPTION
### Description 
___
This PR fixes the ContentCard layout by introducing a fixed card size for consistent appearance across the page. It also improves text handling by clamping the title to 2 lines and updates the card layout so the button is always pinned to the bottom of the card.

### Type of change
___
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update 
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other:

### How to test
___
Go to the News page.

1. Click the Create News button.
2. In the opened form, enter a sufficiently long news text.
3. Fill in the required fields (e.g., title, content).
4. Click Save.
5. Verify that the news item appears in the list.
6. Check how the text is truncated in the preview/card view.

### Video / Screenshots:
___
<img width="1920" height="1032" alt="465" src="https://github.com/user-attachments/assets/e293ee0c-add2-4b31-8fea-023d2515b421" />

