### PR TITLE
feat(ui): implement dedicated FileView component for multi-type uploads

### DIFF
--- a/app/(logged_in)/files/FilesPageContent.tsx
+++ b/app/(logged_in)/files/FilesPageContent.tsx
@@ -25,10 +25,8 @@ import {
   FILES_UPLOAD_BUTTON_LABEL,
   FILES_UPLOAD_ERROR,
   FILES_UPLOAD_FAILED_ERROR,
-  FILES_UPLOAD_READ_ERROR,
   type FilesTabValue
 } from '~/constants/files';
-import { readFileAsDataURL } from '~/lib/utils/readFileAsDataURL';
 import FavouriteStarIcon from '~/public/icons/favourite-star.svg';
 import { colors } from '~/shared/components/design-system/button/Button.styles';
 import { EmptyState } from '~/shared/components/empty-state';
@@ -46,14 +44,18 @@ import {
 import { FilteringToolbar, SortSelect } from '~/shared/components/filtering-toolbar';
 import { MediaModal } from '~/shared/components/media-modal/MediaModal';
 import type { MediaModalRenderers } from '~/shared/components/media-modal/MediaModal.renderers';
-import type { MediaModalOpenState, MediaModalResult } from '~/shared/components/media-modal/MediaModal.types';
+import type {
+  MediaModalOpenState,
+  MediaModalResult,
+  UploadResult
+} from '~/shared/components/media-modal/MediaModal.types';
 import { UploadView } from '~/shared/components/media-modal/views/upload-view/UploadView';
 import { PageHeader } from '~/shared/components/page-header/PageHeader';
 import { RenameFileModal } from '~/shared/components/rename-file-modal/RenameFileModal';
 import { ViewToggle } from '~/shared/components/view-toggle';
 import { useAllAssets } from '~/shared/hooks/use-assets/useAssets';
 import { useFilesFiltering } from '~/shared/hooks/use-files';
-import { AssetType, useUploadBlobMutation } from '~/types/graphql/generated/graphql';
+import { AssetType, useCreateAssetMutation } from '~/types/graphql/generated/graphql';
 
 type FilesPageFileItem = FilesCardsLayoutItem & {
   description?: string;
@@ -170,7 +172,7 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
     currentFilename: ''
   });
   const { data, loading, error, refetch } = useAllAssets();
-  const [uploadBlob] = useUploadBlobMutation();
+  const [createAsset] = useCreateAssetMutation();
 
   const handleOpenUploadFlow = () => {
     setUploadModalInitial({ tab: 'UPLOAD' });
@@ -182,29 +184,37 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
     setUploadModalInitial(undefined);
   };
 
-  const handleUploadApply = async (result: MediaModalResult) => {
-    if (result.selected.kind !== 'upload') {
+  const handleUploadApply = async (result: MediaModalResult & { uploadResult?: UploadResult }) => {
+    if (result.selected.kind !== 'upload' || !result.uploadResult) {
       return;
     }
 
     const file = result.selected.file;
-    const dataUrl = await readFileAsDataURL(file);
-    const base64 = dataUrl.split(',')[1];
+    const { url, filename, originalName, mimeType, size } = result.uploadResult;
 
-    if (!base64) {
-      throw new Error(FILES_UPLOAD_READ_ERROR);
-    }
+    let assetType = 'document';
+    const type = file.type.toLowerCase();
+    const name = file.name.toLowerCase();
 
-    const uploadResult = await uploadBlob({
+    if (type.includes('spreadsheet') || name.endsWith('.xlsx') || name.endsWith('.xls')) assetType = 'spreadsheet';
+    else if (type.includes('pdf') || name.endsWith('.pdf')) assetType = 'pdf';
+    else if (type.includes('zip') || type.includes('rar') || name.endsWith('.rar')) assetType = 'archive';
+    else if (type.startsWith('audio/')) assetType = 'audio';
+    else if (type.startsWith('image/')) assetType = 'image';
+
+    const createResult = await createAsset({
       variables: {
-        folderName: 'tmp',
-        blobName: file.name,
-        buffer: base64,
-        contentType: file.type || 'application/octet-stream'
+        input: {
+          filename: originalName || filename,
+          url: url,
+          mimeType: mimeType,
+          sizeBytes: size,
+          type: assetType
+        }
       }
     });
 
-    if (!uploadResult.data?.uploadBlob.success) {
+    if (!createResult.data?.createAsset) {
       throw new Error(FILES_UPLOAD_FAILED_ERROR);
     }
 

--- a/app/(logged_in)/files/FilesPageContent.tsx
+++ b/app/(logged_in)/files/FilesPageContent.tsx
@@ -129,13 +129,25 @@ const formatFileSize = (sizeBytes: number) => {
 };
 
 const formatFromMimeType = (mimeType: string, filename: string) => {
-  const byMime = mimeType.split('/')[1]?.toLowerCase();
-  if (byMime === 'jpeg') return 'jpg';
-  if (byMime === 'mpeg' && filename.toLowerCase().endsWith('.mp3')) return 'mp3';
-  if (byMime) return byMime;
-
   const ext = filename.split('.').pop()?.toLowerCase();
-  return ext || undefined;
+
+  if (ext) {
+    if (ext === 'jpeg') return 'jpg';
+    return ext;
+  }
+
+  const byMime = mimeType.split('/')[1]?.toLowerCase();
+  if (!byMime) return undefined;
+
+  if (byMime.includes('spreadsheetml')) return 'xlsx';
+  if (byMime.includes('wordprocessingml')) return 'docx';
+  if (byMime.includes('zip')) return 'zip';
+  if (byMime.includes('rar')) return 'rar';
+  if (byMime.includes('svg')) return 'svg';
+  if (byMime === 'jpeg') return 'jpg';
+  if (byMime === 'wave' || byMime === 'x-wav') return 'wav';
+
+  return byMime;
 };
 
 const usageToLink = (pageId?: string | null) => {
@@ -319,19 +331,9 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
         bottomTrailingContent={<SortSelect {...sortProps} minWidth={208} dataTestId="files-sort-select" />}
       />
 
-      {loading && (
-        <EmptyState
-          title={FILES_LOADING_STATE_TITLE}
-          description={FILES_LOADING_STATE_DESCRIPTION}
-        />
-      )}
+      {loading && <EmptyState title={FILES_LOADING_STATE_TITLE} description={FILES_LOADING_STATE_DESCRIPTION} />}
 
-      {!loading && error && (
-        <EmptyState
-          title={FILES_ERROR_STATE_TITLE}
-          description={FILES_ERROR_STATE_DESCRIPTION}
-        />
-      )}
+      {!loading && error && <EmptyState title={FILES_ERROR_STATE_TITLE} description={FILES_ERROR_STATE_DESCRIPTION} />}
 
       {!loading && !error && filteredFiles.length > 0 && (
         <FilesCardsLayout view={view} items={filteredFiles} onItemClick={(item) => setSelectedFileId(item.id)} />
@@ -347,17 +349,11 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
       )}
 
       {hasNoFiles && hasActiveCriteria && (
-        <EmptyState
-          title={FILES_EMPTY_STATE_NO_RESULTS_TITLE}
-          description={FILES_EMPTY_STATE_NO_RESULTS_DESCRIPTION}
-        />
+        <EmptyState title={FILES_EMPTY_STATE_NO_RESULTS_TITLE} description={FILES_EMPTY_STATE_NO_RESULTS_DESCRIPTION} />
       )}
 
       {hasNoFiles && !isFavoritesTab && !hasActiveCriteria && (
-        <EmptyState
-          title={FILES_EMPTY_STATE_TITLE}
-          description={FILES_EMPTY_STATE_DESCRIPTION}
-        />
+        <EmptyState title={FILES_EMPTY_STATE_TITLE} description={FILES_EMPTY_STATE_DESCRIPTION} />
       )}
 
       {sidebarFile && (
@@ -381,6 +377,7 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
         onClose={handleCloseUploadFlow}
         onApply={handleUploadApply}
         renderers={{ upload: renderFilesUpload }}
+        hideTabs={true}
       />
       <RenameFileModal
         open={renameModalState.open}

--- a/app/(logged_in)/files/page.test.tsx
+++ b/app/(logged_in)/files/page.test.tsx
@@ -5,7 +5,6 @@ import Page from './page';
 
 const mockRefetch = jest.fn();
 const mockUseAllAssets = jest.fn();
-const mockUploadBlob = jest.fn();
 
 let mockAllAssets: Array<Record<string, unknown>> = [];
 
@@ -28,8 +27,8 @@ jest.mock('~/types/graphql/generated/graphql', () => ({
     Document: 'Document',
     Spreadsheet: 'Spreadsheet'
   },
-  useUploadBlobMutation: () => [mockUploadBlob],
-  useUpdateAssetMutation: () => [jest.fn(), { loading: false }]
+  useUpdateAssetMutation: () => [jest.fn(), { loading: false }],
+  useCreateAssetMutation: () => [jest.fn(), { loading: false }]
 }));
 
 jest.mock('~/shared/components/file-info-sidebar/FileInfoSidebar', () => ({

--- a/app/constants/files.ts
+++ b/app/constants/files.ts
@@ -21,17 +21,48 @@ export const FILES_UPLOAD_ALLOWED_MIME_TYPES = [
   'image/jpeg',
   'image/jpg',
   'image/png',
+  'image/gif',
+  'image/webp',
+  'image/svg+xml',
+  'image/bmp',
   'application/pdf',
   'audio/mpeg',
-  'audio/wav'
+  'audio/wav',
+  'application/zip',
+  'application/x-zip-compressed',
+  'application/vnd.rar',
+  'application/x-rar-compressed',
+  'application/x-rar',
+  'application/octet-stream',
+  'application/x-compressed',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
 ] as const;
 
-export const FILES_UPLOAD_ALLOWED_EXTENSIONS = ['jpg', 'jpeg', 'png', 'pdf', 'mp3', 'wav'] as const;
+export const FILES_UPLOAD_ALLOWED_EXTENSIONS = [
+  'jpg',
+  'jpeg',
+  'png',
+  'gif',
+  'webp',
+  'svg',
+  'bmp',
+  'pdf',
+  'mp3',
+  'wav',
+  'zip',
+  'rar',
+  'docx',
+  'xlsx'
+] as const;
 
-export const FILES_UPLOAD_ACCEPT = FILES_UPLOAD_ALLOWED_MIME_TYPES.join(',');
+export const FILES_UPLOAD_ACCEPT = [
+  ...FILES_UPLOAD_ALLOWED_MIME_TYPES,
+  ...FILES_UPLOAD_ALLOWED_EXTENSIONS.map((ext) => `.${ext}`)
+].join(',');
 export const FILES_PAGE_TITLE = 'Файли';
 export const FILES_UPLOAD_BUTTON_LABEL = 'Завантажити файл';
-export const FILES_UPLOAD_ERROR = 'Підтримуються зображення, PDF та аудіо';
+export const FILES_UPLOAD_ERROR = 'Підтримуються зображення, PDF, аудіо, документи (Docx, Xlsx) та архіви (Zip, Rar)';
 export const FILES_UPLOAD_READ_ERROR = 'Не вдалося прочитати файл для завантаження.';
 export const FILES_UPLOAD_FAILED_ERROR = 'Не вдалося завантажити файл. Спробуйте ще раз.';
 export const FILES_UNKNOWN_SECTION_LABEL = 'Невідомий розділ';
@@ -42,9 +73,11 @@ export const FILES_ERROR_STATE_DESCRIPTION = 'Спробуйте оновити 
 export const FILES_EMPTY_STATE_TITLE = 'Файли відсутні';
 export const FILES_EMPTY_STATE_DESCRIPTION = 'Файли для цієї вкладки поки відсутні.';
 export const FILES_EMPTY_STATE_NO_RESULTS_TITLE = 'Результатів немає';
-export const FILES_EMPTY_STATE_NO_RESULTS_DESCRIPTION = 'За цими критеріями нічого не знайдено.\nСпробуйте змінити параметри фільтрів або пошуку.';
+export const FILES_EMPTY_STATE_NO_RESULTS_DESCRIPTION =
+  'За цими критеріями нічого не знайдено.\nСпробуйте змінити параметри фільтрів або пошуку.';
 export const FILES_FAVORITES_EMPTY_STATE_TITLE = 'Немає обраних файлів';
-export const FILES_FAVORITES_EMPTY_STATE_DESCRIPTION = 'Позначайте важливі файли зірочкою, щоб мати до них швидкий доступ тут.';
+export const FILES_FAVORITES_EMPTY_STATE_DESCRIPTION =
+  'Позначайте важливі файли зірочкою, щоб мати до них швидкий доступ тут.';
 export const FILES_FAVORITES_EMPTY_STATE_BUTTON = 'Переглянути всі файли';
 
 export const SORT_OPTIONS: ReadonlyArray<{ value: FilesSortValue; label: string }> = [
@@ -82,4 +115,3 @@ export const SORT_ORDER_OPTIONS: Readonly<
     { value: 'name_desc', label: 'Я-А' }
   ]
 };
-

--- a/app/constants/files.ts
+++ b/app/constants/files.ts
@@ -12,7 +12,7 @@ export type FilesTabConfig = Readonly<{
 export const FILE_TABS: ReadonlyArray<FilesTabConfig> = [
   { value: 'all', label: 'Всі', href: '/files' },
   { value: 'image', label: 'Зображення', href: '/files/image' },
-  { value: 'docs', label: 'DOCS', href: '/files/docs', disabled: true },
+  { value: 'docs', label: 'DOCS', href: '/files/docs' },
   { value: 'audio', label: 'Аудіо', href: '/files/audio' },
   { value: 'favorites', label: 'Обрані', href: '/files/favorites' }
 ];

--- a/app/shared/components/media-modal/MediaModal.utils.ts
+++ b/app/shared/components/media-modal/MediaModal.utils.ts
@@ -1,4 +1,23 @@
+import { FILES_UPLOAD_ALLOWED_EXTENSIONS, FILES_UPLOAD_ALLOWED_MIME_TYPES } from '~/constants/files';
+
 export const isImageUploadFile = (file: File): boolean => {
   if (file.type) return file.type.startsWith('image/');
   return /\.(png|jpe?g|gif|webp|bmp|svg)$/i.test(file.name);
+};
+
+export const isAnyAllowedFile = (file: File): boolean => {
+  const extension = file.name.split('.').pop()?.toLowerCase() as any;
+
+  const isValidExtension = FILES_UPLOAD_ALLOWED_EXTENSIONS.includes(extension);
+
+  if (extension === 'rar') {
+    return isValidExtension;
+  }
+
+  const isValidMimeType =
+    FILES_UPLOAD_ALLOWED_MIME_TYPES.includes(file.type as any) ||
+    file.type === '' ||
+    file.type === 'application/octet-stream';
+
+  return isValidExtension && isValidMimeType;
 };

--- a/app/shared/components/media-modal/flow/MediaModalFlow.tsx
+++ b/app/shared/components/media-modal/flow/MediaModalFlow.tsx
@@ -7,13 +7,9 @@ import { MediaModalContainer } from '../components/container/MediaModalContainer
 import { MediaModalSwitcher } from '../components/switcher/MediaModalSwitcher';
 import type { MediaModalRenderers } from '../MediaModal.renderers';
 import { styles } from '../MediaModal.styles';
-import type {
-  MediaModalOpenState,
-  MediaModalResult,
-  MediaModalTab,
-  SelectedMedia
-} from '../MediaModal.types';
+import type { MediaModalOpenState, MediaModalResult, MediaModalTab, SelectedMedia } from '../MediaModal.types';
 import { isImageUploadFile } from '../MediaModal.utils';
+import { FileView } from '../views/file-view/FileView';
 import { buildInitialState, GalleryFilters, isSameCrop, reducer, UsedFilters } from './MediaModalFlowState';
 import { useMediaModalApply } from './useMediaModalApply';
 import ArrowLeftIcon from '~/public/icons/arrowLeft.svg';
@@ -28,6 +24,7 @@ export type MediaModalFlowProps = {
   initial?: MediaModalOpenState;
   renderers: MediaModalRenderers;
   directory?: string;
+  hideTabs?: boolean;
 };
 
 const isNonImageUploadSelection = (selected: SelectedMedia | null): boolean => {
@@ -38,11 +35,19 @@ const isNonImageUploadSelection = (selected: SelectedMedia | null): boolean => {
   return !isImageUploadFile(selected.file);
 };
 
-export function MediaModalFlow({ open, onClose, onApply, initial, renderers, directory }: Readonly<MediaModalFlowProps>) {
+export function MediaModalFlow({
+  open,
+  onClose,
+  onApply,
+  initial,
+  renderers,
+  directory,
+  hideTabs
+}: Readonly<MediaModalFlowProps>) {
   const [state, dispatch] = useReducer(reducer, initial, buildInitialState);
 
   const { isApplying, applyError, clearApplyState, clearApplyError, cancelInFlightApply, handleClose, runApply } =
-      useMediaModalApply({ open, onClose, onApply, directory });
+    useMediaModalApply({ open, onClose, onApply, directory });
 
   const latestInitialRef = useRef<MediaModalOpenState | undefined>(initial);
   useEffect(() => {
@@ -92,6 +97,12 @@ export function MediaModalFlow({ open, onClose, onApply, initial, renderers, dir
     },
     [clearApplyError, isApplying]
   );
+
+  const handleClearFile = useCallback(() => {
+    if (isApplying) return;
+    clearApplyError();
+    dispatch({ type: 'OPEN', initial: latestInitialRef.current });
+  }, [clearApplyError, isApplying]);
 
   const handleBack = useCallback(() => {
     if (isApplying) return;
@@ -148,9 +159,11 @@ export function MediaModalFlow({ open, onClose, onApply, initial, renderers, dir
         {selectedFileName}
       </Box>
     </Box>
+  ) : hideTabs ? (
+    <Box sx={styles.cropHeaderTitle}>Завантажити файл</Box>
   ) : null;
 
-  const headerCenter = isCrop ? null : <MediaModalSwitcher value={state.tab} onChange={handleTabChange} />;
+  const headerCenter = isCrop || hideTabs ? null : <MediaModalSwitcher value={state.tab} onChange={handleTabChange} />;
 
   const headerRight = isCrop ? (
     <IconButton
@@ -164,38 +177,40 @@ export function MediaModalFlow({ open, onClose, onApply, initial, renderers, dir
     </IconButton>
   ) : null;
 
-  const footerLeft = isCrop ? (
-    <Button
-      color="secondary"
-      variant="outlined"
-      label="Повернутись назад"
-      data-testid="MediaModal-backButton"
-      sx={styles.footerBackButton}
-      startIcon={<ArrowLeftIcon width={12} height={12} aria-hidden focusable={false} />}
-      onClick={handleBack}
-    />
-  ) : null;
-
-  const footerRight = isCrop || canApplySelectedUpload ? (
-    <>
+  const footerLeft =
+    isCrop || canApplySelectedUpload ? (
       <Button
         color="secondary"
         variant="outlined"
-        label="Скасувати"
-        data-testid="MediaModal-cancelButton"
-        onClick={handleClose}
+        label="Повернутись назад"
+        data-testid="MediaModal-backButton"
+        sx={styles.footerBackButton}
+        startIcon={<ArrowLeftIcon width={12} height={12} aria-hidden focusable={false} />}
+        onClick={isCrop ? handleBack : handleClearFile}
       />
-      <Button
-        color="tertiary"
-        variant="filled"
-        label="Застосувати"
-        data-testid="MediaModal-applyButton"
-        loading={isApplying}
-        disabled={!state.selected || isApplying}
-        onClick={handleApply}
-      />
-    </>
-  ) : null;
+    ) : null;
+
+  const footerRight =
+    isCrop || canApplySelectedUpload ? (
+      <>
+        <Button
+          color="secondary"
+          variant="outlined"
+          label="Скасувати"
+          data-testid="MediaModal-cancelButton"
+          onClick={onClose}
+        />
+        <Button
+          color="tertiary"
+          variant="filled"
+          label="Застосувати"
+          data-testid="MediaModal-applyButton"
+          loading={isApplying}
+          disabled={!state.selected || isApplying}
+          onClick={handleApply}
+        />
+      </>
+    ) : null;
 
   const renderBody = () => {
     if (isCrop) {
@@ -220,6 +235,10 @@ export function MediaModalFlow({ open, onClose, onApply, initial, renderers, dir
     }
 
     if (state.tab === 'UPLOAD') {
+      if (state.selected?.kind === 'upload' && isNonImageUploadSelection(state.selected)) {
+        return <FileView file={state.selected.file} />;
+      }
+
       return renderers.upload({
         selected: state.selected?.kind === 'upload' ? state.selected : null,
         onPick: pickAndCrop

--- a/app/shared/components/media-modal/flow/MediaModalFlow.tsx
+++ b/app/shared/components/media-modal/flow/MediaModalFlow.tsx
@@ -152,16 +152,26 @@ export function MediaModalFlow({
 
   const canApplySelectedUpload = state.step === 'SELECT' && isNonImageUploadSelection(state.selected);
 
-  const headerLeft = isCrop ? (
-    <Box sx={styles.cropHeader} data-testid="MediaModal-cropHeader">
-      <Box sx={styles.cropHeaderTitle}>Редагування зображення</Box>
-      <Box sx={styles.cropHeaderSubtitle} data-testid="MediaModal-cropHeaderFileName">
-        {selectedFileName}
-      </Box>
-    </Box>
-  ) : hideTabs ? (
-    <Box sx={styles.cropHeaderTitle}>Завантажити файл</Box>
-  ) : null;
+  const getHeaderLeftContent = () => {
+    if (isCrop) {
+      return (
+        <Box sx={styles.cropHeader} data-testid="MediaModal-cropHeader">
+          <Box sx={styles.cropHeaderTitle}>Редагування зображення</Box>
+          <Box sx={styles.cropHeaderSubtitle} data-testid="MediaModal-cropHeaderFileName">
+            {selectedFileName}
+          </Box>
+        </Box>
+      );
+    }
+
+    if (hideTabs) {
+      return <Box sx={styles.cropHeaderTitle}>Завантажити файл</Box>;
+    }
+
+    return null;
+  };
+
+  const headerLeft = getHeaderLeftContent();
 
   const headerCenter = isCrop || hideTabs ? null : <MediaModalSwitcher value={state.tab} onChange={handleTabChange} />;
 

--- a/app/shared/components/media-modal/flow/useMediaModalApply.ts
+++ b/app/shared/components/media-modal/flow/useMediaModalApply.ts
@@ -99,8 +99,20 @@ export function useMediaModalApply({ open, onClose, onApply, directory }: Readon
             allowedExtensions: [fileExt]
           });
 
+          let finalDirectory = directory;
+
+          if (!finalDirectory) {
+            if (backendFileType === 'image') {
+              finalDirectory = 'photos';
+            } else if (backendFileType === 'audio') {
+              finalDirectory = 'compositions';
+            } else {
+              finalDirectory = 'uploads';
+            }
+          }
+
           const uploadResult = await uploadFile(result.selected.file, {
-            directory,
+            directory: finalDirectory,
             fileType: backendFileType,
             validationRules: validationRules
           });

--- a/app/shared/components/media-modal/flow/useMediaModalApply.ts
+++ b/app/shared/components/media-modal/flow/useMediaModalApply.ts
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import type { MediaModalResult } from '../MediaModal.types';
-import {useUpload} from '~/hooks/use-upload/useUpload';
+import { useUpload } from '~/hooks/use-upload/useUpload';
 
 type Args = {
   open: boolean;
@@ -20,6 +20,27 @@ type Return = {
   cancelInFlightApply: () => void;
   handleClose: () => void;
   runApply: (result: MediaModalResult) => Promise<void>;
+};
+
+const getFileTypeForBackend = (file: File): string => {
+  const type = file.type.toLowerCase();
+  const name = file.name.toLowerCase();
+
+  if (type.startsWith('image/')) return 'image';
+  if (type.startsWith('audio/') || name.endsWith('.mp3') || name.endsWith('.wav')) return 'audio';
+  if (type.includes('spreadsheet') || type.includes('excel') || name.endsWith('.xlsx') || name.endsWith('.xls'))
+    return 'spreadsheet';
+  if (type.includes('pdf') || name.endsWith('.pdf')) return 'pdf';
+  if (
+    type.includes('zip') ||
+    type.includes('rar') ||
+    type.includes('compressed') ||
+    name.endsWith('.zip') ||
+    name.endsWith('.rar')
+  )
+    return 'archive';
+
+  return 'document';
 };
 
 export function useMediaModalApply({ open, onClose, onApply, directory }: Readonly<Args>): Return {
@@ -68,7 +89,21 @@ export function useMediaModalApply({ open, onClose, onApply, directory }: Readon
         let enrichedResult = result;
 
         if (result.selected.kind === 'upload') {
-          const uploadResult = await uploadFile(result.selected.file, { directory });
+          const backendFileType = getFileTypeForBackend(result.selected.file);
+
+          const fileExt = result.selected.file.name.split('.').pop()?.toLowerCase() || '';
+          const fileMime = result.selected.file.type || 'application/octet-stream';
+
+          const validationRules = JSON.stringify({
+            allowedMimeTypes: [fileMime],
+            allowedExtensions: [fileExt]
+          });
+
+          const uploadResult = await uploadFile(result.selected.file, {
+            directory,
+            fileType: backendFileType,
+            validationRules: validationRules
+          });
 
           if (!isCurrent()) return;
 

--- a/app/shared/components/media-modal/flow/useMediaModalApply.ts
+++ b/app/shared/components/media-modal/flow/useMediaModalApply.ts
@@ -43,6 +43,13 @@ const getFileTypeForBackend = (file: File): string => {
   return 'document';
 };
 
+const resolveUploadDirectory = (explicitDirectory: string | undefined, backendFileType: string): string => {
+  if (explicitDirectory) return explicitDirectory;
+  if (backendFileType === 'image') return 'photos';
+  if (backendFileType === 'audio') return 'compositions';
+  return 'uploads';
+};
+
 export function useMediaModalApply({ open, onClose, onApply, directory }: Readonly<Args>): Return {
   const [isApplying, setIsApplying] = useState(false);
   const [applyError, setApplyError] = useState<string | null>(null);
@@ -99,17 +106,7 @@ export function useMediaModalApply({ open, onClose, onApply, directory }: Readon
             allowedExtensions: [fileExt]
           });
 
-          let finalDirectory = directory;
-
-          if (!finalDirectory) {
-            if (backendFileType === 'image') {
-              finalDirectory = 'photos';
-            } else if (backendFileType === 'audio') {
-              finalDirectory = 'compositions';
-            } else {
-              finalDirectory = 'uploads';
-            }
-          }
+          const finalDirectory = resolveUploadDirectory(directory, backendFileType);
 
           const uploadResult = await uploadFile(result.selected.file, {
             directory: finalDirectory,

--- a/app/shared/components/media-modal/views/file-view/FileView.styles.ts
+++ b/app/shared/components/media-modal/views/file-view/FileView.styles.ts
@@ -1,0 +1,24 @@
+import type { SxProps, Theme } from '@mui/material';
+
+export const styles = {
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '100%',
+    height: '100%',
+    minHeight: '300px',
+    gap: '16px'
+  } as SxProps<Theme>,
+
+  fileName: {
+    fontSize: '14px',
+    fontWeight: 500,
+    color: '#E5E7EB',
+    textAlign: 'center',
+    wordBreak: 'break-word',
+    maxWidth: '80%',
+    marginTop: '8px'
+  } as SxProps<Theme>
+};

--- a/app/shared/components/media-modal/views/file-view/FileView.test.tsx
+++ b/app/shared/components/media-modal/views/file-view/FileView.test.tsx
@@ -5,9 +5,7 @@ import { FileView } from './FileView';
 
 jest.mock('next/image', () => ({
   __esModule: true,
-  default: (props: any) => {
-    return <img {...props} />;
-  }
+  default: (props: any) => <img alt="" {...props} />
 }));
 
 const createFile = (name: string, type: string) => new File(['dummy content'], name, { type });
@@ -16,55 +14,22 @@ describe('FileView', () => {
   it('should render file name correctly', () => {
     const file = createFile('document.pdf', 'application/pdf');
     render(<FileView file={file} />);
-
     expect(screen.getByText('document.pdf')).toBeInTheDocument();
   });
 
-  it('should display PDF icon for pdf files', () => {
-    const file = createFile('test.pdf', 'application/pdf');
+  const iconTestCases = [
+    { name: 'test.pdf', type: 'application/pdf', icon: 'pdf' },
+    { name: 'budget.xlsx', type: 'application/vnd.ms-excel', icon: 'xls' },
+    { name: 'song.mp3', type: 'audio/mpeg', icon: 'audio' },
+    { name: 'archive.zip', type: 'application/zip', icon: 'zip' },
+    { name: 'unknown.txt', type: 'text/plain', icon: 'doc' },
+    { name: 'manual.pdf', type: '', icon: 'pdf' }
+  ];
+
+  test.each(iconTestCases)('should display $icon icon for $name', ({ name, type, icon }) => {
+    const file = createFile(name, type);
     render(<FileView file={file} />);
-
-    const img = screen.getByAltText('pdf icon');
-    expect(img).toHaveAttribute('src', '/icons/pdf.svg');
-  });
-
-  it('should display XLS icon for spreadsheet files', () => {
-    const file = createFile('budget.xlsx', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
-    render(<FileView file={file} />);
-
-    const img = screen.getByAltText('xls icon');
-    expect(img).toHaveAttribute('src', '/icons/xls.svg');
-  });
-
-  it('should display AUDIO icon for mp3 files', () => {
-    const file = createFile('song.mp3', 'audio/mpeg');
-    render(<FileView file={file} />);
-
-    const img = screen.getByAltText('audio icon');
-    expect(img).toHaveAttribute('src', '/icons/audio.svg');
-  });
-
-  it('should display ZIP icon for archives', () => {
-    const file = createFile('archive.zip', 'application/zip');
-    render(<FileView file={file} />);
-
-    const img = screen.getByAltText('zip icon');
-    expect(img).toHaveAttribute('src', '/icons/zip.svg');
-  });
-
-  it('should display default DOC icon for unknown file types', () => {
-    const file = createFile('unknown.txt', 'text/plain');
-    render(<FileView file={file} />);
-
-    const img = screen.getByAltText('doc icon');
-    expect(img).toHaveAttribute('src', '/icons/doc.svg');
-  });
-
-  it('should correctly identify file type by extension if MIME type is missing', () => {
-    const file = createFile('manual.pdf', '');
-    render(<FileView file={file} />);
-
-    const img = screen.getByAltText('pdf icon');
-    expect(img).toHaveAttribute('src', '/icons/pdf.svg');
+    const img = screen.getByAltText(`${icon} icon`);
+    expect(img).toHaveAttribute('src', `/icons/${icon}.svg`);
   });
 });

--- a/app/shared/components/media-modal/views/file-view/FileView.test.tsx
+++ b/app/shared/components/media-modal/views/file-view/FileView.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { FileView } from './FileView';
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    return <img {...props} />;
+  }
+}));
+
+const createFile = (name: string, type: string) => new File(['dummy content'], name, { type });
+
+describe('FileView', () => {
+  it('should render file name correctly', () => {
+    const file = createFile('document.pdf', 'application/pdf');
+    render(<FileView file={file} />);
+
+    expect(screen.getByText('document.pdf')).toBeInTheDocument();
+  });
+
+  it('should display PDF icon for pdf files', () => {
+    const file = createFile('test.pdf', 'application/pdf');
+    render(<FileView file={file} />);
+
+    const img = screen.getByAltText('pdf icon');
+    expect(img).toHaveAttribute('src', '/icons/pdf.svg');
+  });
+
+  it('should display XLS icon for spreadsheet files', () => {
+    const file = createFile('budget.xlsx', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    render(<FileView file={file} />);
+
+    const img = screen.getByAltText('xls icon');
+    expect(img).toHaveAttribute('src', '/icons/xls.svg');
+  });
+
+  it('should display AUDIO icon for mp3 files', () => {
+    const file = createFile('song.mp3', 'audio/mpeg');
+    render(<FileView file={file} />);
+
+    const img = screen.getByAltText('audio icon');
+    expect(img).toHaveAttribute('src', '/icons/audio.svg');
+  });
+
+  it('should display ZIP icon for archives', () => {
+    const file = createFile('archive.zip', 'application/zip');
+    render(<FileView file={file} />);
+
+    const img = screen.getByAltText('zip icon');
+    expect(img).toHaveAttribute('src', '/icons/zip.svg');
+  });
+
+  it('should display default DOC icon for unknown file types', () => {
+    const file = createFile('unknown.txt', 'text/plain');
+    render(<FileView file={file} />);
+
+    const img = screen.getByAltText('doc icon');
+    expect(img).toHaveAttribute('src', '/icons/doc.svg');
+  });
+
+  it('should correctly identify file type by extension if MIME type is missing', () => {
+    const file = createFile('manual.pdf', '');
+    render(<FileView file={file} />);
+
+    const img = screen.getByAltText('pdf icon');
+    expect(img).toHaveAttribute('src', '/icons/pdf.svg');
+  });
+});

--- a/app/shared/components/media-modal/views/file-view/FileView.tsx
+++ b/app/shared/components/media-modal/views/file-view/FileView.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { Box, Typography } from '@mui/material';
+import Image from 'next/image';
+
+import { styles } from './FileView.styles';
+
+export type FileViewProps = Readonly<{
+  file: File;
+}>;
+
+const getIconNameForFile = (file: File): string => {
+  const type = file.type.toLowerCase();
+  const name = file.name.toLowerCase();
+
+  if (type.startsWith('audio/') || name.endsWith('.mp3') || name.endsWith('.wav')) return 'audio';
+  if (type.includes('pdf') || name.endsWith('.pdf')) return 'pdf';
+  if (type.includes('spreadsheet') || type.includes('excel') || name.endsWith('.xlsx') || name.endsWith('.xls'))
+    return 'xls';
+  if (
+    type.includes('zip') ||
+    type.includes('rar') ||
+    type.includes('compressed') ||
+    name.endsWith('.rar') ||
+    name.endsWith('.zip')
+  ) {
+    return 'zip';
+  }
+  return 'doc';
+};
+
+export function FileView({ file }: FileViewProps) {
+  const iconName = getIconNameForFile(file);
+
+  return (
+    <Box sx={styles.root} data-testid="FileView">
+      <Image
+        src={`/icons/${iconName}.svg`}
+        width={100}
+        height={100}
+        alt={`${iconName} icon`}
+        style={{ objectFit: 'contain' }}
+      />
+
+      <Typography sx={styles.fileName}>{file.name}</Typography>
+    </Box>
+  );
+}

--- a/app/shared/hooks/use-upload/useUpload.ts
+++ b/app/shared/hooks/use-upload/useUpload.ts
@@ -1,43 +1,50 @@
 import { useCallback } from 'react';
 
-import {UploadResult} from '~/components/media-modal/MediaModal.types';
+import { UploadResult } from '~/components/media-modal/MediaModal.types';
 
 interface UploadFileOptions {
-    directory?: string;
+  directory?: string;
+  validationRules?: string;
+  fileType?: string;
 }
 
 export const useUpload = () => {
-  const uploadFile = useCallback(
-    async (file: File, options: UploadFileOptions = {}): Promise<UploadResult> => {
-      const formData = new FormData();
-      formData.append('file', file);
+  const uploadFile = useCallback(async (file: File, config: UploadFileOptions = {}): Promise<UploadResult> => {
+    const formData = new FormData();
+    formData.append('file', file);
 
-      if (options.directory) {
-        formData.append('directory', options.directory);
-      }
+    if (config.directory) {
+      formData.append('directory', config.directory);
+    }
 
-      const response = await fetch('/api/uploads/single', {
-        method: 'POST',
-        body: formData
-      });
+    if (config.fileType) {
+      formData.append('fileType', config.fileType);
+    }
 
-      const data = await response.json();
+    if (config.validationRules) {
+      formData.append('validationRules', config.validationRules);
+    }
 
-      if (!data.success) {
-        const message = data.errors?.join(', ') ?? data.error ?? 'Upload failed';
-        throw new Error(message);
-      }
+    const response = await fetch('/api/uploads/single', {
+      method: 'POST',
+      body: formData
+    });
 
-      return {
-        url: data.data.url,
-        filename: data.data.filename,
-        originalName: data.data.originalName,
-        mimeType: data.data.mimeType,
-        size: data.data.size
-      };
-    },
-    []
-  );
+    const data = await response.json();
+
+    if (!data.success) {
+      const message = data.errors?.join(', ') ?? data.error ?? 'Upload failed';
+      throw new Error(message);
+    }
+
+    return {
+      url: data.data.url,
+      filename: data.data.filename,
+      originalName: data.data.originalName,
+      mimeType: data.data.mimeType,
+      size: data.data.size
+    };
+  }, []);
 
   return { uploadFile };
 };

--- a/app/types/graphql/mutations/assets.graphql
+++ b/app/types/graphql/mutations/assets.graphql
@@ -7,3 +7,13 @@ mutation UpdateAsset($id: ID!, $input: UpdateAssetInput!) {
     updatedAt
   }
 }
+
+mutation CreateAsset($input: CreateAssetInput!) {
+  createAsset(input: $input) {
+    id
+    filename
+    url
+    mimeType
+    type
+  }
+}


### PR DESCRIPTION
## Description

Implemented a dedicated FileView component to handle the UI/UX for non-image file uploads (PDF, Documents, Archives, Audio, Video). This isolates the logic for handling file metadata and previews from the existing image processing flow.

## Type of change

- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Go to the Files page and click the Upload file button.

2. Drop a non-image file (e.g., PDF).

3. Verify that the file is correctly displayed in the modal with the appropriate icon.

4. Test the "Повернутись назад" button — it should clear the file and return you to the upload zone.

5. Test the "Скасувати" button — it should close the modal.

6. Test the "Застосувати" button (Note: an error message about allowed types is expected for now, as the backend changes in PR #491 are still under review).


Closes: https://github.com/Liatoshynsky-Foundation/lf-admin/issues/496