### PR TITLE
fix(cards): correct date display

### DIFF
--- a/app/lib/utils/formatDate.ts
+++ b/app/lib/utils/formatDate.ts
@@ -1,3 +1,10 @@
-export function formatDate(dateString: string): string {
-  return new Date(dateString).toLocaleDateString('uk-UA');
+export function formatDate(inputDate: string): string {
+  const numericTimestamp = Number(inputDate);
+
+  const parsedDate =
+    numericTimestamp && String(numericTimestamp) === inputDate
+      ? new Date(numericTimestamp)
+      : new Date(inputDate);
+
+  return parsedDate.toLocaleDateString('uk-UA');
 }


### PR DESCRIPTION
## Description

Fixed event date display issue. Events were not displaying any date. The root cause was that publishedAt was being passed as a Unix timestamp (milliseconds) instead of an ISO string, causing new Date() to return Invalid Date.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. Open /publications page
2. Switch to "Події" tab
3. Verify that published events show correct date (e.g. "Опубліковано 09.04.2026")
4. Verify that draft events show "Створено" with correct date
5. Verify that news and media mentions still display dates correctly

## Video / Screenshots

<img width="1527" height="950" alt="image" src="https://github.com/user-attachments/assets/2a21b398-9568-453a-86a3-683cb1ec1690" />
