### PR TITLE
feat: replace native blocknote picker

### DIFF
--- a/app/lib/utils/getCustomSlashMenuItems.test.tsx
+++ b/app/lib/utils/getCustomSlashMenuItems.test.tsx
@@ -1,0 +1,237 @@
+import { getDefaultReactSlashMenuItems } from '@blocknote/react';
+import React from 'react';
+
+import { getCustomSlashMenuItems } from './getCustomSlashMenuItems';
+import { StrictBlockNoteEditor } from '~/shared/components/content-editor/types';
+import { MediaModalResult } from '~/shared/components/media-modal/MediaModal.types';
+import { CropResult } from '~/types/common';
+
+type MockSlashMenuItem = {
+  title: string;
+  group: string;
+  aliases?: string[];
+  icon?: React.ReactNode;
+  subtext?: string;
+  onItemClick?: () => Promise<void>;
+};
+
+jest.mock('@blocknote/react', () => ({
+  getDefaultReactSlashMenuItems: jest.fn()
+}));
+
+jest.mock('lucide-react', () => ({
+  ImageIcon: () => <span data-testid="image-icon" />
+}));
+
+const mockInsertBlocks = jest.fn();
+const mockGetTextCursorPosition = jest.fn(() => ({ block: { id: 'mock-block-id' } }));
+
+const mockEditor = {
+  getTextCursorPosition: mockGetTextCursorPosition,
+  insertBlocks: mockInsertBlocks
+} as unknown as StrictBlockNoteEditor;
+
+describe('getCustomSlashMenuItems', () => {
+  const mockOpenMediaModal = jest.fn<Promise<MediaModalResult | null>, []>();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (getDefaultReactSlashMenuItems as jest.Mock).mockReturnValue([
+      { title: 'Heading 1', group: 'Text', aliases: ['h1'] },
+      { title: 'Image', group: 'Media', aliases: ['img'] }, 
+      { title: 'Video', group: 'Media', aliases: ['vid'] }, 
+      { title: 'Divider', group: 'Media', aliases: ['line'] }, 
+      { title: 'File', group: 'Media', aliases: [] }, 
+      { title: 'List', group: 'Text', aliases: ['ul'] }
+    ] as MockSlashMenuItem[]);
+  });
+
+  describe('Menu Composition and Filtering', () => {
+    it('should exclude forbidden titles and inject the custom "Picture" item', () => {
+      const items = getCustomSlashMenuItems(mockEditor, '', mockOpenMediaModal);
+
+      const titles = items.map((item) => item.title);
+
+      expect(titles).not.toContain('Image');
+      expect(titles).not.toContain('Video');
+      expect(titles).not.toContain('File');
+      
+      expect(titles).toContain('Picture');
+      expect(titles).toContain('Heading 1');
+      expect(titles).toContain('List');
+    });
+
+    it('should insert the custom "Picture" item into the Media group', () => {
+      const items = getCustomSlashMenuItems(mockEditor, '', mockOpenMediaModal);
+      const pictureItem = items.find((item) => item.title === 'Picture');
+
+      expect(pictureItem).toBeDefined();
+      expect(pictureItem?.group).toBe('Media');
+      expect(pictureItem?.aliases).toContain('photo');
+    });
+
+    it('should filter items based on the query matching the title', () => {
+      const items = getCustomSlashMenuItems(mockEditor, 'head', mockOpenMediaModal);
+      
+      expect(items).toHaveLength(1);
+      expect(items[0].title).toBe('Heading 1');
+    });
+
+    it('should filter items based on the query matching an alias', () => {
+      const items = getCustomSlashMenuItems(mockEditor, 'ul', mockOpenMediaModal);
+      
+      expect(items).toHaveLength(1);
+      expect(items[0].title).toBe('List');
+    });
+
+    it('should return the custom Picture item if queried by its aliases', () => {
+      const items = getCustomSlashMenuItems(mockEditor, 'зображення', mockOpenMediaModal);
+      
+      expect(items).toHaveLength(1);
+      expect(items[0].title).toBe('Picture');
+    });
+
+    it('should return an empty array if query matches nothing', () => {
+      const items = getCustomSlashMenuItems(mockEditor, 'nonexistentquery', mockOpenMediaModal);
+      
+      expect(items).toHaveLength(0);
+    });
+  });
+
+  describe('Interaction & Modal Flow (onItemClick)', () => {
+    let pictureItemOnClick: () => Promise<void>;
+
+    beforeEach(() => {
+      const items = getCustomSlashMenuItems(mockEditor, 'picture', mockOpenMediaModal) as MockSlashMenuItem[];
+      pictureItemOnClick = items[0].onItemClick!;
+    });
+
+    it('should not insert blocks if the modal is cancelled (returns null)', async () => {
+      mockOpenMediaModal.mockResolvedValue(null);
+
+      await pictureItemOnClick();
+
+      expect(mockOpenMediaModal).toHaveBeenCalledTimes(1);
+      expect(mockInsertBlocks).not.toHaveBeenCalled();
+    });
+
+    it('should not insert blocks if the modal returns an upload without a valid URL', async () => {
+      const mockResult: MediaModalResult = {
+        selected: { 
+          kind: 'upload', 
+          id: 'up-1', 
+          fileName: 'err.jpg', 
+          file: new File([], 'err.jpg') 
+        },
+        crop: null,
+        uploadResult: undefined 
+      };
+      
+      mockOpenMediaModal.mockResolvedValue(mockResult);
+
+      await pictureItemOnClick();
+
+      expect(mockInsertBlocks).not.toHaveBeenCalled();
+    });
+
+    it('should insert a cropped-image block when an uploaded image is successfully returned', async () => {
+      const mockResult: MediaModalResult = {
+        selected: { 
+          kind: 'upload', 
+          id: 'up-2', 
+          fileName: 'my-uploaded-file.jpg', 
+          file: new File([], 'my-uploaded-file.jpg') 
+        },
+        crop: { width: 500, height: 500, x: 10, y: 10 } as unknown as  CropResult,
+        uploadResult: { 
+          url: 'https://example.com/uploaded.jpg',
+          filename: 'hash-name.jpg',
+          originalName: 'my-uploaded-file.jpg',
+          mimeType: 'image/jpeg',
+          size: 1024
+        }
+      };
+      
+      mockOpenMediaModal.mockResolvedValue(mockResult);
+
+      await pictureItemOnClick();
+
+      expect(mockGetTextCursorPosition).toHaveBeenCalled();
+      expect(mockInsertBlocks).toHaveBeenCalledWith(
+        [
+          {
+            type: 'cropped-image',
+            props: {
+              url: 'https://example.com/uploaded.jpg',
+              cropData: JSON.stringify({ width: 500, height: 500, x: 10, y: 10 }),
+              fileName: 'my-uploaded-file.jpg'
+            }
+          }
+        ],
+        { id: 'mock-block-id' },
+        'after'
+      );
+    });
+
+    it('should insert a cropped-image block when a gallery/library image is selected', async () => {
+      const mockResult: MediaModalResult = {
+        selected: { 
+          kind: 'gallery', 
+          id: 'gal-1', 
+          src: 'https://example.com/gallery-img.png', 
+          fileName: 'gallery-pic.png',
+          locale: 'en'
+        },
+        crop: null, 
+        uploadResult: undefined
+      };
+      
+      mockOpenMediaModal.mockResolvedValue(mockResult);
+
+      await pictureItemOnClick();
+
+      expect(mockInsertBlocks).toHaveBeenCalledWith(
+        [
+          {
+            type: 'cropped-image',
+            props: {
+              url: 'https://example.com/gallery-img.png',
+              cropData: '{}', 
+              fileName: 'gallery-pic.png'
+            }
+          }
+        ],
+        { id: 'mock-block-id' },
+        'after'
+      );
+    });
+
+    it('should fallback to "image" if fileName is falsy', async () => {
+      const mockResult: MediaModalResult = {
+        selected: { 
+          kind: 'used', 
+          id: 'usd-1', 
+          src: 'https://example.com/no-name.png', 
+          fileName: '', 
+          locale: 'uk'
+        },
+        crop: null,
+        uploadResult: undefined
+      };
+      
+      mockOpenMediaModal.mockResolvedValue(mockResult);
+
+      await pictureItemOnClick();
+
+      expect(mockInsertBlocks).toHaveBeenCalledWith(
+        expect.any(Array),
+        { id: 'mock-block-id' },
+        'after'
+      );
+
+      const insertedProps = mockInsertBlocks.mock.calls[0][0][0].props;
+      expect(insertedProps.fileName).toBe('image');
+    });
+  });
+});

--- a/app/lib/utils/getCustomSlashMenuItems.test.tsx
+++ b/app/lib/utils/getCustomSlashMenuItems.test.tsx
@@ -71,22 +71,43 @@ describe('getCustomSlashMenuItems', () => {
       expect(pictureItem?.aliases).toContain('photo');
     });
 
-    it('should filter items based on the query matching the title', () => {
-      const items = getCustomSlashMenuItems(mockEditor, 'head', mockOpenMediaModal);
-      expect(items).toHaveLength(1);
-      expect(items[0].title).toBe('Heading 1');
-    });
+    describe('Query Filtering', () => {
+      const testCases = [
+        {
+          scenario: 'filter items based on the query matching the title',
+          query: 'head',
+          expectedLength: 1,
+          expectedTitle: 'Heading 1'
+        },
+        {
+          scenario: 'filter items based on the query matching an alias',
+          query: 'ul',
+          expectedLength: 1,
+          expectedTitle: 'List'
+        },
+        {
+          scenario: 'return the custom Picture item if queried by its aliases',
+          query: 'зображення',
+          expectedLength: 1,
+          expectedTitle: 'Picture'
+        },
+        {
+          scenario: 'return an empty array if query matches nothing',
+          query: 'nonexistentquery',
+          expectedLength: 0,
+          expectedTitle: undefined
+        }
+      ];
 
-    it('should filter items based on the query matching an alias', () => {
-      const items = getCustomSlashMenuItems(mockEditor, 'ul', mockOpenMediaModal);
-      expect(items).toHaveLength(1);
-      expect(items[0].title).toBe('List');
-    });
-
-    it('should return the custom Picture item if queried by its aliases', () => {
-      const items = getCustomSlashMenuItems(mockEditor, 'зображення', mockOpenMediaModal);
-      expect(items).toHaveLength(1);
-      expect(items[0].title).toBe('Picture');
+      it.each(testCases)('should $scenario', ({ query, expectedLength, expectedTitle }) => {
+        const items = getCustomSlashMenuItems(mockEditor, query, mockOpenMediaModal);
+        
+        expect(items).toHaveLength(expectedLength);
+        
+        if (expectedLength > 0) {
+          expect(items[0].title).toBe(expectedTitle);
+        }
+      });
     });
 
     it('should return an empty array if query matches nothing', () => {

--- a/app/lib/utils/getCustomSlashMenuItems.test.tsx
+++ b/app/lib/utils/getCustomSlashMenuItems.test.tsx
@@ -48,14 +48,14 @@ describe('getCustomSlashMenuItems', () => {
   });
 
   describe('Menu Composition and Filtering', () => {
-    it('should exclude forbidden titles and inject the custom "Picture" item', () => {
+    it('should exclude the entire original "Media" group and inject the custom "Picture" item', () => {
       const items = getCustomSlashMenuItems(mockEditor, '', mockOpenMediaModal);
-
       const titles = items.map((item) => item.title);
 
       expect(titles).not.toContain('Image');
       expect(titles).not.toContain('Video');
       expect(titles).not.toContain('File');
+      expect(titles).not.toContain('Divider');
       
       expect(titles).toContain('Picture');
       expect(titles).toContain('Heading 1');
@@ -73,28 +73,24 @@ describe('getCustomSlashMenuItems', () => {
 
     it('should filter items based on the query matching the title', () => {
       const items = getCustomSlashMenuItems(mockEditor, 'head', mockOpenMediaModal);
-      
       expect(items).toHaveLength(1);
       expect(items[0].title).toBe('Heading 1');
     });
 
     it('should filter items based on the query matching an alias', () => {
       const items = getCustomSlashMenuItems(mockEditor, 'ul', mockOpenMediaModal);
-      
       expect(items).toHaveLength(1);
       expect(items[0].title).toBe('List');
     });
 
     it('should return the custom Picture item if queried by its aliases', () => {
       const items = getCustomSlashMenuItems(mockEditor, 'зображення', mockOpenMediaModal);
-      
       expect(items).toHaveLength(1);
       expect(items[0].title).toBe('Picture');
     });
 
     it('should return an empty array if query matches nothing', () => {
       const items = getCustomSlashMenuItems(mockEditor, 'nonexistentquery', mockOpenMediaModal);
-      
       expect(items).toHaveLength(0);
     });
   });
@@ -107,131 +103,73 @@ describe('getCustomSlashMenuItems', () => {
       pictureItemOnClick = items[0].onItemClick!;
     });
 
-    it('should not insert blocks if the modal is cancelled (returns null)', async () => {
-      mockOpenMediaModal.mockResolvedValue(null);
-
+    const triggerClick = async (result: MediaModalResult | null) => {
+      mockOpenMediaModal.mockResolvedValue(result);
       await pictureItemOnClick();
+    };
 
-      expect(mockOpenMediaModal).toHaveBeenCalledTimes(1);
+    const expectNoInsert = async (result: MediaModalResult | null) => {
+      await triggerClick(result);
       expect(mockInsertBlocks).not.toHaveBeenCalled();
-    });
+    };
 
-    it('should not insert blocks if the modal returns an upload without a valid URL', async () => {
-      const mockResult: MediaModalResult = {
-        selected: { 
-          kind: 'upload', 
-          id: 'up-1', 
-          fileName: 'err.jpg', 
-          file: new File([], 'err.jpg') 
-        },
-        crop: null,
-        uploadResult: undefined 
-      };
-      
-      mockOpenMediaModal.mockResolvedValue(mockResult);
-
-      await pictureItemOnClick();
-
-      expect(mockInsertBlocks).not.toHaveBeenCalled();
-    });
-
-    it('should insert a image block when an uploaded image is successfully returned', async () => {
-      const mockResult: MediaModalResult = {
-        selected: { 
-          kind: 'upload', 
-          id: 'up-2', 
-          fileName: 'my-uploaded-file.jpg', 
-          file: new File([], 'my-uploaded-file.jpg') 
-        },
-        crop: { width: 500, height: 500, x: 10, y: 10 } as unknown as  CropResult,
-        uploadResult: { 
-          url: 'https://example.com/uploaded.jpg',
-          filename: 'hash-name.jpg',
-          originalName: 'my-uploaded-file.jpg',
-          mimeType: 'image/jpeg',
-          size: 1024
-        }
-      };
-      
-      mockOpenMediaModal.mockResolvedValue(mockResult);
-
-      await pictureItemOnClick();
-
+    const expectInsert = async (result: MediaModalResult, expectedProps: Record<string, unknown>) => {
+      await triggerClick(result);
       expect(mockGetTextCursorPosition).toHaveBeenCalled();
       expect(mockInsertBlocks).toHaveBeenCalledWith(
-        [
-          {
-            type: 'image',
-            props: {
-              url: 'https://example.com/uploaded.jpg',
-              cropData: JSON.stringify({ width: 500, height: 500, x: 10, y: 10 }),
-              fileName: 'my-uploaded-file.jpg'
-            }
-          }
-        ],
+        [{ type: 'image', props: expectedProps }],
         { id: 'mock-block-id' },
         'after'
       );
+    };
+
+    it('should not insert blocks if the modal is cancelled (returns null)', async () => {
+      await expectNoInsert(null);
+      expect(mockOpenMediaModal).toHaveBeenCalledTimes(1);
     });
 
-    it('should insert a image block when a gallery/library image is selected', async () => {
-      const mockResult: MediaModalResult = {
-        selected: { 
-          kind: 'gallery', 
-          id: 'gal-1', 
-          src: 'https://example.com/gallery-img.png', 
-          fileName: 'gallery-pic.png',
-          locale: 'en'
-        },
+    it('should not insert blocks if the modal returns an upload without a valid uploadResult', async () => {
+      await expectNoInsert({
+        selected: { kind: 'upload', id: 'up-1', fileName: 'err.jpg', file: new File([], 'err.jpg') },
+        crop: null,
+        uploadResult: undefined 
+      });
+    });
+
+    it('should insert an image block when an uploaded image is successfully returned', async () => {
+      await expectInsert({
+        selected: { kind: 'upload', id: 'up-2', fileName: 'my-uploaded-file.jpg', file: new File([], 'my-uploaded-file.jpg') },
+        crop: { width: 500, height: 500, x: 10, y: 10 } as unknown as CropResult,
+        uploadResult: { url: 'https://example.com/uploaded.jpg', filename: 'hash-name.jpg', originalName: 'my-uploaded-file.jpg', mimeType: 'image/jpeg', size: 1024 }
+      }, {
+        url: 'https://example.com/uploaded.jpg',
+        cropData: JSON.stringify({ width: 500, height: 500, x: 10, y: 10 }),
+        fileName: 'my-uploaded-file.jpg'
+      });
+    });
+
+    it('should insert an image block when a gallery/library image is selected', async () => {
+      await expectInsert({
+        selected: { kind: 'gallery', id: 'gal-1', src: 'https://example.com/gallery-img.png', fileName: 'gallery-pic.png', locale: 'en' },
         crop: null, 
         uploadResult: undefined
-      };
-      
-      mockOpenMediaModal.mockResolvedValue(mockResult);
-
-      await pictureItemOnClick();
-
-      expect(mockInsertBlocks).toHaveBeenCalledWith(
-        [
-          {
-            type: 'image',
-            props: {
-              url: 'https://example.com/gallery-img.png',
-              cropData: '{}', 
-              fileName: 'gallery-pic.png'
-            }
-          }
-        ],
-        { id: 'mock-block-id' },
-        'after'
-      );
+      }, {
+        url: 'https://example.com/gallery-img.png',
+        cropData: '{}', 
+        fileName: 'gallery-pic.png'
+      });
     });
 
     it('should fallback to "image" if fileName is falsy', async () => {
-      const mockResult: MediaModalResult = {
-        selected: { 
-          kind: 'used', 
-          id: 'usd-1', 
-          src: 'https://example.com/no-name.png', 
-          fileName: '', 
-          locale: 'uk'
-        },
+      await expectInsert({
+        selected: { kind: 'used', id: 'usd-1', src: 'https://example.com/no-name.png', fileName: '', locale: 'uk' },
         crop: null,
         uploadResult: undefined
-      };
-      
-      mockOpenMediaModal.mockResolvedValue(mockResult);
-
-      await pictureItemOnClick();
-
-      expect(mockInsertBlocks).toHaveBeenCalledWith(
-        expect.any(Array),
-        { id: 'mock-block-id' },
-        'after'
-      );
-
-      const insertedProps = mockInsertBlocks.mock.calls[0][0][0].props;
-      expect(insertedProps.fileName).toBe('image');
+      }, {
+        url: 'https://example.com/no-name.png',
+        cropData: '{}',
+        fileName: 'image'
+      });
     });
   });
 });

--- a/app/lib/utils/getCustomSlashMenuItems.test.tsx
+++ b/app/lib/utils/getCustomSlashMenuItems.test.tsx
@@ -135,7 +135,7 @@ describe('getCustomSlashMenuItems', () => {
       expect(mockInsertBlocks).not.toHaveBeenCalled();
     });
 
-    it('should insert a cropped-image block when an uploaded image is successfully returned', async () => {
+    it('should insert a image block when an uploaded image is successfully returned', async () => {
       const mockResult: MediaModalResult = {
         selected: { 
           kind: 'upload', 
@@ -161,7 +161,7 @@ describe('getCustomSlashMenuItems', () => {
       expect(mockInsertBlocks).toHaveBeenCalledWith(
         [
           {
-            type: 'cropped-image',
+            type: 'image',
             props: {
               url: 'https://example.com/uploaded.jpg',
               cropData: JSON.stringify({ width: 500, height: 500, x: 10, y: 10 }),
@@ -174,7 +174,7 @@ describe('getCustomSlashMenuItems', () => {
       );
     });
 
-    it('should insert a cropped-image block when a gallery/library image is selected', async () => {
+    it('should insert a image block when a gallery/library image is selected', async () => {
       const mockResult: MediaModalResult = {
         selected: { 
           kind: 'gallery', 
@@ -194,7 +194,7 @@ describe('getCustomSlashMenuItems', () => {
       expect(mockInsertBlocks).toHaveBeenCalledWith(
         [
           {
-            type: 'cropped-image',
+            type: 'image',
             props: {
               url: 'https://example.com/gallery-img.png',
               cropData: '{}', 

--- a/app/lib/utils/getCustomSlashMenuItems.tsx
+++ b/app/lib/utils/getCustomSlashMenuItems.tsx
@@ -1,0 +1,63 @@
+import { getDefaultReactSlashMenuItems } from '@blocknote/react';
+import { ImageIcon } from 'lucide-react';
+
+import { StrictBlockNoteEditor } from '~/shared/components/content-editor/types';
+import { MediaModalResult } from '~/shared/components/media-modal/MediaModal.types';
+
+export const getCustomSlashMenuItems = (
+  editor: StrictBlockNoteEditor, 
+  query: string,
+  openMediaModal: () => Promise<MediaModalResult | null>
+) => {
+  const defaultItems = getDefaultReactSlashMenuItems(editor);
+
+  const customImageItem = {
+    title: 'Picture',
+    aliases: ['image', 'img', 'picture', 'photo', 'фото', 'зображення'],
+    group: 'Media',
+    icon: <ImageIcon size={18} />,
+    subtext: 'Pick photo',
+    onItemClick: async () => {
+      const result = await openMediaModal();
+      if (result) {
+        const { selected, uploadResult, crop } = result;
+        const actualUrlString = uploadResult?.url ?? (selected.kind === 'upload' ? null : selected.src);
+
+        if (actualUrlString) {
+          const currentBlock = editor.getTextCursorPosition().block;
+          editor.insertBlocks(
+            [
+              {
+                type: 'cropped-image',
+                props: {
+                  url: actualUrlString,
+                  cropData: JSON.stringify(crop || {}),
+                  fileName: selected.fileName || 'image'
+                }
+              }
+            ],
+            currentBlock,
+            'after'
+          );
+        }
+      }
+    }
+  };
+
+  const EXCLUDED_TITLES = ['Image', 'Image (Upload)', 'Video', 'File', 'Audio'];
+  const filteredItems = defaultItems.filter((item) => !EXCLUDED_TITLES.includes(item.title));
+
+  const mediaGroupIndex = filteredItems.findIndex((item) => item.group === 'Media');
+  if (mediaGroupIndex !== -1) {
+    filteredItems.splice(mediaGroupIndex, 0, customImageItem);
+  } else {
+    filteredItems.push(customImageItem);
+  }
+
+  const queryLower = query.toLowerCase();
+  return filteredItems.filter(
+    (item) =>
+      item.title.toLowerCase().includes(queryLower) ||
+      item.aliases?.some((alias: string) => alias.toLowerCase().includes(queryLower))
+  );
+};

--- a/app/lib/utils/getCustomSlashMenuItems.tsx
+++ b/app/lib/utils/getCustomSlashMenuItems.tsx
@@ -28,7 +28,7 @@ export const getCustomSlashMenuItems = (
           editor.insertBlocks(
             [
               {
-                type: 'cropped-image',
+                type: 'image',
                 props: {
                   url: actualUrlString,
                   cropData: JSON.stringify(crop || {}),

--- a/app/lib/utils/getCustomSlashMenuItems.tsx
+++ b/app/lib/utils/getCustomSlashMenuItems.tsx
@@ -5,7 +5,7 @@ import { StrictBlockNoteEditor } from '~/shared/components/content-editor/types'
 import { MediaModalResult } from '~/shared/components/media-modal/MediaModal.types';
 
 export const getCustomSlashMenuItems = (
-  editor: StrictBlockNoteEditor, 
+  editor: StrictBlockNoteEditor,
   query: string,
   openMediaModal: () => Promise<MediaModalResult | null>
 ) => {
@@ -44,15 +44,9 @@ export const getCustomSlashMenuItems = (
     }
   };
 
-  const EXCLUDED_TITLES = ['Image', 'Image (Upload)', 'Video', 'File', 'Audio'];
-  const filteredItems = defaultItems.filter((item) => !EXCLUDED_TITLES.includes(item.title));
+  const filteredItems = defaultItems.filter((item) => item.group !== 'Media');
 
-  const mediaGroupIndex = filteredItems.findIndex((item) => item.group === 'Media');
-  if (mediaGroupIndex !== -1) {
-    filteredItems.splice(mediaGroupIndex, 0, customImageItem);
-  } else {
-    filteredItems.push(customImageItem);
-  }
+  filteredItems.push(customImageItem);
 
   const queryLower = query.toLowerCase();
   return filteredItems.filter(

--- a/app/shared/components/content-editor/BlockNoteEditor.styles.ts
+++ b/app/shared/components/content-editor/BlockNoteEditor.styles.ts
@@ -2,6 +2,7 @@ import { SxProps, Theme } from '@mui/material';
 
 export const styles: Record<string, SxProps<Theme>> = {
   container: {
+    overflow: 'hidden',
     width: '100%',
     backgroundColor: '#fff',
     borderRadius: '8px',
@@ -9,10 +10,10 @@ export const styles: Record<string, SxProps<Theme>> = {
     padding: '24px',
     fontFamily: 'Mulish, sans-serif',
     '& .bn-container': {
-      width: '100%',
+      width: '100%'
     },
     '& .bn-editor': {
-      minHeight: '400px',
+      minHeight: '400px'
     },
     // Hide native file input when using custom file picker
     '&.custom-file-picker-enabled': {

--- a/app/shared/components/content-editor/BlockNoteEditor.test.tsx
+++ b/app/shared/components/content-editor/BlockNoteEditor.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import React from 'react';
 
 import { BlockNoteEditor } from './BlockNoteEditor';
+import { MediaModalResult } from '~/shared/components/media-modal/MediaModal.types';
 
 type SlashMenuItem = {
   title: string;
@@ -13,19 +14,29 @@ type ToolbarItem = {
   type?: string;
 };
 
-const mockInsertBlocks = jest.fn();
-const mockUpdateBlock = jest.fn();
-const mockGetTextCursorPosition = jest.fn(() => ({ block: { id: 'mock-block-id' } }));
-
-const mockEditor = {
-  document: [],
-  getTextCursorPosition: mockGetTextCursorPosition,
-  insertBlocks: mockInsertBlocks,
-  updateBlock: mockUpdateBlock
+type MockBlock = {
+  id?: string;
+  type: string;
+  props?: Record<string, unknown>;
 };
 
-let capturedCreateOptions: { uploadFile: (file: File) => Promise<string> } | null = null;
-let capturedSelectedBlocks: { id: string; type: string }[] = [];
+type CreateOptions = {
+  uploadFile: (file: File) => Promise<string>;
+  onChange?: () => void;
+};
+
+const mockUpdateBlock = jest.fn();
+const mockForEachBlock = jest.fn();
+
+let mockDocumentState: MockBlock[] = [];
+let capturedCreateOptions: CreateOptions | null = null;
+let captureSlashMenuOpenMediaModal: (() => Promise<MediaModalResult | null>) | null = null;
+
+const mockEditor = {
+  document: mockDocumentState,
+  updateBlock: mockUpdateBlock,
+  forEachBlock: mockForEachBlock
+};
 
 jest.mock('@blocknote/core', () => ({
   BlockNoteSchema: {
@@ -36,56 +47,53 @@ jest.mock('@blocknote/core', () => ({
   defaultStyleSpecs: {}
 }));
 
+jest.mock('~/lib/utils/getCustomSlashMenuItems', () => ({
+  getCustomSlashMenuItems: jest.fn(
+    (
+      _editor: unknown,
+      _query: string,
+      openModal: () => Promise<MediaModalResult | null>
+    ) => {
+      captureSlashMenuOpenMediaModal = openModal;
+      return [
+        {
+          title: 'Picture',
+          onItemClick: async () => {
+            await openModal();
+          }
+        }
+      ];
+    }
+  )
+}));
+
 jest.mock('@blocknote/react', () => ({
-  useCreateBlockNote: jest.fn((options: { uploadFile: (file: File) => Promise<string> }) => {
+  useCreateBlockNote: jest.fn((options: CreateOptions) => {
     capturedCreateOptions = options;
     return mockEditor;
   }),
-  getDefaultReactSlashMenuItems: jest.fn(() => [
-    { title: 'Heading', group: 'Text' },
-    { title: 'Image', group: 'Media' },
-    { title: 'Image (Upload)', group: 'Media' }
-  ]),
-  SuggestionMenuController: ({ getItems }: { getItems: (query: string) => Promise<SlashMenuItem[]> }) => {
-    return (
-      <div data-testid="suggestion-menu-controller">
-        <button
-          data-testid="trigger-custom-slash-item"
-          onClick={async () => {
-            const items = await getItems('pic');
-            const pictureItem = items.find((i: SlashMenuItem) => i.title === 'Picture');
-            if (pictureItem && pictureItem.onItemClick) {
-              await pictureItem.onItemClick();
-            }
-          }}
-        >
-          Trigger Slash Menu
-        </button>
-      </div>
-    );
-  },
-  useSelectedBlocks: () => capturedSelectedBlocks,
-  useComponentsContext: () => ({
-    FormattingToolbar: {
-      Button: ({ label, onClick }: { label: string; onClick: () => void }) => (
-        <button data-testid="custom-replace-button" onClick={onClick}>
-          {label}
-        </button>
-      )
-    }
-  }),
+  SuggestionMenuController: ({ getItems }: { getItems: (query: string) => Promise<SlashMenuItem[]> }) => (
+    <div data-testid="suggestion-menu-controller">
+      <button
+        data-testid="trigger-slash-menu"
+        onClick={async () => {
+          const items = await getItems('');
+          if (items[0]?.onItemClick) await items[0].onItemClick();
+        }}
+      >
+        Open Slash Menu
+      </button>
+    </div>
+  ),
   getFormattingToolbarItems: (): ToolbarItem[] => [{ key: 'boldButton' }, { key: 'replaceFileButton' }],
-  FormattingToolbar: ({ children }: { children: any[] }) => (
+  FormattingToolbar: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="formatting-toolbar">
-      {Array.isArray(children)
-        ? children.map((child, idx) =>
-          React.isValidElement(child) ? (
-            React.cloneElement(child, { key: child.key || idx } as any)
-          ) : (
-            <span key={child.key || idx}>{child.key}</span>
-          )
-        )
-        : children}
+      {React.Children.map(children, (child, idx) => {
+        if (React.isValidElement(child)) {
+          return React.cloneElement(child, { key: child.key || String(idx) } as React.Attributes);
+        }
+        return <span key={idx}>{child as React.ReactNode}</span>;
+      })}
     </div>
   ),
   FormattingToolbarController: ({ formattingToolbar }: { formattingToolbar: () => React.ReactNode }) => (
@@ -94,16 +102,32 @@ jest.mock('@blocknote/react', () => ({
 }));
 
 jest.mock('@blocknote/mantine', () => ({
-  BlockNoteView: ({ children, editable }: { children: React.ReactNode; editable: boolean }) => (
+  BlockNoteView: ({
+    children,
+    editable,
+    onChange
+  }: {
+    children: React.ReactNode;
+    editable?: boolean;
+    onChange?: () => void;
+  }) => (
     <div data-testid="blocknote-editor" data-editable={editable}>
+      <button data-testid="trigger-editor-change" onClick={onChange} />
       {children}
     </div>
   )
 }));
 
-jest.mock('@blocknote/xl-multi-column', () => ({
-  multiColumnDropCursor: {},
-  withMultiColumn: jest.fn((schema: unknown) => schema)
+jest.mock('./cropped-image-block/CroppedImageBlock', () => ({
+  CroppedImageBlock: jest.fn(() => ({}))
+}));
+
+jest.mock('./custom-replace-button/CustomReplaceButton', () => ({
+  CustomReplaceButton: ({ openMediaModal }: { openMediaModal: () => Promise<MediaModalResult | null> }) => (
+    <button data-testid="custom-replace-button" onClick={openMediaModal}>
+      Replace
+    </button>
+  )
 }));
 
 jest.mock('~/shared/components/media-modal/MediaModal', () => ({
@@ -114,7 +138,7 @@ jest.mock('~/shared/components/media-modal/MediaModal', () => ({
   }: {
     open: boolean;
     onClose: () => void;
-    onApply: (result: { selected: { kind: string; src?: string }; uploadResult: null }) => void;
+    onApply: (result: MediaModalResult) => void;
   }) => {
     if (!open) return null;
     return (
@@ -123,8 +147,15 @@ jest.mock('~/shared/components/media-modal/MediaModal', () => ({
           data-testid="modal-apply-success"
           onClick={() =>
             onApply({
-              selected: { kind: 'library', src: 'https://example.com/mock-image.png' },
-              uploadResult: null
+              selected: {
+                kind: 'gallery',
+                src: 'https://example.com/mock-image.png',
+                id: '1',
+                fileName: 'mock',
+                locale: 'en'
+              },
+              crop: null,
+              uploadResult: undefined
             })
           }
         >
@@ -142,12 +173,14 @@ describe('BlockNoteEditor', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     capturedCreateOptions = null;
-    capturedSelectedBlocks = [];
+    captureSlashMenuOpenMediaModal = null;
+    mockDocumentState = [];
+    mockEditor.document = mockDocumentState;
   });
 
-  describe('1. Mounting', () => {
+  describe('1. Mounting & Rendering', () => {
     it('should render the loading state initially, then render the BlockNoteView', async () => {
-      render(<BlockNoteEditor editable={true} />);
+      render(<BlockNoteEditor />);
 
       const editor = await screen.findByTestId('blocknote-editor');
       expect(editor).toBeInTheDocument();
@@ -155,9 +188,17 @@ describe('BlockNoteEditor', () => {
       expect(screen.getByTestId('suggestion-menu-controller')).toBeInTheDocument();
       expect(screen.getByTestId('formatting-toolbar-controller')).toBeInTheDocument();
     });
+
+    it('should inject the CustomReplaceButton into the formatting toolbar', async () => {
+      render(<BlockNoteEditor />);
+      await screen.findByTestId('blocknote-editor');
+
+      expect(screen.getByTestId('custom-replace-button')).toBeInTheDocument();
+      expect(screen.queryByText('replaceFileButton')).not.toBeInTheDocument();
+    });
   });
 
-  describe('2. Silent Upload (Drag & Drop)', () => {
+  describe('2. Silent File Uploads', () => {
     it('should successfully trigger the fileUpload.handler and return the URL', async () => {
       const mockHandler = jest.fn().mockResolvedValue('https://example.com/silent-upload.png');
 
@@ -191,40 +232,110 @@ describe('BlockNoteEditor', () => {
     });
   });
 
-  describe('3. The Promise Flow (Success)', () => {
-    it('should open the modal, wait for application, and insert the block with exact URL', async () => {
-      render(<BlockNoteEditor />);
+  describe('3. Editor Change & Native Block Interception', () => {
+    it('should call onChange prop and convert native "image" blocks to "cropped-image"', async () => {
+      const onChangeMock = jest.fn();
+      mockDocumentState = [{ type: 'paragraph' }];
+      mockEditor.document = mockDocumentState;
 
+      mockForEachBlock.mockImplementation((callback: (block: MockBlock) => boolean) => {
+        callback({
+          id: 'native-img-block',
+          type: 'image',
+          props: { url: 'http://test.com/img.png', name: 'test.png', caption: 'Test' }
+        });
+      });
+
+      render(<BlockNoteEditor onChange={onChangeMock} />);
+      await screen.findByTestId('blocknote-editor');
+
+      fireEvent.click(screen.getByTestId('trigger-editor-change'));
+
+      expect(onChangeMock).toHaveBeenCalledWith(mockDocumentState);
+
+      expect(mockUpdateBlock).toHaveBeenCalledWith('native-img-block', {
+        type: 'cropped-image',
+        props: {
+          url: 'http://test.com/img.png',
+          fileName: 'test.png',
+          cropData: '{}',
+          width: 512,
+          showPreview: true,
+          caption: 'Test'
+        }
+      });
+    });
+
+    it('should provide default filename and caption when intercepting native image if missing', async () => {
+      mockForEachBlock.mockImplementation((callback: (block: MockBlock) => boolean) => {
+        callback({
+          id: 'native-img-block',
+          type: 'image',
+          props: { url: 'http://test.com/img.png' } 
+        });
+      });
+
+      render(<BlockNoteEditor />);
+      await screen.findByTestId('blocknote-editor');
+
+      fireEvent.click(screen.getByTestId('trigger-editor-change'));
+
+      expect(mockUpdateBlock).toHaveBeenCalledWith('native-img-block', {
+        type: 'cropped-image',
+        props: expect.objectContaining({
+          fileName: 'Завантажене зображення',
+          caption: ''
+        })
+      });
+    });
+  });
+
+  describe('4. The Media Modal Promise Flow', () => {
+    it('should resolve the promise and close the modal when Apply is clicked', async () => {
+      render(<BlockNoteEditor />);
+      await screen.findByTestId('blocknote-editor');
+
+      let promiseResult: MediaModalResult | null | undefined;
       await act(async () => {
-        fireEvent.click(screen.getByTestId('trigger-custom-slash-item'));
+        fireEvent.click(screen.getByTestId('trigger-slash-menu'));
+      });
+
+      captureSlashMenuOpenMediaModal!().then((res) => {
+        promiseResult = res;
       });
 
       const modal = await screen.findByTestId('media-modal');
       expect(modal).toBeInTheDocument();
-      expect(mockInsertBlocks).not.toHaveBeenCalled();
 
       await act(async () => {
         fireEvent.click(screen.getByTestId('modal-apply-success'));
       });
 
       expect(screen.queryByTestId('media-modal')).not.toBeInTheDocument();
-
-      expect(mockGetTextCursorPosition).toHaveBeenCalled();
-      expect(mockInsertBlocks).toHaveBeenCalledTimes(1);
-      expect(mockInsertBlocks).toHaveBeenCalledWith(
-        [{ type: 'image', props: { url: 'https://example.com/mock-image.png' } }],
-        { id: 'mock-block-id' },
-        'after'
-      );
+      expect(promiseResult).toEqual({
+        selected: { 
+          kind: 'gallery', 
+          src: 'https://example.com/mock-image.png', 
+          id: '1', 
+          fileName: 'mock', 
+          locale: 'en' 
+        },
+        crop: null,
+        uploadResult: undefined
+      });
     });
-  });
 
-  describe('4. The Promise Flow (Cancellation)', () => {
-    it('should open the modal, fire onClose, and NEVER call editor.insertBlocks', async () => {
+    it('should resolve the promise with null and close the modal when Cancel is clicked', async () => {
       render(<BlockNoteEditor />);
+      await screen.findByTestId('blocknote-editor');
 
+      let promiseResult: MediaModalResult | null | undefined = undefined;
       await act(async () => {
-        fireEvent.click(screen.getByTestId('trigger-custom-slash-item'));
+        fireEvent.click(screen.getByTestId('trigger-slash-menu'));
+      });
+
+      captureSlashMenuOpenMediaModal!().then((res) => {
+        promiseResult = res;
       });
 
       expect(await screen.findByTestId('media-modal')).toBeInTheDocument();
@@ -234,53 +345,7 @@ describe('BlockNoteEditor', () => {
       });
 
       expect(screen.queryByTestId('media-modal')).not.toBeInTheDocument();
-
-      expect(mockInsertBlocks).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('5. Formatting Toolbar Replace Flow', () => {
-    it('should not render the CustomReplaceButton if no blocks are selected', () => {
-      capturedSelectedBlocks = [];
-      render(<BlockNoteEditor />);
-
-      expect(screen.queryByTestId('custom-replace-button')).not.toBeInTheDocument();
-    });
-
-    it('should not render the CustomReplaceButton if the selected block is not an image', () => {
-      capturedSelectedBlocks = [{ id: 'text-1', type: 'paragraph' }];
-      render(<BlockNoteEditor />);
-
-      expect(screen.queryByTestId('custom-replace-button')).not.toBeInTheDocument();
-    });
-
-    it('should render the CustomReplaceButton when exactly one image block is selected', () => {
-      capturedSelectedBlocks = [{ id: 'img-1', type: 'image' }];
-      render(<BlockNoteEditor />);
-
-      expect(screen.getByTestId('custom-replace-button')).toBeInTheDocument();
-    });
-
-    it('should open the modal and update the block when the CustomReplaceButton is clicked and applied', async () => {
-      capturedSelectedBlocks = [{ id: 'img-1', type: 'image' }];
-      render(<BlockNoteEditor />);
-
-      await act(async () => {
-        fireEvent.click(screen.getByTestId('custom-replace-button'));
-      });
-
-      const modal = await screen.findByTestId('media-modal');
-      expect(modal).toBeInTheDocument();
-
-      await act(async () => {
-        fireEvent.click(screen.getByTestId('modal-apply-success'));
-      });
-
-      expect(mockUpdateBlock).toHaveBeenCalledTimes(1);
-      expect(mockUpdateBlock).toHaveBeenCalledWith('img-1', {
-        type: 'image',
-        props: { url: 'https://example.com/mock-image.png' }
-      });
+      expect(promiseResult).toBeNull();
     });
   });
 });

--- a/app/shared/components/content-editor/BlockNoteEditor.test.tsx
+++ b/app/shared/components/content-editor/BlockNoteEditor.test.tsx
@@ -1,4 +1,22 @@
-import { render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { BlockNoteEditor } from './BlockNoteEditor';
+
+type SlashMenuItem = {
+  title: string;
+  onItemClick?: () => Promise<void>;
+};
+
+const mockInsertBlocks = jest.fn();
+const mockGetTextCursorPosition = jest.fn(() => ({ block: { id: 'mock-block-id' } }));
+const mockEditor = {
+  document: [],
+  getTextCursorPosition: mockGetTextCursorPosition,
+  insertBlocks: mockInsertBlocks
+};
+
+let capturedCreateOptions: { uploadFile: (file: File) => Promise<string> } | null = null;
 
 jest.mock('@blocknote/core', () => ({
   BlockNoteSchema: {
@@ -10,59 +28,180 @@ jest.mock('@blocknote/core', () => ({
 }));
 
 jest.mock('@blocknote/react', () => ({
-  useCreateBlockNote: jest.fn(() => ({
-    document: [],
-    getTextCursorPosition: jest.fn(() => ({ block: {} })),
-    insertBlocks: jest.fn()
-  }))
+  useCreateBlockNote: jest.fn((options: { uploadFile: (file: File) => Promise<string> }) => {
+    capturedCreateOptions = options;
+    return mockEditor;
+  }),
+  getDefaultReactSlashMenuItems: jest.fn(() => [
+    { title: 'Heading', group: 'Text' },
+    { title: 'Image', group: 'Media' },
+    { title: 'Image (Upload)', group: 'Media' }
+  ]),
+  SuggestionMenuController: ({ getItems }: { getItems: (query: string) => Promise<SlashMenuItem[]> }) => {
+    return (
+      <div data-testid="suggestion-menu-controller">
+        <button
+          data-testid="trigger-custom-slash-item"
+          onClick={async () => {
+            const items = await getItems('pic');
+            const pictureItem = items.find((i: SlashMenuItem) => i.title === 'Picture');
+            if (pictureItem && pictureItem.onItemClick) {
+              await pictureItem.onItemClick();
+            }
+          }}
+        >
+          Trigger Slash Menu
+        </button>
+      </div>
+    );
+  }
 }));
 
 jest.mock('@blocknote/mantine', () => ({
-  BlockNoteView: ({ editable }: { editable: boolean }) => (
+  BlockNoteView: ({ children, editable }: { children: React.ReactNode; editable: boolean }) => (
     <div data-testid="blocknote-editor" data-editable={editable}>
-      BlockNote Editor
+      {children}
     </div>
   )
 }));
 
 jest.mock('@blocknote/xl-multi-column', () => ({
   multiColumnDropCursor: {},
-  withMultiColumn: jest.fn((schema) => schema)
+  withMultiColumn: jest.fn((schema: unknown) => schema)
 }));
 
-import { BlockNoteEditor } from './BlockNoteEditor';
+jest.mock('~/shared/components/media-modal/MediaModal', () => ({
+  MediaModal: ({
+    open,
+    onClose,
+    onApply
+  }: {
+    open: boolean;
+    onClose: () => void;
+    onApply: (result: { selected: { kind: string; src?: string }; uploadResult: null }) => void;
+  }) => {
+    if (!open) return null;
+    return (
+      <div data-testid="media-modal">
+        <button
+          data-testid="modal-apply-success"
+          onClick={() =>
+            onApply({
+              selected: { kind: 'library', src: 'https://example.com/mock-image.png' },
+              uploadResult: null
+            })
+          }
+        >
+          Apply Success
+        </button>
+        <button data-testid="modal-close" onClick={onClose}>
+          Cancel Close
+        </button>
+      </div>
+    );
+  }
+}));
 
 describe('BlockNoteEditor', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    capturedCreateOptions = null;
   });
 
-  it('should render the editor after mounting', async () => {
-    render(<BlockNoteEditor />);
+  describe('1. Mounting', () => {
+    it('should render the loading state initially, then render the BlockNoteView', async () => {
+      render(<BlockNoteEditor editable={true} />);
 
-    const editor = await screen.findByTestId('blocknote-editor');
-    expect(editor).toBeInTheDocument();
-    expect(editor).toHaveAttribute('data-editable', 'true');
+      const editor = await screen.findByTestId('blocknote-editor');
+      expect(editor).toBeInTheDocument();
+      expect(editor).toHaveAttribute('data-editable', 'true');
+      expect(screen.getByTestId('suggestion-menu-controller')).toBeInTheDocument();
+    });
   });
 
-  it('should render the editor with custom props', async () => {
-    const onChange = jest.fn();
-    const onSave = jest.fn();
+  describe('2. Silent Upload (Drag & Drop)', () => {
+    it('should successfully trigger the fileUpload.handler and return the URL', async () => {
+      const mockHandler = jest.fn().mockResolvedValue('https://example.com/silent-upload.png');
 
-    render(
-      <BlockNoteEditor
-        onChange={onChange}
-        placeholder="Custom placeholder"
-        editable={false}
-        minHeight="500px"
-        keyboardShortcuts={{
-          onSave
-        }}
-      />
-    );
+      render(
+        <BlockNoteEditor
+          fileUpload={{ handler: mockHandler, maxFileSize: 50000 }}
+        />
+      );
 
-    const editor = await screen.findByTestId('blocknote-editor');
-    expect(editor).toBeInTheDocument();
-    expect(editor).toHaveAttribute('data-editable', 'false');
+      await waitFor(() => expect(capturedCreateOptions).not.toBeNull());
+
+      const fakeFile = new File(['dummy content'], 'test.png', { type: 'image/png' });
+      Object.defineProperty(fakeFile, 'size', { value: 1024 });
+
+      const resultUrl = await capturedCreateOptions!.uploadFile(fakeFile);
+
+      expect(mockHandler).toHaveBeenCalledWith(fakeFile);
+      expect(resultUrl).toBe('https://example.com/silent-upload.png');
+    });
+
+    it('should enforce the maxFileSize error logic', async () => {
+      const mockHandler = jest.fn();
+
+      render(
+        <BlockNoteEditor
+          fileUpload={{ handler: mockHandler, maxFileSize: 100 }}
+        />
+      );
+
+      await waitFor(() => expect(capturedCreateOptions).not.toBeNull());
+
+      const fakeFile = new File(['dummy content'], 'test.png', { type: 'image/png' });
+      Object.defineProperty(fakeFile, 'size', { value: 5000 });
+
+      await expect(capturedCreateOptions!.uploadFile(fakeFile)).rejects.toThrow('File size exceeds maximum allowed size');
+      expect(mockHandler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('3. The Promise Flow (Success)', () => {
+    it('should open the modal, wait for application, and insert the block with exact URL', async () => {
+      render(<BlockNoteEditor />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('trigger-custom-slash-item'));
+      });
+
+      const modal = await screen.findByTestId('media-modal');
+      expect(modal).toBeInTheDocument();
+      expect(mockInsertBlocks).not.toHaveBeenCalled();
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('modal-apply-success'));
+      });
+
+      expect(screen.queryByTestId('media-modal')).not.toBeInTheDocument();
+
+      expect(mockGetTextCursorPosition).toHaveBeenCalled();
+      expect(mockInsertBlocks).toHaveBeenCalledTimes(1);
+      expect(mockInsertBlocks).toHaveBeenCalledWith(
+        [{ type: 'image', props: { url: 'https://example.com/mock-image.png' } }],
+        { id: 'mock-block-id' },
+        'after'
+      );
+    });
+  });
+
+  describe('4. The Promise Flow (Cancellation)', () => {
+    it('should open the modal, fire onClose, and NEVER call editor.insertBlocks', async () => {
+      render(<BlockNoteEditor />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('trigger-custom-slash-item'));
+      });
+
+      expect(await screen.findByTestId('media-modal')).toBeInTheDocument();
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('modal-close'));
+      });
+      expect(screen.queryByTestId('media-modal')).not.toBeInTheDocument();
+      expect(mockInsertBlocks).not.toHaveBeenCalled();
+    });
   });
 });

--- a/app/shared/components/content-editor/BlockNoteEditor.test.tsx
+++ b/app/shared/components/content-editor/BlockNoteEditor.test.tsx
@@ -8,15 +8,24 @@ type SlashMenuItem = {
   onItemClick?: () => Promise<void>;
 };
 
+type ToolbarItem = {
+  key: string;
+  type?: string;
+};
+
 const mockInsertBlocks = jest.fn();
+const mockUpdateBlock = jest.fn();
 const mockGetTextCursorPosition = jest.fn(() => ({ block: { id: 'mock-block-id' } }));
+
 const mockEditor = {
   document: [],
   getTextCursorPosition: mockGetTextCursorPosition,
-  insertBlocks: mockInsertBlocks
+  insertBlocks: mockInsertBlocks,
+  updateBlock: mockUpdateBlock
 };
 
 let capturedCreateOptions: { uploadFile: (file: File) => Promise<string> } | null = null;
+let capturedSelectedBlocks: { id: string; type: string }[] = [];
 
 jest.mock('@blocknote/core', () => ({
   BlockNoteSchema: {
@@ -54,7 +63,34 @@ jest.mock('@blocknote/react', () => ({
         </button>
       </div>
     );
-  }
+  },
+  useSelectedBlocks: () => capturedSelectedBlocks,
+  useComponentsContext: () => ({
+    FormattingToolbar: {
+      Button: ({ label, onClick }: { label: string; onClick: () => void }) => (
+        <button data-testid="custom-replace-button" onClick={onClick}>
+          {label}
+        </button>
+      )
+    }
+  }),
+  getFormattingToolbarItems: (): ToolbarItem[] => [{ key: 'boldButton' }, { key: 'replaceFileButton' }],
+  FormattingToolbar: ({ children }: { children: any[] }) => (
+    <div data-testid="formatting-toolbar">
+      {Array.isArray(children)
+        ? children.map((child, idx) =>
+          React.isValidElement(child) ? (
+            React.cloneElement(child, { key: child.key || idx } as any)
+          ) : (
+            <span key={child.key || idx}>{child.key}</span>
+          )
+        )
+        : children}
+    </div>
+  ),
+  FormattingToolbarController: ({ formattingToolbar }: { formattingToolbar: () => React.ReactNode }) => (
+    <div data-testid="formatting-toolbar-controller">{formattingToolbar()}</div>
+  )
 }));
 
 jest.mock('@blocknote/mantine', () => ({
@@ -106,6 +142,7 @@ describe('BlockNoteEditor', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     capturedCreateOptions = null;
+    capturedSelectedBlocks = [];
   });
 
   describe('1. Mounting', () => {
@@ -116,6 +153,7 @@ describe('BlockNoteEditor', () => {
       expect(editor).toBeInTheDocument();
       expect(editor).toHaveAttribute('data-editable', 'true');
       expect(screen.getByTestId('suggestion-menu-controller')).toBeInTheDocument();
+      expect(screen.getByTestId('formatting-toolbar-controller')).toBeInTheDocument();
     });
   });
 
@@ -123,11 +161,7 @@ describe('BlockNoteEditor', () => {
     it('should successfully trigger the fileUpload.handler and return the URL', async () => {
       const mockHandler = jest.fn().mockResolvedValue('https://example.com/silent-upload.png');
 
-      render(
-        <BlockNoteEditor
-          fileUpload={{ handler: mockHandler, maxFileSize: 50000 }}
-        />
-      );
+      render(<BlockNoteEditor fileUpload={{ handler: mockHandler, maxFileSize: 50000 }} />);
 
       await waitFor(() => expect(capturedCreateOptions).not.toBeNull());
 
@@ -143,18 +177,16 @@ describe('BlockNoteEditor', () => {
     it('should enforce the maxFileSize error logic', async () => {
       const mockHandler = jest.fn();
 
-      render(
-        <BlockNoteEditor
-          fileUpload={{ handler: mockHandler, maxFileSize: 100 }}
-        />
-      );
+      render(<BlockNoteEditor fileUpload={{ handler: mockHandler, maxFileSize: 100 }} />);
 
       await waitFor(() => expect(capturedCreateOptions).not.toBeNull());
 
       const fakeFile = new File(['dummy content'], 'test.png', { type: 'image/png' });
       Object.defineProperty(fakeFile, 'size', { value: 5000 });
 
-      await expect(capturedCreateOptions!.uploadFile(fakeFile)).rejects.toThrow('File size exceeds maximum allowed size');
+      await expect(capturedCreateOptions!.uploadFile(fakeFile)).rejects.toThrow(
+        'File size exceeds maximum allowed size'
+      );
       expect(mockHandler).not.toHaveBeenCalled();
     });
   });
@@ -200,8 +232,55 @@ describe('BlockNoteEditor', () => {
       await act(async () => {
         fireEvent.click(screen.getByTestId('modal-close'));
       });
+
       expect(screen.queryByTestId('media-modal')).not.toBeInTheDocument();
+
       expect(mockInsertBlocks).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('5. Formatting Toolbar Replace Flow', () => {
+    it('should not render the CustomReplaceButton if no blocks are selected', () => {
+      capturedSelectedBlocks = [];
+      render(<BlockNoteEditor />);
+
+      expect(screen.queryByTestId('custom-replace-button')).not.toBeInTheDocument();
+    });
+
+    it('should not render the CustomReplaceButton if the selected block is not an image', () => {
+      capturedSelectedBlocks = [{ id: 'text-1', type: 'paragraph' }];
+      render(<BlockNoteEditor />);
+
+      expect(screen.queryByTestId('custom-replace-button')).not.toBeInTheDocument();
+    });
+
+    it('should render the CustomReplaceButton when exactly one image block is selected', () => {
+      capturedSelectedBlocks = [{ id: 'img-1', type: 'image' }];
+      render(<BlockNoteEditor />);
+
+      expect(screen.getByTestId('custom-replace-button')).toBeInTheDocument();
+    });
+
+    it('should open the modal and update the block when the CustomReplaceButton is clicked and applied', async () => {
+      capturedSelectedBlocks = [{ id: 'img-1', type: 'image' }];
+      render(<BlockNoteEditor />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('custom-replace-button'));
+      });
+
+      const modal = await screen.findByTestId('media-modal');
+      expect(modal).toBeInTheDocument();
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('modal-apply-success'));
+      });
+
+      expect(mockUpdateBlock).toHaveBeenCalledTimes(1);
+      expect(mockUpdateBlock).toHaveBeenCalledWith('img-1', {
+        type: 'image',
+        props: { url: 'https://example.com/mock-image.png' }
+      });
     });
   });
 });

--- a/app/shared/components/content-editor/BlockNoteEditor.test.tsx
+++ b/app/shared/components/content-editor/BlockNoteEditor.test.tsx
@@ -26,7 +26,6 @@ type CreateOptions = {
 };
 
 const mockUpdateBlock = jest.fn();
-const mockForEachBlock = jest.fn();
 
 let mockDocumentState: MockBlock[] = [];
 let capturedCreateOptions: CreateOptions | null = null;
@@ -34,8 +33,7 @@ let captureSlashMenuOpenMediaModal: (() => Promise<MediaModalResult | null>) | n
 
 const mockEditor = {
   document: mockDocumentState,
-  updateBlock: mockUpdateBlock,
-  forEachBlock: mockForEachBlock
+  updateBlock: mockUpdateBlock
 };
 
 jest.mock('@blocknote/core', () => ({
@@ -49,11 +47,7 @@ jest.mock('@blocknote/core', () => ({
 
 jest.mock('~/lib/utils/getCustomSlashMenuItems', () => ({
   getCustomSlashMenuItems: jest.fn(
-    (
-      _editor: unknown,
-      _query: string,
-      openModal: () => Promise<MediaModalResult | null>
-    ) => {
+    (_editor: unknown, _query: string, openModal: () => Promise<MediaModalResult | null>) => {
       captureSlashMenuOpenMediaModal = openModal;
       return [
         {
@@ -86,14 +80,18 @@ jest.mock('@blocknote/react', () => ({
     </div>
   ),
   getFormattingToolbarItems: (): ToolbarItem[] => [{ key: 'boldButton' }, { key: 'replaceFileButton' }],
-  FormattingToolbar: ({ children }: { children: React.ReactNode }) => (
+  FormattingToolbar: ({ children }: { children: (React.ReactElement | ToolbarItem)[] }) => (
     <div data-testid="formatting-toolbar">
-      {React.Children.map(children, (child, idx) => {
-        if (React.isValidElement(child)) {
-          return React.cloneElement(child, { key: child.key || String(idx) } as React.Attributes);
-        }
-        return <span key={idx}>{child as React.ReactNode}</span>;
-      })}
+      {Array.isArray(children)
+        ? children.map((child, idx) => {
+          // If it's our CustomReplaceButton React element
+          if (React.isValidElement(child)) {
+            return React.cloneElement(child, { key: child.key || String(idx) } as React.Attributes);
+          }
+          const item = child as ToolbarItem;
+          return <span key={item.key || String(idx)}>{item.key}</span>;
+        })
+        : null}
     </div>
   ),
   FormattingToolbarController: ({ formattingToolbar }: { formattingToolbar: () => React.ReactNode }) => (
@@ -232,61 +230,20 @@ describe('BlockNoteEditor', () => {
     });
   });
 
-  describe('3. Editor Change & Native Block Interception', () => {
-    it('should call onChange prop and convert native "image" blocks to "cropped-image"', async () => {
+  describe('3. Editor Change', () => {
+    it('should call onChange prop with the current document state', async () => {
       const onChangeMock = jest.fn();
       mockDocumentState = [{ type: 'paragraph' }];
       mockEditor.document = mockDocumentState;
 
-      mockForEachBlock.mockImplementation((callback: (block: MockBlock) => boolean) => {
-        callback({
-          id: 'native-img-block',
-          type: 'image',
-          props: { url: 'http://test.com/img.png', name: 'test.png', caption: 'Test' }
-        });
-      });
-
       render(<BlockNoteEditor onChange={onChangeMock} />);
       await screen.findByTestId('blocknote-editor');
-
       fireEvent.click(screen.getByTestId('trigger-editor-change'));
 
+      expect(onChangeMock).toHaveBeenCalledTimes(1);
       expect(onChangeMock).toHaveBeenCalledWith(mockDocumentState);
 
-      expect(mockUpdateBlock).toHaveBeenCalledWith('native-img-block', {
-        type: 'cropped-image',
-        props: {
-          url: 'http://test.com/img.png',
-          fileName: 'test.png',
-          cropData: '{}',
-          width: 512,
-          showPreview: true,
-          caption: 'Test'
-        }
-      });
-    });
-
-    it('should provide default filename and caption when intercepting native image if missing', async () => {
-      mockForEachBlock.mockImplementation((callback: (block: MockBlock) => boolean) => {
-        callback({
-          id: 'native-img-block',
-          type: 'image',
-          props: { url: 'http://test.com/img.png' } 
-        });
-      });
-
-      render(<BlockNoteEditor />);
-      await screen.findByTestId('blocknote-editor');
-
-      fireEvent.click(screen.getByTestId('trigger-editor-change'));
-
-      expect(mockUpdateBlock).toHaveBeenCalledWith('native-img-block', {
-        type: 'cropped-image',
-        props: expect.objectContaining({
-          fileName: 'Завантажене зображення',
-          caption: ''
-        })
-      });
+      expect(mockUpdateBlock).not.toHaveBeenCalled();
     });
   });
 
@@ -313,12 +270,12 @@ describe('BlockNoteEditor', () => {
 
       expect(screen.queryByTestId('media-modal')).not.toBeInTheDocument();
       expect(promiseResult).toEqual({
-        selected: { 
-          kind: 'gallery', 
-          src: 'https://example.com/mock-image.png', 
-          id: '1', 
-          fileName: 'mock', 
-          locale: 'en' 
+        selected: {
+          kind: 'gallery',
+          src: 'https://example.com/mock-image.png',
+          id: '1',
+          fileName: 'mock',
+          locale: 'en'
         },
         crop: null,
         uploadResult: undefined

--- a/app/shared/components/content-editor/BlockNoteEditor.tsx
+++ b/app/shared/components/content-editor/BlockNoteEditor.tsx
@@ -11,9 +11,7 @@ import {
 } from '@blocknote/core';
 import { BlockNoteView } from '@blocknote/mantine';
 import {
-  FormattingToolbar,
   FormattingToolbarController,
-  getFormattingToolbarItems,
   SuggestionMenuController,
   useCreateBlockNote
 } from '@blocknote/react';
@@ -22,7 +20,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { styles } from './BlockNoteEditor.styles';
 import { CroppedImageBlock } from './cropped-image-block/CroppedImageBlock';
-import { CustomReplaceButton } from './custom-replace-button/CustomReplaceButton';
+import { CustomFormattingToolbar } from './custom-formatting-toolbar/CustomFormattingToolbar';
 import { BlockNoteEditorProps } from './types';
 import { getCustomSlashMenuItems } from '~/lib/utils/getCustomSlashMenuItems';
 import { sxToArray } from '~/lib/utils/sxToArray';
@@ -125,7 +123,6 @@ export const BlockNoteEditor = (props: BlockNoteEditorProps) => {
 
   useEffect(() => {
     setIsMounted(true);
-
   }, []);
 
   if (!isMounted) {
@@ -151,21 +148,12 @@ export const BlockNoteEditor = (props: BlockNoteEditorProps) => {
           triggerCharacter="/"
           getItems={async (query) => getCustomSlashMenuItems(editor, query, openMediaModal)}
         />
-
         <FormattingToolbarController
-          formattingToolbar={() => {
-            const items = getFormattingToolbarItems();
-            const replaceIndex = items.findIndex((item) => item.key === 'replaceFileButton');
-
-            if (replaceIndex !== -1) {
-              items.splice(
-                replaceIndex,
-                1,
-                <CustomReplaceButton key="customReplaceButton" openMediaModal={openMediaModal} />
-              );
-            }
-            return <FormattingToolbar>{items}</FormattingToolbar>;
-          }}
+          formattingToolbar={() => (
+            <CustomFormattingToolbar
+              openMediaModal={openMediaModal}
+            />
+          )}
         />
       </BlockNoteView>
 

--- a/app/shared/components/content-editor/BlockNoteEditor.tsx
+++ b/app/shared/components/content-editor/BlockNoteEditor.tsx
@@ -10,10 +10,19 @@ import {
   defaultStyleSpecs
 } from '@blocknote/core';
 import { BlockNoteView } from '@blocknote/mantine';
-import { getDefaultReactSlashMenuItems, SuggestionMenuController, useCreateBlockNote } from '@blocknote/react';
+import {
+  FormattingToolbar,
+  FormattingToolbarController,
+  getDefaultReactSlashMenuItems,
+  getFormattingToolbarItems,
+  SuggestionMenuController,
+  useComponentsContext,
+  useCreateBlockNote,
+  useSelectedBlocks
+} from '@blocknote/react';
 import { multiColumnDropCursor, withMultiColumn } from '@blocknote/xl-multi-column';
 import { Box } from '@mui/material';
-import { Image as ImageIcon } from 'lucide-react';
+import { Image as ImageIcon, Replace } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { styles } from './BlockNoteEditor.styles';
@@ -43,13 +52,11 @@ export const BlockNoteEditor = ({
 }: BlockNoteEditorProps) => {
   const [isMounted, setIsMounted] = useState(false);
 
-  
   const [isMediaModalOpen, setIsMediaModalOpen] = useState(false);
   const pendingInsertRef = useRef<{ resolve: (url: string | null) => void } | null>(null);
 
   const uploadHandler = useMemo(() => fileUpload?.handler || defaultFileUploadHandler, [fileUpload?.handler]);
 
-  
   const handleSilentFileUpload = useCallback(
     async (file: File): Promise<string> => {
       if (fileUpload?.maxFileSize && file.size > fileUpload.maxFileSize) {
@@ -73,7 +80,7 @@ export const BlockNoteEditor = ({
   const editor = useCreateBlockNote(
     {
       schema,
-      uploadFile: handleSilentFileUpload, 
+      uploadFile: handleSilentFileUpload,
       initialContent: initialContent || undefined,
       dropCursor: multiColumnDropCursor,
       placeholders: { default: placeholder }
@@ -125,6 +132,37 @@ export const BlockNoteEditor = ({
     );
   }
 
+  // 📍 Put this right above your return statement
+  const CustomReplaceButton = () => {
+    // This hook gives us access to BlockNote's native, themed UI components
+    const Components = useComponentsContext()!;
+    const selectedBlocks = useSelectedBlocks(editor);
+
+    // Check if exactly one block is selected, and verify it is an image
+    const block = selectedBlocks.length === 1 ? selectedBlocks[0] : undefined;
+    if (block === undefined || block.type !== 'image') {
+      return null;
+    }
+
+    return (
+      <Components.FormattingToolbar.Button
+        label="Replace image"
+        mainTooltip="Замінити зображення"
+        icon={<Replace size={18} />}
+        onClick={async () => {
+          const finalUrl = await openMediaModal();
+
+          if (finalUrl) {
+            editor.updateBlock(block.id, {
+              type: 'image',
+              props: { url: finalUrl }
+            });
+          }
+        }}
+      />
+    );
+  };
+
   return (
     <Box sx={[styles.container, ...sxToArray(sx), { minHeight }]}>
       <BlockNoteView
@@ -133,7 +171,8 @@ export const BlockNoteEditor = ({
         onChange={handleEditorChange}
         theme="light"
         sideMenu={sideMenu}
-        slashMenu={false} 
+        slashMenu={false}
+        formattingToolbar={false}
       >
         <SuggestionMenuController
           triggerCharacter="/"
@@ -177,13 +216,25 @@ export const BlockNoteEditor = ({
             });
           }}
         />
+        <FormattingToolbarController
+          formattingToolbar={() => {
+            const items = getFormattingToolbarItems();
+            const replaceIndex = items.findIndex((item) => item.key === 'replaceFileButton');
+
+            if (replaceIndex !== -1) {
+              items.splice(replaceIndex, 1, <CustomReplaceButton key="customReplaceButton" />);
+            }
+
+            return <FormattingToolbar>{items}</FormattingToolbar>;
+          }}
+        />
       </BlockNoteView>
 
       <MediaModal
         open={isMediaModalOpen}
         onClose={handleCloseMediaModal}
         onApply={handleApplyMediaModal}
-        directory="photos" 
+        directory="photos"
       />
     </Box>
   );

--- a/app/shared/components/content-editor/BlockNoteEditor.tsx
+++ b/app/shared/components/content-editor/BlockNoteEditor.tsx
@@ -13,23 +13,28 @@ import { BlockNoteView } from '@blocknote/mantine';
 import {
   FormattingToolbar,
   FormattingToolbarController,
-  getDefaultReactSlashMenuItems,
   getFormattingToolbarItems,
   SuggestionMenuController,
-  useComponentsContext,
-  useCreateBlockNote,
-  useSelectedBlocks
+  useCreateBlockNote
 } from '@blocknote/react';
-import { multiColumnDropCursor, withMultiColumn } from '@blocknote/xl-multi-column';
 import { Box } from '@mui/material';
-import { Image as ImageIcon, Replace } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { styles } from './BlockNoteEditor.styles';
+import { CroppedImageBlock } from './cropped-image-block/CroppedImageBlock';
+import { CustomReplaceButton } from './custom-replace-button/CustomReplaceButton';
 import { BlockNoteEditorProps } from './types';
+import { getCustomSlashMenuItems } from '~/lib/utils/getCustomSlashMenuItems';
 import { sxToArray } from '~/lib/utils/sxToArray';
 import { MediaModal } from '~/shared/components/media-modal/MediaModal';
 import type { MediaModalResult } from '~/shared/components/media-modal/MediaModal.types';
+
+const DEFAULT_EDITOR_SETTINGS = {
+  placeholder: 'Почніть вводити текст або використайте "/" для команд...',
+  editable: true,
+  sideMenu: false,
+  minHeight: '800px'
+} as const;
 
 const defaultFileUploadHandler = async (file: File): Promise<string> => {
   return new Promise((resolve, reject) => {
@@ -40,20 +45,32 @@ const defaultFileUploadHandler = async (file: File): Promise<string> => {
   });
 };
 
-export const BlockNoteEditor = ({
-  initialContent,
-  onChange,
-  placeholder = 'Почніть вводити текст або використайте "/" для команд...',
-  editable = true,
-  sideMenu = false,
-  minHeight = '800px',
-  fileUpload,
-  sx
-}: BlockNoteEditorProps) => {
-  const [isMounted, setIsMounted] = useState(false);
+export const customSchema = BlockNoteSchema.create(
+  BlockNoteSchema.create({
+    blockSpecs: {
+      ...defaultBlockSpecs,
+      'cropped-image': CroppedImageBlock()
+    },
+    inlineContentSpecs: defaultInlineContentSpecs,
+    styleSpecs: defaultStyleSpecs
+  })
+);
 
+export const BlockNoteEditor = (props: BlockNoteEditorProps) => {
+  const {
+    initialContent,
+    onChange,
+    fileUpload,
+    sx,
+    placeholder = DEFAULT_EDITOR_SETTINGS.placeholder,
+    editable = DEFAULT_EDITOR_SETTINGS.editable,
+    sideMenu = DEFAULT_EDITOR_SETTINGS.sideMenu,
+    minHeight = DEFAULT_EDITOR_SETTINGS.minHeight
+  } = props;
+
+  const [isMounted, setIsMounted] = useState(false);
   const [isMediaModalOpen, setIsMediaModalOpen] = useState(false);
-  const pendingInsertRef = useRef<{ resolve: (url: string | null) => void } | null>(null);
+  const pendingInsertRef = useRef<{ resolve: (url: MediaModalResult | null) => void } | null>(null);
 
   const uploadHandler = useMemo(() => fileUpload?.handler || defaultFileUploadHandler, [fileUpload?.handler]);
 
@@ -67,28 +84,17 @@ export const BlockNoteEditor = ({
     [uploadHandler, fileUpload?.maxFileSize]
   );
 
-  const schema = useMemo(() => {
-    return withMultiColumn(
-      BlockNoteSchema.create({
-        blockSpecs: defaultBlockSpecs,
-        inlineContentSpecs: defaultInlineContentSpecs,
-        styleSpecs: defaultStyleSpecs
-      })
-    );
-  }, []);
-
   const editor = useCreateBlockNote(
     {
-      schema,
+      schema: customSchema,
       uploadFile: handleSilentFileUpload,
       initialContent: initialContent || undefined,
-      dropCursor: multiColumnDropCursor,
       placeholders: { default: placeholder }
     },
     [isMounted]
   );
 
-  const openMediaModal = useCallback((): Promise<string | null> => {
+  const openMediaModal = useCallback((): Promise<MediaModalResult | null> => {
     return new Promise((resolve) => {
       pendingInsertRef.current = { resolve };
       setIsMediaModalOpen(true);
@@ -96,11 +102,8 @@ export const BlockNoteEditor = ({
   }, []);
 
   const handleApplyMediaModal = useCallback((result: MediaModalResult) => {
-    const { selected, uploadResult } = result;
-    const url = uploadResult?.url ?? (selected.kind === 'upload' ? null : selected.src);
-
     if (pendingInsertRef.current) {
-      pendingInsertRef.current.resolve(url || null);
+      pendingInsertRef.current.resolve(result);
       pendingInsertRef.current = null;
     }
     setIsMediaModalOpen(false);
@@ -118,10 +121,27 @@ export const BlockNoteEditor = ({
     if (onChange && editor) {
       onChange(editor.document as Block[]);
     }
+    editor.forEachBlock((block) => {
+      if (block.type === 'image') {
+        editor.updateBlock(block.id, {
+          type: 'cropped-image',
+          props: {
+            url: block.props.url,
+            fileName: block.props.name || 'Завантажене зображення',
+            cropData: '{}',
+            width: 512,
+            showPreview: true,
+            caption: block.props.caption || ''
+          }
+        });
+      }
+      return true;
+    });
   }, [editor, onChange]);
 
   useEffect(() => {
     setIsMounted(true);
+
   }, []);
 
   if (!isMounted) {
@@ -131,37 +151,6 @@ export const BlockNoteEditor = ({
       </Box>
     );
   }
-
-  // 📍 Put this right above your return statement
-  const CustomReplaceButton = () => {
-    // This hook gives us access to BlockNote's native, themed UI components
-    const Components = useComponentsContext()!;
-    const selectedBlocks = useSelectedBlocks(editor);
-
-    // Check if exactly one block is selected, and verify it is an image
-    const block = selectedBlocks.length === 1 ? selectedBlocks[0] : undefined;
-    if (block === undefined || block.type !== 'image') {
-      return null;
-    }
-
-    return (
-      <Components.FormattingToolbar.Button
-        label="Replace image"
-        mainTooltip="Замінити зображення"
-        icon={<Replace size={18} />}
-        onClick={async () => {
-          const finalUrl = await openMediaModal();
-
-          if (finalUrl) {
-            editor.updateBlock(block.id, {
-              type: 'image',
-              props: { url: finalUrl }
-            });
-          }
-        }}
-      />
-    );
-  };
 
   return (
     <Box sx={[styles.container, ...sxToArray(sx), { minHeight }]}>
@@ -176,55 +165,21 @@ export const BlockNoteEditor = ({
       >
         <SuggestionMenuController
           triggerCharacter="/"
-          getItems={async (query) => {
-            const defaultItems = getDefaultReactSlashMenuItems(editor);
-
-            const customImageItem = {
-              title: 'Picture',
-              aliases: ['image', 'img', 'picture', 'photo', 'фото', 'зображення'],
-              group: 'Media',
-              icon: <ImageIcon size={18} />,
-              subtext: 'Pick photo',
-              onItemClick: async () => {
-                const finalUrl = await openMediaModal();
-
-                if (finalUrl) {
-                  const currentBlock = editor.getTextCursorPosition().block;
-                  editor.insertBlocks([{ type: 'image', props: { url: finalUrl } }], currentBlock, 'after');
-                }
-              }
-            };
-
-            const filteredItems = defaultItems.filter(
-              (item) => item.title !== 'Image' && item.title !== 'Image (Upload)'
-            );
-
-            const mediaGroupIndex = filteredItems.findIndex((item) => item.group === 'Media');
-
-            if (mediaGroupIndex !== -1) {
-              filteredItems.splice(mediaGroupIndex, 0, customImageItem);
-            } else {
-              filteredItems.push(customImageItem);
-            }
-
-            return filteredItems.filter((item) => {
-              const queryLower = query.toLowerCase();
-              const matchesTitle = item.title.toLowerCase().includes(queryLower);
-              const matchesAlias = item.aliases?.some((alias: string) => alias.toLowerCase().includes(queryLower));
-
-              return matchesTitle || matchesAlias;
-            });
-          }}
+          getItems={async (query) => getCustomSlashMenuItems(editor, query, openMediaModal)}
         />
+
         <FormattingToolbarController
           formattingToolbar={() => {
             const items = getFormattingToolbarItems();
             const replaceIndex = items.findIndex((item) => item.key === 'replaceFileButton');
 
             if (replaceIndex !== -1) {
-              items.splice(replaceIndex, 1, <CustomReplaceButton key="customReplaceButton" />);
+              items.splice(
+                replaceIndex,
+                1,
+                <CustomReplaceButton key="customReplaceButton" openMediaModal={openMediaModal} />
+              );
             }
-
             return <FormattingToolbar>{items}</FormattingToolbar>;
           }}
         />

--- a/app/shared/components/content-editor/BlockNoteEditor.tsx
+++ b/app/shared/components/content-editor/BlockNoteEditor.tsx
@@ -49,7 +49,7 @@ export const customSchema = BlockNoteSchema.create(
   BlockNoteSchema.create({
     blockSpecs: {
       ...defaultBlockSpecs,
-      'cropped-image': CroppedImageBlock()
+      image: CroppedImageBlock()
     },
     inlineContentSpecs: defaultInlineContentSpecs,
     styleSpecs: defaultStyleSpecs
@@ -121,22 +121,6 @@ export const BlockNoteEditor = (props: BlockNoteEditorProps) => {
     if (onChange && editor) {
       onChange(editor.document as Block[]);
     }
-    editor.forEachBlock((block) => {
-      if (block.type === 'image') {
-        editor.updateBlock(block.id, {
-          type: 'cropped-image',
-          props: {
-            url: block.props.url,
-            fileName: block.props.name || 'Завантажене зображення',
-            cropData: '{}',
-            width: 512,
-            showPreview: true,
-            caption: block.props.caption || ''
-          }
-        });
-      }
-      return true;
-    });
   }, [editor, onChange]);
 
   useEffect(() => {

--- a/app/shared/components/content-editor/BlockNoteEditor.tsx
+++ b/app/shared/components/content-editor/BlockNoteEditor.tsx
@@ -10,30 +10,23 @@ import {
   defaultStyleSpecs
 } from '@blocknote/core';
 import { BlockNoteView } from '@blocknote/mantine';
-import { useCreateBlockNote } from '@blocknote/react';
+import { getDefaultReactSlashMenuItems, SuggestionMenuController, useCreateBlockNote } from '@blocknote/react';
 import { multiColumnDropCursor, withMultiColumn } from '@blocknote/xl-multi-column';
 import { Box } from '@mui/material';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Image as ImageIcon } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { styles } from './BlockNoteEditor.styles';
 import { BlockNoteEditorProps } from './types';
-import { useFilePickerUpload } from './useFilePickerUpload';
 import { sxToArray } from '~/lib/utils/sxToArray';
+import { MediaModal } from '~/shared/components/media-modal/MediaModal';
+import type { MediaModalResult } from '~/shared/components/media-modal/MediaModal.types';
 
 const defaultFileUploadHandler = async (file: File): Promise<string> => {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
-    reader.onload = (e) => {
-      const result = e.target?.result;
-      if (result) {
-        resolve(result as string);
-      } else {
-        reject(new Error('Failed to read file'));
-      }
-    };
-    reader.onerror = () => {
-      reject(new Error('Failed to read file'));
-    };
+    reader.onload = (e) => resolve(e.target?.result as string);
+    reader.onerror = () => reject(new Error('Failed to read file'));
     reader.readAsDataURL(file);
   });
 };
@@ -46,162 +39,83 @@ export const BlockNoteEditor = ({
   sideMenu = false,
   minHeight = '800px',
   fileUpload,
-  keyboardShortcuts,
   sx
 }: BlockNoteEditorProps) => {
   const [isMounted, setIsMounted] = useState(false);
 
+  
+  const [isMediaModalOpen, setIsMediaModalOpen] = useState(false);
+  const pendingInsertRef = useRef<{ resolve: (url: string | null) => void } | null>(null);
+
   const uploadHandler = useMemo(() => fileUpload?.handler || defaultFileUploadHandler, [fileUpload?.handler]);
 
-  const { openCustomPicker, modalProps } = useFilePickerUpload({
-    customFilePickerModal: fileUpload?.customModal
-  });
-
-  const handleFileUpload = useCallback(
+  
+  const handleSilentFileUpload = useCallback(
     async (file: File): Promise<string> => {
       if (fileUpload?.maxFileSize && file.size > fileUpload.maxFileSize) {
-        throw new Error(`File size exceeds maximum allowed size of ${fileUpload.maxFileSize} bytes`);
+        throw new Error('File size exceeds maximum allowed size');
       }
-
-      if (fileUpload?.allowedMimeTypes && !fileUpload.allowedMimeTypes.includes(file.type)) {
-        throw new Error(`File type ${file.type} is not allowed`);
-      }
-
       return uploadHandler(file);
     },
-    [uploadHandler, fileUpload?.maxFileSize, fileUpload?.allowedMimeTypes]
+    [uploadHandler, fileUpload?.maxFileSize]
   );
 
   const schema = useMemo(() => {
-    const baseSchema = BlockNoteSchema.create({
-      blockSpecs: {
-        ...defaultBlockSpecs
-      },
-      inlineContentSpecs: {
-        ...defaultInlineContentSpecs
-      },
-      styleSpecs: {
-        ...defaultStyleSpecs
-      }
-    });
-
-    return withMultiColumn(baseSchema);
+    return withMultiColumn(
+      BlockNoteSchema.create({
+        blockSpecs: defaultBlockSpecs,
+        inlineContentSpecs: defaultInlineContentSpecs,
+        styleSpecs: defaultStyleSpecs
+      })
+    );
   }, []);
 
   const editor = useCreateBlockNote(
     {
       schema,
-      uploadFile: handleFileUpload,
+      uploadFile: handleSilentFileUpload, 
       initialContent: initialContent || undefined,
       dropCursor: multiColumnDropCursor,
-      placeholders: { default: placeholder, }
+      placeholders: { default: placeholder }
     },
     [isMounted]
   );
 
-  useEffect(() => {
-    setIsMounted(true);
+  const openMediaModal = useCallback((): Promise<string | null> => {
+    return new Promise((resolve) => {
+      pendingInsertRef.current = { resolve };
+      setIsMediaModalOpen(true);
+    });
   }, []);
 
-  useEffect(() => {
-    if (!openCustomPicker || !editor) {
-      return;
+  const handleApplyMediaModal = useCallback((result: MediaModalResult) => {
+    const { selected, uploadResult } = result;
+    const url = uploadResult?.url ?? (selected.kind === 'upload' ? null : selected.src);
+
+    if (pendingInsertRef.current) {
+      pendingInsertRef.current.resolve(url || null);
+      pendingInsertRef.current = null;
     }
+    setIsMediaModalOpen(false);
+  }, []);
 
-    const handleClick = async (event: MouseEvent) => {
-      const target = event.target as HTMLElement;
-
-      if (target instanceof HTMLInputElement && target.type === 'file') {
-        if (target.dataset.customFilePicker === 'true') {
-          return;
-        }
-
-        const isBlockNoteFileInput =
-          target.accept?.includes('image') ||
-          target.closest('[data-node-type]') ||
-          target.id?.includes('blocknote') ||
-          target.closest('.bn-');
-
-        if (isBlockNoteFileInput) {
-          event.preventDefault();
-          event.stopImmediatePropagation();
-
-          try {
-            const selectedFile = await openCustomPicker();
-            if (selectedFile) {
-              const fileUrl = await handleFileUpload(selectedFile);
-
-              const currentBlock = editor.getTextCursorPosition().block;
-              editor.insertBlocks(
-                [
-                  {
-                    type: 'image',
-                    props: {
-                      url: fileUrl,
-                      name: selectedFile.name
-                    }
-                  }
-                ],
-                currentBlock,
-                'after'
-              );
-            }
-          } catch (error) {
-            console.error('Error handling file selection:', error);
-          }
-        }
-      }
-    };
-
-    const handleFocus = (event: FocusEvent) => {
-      const target = event.target as HTMLElement;
-
-      if (target instanceof HTMLInputElement && target.type === 'file' && target.dataset.customFilePicker === 'true') {
-        return;
-      }
-
-      if (
-        target instanceof HTMLInputElement &&
-        target.type === 'file' &&
-        (target.accept?.includes('image') || target.closest('[data-node-type]'))
-      ) {
-        event.preventDefault();
-        event.stopImmediatePropagation();
-      }
-    };
-
-    document.addEventListener('click', handleClick, true);
-    document.addEventListener('focus', handleFocus, true);
-
-    return () => {
-      document.removeEventListener('click', handleClick, true);
-      document.removeEventListener('focus', handleFocus, true);
-    };
-  }, [openCustomPicker, handleFileUpload, editor]);
+  const handleCloseMediaModal = useCallback(() => {
+    if (pendingInsertRef.current) {
+      pendingInsertRef.current.resolve(null);
+      pendingInsertRef.current = null;
+    }
+    setIsMediaModalOpen(false);
+  }, []);
 
   const handleEditorChange = useCallback(() => {
-    if (onChange) {
-      const content = editor.document;
-      onChange(content as Block[]);
+    if (onChange && editor) {
+      onChange(editor.document as Block[]);
     }
   }, [editor, onChange]);
 
   useEffect(() => {
-    if (!keyboardShortcuts?.onSave) {
-      return;
-    }
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      // Cmd/Ctrl + S to save
-      if ((e.metaKey || e.ctrlKey) && e.key === 's') {
-        e.preventDefault();
-        keyboardShortcuts.onSave?.();
-      }
-    };
-
-    globalThis.addEventListener('keydown', handleKeyDown);
-    return () => globalThis.removeEventListener('keydown', handleKeyDown);
-  }, [keyboardShortcuts]);
+    setIsMounted(true);
+  }, []);
 
   if (!isMounted) {
     return (
@@ -218,11 +132,59 @@ export const BlockNoteEditor = ({
         editable={editable}
         onChange={handleEditorChange}
         theme="light"
-        data-theming-css-variables-demo
         sideMenu={sideMenu}
-      />
+        slashMenu={false} 
+      >
+        <SuggestionMenuController
+          triggerCharacter="/"
+          getItems={async (query) => {
+            const defaultItems = getDefaultReactSlashMenuItems(editor);
 
-      {modalProps && fileUpload?.customModal?.(modalProps)}
+            const customImageItem = {
+              title: 'Picture',
+              aliases: ['image', 'img', 'picture', 'photo', 'фото', 'зображення'],
+              group: 'Media',
+              icon: <ImageIcon size={18} />,
+              subtext: 'Pick photo',
+              onItemClick: async () => {
+                const finalUrl = await openMediaModal();
+
+                if (finalUrl) {
+                  const currentBlock = editor.getTextCursorPosition().block;
+                  editor.insertBlocks([{ type: 'image', props: { url: finalUrl } }], currentBlock, 'after');
+                }
+              }
+            };
+
+            const filteredItems = defaultItems.filter(
+              (item) => item.title !== 'Image' && item.title !== 'Image (Upload)'
+            );
+
+            const mediaGroupIndex = filteredItems.findIndex((item) => item.group === 'Media');
+
+            if (mediaGroupIndex !== -1) {
+              filteredItems.splice(mediaGroupIndex, 0, customImageItem);
+            } else {
+              filteredItems.push(customImageItem);
+            }
+
+            return filteredItems.filter((item) => {
+              const queryLower = query.toLowerCase();
+              const matchesTitle = item.title.toLowerCase().includes(queryLower);
+              const matchesAlias = item.aliases?.some((alias: string) => alias.toLowerCase().includes(queryLower));
+
+              return matchesTitle || matchesAlias;
+            });
+          }}
+        />
+      </BlockNoteView>
+
+      <MediaModal
+        open={isMediaModalOpen}
+        onClose={handleCloseMediaModal}
+        onApply={handleApplyMediaModal}
+        directory="photos" 
+      />
     </Box>
   );
 };

--- a/app/shared/components/content-editor/BlockNoteEditor.tsx
+++ b/app/shared/components/content-editor/BlockNoteEditor.tsx
@@ -10,11 +10,7 @@ import {
   defaultStyleSpecs
 } from '@blocknote/core';
 import { BlockNoteView } from '@blocknote/mantine';
-import {
-  FormattingToolbarController,
-  SuggestionMenuController,
-  useCreateBlockNote
-} from '@blocknote/react';
+import { FormattingToolbarController, SuggestionMenuController, useCreateBlockNote } from '@blocknote/react';
 import { Box } from '@mui/material';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
@@ -125,6 +121,13 @@ export const BlockNoteEditor = (props: BlockNoteEditorProps) => {
     setIsMounted(true);
   }, []);
 
+  const renderFormattingToolbar = useCallback(
+    () => (
+      <CustomFormattingToolbar  openMediaModal={openMediaModal} />
+    ),
+    [openMediaModal]
+  );
+
   if (!isMounted) {
     return (
       <Box sx={{ ...styles.container, minHeight }}>
@@ -149,11 +152,7 @@ export const BlockNoteEditor = (props: BlockNoteEditorProps) => {
           getItems={async (query) => getCustomSlashMenuItems(editor, query, openMediaModal)}
         />
         <FormattingToolbarController
-          formattingToolbar={() => (
-            <CustomFormattingToolbar
-              openMediaModal={openMediaModal}
-            />
-          )}
+          formattingToolbar={renderFormattingToolbar}
         />
       </BlockNoteView>
 

--- a/app/shared/components/content-editor/cropped-image-block/CroppedImageBlock.styles.ts
+++ b/app/shared/components/content-editor/cropped-image-block/CroppedImageBlock.styles.ts
@@ -1,0 +1,56 @@
+import { SxProps, Theme } from '@mui/material';
+
+export const styles = {
+  mainContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    my: 1
+  },
+  fileCard: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 1.5,
+    p: 1.5,
+    pr: 2,
+    borderRadius: 2,
+    cursor: 'pointer',
+    backgroundColor: 'background.default',
+    '&:hover': { backgroundColor: 'action.hover' }
+  },
+  fileIconBox: {
+    p: 1,
+    backgroundColor: 'primary.light',
+    borderRadius: 1,
+    color: 'primary.main',
+    display: 'flex'
+  },
+  fileName: {
+    fontWeight: 500
+  },
+  imageStateContainer: {
+    position: 'relative',
+    '&:hover .overlay-controls': { opacity: 1 }
+  },
+  resizeHandle: {
+    position: 'absolute',
+    right: -12,
+    top: '50%',
+    transform: 'translateY(-50%)',
+    width: 24,
+    height: 48,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    color: 'white',
+    borderRadius: 1,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    cursor: 'col-resize',
+    opacity: 0,
+    transition: 'opacity 0.2s',
+    '&:hover': { backgroundColor: 'primary.main', opacity: 1 }
+  },
+  captionInput: {
+    color: 'text.secondary',
+    fontSize: '0.875rem'
+  }
+} satisfies Record<string, SxProps<Theme>>;

--- a/app/shared/components/content-editor/cropped-image-block/CroppedImageBlock.test.tsx
+++ b/app/shared/components/content-editor/cropped-image-block/CroppedImageBlock.test.tsx
@@ -155,7 +155,7 @@ describe('CroppedImageBlock', () => {
       fireEvent.click(fileCard);
 
       expect(mockEditor.updateBlock).toHaveBeenCalledWith('test-block', {
-        type: 'cropped-image',
+        type: 'image',
         props: { showPreview: true } 
       });
     });
@@ -167,7 +167,7 @@ describe('CroppedImageBlock', () => {
       fireEvent.change(captionInput, { target: { value: 'New Caption' } });
 
       expect(mockEditor.updateBlock).toHaveBeenCalledWith('test-block', {
-        type: 'cropped-image',
+        type: 'image',
         props: { caption: 'New Caption' }
       });
     });
@@ -198,7 +198,7 @@ describe('CroppedImageBlock', () => {
       fireEvent.mouseUp(document, { clientX: 150 });
 
       expect(mockEditor.updateBlock).toHaveBeenCalledWith('test-block', {
-        type: 'cropped-image',
+        type: 'image',
         props: { width: 550 }
       });
     });
@@ -213,7 +213,7 @@ describe('CroppedImageBlock', () => {
       fireEvent.mouseUp(document, { clientX: 100 });
 
       expect(mockEditor.updateBlock).toHaveBeenCalledWith('test-block', {
-        type: 'cropped-image',
+        type: 'image',
         props: { width: 150 }
       });
     });

--- a/app/shared/components/content-editor/cropped-image-block/CroppedImageBlock.test.tsx
+++ b/app/shared/components/content-editor/cropped-image-block/CroppedImageBlock.test.tsx
@@ -135,11 +135,11 @@ describe('CroppedImageBlock', () => {
       renderBlock(defaultProps);
 
       expect(screen.queryByTestId('file-image-icon')).not.toBeInTheDocument();
-      
+
       const image = screen.getByAltText('image.png');
       expect(image).toBeInTheDocument();
       expect(image).toHaveAttribute('src', 'http://example.com/image.png');
-      
+
       const captionInput = screen.getByPlaceholderText('Додати підпис...');
       expect(captionInput).toBeInTheDocument();
       expect(captionInput).toHaveValue('Initial Caption');
@@ -156,7 +156,7 @@ describe('CroppedImageBlock', () => {
 
       expect(mockEditor.updateBlock).toHaveBeenCalledWith('test-block', {
         type: 'image',
-        props: { showPreview: true } 
+        props: { showPreview: true }
       });
     });
 
@@ -174,12 +174,12 @@ describe('CroppedImageBlock', () => {
 
     it('should trigger e.stopPropagation() when pressing a key inside the caption input', () => {
       renderBlock(defaultProps);
-      
+
       const captionInput = screen.getByPlaceholderText('Додати підпис...') as HTMLElement;
-      
+
       const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
       const stopPropagationSpy = jest.spyOn(event, 'stopPropagation');
-      
+
       fireEvent(captionInput, event);
 
       expect(stopPropagationSpy).toHaveBeenCalledTimes(1);
@@ -207,9 +207,9 @@ describe('CroppedImageBlock', () => {
       renderBlock(defaultProps);
 
       const dragHandle = screen.getByTestId('grip-horizontal-icon').parentElement as HTMLElement;
-      
+
       fireEvent.mouseDown(dragHandle, { clientX: 500 });
-      fireEvent.mouseMove(document, { clientX: 100 }); 
+      fireEvent.mouseMove(document, { clientX: 100 });
       fireEvent.mouseUp(document, { clientX: 100 });
 
       expect(mockEditor.updateBlock).toHaveBeenCalledWith('test-block', {
@@ -246,13 +246,13 @@ describe('CroppedImageBlock', () => {
 
     it('should correctly reconstruct props from an img element in parse', () => {
       const element = document.createElement('img');
-      element.setAttribute('src', 'http://test.com/parsed.jpg');
-      element.setAttribute('data-custom-cropped', 'true');
-      element.setAttribute('data-width', '400');
-      element.setAttribute('alt', 'parsed.jpg');
-      element.setAttribute('data-crop-data', '{"x":50}');
-      element.setAttribute('data-preview', 'true');
-      element.setAttribute('data-caption', 'Parsed Caption');
+      element.dataset.src = 'http://test.com/parsed.jpg';
+      element.dataset.customCropped = 'true';
+      element.dataset.width = '400';
+      element.dataset.alt = 'parsed.jpg';
+      element.dataset.cropData = '{"x":50}';
+      element.dataset.preview = 'true';
+      element.dataset.caption = 'Parsed Caption';
 
       const parsedProps = blockImplementation.parse(element);
 
@@ -265,11 +265,11 @@ describe('CroppedImageBlock', () => {
         caption: 'Parsed Caption'
       });
     });
-      
+
     it('should return undefined in parse if element does not have data-custom-cropped', () => {
       const element = document.createElement('div');
       const parsedProps = blockImplementation.parse(element);
-      
+
       expect(parsedProps).toBeUndefined();
     });
   });

--- a/app/shared/components/content-editor/cropped-image-block/CroppedImageBlock.test.tsx
+++ b/app/shared/components/content-editor/cropped-image-block/CroppedImageBlock.test.tsx
@@ -44,13 +44,6 @@ type BlockImplementation = {
   parse: (el: HTMLElement) => Partial<MockBlockProps> | undefined;
 };
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => {
-    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
-    return <img {...props} />;
-  }
-}));
 
 jest.mock('@blocknote/react', () => ({
   createReactBlockSpec: jest.fn(() => jest.fn())

--- a/app/shared/components/content-editor/cropped-image-block/CroppedImageBlock.test.tsx
+++ b/app/shared/components/content-editor/cropped-image-block/CroppedImageBlock.test.tsx
@@ -13,7 +13,7 @@ type MockBlockProps = {
   fileName: string;
   cropData: string;
   width: number;
-  textAlignment: 'left' | 'center' | 'right' | 'justify';
+  textAlignment: 'left' | 'center' | 'right';
   textColor: string;
 };
 
@@ -58,7 +58,7 @@ jest.mock('@blocknote/react', () => ({
 
 jest.mock('@blocknote/core', () => ({
   defaultProps: {
-    textAlignment: { default: 'left', values: ['left', 'center', 'right', 'justify'] },
+    textAlignment: { default: 'left', values: ['left', 'center', 'right'] },
     textColor: { default: 'default' }
   }
 }));

--- a/app/shared/components/content-editor/cropped-image-block/CroppedImageBlock.test.tsx
+++ b/app/shared/components/content-editor/cropped-image-block/CroppedImageBlock.test.tsx
@@ -1,0 +1,276 @@
+import { createReactBlockSpec } from '@blocknote/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+type MockEditor = {
+  updateBlock: jest.Mock;
+};
+
+type MockBlockProps = {
+  url: string;
+  showPreview: boolean;
+  caption: string;
+  fileName: string;
+  cropData: string;
+  width: number;
+  textAlignment: 'left' | 'center' | 'right' | 'justify';
+  textColor: string;
+};
+
+type MockBlock = {
+  id: string;
+  props: MockBlockProps;
+};
+
+type ComponentProps = {
+  block: MockBlock;
+  editor: MockEditor;
+};
+
+type ExternalHTMLProps = {
+  src?: string;
+  alt?: string;
+  'data-custom-cropped'?: string;
+  'data-width'?: string;
+  'data-crop-data'?: string;
+  'data-filename'?: string;
+  'data-preview'?: string;
+  'data-caption'?: string;
+};
+
+type BlockImplementation = {
+  render: React.FC<ComponentProps>;
+  toExternalHTML: (props: { block: MockBlock }) => React.ReactElement<ExternalHTMLProps>;
+  parse: (el: HTMLElement) => Partial<MockBlockProps> | undefined;
+};
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => {
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    return <img {...props} />;
+  }
+}));
+
+jest.mock('@blocknote/react', () => ({
+  createReactBlockSpec: jest.fn(() => jest.fn())
+}));
+
+jest.mock('@blocknote/core', () => ({
+  defaultProps: {
+    textAlignment: { default: 'left', values: ['left', 'center', 'right', 'justify'] },
+    textColor: { default: 'default' }
+  }
+}));
+
+jest.mock('~/hooks/use-cropped-image/use-cropped-image', () => ({
+  useCroppedImage: jest.fn(() => ({
+    styles: { container: { overflow: 'hidden' }, image: { objectFit: 'cover' } },
+    onLoad: jest.fn()
+  }))
+}));
+
+jest.mock('lucide-react', () => ({
+  FileImage: () => <span data-testid="file-image-icon" />,
+  GripHorizontal: () => <span data-testid="grip-horizontal-icon" />
+}));
+
+import './CroppedImageBlock';
+
+const blockImplementation = (createReactBlockSpec as jest.Mock).mock.calls[0][1] as BlockImplementation;
+
+const renderBlock = (props: ComponentProps) => {
+  const Component = blockImplementation.render;
+  return render(<Component {...props} />);
+};
+
+describe('CroppedImageBlock', () => {
+  let mockEditor: MockEditor;
+  let defaultProps: ComponentProps;
+
+  beforeEach(() => {
+    mockEditor = {
+      updateBlock: jest.fn()
+    };
+
+    defaultProps = {
+      block: {
+        id: 'test-block',
+        props: {
+          url: 'http://example.com/image.png',
+          showPreview: true,
+          caption: 'Initial Caption',
+          fileName: 'image.png',
+          cropData: '{}',
+          width: 500,
+          textAlignment: 'center',
+          textColor: 'default'
+        }
+      },
+      editor: mockEditor
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Rendering States', () => {
+    it('should return null if url is empty', () => {
+      defaultProps.block.props.url = '';
+      const { container } = renderBlock(defaultProps);
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('should render the File Card (collapsed state) when showPreview is false', () => {
+      defaultProps.block.props.showPreview = false;
+      renderBlock(defaultProps);
+
+      expect(screen.getByTestId('file-image-icon')).toBeInTheDocument();
+      expect(screen.getByText('image.png')).toBeInTheDocument();
+      expect(screen.queryByPlaceholderText('Додати підпис...')).not.toBeInTheDocument();
+    });
+
+    it('should render the expanded image and caption input when showPreview is true', () => {
+      renderBlock(defaultProps);
+
+      expect(screen.queryByTestId('file-image-icon')).not.toBeInTheDocument();
+      
+      const image = screen.getByAltText('image.png');
+      expect(image).toBeInTheDocument();
+      expect(image).toHaveAttribute('src', 'http://example.com/image.png');
+      
+      const captionInput = screen.getByPlaceholderText('Додати підпис...');
+      expect(captionInput).toBeInTheDocument();
+      expect(captionInput).toHaveValue('Initial Caption');
+    });
+  });
+
+  describe('Interactions', () => {
+    it('should call editor.updateBlock to set showPreview: true when clicking the File Card', () => {
+      defaultProps.block.props.showPreview = false;
+      renderBlock(defaultProps);
+
+      const fileCard = screen.getByText('image.png').closest('.MuiPaper-root') as HTMLElement;
+      fireEvent.click(fileCard);
+
+      expect(mockEditor.updateBlock).toHaveBeenCalledWith('test-block', {
+        type: 'cropped-image',
+        props: { showPreview: true } 
+      });
+    });
+
+    it('should call editor.updateBlock with the new caption string when typing in the caption input', () => {
+      renderBlock(defaultProps);
+
+      const captionInput = screen.getByPlaceholderText('Додати підпис...') as HTMLElement;
+      fireEvent.change(captionInput, { target: { value: 'New Caption' } });
+
+      expect(mockEditor.updateBlock).toHaveBeenCalledWith('test-block', {
+        type: 'cropped-image',
+        props: { caption: 'New Caption' }
+      });
+    });
+
+    it('should trigger e.stopPropagation() when pressing a key inside the caption input', () => {
+      renderBlock(defaultProps);
+      
+      const captionInput = screen.getByPlaceholderText('Додати підпис...') as HTMLElement;
+      
+      const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
+      const stopPropagationSpy = jest.spyOn(event, 'stopPropagation');
+      
+      fireEvent(captionInput, event);
+
+      expect(stopPropagationSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Resize Logic (Mouse Events)', () => {
+    it('should update width on mouse move and apply on mouse up', () => {
+      renderBlock(defaultProps);
+
+      const dragHandle = screen.getByTestId('grip-horizontal-icon').parentElement as HTMLElement;
+      expect(dragHandle).toBeInTheDocument();
+
+      fireEvent.mouseDown(dragHandle, { clientX: 100 });
+      fireEvent.mouseMove(document, { clientX: 150 });
+      fireEvent.mouseUp(document, { clientX: 150 });
+
+      expect(mockEditor.updateBlock).toHaveBeenCalledWith('test-block', {
+        type: 'cropped-image',
+        props: { width: 550 }
+      });
+    });
+
+    it('should respect the minimum width of 150px during resize', () => {
+      renderBlock(defaultProps);
+
+      const dragHandle = screen.getByTestId('grip-horizontal-icon').parentElement as HTMLElement;
+      
+      fireEvent.mouseDown(dragHandle, { clientX: 500 });
+      fireEvent.mouseMove(document, { clientX: 100 }); 
+      fireEvent.mouseUp(document, { clientX: 100 });
+
+      expect(mockEditor.updateBlock).toHaveBeenCalledWith('test-block', {
+        type: 'cropped-image',
+        props: { width: 150 }
+      });
+    });
+  });
+
+  describe('Serialization Methods (toExternalHTML & parse)', () => {
+    it('should return a React element with correct props in toExternalHTML', () => {
+      const dummyProps: MockBlockProps = {
+        url: 'http://test.com/img.jpg',
+        caption: 'Test Caption',
+        fileName: 'test.jpg',
+        width: 300,
+        showPreview: true,
+        cropData: '{"x":10}',
+        textAlignment: 'center',
+        textColor: 'default'
+      };
+
+      const result = blockImplementation.toExternalHTML({ block: { id: 'mock-1', props: dummyProps } });
+
+      expect(result.type).toBe('img');
+      expect(result.props.src).toBe('http://test.com/img.jpg');
+      expect(result.props['data-custom-cropped']).toBe('true');
+      expect(result.props['data-width']).toBe('300');
+      expect(result.props['data-crop-data']).toBe('{"x":10}');
+      expect(result.props['alt']).toBe('test.jpg');
+      expect(result.props['data-preview']).toBe('true');
+      expect(result.props['data-caption']).toBe('Test Caption');
+    });
+
+    it('should correctly reconstruct props from an img element in parse', () => {
+      const element = document.createElement('img');
+      element.setAttribute('src', 'http://test.com/parsed.jpg');
+      element.setAttribute('data-custom-cropped', 'true');
+      element.setAttribute('data-width', '400');
+      element.setAttribute('alt', 'parsed.jpg');
+      element.setAttribute('data-crop-data', '{"x":50}');
+      element.setAttribute('data-preview', 'true');
+      element.setAttribute('data-caption', 'Parsed Caption');
+
+      const parsedProps = blockImplementation.parse(element);
+
+      expect(parsedProps).toEqual({
+        url: 'http://test.com/parsed.jpg',
+        width: 400,
+        fileName: 'parsed.jpg',
+        cropData: '{"x":50}',
+        showPreview: true,
+        caption: 'Parsed Caption'
+      });
+    });
+      
+    it('should return undefined in parse if element does not have data-custom-cropped', () => {
+      const element = document.createElement('div');
+      const parsedProps = blockImplementation.parse(element);
+      
+      expect(parsedProps).toBeUndefined();
+    });
+  });
+});

--- a/app/shared/components/content-editor/cropped-image-block/CroppedImageBlock.tsx
+++ b/app/shared/components/content-editor/cropped-image-block/CroppedImageBlock.tsx
@@ -1,4 +1,4 @@
-import { defaultProps } from '@blocknote/core';
+import { BlockNoteEditor, BlockSchema, defaultProps, InlineContentSchema, StyleSchema } from '@blocknote/core';
 import { createReactBlockSpec } from '@blocknote/react';
 import { Box, InputBase, Paper, Typography } from '@mui/material';
 import { FileImage, GripHorizontal } from 'lucide-react';
@@ -7,11 +7,37 @@ import { useState } from 'react';
 
 import { styles } from './CroppedImageBlock.styles';
 import { useCroppedImage } from '~/hooks/use-cropped-image/use-cropped-image';
+type CroppedImageProps = {
+  textAlignment: 'left' | 'center' | 'right'
+  textColor: string;
+  url: string;
+  cropData: string;
+  fileName: string;
+  caption: string;
+  width: number;
+  showPreview: boolean;
+};
+
+type StrictEditor = Omit<BlockNoteEditor<BlockSchema, InlineContentSchema, StyleSchema>, 'updateBlock'> & {
+  updateBlock: (
+    id: string,
+    blockUpdate: { type: 'cropped-image'; props: Partial<CroppedImageProps> } 
+  ) => void;
+};
+
+interface CroppedImageRendererProps {
+  block: {
+    id: string;
+    type: 'cropped-image';
+    props: CroppedImageProps;
+  };
+  editor: StrictEditor; 
+}
 
 const EDITOR_PREVIEW_W = 600;
 const EDITOR_PREVIEW_H = 400;
 
-const CroppedImageRenderer = ({ props }: { props: any }) => {
+const CroppedImageRenderer = ({ props }: { props: CroppedImageRendererProps }) => {
   const [tempWidth, setTempWidth] = useState<number | null>(null);
 
   const savedCrop = JSON.parse(props.block.props.cropData);
@@ -22,10 +48,13 @@ const CroppedImageRenderer = ({ props }: { props: any }) => {
 
   if (!props.block.props.url) return null;
 
-  const handleUpdateProp = <K extends keyof typeof props.block.props>(key: K, value: (typeof props.block.props)[K]) => {
+  const handleUpdateProp = <K extends keyof CroppedImageRendererProps['block']['props']>(
+    key: K,
+    value: CroppedImageRendererProps['block']['props'][K]
+  ) => {
     props.editor.updateBlock(props.block.id, {
       type: 'cropped-image',
-      props: { ...props.block.props, [key]: value }
+      props: { [key]: value } 
     });
   };
 
@@ -112,24 +141,23 @@ const CroppedImageRenderer = ({ props }: { props: any }) => {
 
 export const CroppedImageBlock = createReactBlockSpec(
   {
-    type: 'cropped-image',
+    type: 'cropped-image', 
     propSchema: {
       textAlignment: defaultProps.textAlignment,
       textColor: defaultProps.textColor,
-      url: { default: '', type: 'string' },
-      cropData: { default: '{}', type: 'string' },
-      fileName: { default: 'image', type: 'string' },
-      caption: { default: '', type: 'string' },
-      width: { default: 512, type: 'number' },
-      showPreview: { default: true, type: 'boolean' }
+      url: { default: '' },
+      cropData: { default: '{}' },
+      fileName: { default: 'image' },
+      caption: { default: '' },
+      width: { default: 512 },
+      showPreview: { default: true }
     },
     content: 'none'
   },
   {
-    render: (props) => <CroppedImageRenderer props={props} />,
+    render: (props) => <CroppedImageRenderer props={props as unknown as CroppedImageRendererProps} />,
 
     toExternalHTML: (props) => {
-      // Again, crutch is settled because toExternalHTML renders to clipboard and not to the screen
        
       return (
         <img
@@ -146,7 +174,7 @@ export const CroppedImageBlock = createReactBlockSpec(
 
     parse: (el) => {
       const img = el.tagName.toLowerCase() === 'img' ? el : el.querySelector('img');
-
+      
       if (img && img.hasAttribute('data-custom-cropped')) {
         return {
           url: img.getAttribute('src') || '',
@@ -157,8 +185,8 @@ export const CroppedImageBlock = createReactBlockSpec(
           caption: img.getAttribute('data-caption') || ''
         };
       }
-
-      return undefined;
+      
+      return undefined; 
     }
   }
 );

--- a/app/shared/components/content-editor/cropped-image-block/CroppedImageBlock.tsx
+++ b/app/shared/components/content-editor/cropped-image-block/CroppedImageBlock.tsx
@@ -56,21 +56,7 @@ const CroppedImageRenderer = ({ props }: { props: CroppedImageRendererProps }) =
 
   return (
     <Box sx={[styles.mainContainer, { alignItems: props.block.props.textAlignment }]}>
-      {!props.block.props.showPreview ? (
-        <Paper
-          variant="outlined"
-          sx={styles.fileCard}
-          contentEditable={false}
-          onClick={() => handleUpdateProp('showPreview', true)}
-        >
-          <Box sx={styles.fileIconBox}>
-            <FileImage size={24} />
-          </Box>
-          <Typography variant="body2" sx={styles.fileName}>
-            {props.block.props.fileName}
-          </Typography>
-        </Paper>
-      ) : (
+      {props.block.props.showPreview ? (
         <Box sx={[styles.imageStateContainer, { width: currentWidth }]} contentEditable={false}>
           <Box sx={{ ...cropStyles.container, width: currentWidth, height: currentHeight }}>
             <Image
@@ -94,6 +80,20 @@ const CroppedImageRenderer = ({ props }: { props: CroppedImageRendererProps }) =
             <GripHorizontal size={16} style={{ transform: 'rotate(90deg)' }} />
           </Box>
         </Box>
+      ) : (
+        <Paper
+          variant="outlined"
+          sx={styles.fileCard}
+          contentEditable={false}
+          onClick={() => handleUpdateProp('showPreview', true)}
+        >
+          <Box sx={styles.fileIconBox}>
+            <FileImage size={24} />
+          </Box>
+          <Typography variant="body2" sx={styles.fileName}>
+            {props.block.props.fileName}
+          </Typography>
+        </Paper>
       )}
       {props.block.props.showPreview && (
         <InputBase

--- a/app/shared/components/content-editor/cropped-image-block/CroppedImageBlock.tsx
+++ b/app/shared/components/content-editor/cropped-image-block/CroppedImageBlock.tsx
@@ -2,7 +2,6 @@ import { defaultProps } from '@blocknote/core';
 import { createReactBlockSpec } from '@blocknote/react';
 import { Box, InputBase, Paper, Typography } from '@mui/material';
 import { FileImage, GripHorizontal } from 'lucide-react';
-import Image from 'next/image';
 import { useState } from 'react';
 
 import { CroppedImageRendererProps } from '../types';
@@ -59,15 +58,14 @@ const CroppedImageRenderer = ({ props }: { props: CroppedImageRendererProps }) =
       {props.block.props.showPreview ? (
         <Box sx={[styles.imageStateContainer, { width: currentWidth }]} contentEditable={false}>
           <Box sx={{ ...cropStyles.container, width: currentWidth, height: currentHeight }}>
-            <Image
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
               draggable={false}
               src={props.block.props.url}
               alt={props.block.props.fileName}
               onLoad={onImgLoad}
               width={currentWidth}
               height={currentHeight}
-              // Crutch(unoptimized={true}) settled to achieve correct crop within it's boundaries
-              unoptimized={true}
               style={{
                 ...cropStyles.image,
                 maxWidth: 'none',

--- a/app/shared/components/content-editor/cropped-image-block/CroppedImageBlock.tsx
+++ b/app/shared/components/content-editor/cropped-image-block/CroppedImageBlock.tsx
@@ -1,0 +1,164 @@
+import { defaultProps } from '@blocknote/core';
+import { createReactBlockSpec } from '@blocknote/react';
+import { Box, InputBase, Paper, Typography } from '@mui/material';
+import { FileImage, GripHorizontal } from 'lucide-react';
+import Image from 'next/image';
+import { useState } from 'react';
+
+import { styles } from './CroppedImageBlock.styles';
+import { useCroppedImage } from '~/hooks/use-cropped-image/use-cropped-image';
+
+const EDITOR_PREVIEW_W = 600;
+const EDITOR_PREVIEW_H = 400;
+
+const CroppedImageRenderer = ({ props }: { props: any }) => {
+  const [tempWidth, setTempWidth] = useState<number | null>(null);
+
+  const savedCrop = JSON.parse(props.block.props.cropData);
+  const currentWidth = tempWidth ?? props.block.props.width;
+  const currentHeight = (currentWidth / EDITOR_PREVIEW_W) * EDITOR_PREVIEW_H;
+
+  const { styles: cropStyles, onLoad: onImgLoad } = useCroppedImage(savedCrop, currentWidth, currentHeight);
+
+  if (!props.block.props.url) return null;
+
+  const handleUpdateProp = <K extends keyof typeof props.block.props>(key: K, value: (typeof props.block.props)[K]) => {
+    props.editor.updateBlock(props.block.id, {
+      type: 'cropped-image',
+      props: { ...props.block.props, [key]: value }
+    });
+  };
+
+  const handleResizeStart = (e: React.MouseEvent) => {
+    e.preventDefault();
+    const startX = e.clientX;
+    const startWidth = props.block.props.width;
+
+    const handleMouseMove = (moveEvent: MouseEvent) => {
+      setTempWidth(Math.max(150, startWidth + (moveEvent.clientX - startX)));
+    };
+
+    const handleMouseUp = (upEvent: MouseEvent) => {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+      const finalWidth = Math.max(150, startWidth + (upEvent.clientX - startX));
+      setTempWidth(null);
+      handleUpdateProp('width', finalWidth);
+    };
+
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+  };
+
+  return (
+    <Box sx={[styles.mainContainer, { alignItems: props.block.props.textAlignment }]}>
+      {!props.block.props.showPreview ? (
+        <Paper
+          variant="outlined"
+          sx={styles.fileCard}
+          contentEditable={false}
+          onClick={() => handleUpdateProp('showPreview', true)}
+        >
+          <Box sx={styles.fileIconBox}>
+            <FileImage size={24} />
+          </Box>
+          <Typography variant="body2" sx={styles.fileName}>
+            {props.block.props.fileName}
+          </Typography>
+        </Paper>
+      ) : (
+        <Box sx={[styles.imageStateContainer, { width: currentWidth }]} contentEditable={false}>
+          <Box sx={{ ...cropStyles.container, width: currentWidth, height: currentHeight }}>
+            <Image
+              draggable={false}
+              src={props.block.props.url}
+              alt={props.block.props.fileName}
+              onLoad={onImgLoad}
+              width={currentWidth}
+              height={currentHeight}
+              // Crutch(unoptimized={true}) settled to achieve correct crop within it's boundaries
+              unoptimized={true}
+              style={{
+                ...cropStyles.image,
+                maxWidth: 'none',
+                maxHeight: 'none',
+                userSelect: 'none'
+              }}
+            />
+          </Box>
+          <Box className="overlay-controls" onMouseDown={handleResizeStart} sx={styles.resizeHandle}>
+            <GripHorizontal size={16} style={{ transform: 'rotate(90deg)' }} />
+          </Box>
+        </Box>
+      )}
+      {props.block.props.showPreview && (
+        <InputBase
+          placeholder="Додати підпис..."
+          value={props.block.props.caption}
+          onChange={(e) => handleUpdateProp('caption', e.target.value)}
+          onKeyDown={(e) => e.stopPropagation()}
+          sx={[
+            styles.captionInput,
+            {
+              width: currentWidth,
+              '& input': { textAlign: props.block.props.textAlignment === 'left' ? 'left' : 'center' }
+            }
+          ]}
+        />
+      )}
+    </Box>
+  );
+};
+
+export const CroppedImageBlock = createReactBlockSpec(
+  {
+    type: 'cropped-image',
+    propSchema: {
+      textAlignment: defaultProps.textAlignment,
+      textColor: defaultProps.textColor,
+      url: { default: '', type: 'string' },
+      cropData: { default: '{}', type: 'string' },
+      fileName: { default: 'image', type: 'string' },
+      caption: { default: '', type: 'string' },
+      width: { default: 512, type: 'number' },
+      showPreview: { default: true, type: 'boolean' }
+    },
+    content: 'none'
+  },
+  {
+    render: (props) => <CroppedImageRenderer props={props} />,
+
+    toExternalHTML: (props) => {
+      // Again, crutch is settled because toExternalHTML renders to clipboard and not to the screen
+       
+      return (
+        <img
+          src={props.block.props.url}
+          alt={props.block.props.fileName}
+          data-custom-cropped="true"
+          data-crop-data={props.block.props.cropData}
+          data-width={props.block.props.width.toString()}
+          data-preview={props.block.props.showPreview.toString()}
+          data-caption={props.block.props.caption}
+        />
+      );
+    },
+
+    parse: (el) => {
+      const img = el.tagName.toLowerCase() === 'img' ? el : el.querySelector('img');
+
+      if (img && img.hasAttribute('data-custom-cropped')) {
+        return {
+          url: img.getAttribute('src') || '',
+          fileName: img.getAttribute('alt') || 'image',
+          cropData: img.getAttribute('data-crop-data') || '{}',
+          width: parseInt(img.getAttribute('data-width') || '512', 10),
+          showPreview: img.getAttribute('data-preview') === 'true',
+          caption: img.getAttribute('data-caption') || ''
+        };
+      }
+
+      return undefined;
+    }
+  }
+);

--- a/app/shared/components/content-editor/cropped-image-block/CroppedImageBlock.tsx
+++ b/app/shared/components/content-editor/cropped-image-block/CroppedImageBlock.tsx
@@ -29,7 +29,7 @@ const CroppedImageRenderer = ({ props }: { props: CroppedImageRendererProps }) =
   ) => {
     props.editor.updateBlock(props.block.id, {
       type: 'image',
-      props: { [key]: value } 
+      props: { [key]: value }
     });
   };
 
@@ -116,7 +116,7 @@ const CroppedImageRenderer = ({ props }: { props: CroppedImageRendererProps }) =
 
 export const CroppedImageBlock = createReactBlockSpec(
   {
-    type: 'image', 
+    type: 'image',
     propSchema: {
       textAlignment: defaultProps.textAlignment,
       textColor: defaultProps.textColor,
@@ -133,7 +133,6 @@ export const CroppedImageBlock = createReactBlockSpec(
     render: (props) => <CroppedImageRenderer props={props as unknown as CroppedImageRendererProps} />,
 
     toExternalHTML: (props) => {
-       
       return (
         <img
           src={props.block.props.url}
@@ -149,19 +148,20 @@ export const CroppedImageBlock = createReactBlockSpec(
 
     parse: (el) => {
       const img = el.tagName.toLowerCase() === 'img' ? el : el.querySelector('img');
-      
+
       if (img) {
+        const { src, alt, cropData, width, preview, caption } = img.dataset;
         return {
-          url: img.getAttribute('src') || '',
-          fileName: img.getAttribute('alt') || 'image',
-          cropData: img.getAttribute('data-crop-data') || '{}',
-          width: parseInt(img.getAttribute('data-width') || '512', 10),
-          showPreview: img.getAttribute('data-preview') === 'true',
-          caption: img.getAttribute('data-caption') || ''
+          url: src || '',
+          fileName: alt || 'image',
+          cropData: cropData || '{}',
+          width: Number.parseInt(width || '512', 10),
+          showPreview: preview === 'true',
+          caption: caption || ''
         };
       }
-      
-      return undefined; 
+
+      return undefined;
     }
   }
 );

--- a/app/shared/components/content-editor/cropped-image-block/CroppedImageBlock.tsx
+++ b/app/shared/components/content-editor/cropped-image-block/CroppedImageBlock.tsx
@@ -1,38 +1,13 @@
-import { BlockNoteEditor, BlockSchema, defaultProps, InlineContentSchema, StyleSchema } from '@blocknote/core';
+import { defaultProps } from '@blocknote/core';
 import { createReactBlockSpec } from '@blocknote/react';
 import { Box, InputBase, Paper, Typography } from '@mui/material';
 import { FileImage, GripHorizontal } from 'lucide-react';
 import Image from 'next/image';
 import { useState } from 'react';
 
+import { CroppedImageRendererProps } from '../types';
 import { styles } from './CroppedImageBlock.styles';
 import { useCroppedImage } from '~/hooks/use-cropped-image/use-cropped-image';
-type CroppedImageProps = {
-  textAlignment: 'left' | 'center' | 'right'
-  textColor: string;
-  url: string;
-  cropData: string;
-  fileName: string;
-  caption: string;
-  width: number;
-  showPreview: boolean;
-};
-
-type StrictEditor = Omit<BlockNoteEditor<BlockSchema, InlineContentSchema, StyleSchema>, 'updateBlock'> & {
-  updateBlock: (
-    id: string,
-    blockUpdate: { type: 'cropped-image'; props: Partial<CroppedImageProps> } 
-  ) => void;
-};
-
-interface CroppedImageRendererProps {
-  block: {
-    id: string;
-    type: 'cropped-image';
-    props: CroppedImageProps;
-  };
-  editor: StrictEditor; 
-}
 
 const EDITOR_PREVIEW_W = 600;
 const EDITOR_PREVIEW_H = 400;

--- a/app/shared/components/content-editor/cropped-image-block/CroppedImageBlock.tsx
+++ b/app/shared/components/content-editor/cropped-image-block/CroppedImageBlock.tsx
@@ -28,7 +28,7 @@ const CroppedImageRenderer = ({ props }: { props: CroppedImageRendererProps }) =
     value: CroppedImageRendererProps['block']['props'][K]
   ) => {
     props.editor.updateBlock(props.block.id, {
-      type: 'cropped-image',
+      type: 'image',
       props: { [key]: value } 
     });
   };
@@ -116,7 +116,7 @@ const CroppedImageRenderer = ({ props }: { props: CroppedImageRendererProps }) =
 
 export const CroppedImageBlock = createReactBlockSpec(
   {
-    type: 'cropped-image', 
+    type: 'image', 
     propSchema: {
       textAlignment: defaultProps.textAlignment,
       textColor: defaultProps.textColor,
@@ -150,7 +150,7 @@ export const CroppedImageBlock = createReactBlockSpec(
     parse: (el) => {
       const img = el.tagName.toLowerCase() === 'img' ? el : el.querySelector('img');
       
-      if (img && img.hasAttribute('data-custom-cropped')) {
+      if (img) {
         return {
           url: img.getAttribute('src') || '',
           fileName: img.getAttribute('alt') || 'image',

--- a/app/shared/components/content-editor/custom-formatting-toolbar/CustomFormattingToolbar.test.tsx
+++ b/app/shared/components/content-editor/custom-formatting-toolbar/CustomFormattingToolbar.test.tsx
@@ -12,16 +12,18 @@ type ToolbarItem = {
 
 jest.mock('@blocknote/react', () => ({
   getFormattingToolbarItems: jest.fn(),
-  FormattingToolbar: ({ children }: { children: React.ReactNode }) => (
+  FormattingToolbar: ({ children }: { children: (React.ReactElement | ToolbarItem)[] }) => (
     <div data-testid="formatting-toolbar">
-      {React.Children.map(children, (child, idx) => {
-        if (React.isValidElement(child)) {
-          return React.cloneElement(child, { key: child.key || String(idx) } as React.Attributes);
-        }
-        
-        const item = child as unknown as ToolbarItem;
-        return <span key={item.key || String(idx)} data-testid={`default-item-${item.key}`}>{item.key}</span>;
-      })}
+      {Array.isArray(children)
+        ? children.map((child, idx) => {
+          if (React.isValidElement(child)) {
+            return React.cloneElement(child, { key: child.key || String(idx) } as React.Attributes);
+          }
+            
+          const item = child as ToolbarItem;
+          return <span key={item.key || String(idx)} data-testid={`default-item-${item.key}`}>{item.key}</span>;
+        })
+        : null}
     </div>
   )
 }));

--- a/app/shared/components/content-editor/custom-formatting-toolbar/CustomFormattingToolbar.test.tsx
+++ b/app/shared/components/content-editor/custom-formatting-toolbar/CustomFormattingToolbar.test.tsx
@@ -1,0 +1,80 @@
+import { getFormattingToolbarItems } from '@blocknote/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { MediaModalResult } from '../../media-modal/MediaModal.types';
+import { CustomFormattingToolbar } from './CustomFormattingToolbar';
+
+type ToolbarItem = {
+  key: string;
+  type?: string;
+};
+
+jest.mock('@blocknote/react', () => ({
+  getFormattingToolbarItems: jest.fn(),
+  FormattingToolbar: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="formatting-toolbar">
+      {React.Children.map(children, (child, idx) => {
+        if (React.isValidElement(child)) {
+          return React.cloneElement(child, { key: child.key || String(idx) } as React.Attributes);
+        }
+        
+        const item = child as unknown as ToolbarItem;
+        return <span key={item.key || String(idx)} data-testid={`default-item-${item.key}`}>{item.key}</span>;
+      })}
+    </div>
+  )
+}));
+
+jest.mock('../custom-replace-button/CustomReplaceButton', () => ({
+  CustomReplaceButton: ({ openMediaModal }: { openMediaModal: () => Promise<MediaModalResult | null> }) => (
+    <button data-testid="custom-replace-button" onClick={openMediaModal}>
+      Replace
+    </button>
+  )
+}));
+
+describe('CustomFormattingToolbar', () => {
+  const mockOpenMediaModal = jest.fn<Promise<MediaModalResult | null>, []>();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render standard items and not inject CustomReplaceButton if replaceFileButton is missing', () => {
+    (getFormattingToolbarItems as jest.Mock).mockReturnValue([
+      { key: 'boldButton' },
+      { key: 'italicButton' }
+    ]);
+
+    render(<CustomFormattingToolbar openMediaModal={mockOpenMediaModal} />);
+
+    expect(screen.getByTestId('formatting-toolbar')).toBeInTheDocument();
+    
+    expect(screen.getByTestId('default-item-boldButton')).toBeInTheDocument();
+    expect(screen.getByTestId('default-item-italicButton')).toBeInTheDocument();
+    
+    expect(screen.queryByTestId('custom-replace-button')).not.toBeInTheDocument();
+  });
+
+  it('should replace replaceFileButton with CustomReplaceButton and pass down openMediaModal', () => {
+    (getFormattingToolbarItems as jest.Mock).mockReturnValue([
+      { key: 'boldButton' },
+      { key: 'replaceFileButton' },
+      { key: 'italicButton' }
+    ]);
+
+    render(<CustomFormattingToolbar openMediaModal={mockOpenMediaModal} />);
+
+    expect(screen.getByTestId('default-item-boldButton')).toBeInTheDocument();
+    expect(screen.getByTestId('default-item-italicButton')).toBeInTheDocument();
+
+    expect(screen.queryByTestId('default-item-replaceFileButton')).not.toBeInTheDocument();
+
+    const customButton = screen.getByTestId('custom-replace-button');
+    expect(customButton).toBeInTheDocument();
+
+    fireEvent.click(customButton);
+    expect(mockOpenMediaModal).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/shared/components/content-editor/custom-formatting-toolbar/CustomFormattingToolbar.tsx
+++ b/app/shared/components/content-editor/custom-formatting-toolbar/CustomFormattingToolbar.tsx
@@ -1,0 +1,18 @@
+import {  FormattingToolbar, getFormattingToolbarItems } from '@blocknote/react';
+
+import { MediaModalResult } from '../../media-modal/MediaModal.types';
+import { CustomReplaceButton } from '../custom-replace-button/CustomReplaceButton';
+interface Props {
+  openMediaModal: () => Promise<MediaModalResult | null>;
+}
+
+export const CustomFormattingToolbar = ({ openMediaModal }: Props) => {
+  const items = getFormattingToolbarItems();
+  const replaceIndex = items.findIndex((item) => item.key === 'replaceFileButton');
+
+  if (replaceIndex !== -1) {
+    items.splice(replaceIndex, 1, <CustomReplaceButton key="customReplaceButton" openMediaModal={openMediaModal} />);
+  }
+
+  return <FormattingToolbar>{items}</FormattingToolbar>;
+};

--- a/app/shared/components/content-editor/custom-replace-button/CustomReplaceButton.test.tsx
+++ b/app/shared/components/content-editor/custom-replace-button/CustomReplaceButton.test.tsx
@@ -102,47 +102,64 @@ describe('CustomReplaceButton', () => {
       await expectNoUpdate(null);
     });
 
-    it('should not update the block if the modal returns an upload without a valid uploadResult', async () => {
-      await expectNoUpdate({
-        selected: { kind: 'upload', id: 'up-1', fileName: 'err.jpg', file: new File([], 'err.jpg') },
-        crop: null,
-        uploadResult: undefined
-      });
-    });
+    describe('Modal Return Scenarios', () => {
+      const testCases = [
+        {
+          scenario: 'not update the block if the modal returns an upload without a valid uploadResult',
+          modalResult: {
+            selected: { kind: 'upload', id: 'up-1', fileName: 'err.jpg', file: new File([], 'err.jpg') },
+            crop: null,
+            uploadResult: undefined
+          },
+          expectedProps: null 
+        },
+        {
+          scenario: 'update the block correctly when an uploaded image is successfully returned',
+          modalResult: {
+            selected: { kind: 'upload', id: 'up-2', fileName: 'my-uploaded-file.jpg', file: new File([], 'my-uploaded-file.jpg') },
+            crop: { width: 500, height: 500, x: 10, y: 10 } as unknown as CropResult,
+            uploadResult: { url: 'https://example.com/uploaded.jpg', filename: 'hash.jpg', originalName: 'file.jpg', mimeType: 'image/jpeg', size: 1024 }
+          },
+          expectedProps: {
+            url: 'https://example.com/uploaded.jpg',
+            cropData: JSON.stringify({ width: 500, height: 500, x: 10, y: 10 }),
+            fileName: 'my-uploaded-file.jpg'
+          }
+        },
+        {
+          scenario: 'update the block correctly when a gallery image is selected',
+          modalResult: {
+            selected: { kind: 'gallery', id: 'gal-1', src: 'https://example.com/gallery-img.png', fileName: 'gallery-pic.png', locale: 'en' },
+            crop: null,
+            uploadResult: undefined
+          },
+          expectedProps: {
+            url: 'https://example.com/gallery-img.png',
+            cropData: '{}',
+            fileName: 'gallery-pic.png'
+          }
+        },
+        {
+          scenario: 'fallback to "image" if fileName is falsy',
+          modalResult: {
+            selected: { kind: 'used', id: 'usd-1', src: 'https://example.com/no-name.png', fileName: '', locale: 'uk' },
+            crop: null,
+            uploadResult: undefined
+          },
+          expectedProps: {
+            url: 'https://example.com/no-name.png',
+            cropData: '{}',
+            fileName: 'image'
+          }
+        }
+      ];
 
-    it('should update the block correctly when an uploaded image is successfully returned', async () => {
-      await expectUpdate({
-        selected: { kind: 'upload', id: 'up-2', fileName: 'my-uploaded-file.jpg', file: new File([], 'my-uploaded-file.jpg') },
-        crop: { width: 500, height: 500, x: 10, y: 10 } as unknown as CropResult,
-        uploadResult: { url: 'https://example.com/uploaded.jpg', filename: 'hash.jpg', originalName: 'file.jpg', mimeType: 'image/jpeg', size: 1024 }
-      }, {
-        url: 'https://example.com/uploaded.jpg',
-        cropData: JSON.stringify({ width: 500, height: 500, x: 10, y: 10 }),
-        fileName: 'my-uploaded-file.jpg'
-      });
-    });
-
-    it('should update the block correctly when a gallery image is selected', async () => {
-      await expectUpdate({
-        selected: { kind: 'gallery', id: 'gal-1', src: 'https://example.com/gallery-img.png', fileName: 'gallery-pic.png', locale: 'en' },
-        crop: null,
-        uploadResult: undefined
-      }, {
-        url: 'https://example.com/gallery-img.png',
-        cropData: '{}',
-        fileName: 'gallery-pic.png'
-      });
-    });
-
-    it('should fallback to "image" if fileName is falsy', async () => {
-      await expectUpdate({
-        selected: { kind: 'used', id: 'usd-1', src: 'https://example.com/no-name.png', fileName: '', locale: 'uk' },
-        crop: null,
-        uploadResult: undefined
-      }, {
-        url: 'https://example.com/no-name.png',
-        cropData: '{}',
-        fileName: 'image'
+      it.each(testCases)('should $scenario', async ({ modalResult, expectedProps }) => {
+        if (expectedProps === null) {
+          await expectNoUpdate(modalResult as MediaModalResult);
+        } else {
+          await expectUpdate(modalResult as MediaModalResult, expectedProps);
+        }
       });
     });
   });

--- a/app/shared/components/content-editor/custom-replace-button/CustomReplaceButton.test.tsx
+++ b/app/shared/components/content-editor/custom-replace-button/CustomReplaceButton.test.tsx
@@ -6,32 +6,19 @@ import { MediaModalResult } from '../../media-modal/MediaModal.types';
 import { CustomReplaceButton } from './CustomReplaceButton';
 import { CropResult } from '~/types/common';
 
-type MockBlock = {
-  id: string;
-  type: string;
-};
-
-type ButtonProps = {
-  label: string;
-  onClick: () => void;
-};
+type MockBlock = { id: string; type: string };
+type ButtonProps = { label: string; onClick: () => void };
 
 const mockUpdateBlock = jest.fn();
 
-jest.mock('lucide-react', () => ({
-  Replace: () => <span data-testid="replace-icon" />
-}));
+jest.mock('lucide-react', () => ({ Replace: () => <span data-testid="replace-icon" /> }));
 
 jest.mock('@blocknote/react', () => ({
-  useBlockNoteEditor: () => ({
-    updateBlock: mockUpdateBlock
-  }),
+  useBlockNoteEditor: () => ({ updateBlock: mockUpdateBlock }),
   useComponentsContext: () => ({
     FormattingToolbar: {
       Button: ({ label, onClick }: ButtonProps) => (
-        <button data-testid="formatting-toolbar-btn" onClick={onClick}>
-          {label}
-        </button>
+        <button data-testid="formatting-toolbar-btn" onClick={onClick}>{label}</button>
       )
     }
   }),
@@ -41,208 +28,121 @@ jest.mock('@blocknote/react', () => ({
 describe('CustomReplaceButton', () => {
   const mockOpenMediaModal = jest.fn<Promise<MediaModalResult | null>, []>();
 
+  const renderComponent = () => render(<CustomReplaceButton openMediaModal={mockOpenMediaModal} />);
+  const setMockBlocks = (blocks: MockBlock[]) => (useSelectedBlocks as jest.Mock).mockReturnValue(blocks);
+  const clickButton = () => fireEvent.click(screen.getByTestId('formatting-toolbar-btn'));
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   describe('Visibility & Rendering Rules', () => {
-    it('should return null and not render if no blocks are selected', () => {
-      (useSelectedBlocks as jest.Mock).mockReturnValue([]);
+    const expectEmptyDOM = () => expect(renderComponent().container).toBeEmptyDOMElement();
 
-      const { container } = render(<CustomReplaceButton openMediaModal={mockOpenMediaModal} />);
-      
-      expect(container).toBeEmptyDOMElement();
+    it('should return null and not render if no blocks are selected', () => {
+      setMockBlocks([]);
+      expectEmptyDOM();
     });
 
     it('should return null and not render if multiple blocks are selected', () => {
-      const selectedBlocks: MockBlock[] = [
-        { id: '1', type: 'image' },
-        { id: '2', type: 'image' }
-      ];
-      (useSelectedBlocks as jest.Mock).mockReturnValue(selectedBlocks);
-
-      const { container } = render(<CustomReplaceButton openMediaModal={mockOpenMediaModal} />);
-      
-      expect(container).toBeEmptyDOMElement();
+      setMockBlocks([ { id: '1', type: 'image' }, { id: '2', type: 'image' } ]);
+      expectEmptyDOM();
     });
 
     it('should return null and not render if the selected block is not an image', () => {
-      const selectedBlocks: MockBlock[] = [{ id: '1', type: 'paragraph' }];
-      (useSelectedBlocks as jest.Mock).mockReturnValue(selectedBlocks);
-
-      const { container } = render(<CustomReplaceButton openMediaModal={mockOpenMediaModal} />);
-      
-      expect(container).toBeEmptyDOMElement();
+      setMockBlocks([{ id: '1', type: 'paragraph' }]);
+      expectEmptyDOM();
     });
 
     it('should render the button if exactly one "image" block is selected', () => {
-      const selectedBlocks: MockBlock[] = [{ id: 'img-1', type: 'image' }];
-      (useSelectedBlocks as jest.Mock).mockReturnValue(selectedBlocks);
-
-      render(<CustomReplaceButton openMediaModal={mockOpenMediaModal} />);
+      setMockBlocks([{ id: 'img-1', type: 'image' }]);
+      renderComponent();
       
       expect(screen.getByTestId('formatting-toolbar-btn')).toBeInTheDocument();
       expect(screen.getByText('Replace image')).toBeInTheDocument();
-    });
-
-    it('should render the button if exactly one "image" block is selected', () => {
-      const selectedBlocks: MockBlock[] = [{ id: 'img-1', type: 'image' }];
-      (useSelectedBlocks as jest.Mock).mockReturnValue(selectedBlocks);
-
-      render(<CustomReplaceButton openMediaModal={mockOpenMediaModal} />);
-      
-      expect(screen.getByTestId('formatting-toolbar-btn')).toBeInTheDocument();
     });
   });
 
   describe('Interaction & Modal Flow', () => {
     beforeEach(() => {
-      const selectedBlocks: MockBlock[] = [{ id: 'target-block-id', type: 'image' }];
-      (useSelectedBlocks as jest.Mock).mockReturnValue(selectedBlocks);
+      setMockBlocks([{ id: 'target-block-id', type: 'image' }]);
     });
 
-    it('should call openMediaModal when clicked', async () => {
-      mockOpenMediaModal.mockResolvedValue(null);
-      render(<CustomReplaceButton openMediaModal={mockOpenMediaModal} />);
+    const triggerModalFlow = (modalResult: MediaModalResult | null) => {
+      mockOpenMediaModal.mockResolvedValue(modalResult);
+      renderComponent();
+      clickButton();
+    };
 
-      fireEvent.click(screen.getByTestId('formatting-toolbar-btn'));
+    const expectNoUpdate = async (modalResult: MediaModalResult | null) => {
+      triggerModalFlow(modalResult);
+      await waitFor(() => {
+        expect(mockOpenMediaModal).toHaveBeenCalled();
+        expect(mockUpdateBlock).not.toHaveBeenCalled();
+      });
+    };
 
+    const expectUpdate = async (modalResult: MediaModalResult, expectedProps: Record<string, any>) => {
+      triggerModalFlow(modalResult);
+      await waitFor(() => {
+        expect(mockUpdateBlock).toHaveBeenCalledTimes(1);
+        expect(mockUpdateBlock).toHaveBeenCalledWith('target-block-id', {
+          type: 'image',
+          props: expectedProps
+        });
+      });
+    };
+
+    it('should call openMediaModal when clicked', () => {
+      triggerModalFlow(null);
       expect(mockOpenMediaModal).toHaveBeenCalledTimes(1);
     });
 
     it('should not update the block if the modal is cancelled (returns null)', async () => {
-      mockOpenMediaModal.mockResolvedValue(null);
-      render(<CustomReplaceButton openMediaModal={mockOpenMediaModal} />);
-
-      fireEvent.click(screen.getByTestId('formatting-toolbar-btn'));
-
-      await waitFor(() => {
-        expect(mockOpenMediaModal).toHaveBeenCalled();
-        expect(mockUpdateBlock).not.toHaveBeenCalled();
-      });
+      await expectNoUpdate(null);
     });
 
     it('should not update the block if the modal returns an upload without a valid uploadResult', async () => {
-      const mockResult: MediaModalResult = {
-        selected: { 
-          kind: 'upload', 
-          id: 'up-1', 
-          fileName: 'err.jpg', 
-          file: new File([], 'err.jpg') 
-        },
+      await expectNoUpdate({
+        selected: { kind: 'upload', id: 'up-1', fileName: 'err.jpg', file: new File([], 'err.jpg') },
         crop: null,
-        uploadResult: undefined 
-      };
-      
-      mockOpenMediaModal.mockResolvedValue(mockResult);
-
-      render(<CustomReplaceButton openMediaModal={mockOpenMediaModal} />);
-
-      fireEvent.click(screen.getByTestId('formatting-toolbar-btn'));
-
-      await waitFor(() => {
-        expect(mockOpenMediaModal).toHaveBeenCalled();
-        expect(mockUpdateBlock).not.toHaveBeenCalled();
+        uploadResult: undefined
       });
     });
 
     it('should update the block correctly when an uploaded image is successfully returned', async () => {
-      const mockResult: MediaModalResult = {
-        selected: { 
-          kind: 'upload', 
-          id: 'up-2', 
-          fileName: 'my-uploaded-file.jpg', 
-          file: new File([], 'my-uploaded-file.jpg') 
-        },
+      await expectUpdate({
+        selected: { kind: 'upload', id: 'up-2', fileName: 'my-uploaded-file.jpg', file: new File([], 'my-uploaded-file.jpg') },
         crop: { width: 500, height: 500, x: 10, y: 10 } as unknown as CropResult,
-        uploadResult: { 
-          url: 'https://example.com/uploaded.jpg',
-          filename: 'hash-name.jpg',
-          originalName: 'my-uploaded-file.jpg',
-          mimeType: 'image/jpeg',
-          size: 1024
-        }
-      };
-      
-      mockOpenMediaModal.mockResolvedValue(mockResult);
-
-      render(<CustomReplaceButton openMediaModal={mockOpenMediaModal} />);
-
-      fireEvent.click(screen.getByTestId('formatting-toolbar-btn'));
-
-      await waitFor(() => {
-        expect(mockUpdateBlock).toHaveBeenCalledTimes(1);
-        expect(mockUpdateBlock).toHaveBeenCalledWith('target-block-id', {
-          type: 'image',
-          props: {
-            url: 'https://example.com/uploaded.jpg',
-            cropData: JSON.stringify({ width: 500, height: 500, x: 10, y: 10 }),
-            fileName: 'my-uploaded-file.jpg'
-          }
-        });
+        uploadResult: { url: 'https://example.com/uploaded.jpg', filename: 'hash.jpg', originalName: 'file.jpg', mimeType: 'image/jpeg', size: 1024 }
+      }, {
+        url: 'https://example.com/uploaded.jpg',
+        cropData: JSON.stringify({ width: 500, height: 500, x: 10, y: 10 }),
+        fileName: 'my-uploaded-file.jpg'
       });
     });
 
     it('should update the block correctly when a gallery image is selected', async () => {
-      const mockResult: MediaModalResult = {
-        selected: { 
-          kind: 'gallery', 
-          id: 'gal-1', 
-          src: 'https://example.com/gallery-img.png', 
-          fileName: 'gallery-pic.png',
-          locale: 'en'
-        },
-        crop: null, 
+      await expectUpdate({
+        selected: { kind: 'gallery', id: 'gal-1', src: 'https://example.com/gallery-img.png', fileName: 'gallery-pic.png', locale: 'en' },
+        crop: null,
         uploadResult: undefined
-      };
-      
-      mockOpenMediaModal.mockResolvedValue(mockResult);
-
-      render(<CustomReplaceButton openMediaModal={mockOpenMediaModal} />);
-
-      fireEvent.click(screen.getByTestId('formatting-toolbar-btn'));
-
-      await waitFor(() => {
-        expect(mockUpdateBlock).toHaveBeenCalledTimes(1);
-        expect(mockUpdateBlock).toHaveBeenCalledWith('target-block-id', {
-          type: 'image',
-          props: {
-            url: 'https://example.com/gallery-img.png',
-            cropData: '{}', 
-            fileName: 'gallery-pic.png'
-          }
-        });
+      }, {
+        url: 'https://example.com/gallery-img.png',
+        cropData: '{}',
+        fileName: 'gallery-pic.png'
       });
     });
 
     it('should fallback to "image" if fileName is falsy', async () => {
-      const mockResult: MediaModalResult = {
-        selected: { 
-          kind: 'used', 
-          id: 'usd-1', 
-          src: 'https://example.com/no-name.png', 
-          fileName: '', 
-          locale: 'uk'
-        },
+      await expectUpdate({
+        selected: { kind: 'used', id: 'usd-1', src: 'https://example.com/no-name.png', fileName: '', locale: 'uk' },
         crop: null,
         uploadResult: undefined
-      };
-      
-      mockOpenMediaModal.mockResolvedValue(mockResult);
-
-      render(<CustomReplaceButton openMediaModal={mockOpenMediaModal} />);
-
-      fireEvent.click(screen.getByTestId('formatting-toolbar-btn'));
-
-      await waitFor(() => {
-        expect(mockUpdateBlock).toHaveBeenCalledWith('target-block-id', {
-          type: 'image',
-          props: {
-            url: 'https://example.com/no-name.png',
-            cropData: '{}',
-            fileName: 'image' 
-          }
-        });
+      }, {
+        url: 'https://example.com/no-name.png',
+        cropData: '{}',
+        fileName: 'image'
       });
     });
   });

--- a/app/shared/components/content-editor/custom-replace-button/CustomReplaceButton.test.tsx
+++ b/app/shared/components/content-editor/custom-replace-button/CustomReplaceButton.test.tsx
@@ -1,0 +1,249 @@
+import { useSelectedBlocks } from '@blocknote/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { MediaModalResult } from '../../media-modal/MediaModal.types';
+import { CustomReplaceButton } from './CustomReplaceButton';
+import { CropResult } from '~/types/common';
+
+type MockBlock = {
+  id: string;
+  type: string;
+};
+
+type ButtonProps = {
+  label: string;
+  onClick: () => void;
+};
+
+const mockUpdateBlock = jest.fn();
+
+jest.mock('lucide-react', () => ({
+  Replace: () => <span data-testid="replace-icon" />
+}));
+
+jest.mock('@blocknote/react', () => ({
+  useBlockNoteEditor: () => ({
+    updateBlock: mockUpdateBlock
+  }),
+  useComponentsContext: () => ({
+    FormattingToolbar: {
+      Button: ({ label, onClick }: ButtonProps) => (
+        <button data-testid="formatting-toolbar-btn" onClick={onClick}>
+          {label}
+        </button>
+      )
+    }
+  }),
+  useSelectedBlocks: jest.fn()
+}));
+
+describe('CustomReplaceButton', () => {
+  const mockOpenMediaModal = jest.fn<Promise<MediaModalResult | null>, []>();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Visibility & Rendering Rules', () => {
+    it('should return null and not render if no blocks are selected', () => {
+      (useSelectedBlocks as jest.Mock).mockReturnValue([]);
+
+      const { container } = render(<CustomReplaceButton openMediaModal={mockOpenMediaModal} />);
+      
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('should return null and not render if multiple blocks are selected', () => {
+      const selectedBlocks: MockBlock[] = [
+        { id: '1', type: 'image' },
+        { id: '2', type: 'image' }
+      ];
+      (useSelectedBlocks as jest.Mock).mockReturnValue(selectedBlocks);
+
+      const { container } = render(<CustomReplaceButton openMediaModal={mockOpenMediaModal} />);
+      
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('should return null and not render if the selected block is not an image or cropped-image', () => {
+      const selectedBlocks: MockBlock[] = [{ id: '1', type: 'paragraph' }];
+      (useSelectedBlocks as jest.Mock).mockReturnValue(selectedBlocks);
+
+      const { container } = render(<CustomReplaceButton openMediaModal={mockOpenMediaModal} />);
+      
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('should render the button if exactly one "image" block is selected', () => {
+      const selectedBlocks: MockBlock[] = [{ id: 'img-1', type: 'image' }];
+      (useSelectedBlocks as jest.Mock).mockReturnValue(selectedBlocks);
+
+      render(<CustomReplaceButton openMediaModal={mockOpenMediaModal} />);
+      
+      expect(screen.getByTestId('formatting-toolbar-btn')).toBeInTheDocument();
+      expect(screen.getByText('Replace image')).toBeInTheDocument();
+    });
+
+    it('should render the button if exactly one "cropped-image" block is selected', () => {
+      const selectedBlocks: MockBlock[] = [{ id: 'img-1', type: 'cropped-image' }];
+      (useSelectedBlocks as jest.Mock).mockReturnValue(selectedBlocks);
+
+      render(<CustomReplaceButton openMediaModal={mockOpenMediaModal} />);
+      
+      expect(screen.getByTestId('formatting-toolbar-btn')).toBeInTheDocument();
+    });
+  });
+
+  describe('Interaction & Modal Flow', () => {
+    beforeEach(() => {
+      const selectedBlocks: MockBlock[] = [{ id: 'target-block-id', type: 'image' }];
+      (useSelectedBlocks as jest.Mock).mockReturnValue(selectedBlocks);
+    });
+
+    it('should call openMediaModal when clicked', async () => {
+      mockOpenMediaModal.mockResolvedValue(null);
+      render(<CustomReplaceButton openMediaModal={mockOpenMediaModal} />);
+
+      fireEvent.click(screen.getByTestId('formatting-toolbar-btn'));
+
+      expect(mockOpenMediaModal).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not update the block if the modal is cancelled (returns null)', async () => {
+      mockOpenMediaModal.mockResolvedValue(null);
+      render(<CustomReplaceButton openMediaModal={mockOpenMediaModal} />);
+
+      fireEvent.click(screen.getByTestId('formatting-toolbar-btn'));
+
+      await waitFor(() => {
+        expect(mockOpenMediaModal).toHaveBeenCalled();
+        expect(mockUpdateBlock).not.toHaveBeenCalled();
+      });
+    });
+
+    it('should not update the block if the modal returns an upload without a valid uploadResult', async () => {
+      const mockResult: MediaModalResult = {
+        selected: { 
+          kind: 'upload', 
+          id: 'up-1', 
+          fileName: 'err.jpg', 
+          file: new File([], 'err.jpg') 
+        },
+        crop: null,
+        uploadResult: undefined 
+      };
+      
+      mockOpenMediaModal.mockResolvedValue(mockResult);
+
+      render(<CustomReplaceButton openMediaModal={mockOpenMediaModal} />);
+
+      fireEvent.click(screen.getByTestId('formatting-toolbar-btn'));
+
+      await waitFor(() => {
+        expect(mockOpenMediaModal).toHaveBeenCalled();
+        expect(mockUpdateBlock).not.toHaveBeenCalled();
+      });
+    });
+
+    it('should update the block correctly when an uploaded image is successfully returned', async () => {
+      const mockResult: MediaModalResult = {
+        selected: { 
+          kind: 'upload', 
+          id: 'up-2', 
+          fileName: 'my-uploaded-file.jpg', 
+          file: new File([], 'my-uploaded-file.jpg') 
+        },
+        crop: { width: 500, height: 500, x: 10, y: 10 } as unknown as CropResult,
+        uploadResult: { 
+          url: 'https://example.com/uploaded.jpg',
+          filename: 'hash-name.jpg',
+          originalName: 'my-uploaded-file.jpg',
+          mimeType: 'image/jpeg',
+          size: 1024
+        }
+      };
+      
+      mockOpenMediaModal.mockResolvedValue(mockResult);
+
+      render(<CustomReplaceButton openMediaModal={mockOpenMediaModal} />);
+
+      fireEvent.click(screen.getByTestId('formatting-toolbar-btn'));
+
+      await waitFor(() => {
+        expect(mockUpdateBlock).toHaveBeenCalledTimes(1);
+        expect(mockUpdateBlock).toHaveBeenCalledWith('target-block-id', {
+          type: 'cropped-image',
+          props: {
+            url: 'https://example.com/uploaded.jpg',
+            cropData: JSON.stringify({ width: 500, height: 500, x: 10, y: 10 }),
+            fileName: 'my-uploaded-file.jpg'
+          }
+        });
+      });
+    });
+
+    it('should update the block correctly when a gallery image is selected', async () => {
+      const mockResult: MediaModalResult = {
+        selected: { 
+          kind: 'gallery', 
+          id: 'gal-1', 
+          src: 'https://example.com/gallery-img.png', 
+          fileName: 'gallery-pic.png',
+          locale: 'en'
+        },
+        crop: null, 
+        uploadResult: undefined
+      };
+      
+      mockOpenMediaModal.mockResolvedValue(mockResult);
+
+      render(<CustomReplaceButton openMediaModal={mockOpenMediaModal} />);
+
+      fireEvent.click(screen.getByTestId('formatting-toolbar-btn'));
+
+      await waitFor(() => {
+        expect(mockUpdateBlock).toHaveBeenCalledTimes(1);
+        expect(mockUpdateBlock).toHaveBeenCalledWith('target-block-id', {
+          type: 'cropped-image',
+          props: {
+            url: 'https://example.com/gallery-img.png',
+            cropData: '{}', 
+            fileName: 'gallery-pic.png'
+          }
+        });
+      });
+    });
+
+    it('should fallback to "image" if fileName is falsy', async () => {
+      const mockResult: MediaModalResult = {
+        selected: { 
+          kind: 'used', 
+          id: 'usd-1', 
+          src: 'https://example.com/no-name.png', 
+          fileName: '', 
+          locale: 'uk'
+        },
+        crop: null,
+        uploadResult: undefined
+      };
+      
+      mockOpenMediaModal.mockResolvedValue(mockResult);
+
+      render(<CustomReplaceButton openMediaModal={mockOpenMediaModal} />);
+
+      fireEvent.click(screen.getByTestId('formatting-toolbar-btn'));
+
+      await waitFor(() => {
+        expect(mockUpdateBlock).toHaveBeenCalledWith('target-block-id', {
+          type: 'cropped-image',
+          props: {
+            url: 'https://example.com/no-name.png',
+            cropData: '{}',
+            fileName: 'image' 
+          }
+        });
+      });
+    });
+  });
+});

--- a/app/shared/components/content-editor/custom-replace-button/CustomReplaceButton.test.tsx
+++ b/app/shared/components/content-editor/custom-replace-button/CustomReplaceButton.test.tsx
@@ -66,7 +66,7 @@ describe('CustomReplaceButton', () => {
       expect(container).toBeEmptyDOMElement();
     });
 
-    it('should return null and not render if the selected block is not an image or cropped-image', () => {
+    it('should return null and not render if the selected block is not an image', () => {
       const selectedBlocks: MockBlock[] = [{ id: '1', type: 'paragraph' }];
       (useSelectedBlocks as jest.Mock).mockReturnValue(selectedBlocks);
 
@@ -85,8 +85,8 @@ describe('CustomReplaceButton', () => {
       expect(screen.getByText('Replace image')).toBeInTheDocument();
     });
 
-    it('should render the button if exactly one "cropped-image" block is selected', () => {
-      const selectedBlocks: MockBlock[] = [{ id: 'img-1', type: 'cropped-image' }];
+    it('should render the button if exactly one "image" block is selected', () => {
+      const selectedBlocks: MockBlock[] = [{ id: 'img-1', type: 'image' }];
       (useSelectedBlocks as jest.Mock).mockReturnValue(selectedBlocks);
 
       render(<CustomReplaceButton openMediaModal={mockOpenMediaModal} />);
@@ -173,7 +173,7 @@ describe('CustomReplaceButton', () => {
       await waitFor(() => {
         expect(mockUpdateBlock).toHaveBeenCalledTimes(1);
         expect(mockUpdateBlock).toHaveBeenCalledWith('target-block-id', {
-          type: 'cropped-image',
+          type: 'image',
           props: {
             url: 'https://example.com/uploaded.jpg',
             cropData: JSON.stringify({ width: 500, height: 500, x: 10, y: 10 }),
@@ -205,7 +205,7 @@ describe('CustomReplaceButton', () => {
       await waitFor(() => {
         expect(mockUpdateBlock).toHaveBeenCalledTimes(1);
         expect(mockUpdateBlock).toHaveBeenCalledWith('target-block-id', {
-          type: 'cropped-image',
+          type: 'image',
           props: {
             url: 'https://example.com/gallery-img.png',
             cropData: '{}', 
@@ -236,7 +236,7 @@ describe('CustomReplaceButton', () => {
 
       await waitFor(() => {
         expect(mockUpdateBlock).toHaveBeenCalledWith('target-block-id', {
-          type: 'cropped-image',
+          type: 'image',
           props: {
             url: 'https://example.com/no-name.png',
             cropData: '{}',

--- a/app/shared/components/content-editor/custom-replace-button/CustomReplaceButton.tsx
+++ b/app/shared/components/content-editor/custom-replace-button/CustomReplaceButton.tsx
@@ -1,0 +1,49 @@
+import { useBlockNoteEditor, useComponentsContext, useSelectedBlocks } from '@blocknote/react';
+import { Replace } from 'lucide-react';
+
+import { MediaModalResult } from '../../media-modal/MediaModal.types';
+import { customSchema } from '../BlockNoteEditor';
+
+export const CustomReplaceButton = ({
+  openMediaModal
+}: {
+    openMediaModal: () => Promise<MediaModalResult | null>;
+  }) => {
+  const editor = useBlockNoteEditor<typeof customSchema.blockSchema>();
+  const Components = useComponentsContext()!;
+  const selectedBlocks = useSelectedBlocks(editor);
+
+  const block = selectedBlocks.length === 1 ? selectedBlocks[0] : undefined;
+
+  if (block === undefined || (block.type !== 'image' && block.type !== 'cropped-image')) {
+    return null;
+  }
+
+  return (
+    <Components.FormattingToolbar.Button
+      label="Replace image"
+      mainTooltip="Replace image"
+      icon={<Replace size={18} />}
+      onClick={async () => {
+        const result = await openMediaModal();
+
+        if (result) {
+          const { selected, uploadResult, crop } = result;
+
+          const actualUrlString = uploadResult?.url ?? (selected.kind === 'upload' ? null : selected.src);
+
+          if (actualUrlString) {
+            editor.updateBlock(block.id, {
+              type: 'cropped-image',
+              props: {
+                url: actualUrlString,
+                cropData: JSON.stringify(crop || {}),
+                fileName: selected.fileName || 'image'
+              }
+            });
+          }
+        }
+      }}
+    />
+  );
+};

--- a/app/shared/components/content-editor/custom-replace-button/CustomReplaceButton.tsx
+++ b/app/shared/components/content-editor/custom-replace-button/CustomReplaceButton.tsx
@@ -15,7 +15,7 @@ export const CustomReplaceButton = ({
 
   const block = selectedBlocks.length === 1 ? selectedBlocks[0] : undefined;
 
-  if (block === undefined || (block.type !== 'image' && block.type !== 'cropped-image')) {
+  if (block === undefined || (block.type !== 'image')) {
     return null;
   }
 
@@ -34,7 +34,7 @@ export const CustomReplaceButton = ({
 
           if (actualUrlString) {
             editor.updateBlock(block.id, {
-              type: 'cropped-image',
+              type: 'image',
               props: {
                 url: actualUrlString,
                 cropData: JSON.stringify(crop || {}),

--- a/app/shared/components/content-editor/types.ts
+++ b/app/shared/components/content-editor/types.ts
@@ -1,6 +1,8 @@
-import { Block } from '@blocknote/core';
+import { Block, BlockNoteEditor, BlockSchema, InlineContentSchema, StyleSchema } from '@blocknote/core';
 import { SxProps, Theme } from '@mui/material';
 import { ReactElement } from 'react';
+
+import { customSchema } from './BlockNoteEditor';
 
 export interface FilePickerModalProps {
   isOpen: boolean;
@@ -27,7 +29,7 @@ export interface BlockNoteEditorProps {
   keyboardShortcuts?: {
     onSave?: () => void;
   };
-  sx?: SxProps<Theme>
+  sx?: SxProps<Theme>;
 }
 
 export interface SerializedContent {
@@ -40,6 +42,41 @@ export interface ContentPersistence {
   onSave?: (content: SerializedContent) => Promise<boolean>;
   onChange?: (content: SerializedContent) => void;
   autoSaveInterval?: number;
+}
+
+export type StrictBlockNoteEditor = BlockNoteEditor<
+  typeof customSchema.blockSchema,
+  typeof customSchema.inlineContentSchema,
+  typeof customSchema.styleSchema
+>;
+
+export type CroppedImageProps = {
+  textAlignment: 'left' | 'center' | 'right'
+  textColor: string;
+  url: string;
+  cropData: string;
+  fileName: string;
+  caption: string;
+  width: number;
+  showPreview: boolean;
+};
+
+
+export type StrictEditor = Omit<BlockNoteEditor<BlockSchema, InlineContentSchema, StyleSchema>, 'updateBlock'> & {
+
+  updateBlock: (
+    id: string,
+    blockUpdate: { type: 'cropped-image'; props: Partial<CroppedImageProps> } 
+  ) => void;
+};
+
+export interface CroppedImageRendererProps {
+  block: {
+    id: string;
+    type: 'cropped-image';
+    props: CroppedImageProps;
+  };
+  editor: StrictEditor; 
 }
 
 export interface ContentEditorProps {
@@ -57,7 +94,7 @@ export interface ContentEditorProps {
   renderSaveButton?: (props: { onSave: () => void; isSaving: boolean }) => ReactElement;
 
   onSaveComplete?: (success: boolean) => void;
-  sx?: SxProps<Theme>
+  sx?: SxProps<Theme>;
 }
 
 export const CONTENT_VERSION = '1.0.0';

--- a/app/shared/components/content-editor/types.ts
+++ b/app/shared/components/content-editor/types.ts
@@ -66,14 +66,14 @@ export type StrictEditor = Omit<BlockNoteEditor<BlockSchema, InlineContentSchema
 
   updateBlock: (
     id: string,
-    blockUpdate: { type: 'cropped-image'; props: Partial<CroppedImageProps> } 
+    blockUpdate: { type: 'image'; props: Partial<CroppedImageProps> } 
   ) => void;
 };
 
 export interface CroppedImageRendererProps {
   block: {
     id: string;
-    type: 'cropped-image';
+    type: 'image';
     props: CroppedImageProps;
   };
   editor: StrictEditor; 


### PR DESCRIPTION
## Description

Overhauled the image interaction behavior within the rich-text editor by integrating our custom image picker. `BlockNoteEditor.tsx` has been updated to bypass the native image upload flow in favor of our `MediaModal`, utilizing a Promise-based modal approach to handle image selection and repalacement seemlessly.

## Key changes:
- **`CroppedImageBlock`:** A new custom block designed specifically to render and display the cropped images selected by the user.
- **`CustomReplaceButton`:** Added to the formatting toolbar, overriding the standard replace behavior to ensure users are routed through our custom media flow when swapping images.
- **`getCustomSlashMenuItems`:** A new helper function that filters and customizes the items available in BlockNote's slash menu, ensuring our custom image picker is surfaced correctly, and also removes other media blocks.

## Type of change

- [x] New feature
- [x] Refactoring / Tech debt

## How to test

1. Pull the branch locally and start the application.
2. Navigate to a page utilizing the `BlockNoteEditor` (e.g., publication edit page).
3. **Test Slash Menu:** Type `/` to open the block menu. Verify that the custom image option appears (filtered via `getCustomSlashMenuItems`) and other media blocks(Audio, Video, File) are removed.
4. **Test Media Modal Integration:** Select the image option. Verify that our custom `MediaModal` opens instead of the default BlockNote uploader. 
5. **Test Image Insertion:** Select/crop an image via the modal and confirm it. Verify that the Promise resolves and the image is successfully rendered in the editor using the new `CroppedImageBlock`.
6. **Test Image Replacement:** Click on the newly inserted image to open the formatting toolbar. Click the custom replace button (`CustomReplaceButton`) and verify it re-opens the `MediaModal` to swap the image.
7. **Test Image Copy/Paste:** Click at image, and hit `Ctrl+C`, and then, scroll downwards and paste it(`Ctrl+V`), verify that image pasted with crop persisted.
8. **Test Image Drag&Drop** Drag a handle on the left side from image, and drop it to other row.`
## Video / Screenshots

**Slash Menu & Modal Trigger:**
<img width="448" height="117" alt="image" src="https://github.com/user-attachments/assets/8c196c48-a33f-4aaa-bd24-95f00d184e73" />

**CroppedImageBlock & Replace Toolbar:**
<img width="764" height="602" alt="image" src="https://github.com/user-attachments/assets/6cb919b0-9c3e-4420-aeae-364c3ae211f2" />

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board