### PR TITLE
fix: remove doble headers on thr seo data editing page

### DIFF
--- a/app/(logged_in)/publications/[type]/[id]/seo/page.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/seo/page.tsx
@@ -44,7 +44,7 @@ export default function PublicatiosSeoPage() {
         <TitleDropdown type="SEO" title={`Редагування ${PAGE_TITLES[type]}`} renderMenuOpen={false} />
       </DividedHeader>
 
-      <CreatePublicationView data={publicationData} />
+      <CreatePublicationView data={publicationData}  showHeader={false} />
     </Box>
   );
 }

--- a/app/(logged_in)/publications/[type]/[id]/seo/page.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/seo/page.tsx
@@ -44,7 +44,7 @@ export default function PublicatiosSeoPage() {
         <TitleDropdown type="SEO" title={`Редагування ${PAGE_TITLES[type]}`} renderMenuOpen={false} />
       </DividedHeader>
 
-      <CreatePublicationView data={publicationData}  showHeader={false} />
+      <CreatePublicationView data={publicationData} mode="seo" />
     </Box>
   );
 }

--- a/app/(logged_in)/publications/[type]/create/CreatePublicationsView.tsx
+++ b/app/(logged_in)/publications/[type]/create/CreatePublicationsView.tsx
@@ -29,11 +29,12 @@ import { BaseContentStatuses } from '~/types/enums/common.enums';
 interface PublicationViewProps {
   data: ReturnType<typeof useUpsertPublication>;
   mode?: 'edit' | 'create';
+  showHeader?: boolean;
 }
 
 
 
-export default function CreatePublicationsView({ data, mode = 'create' }: Readonly<PublicationViewProps>) {
+export default function CreatePublicationsView({ data, mode = 'create', showHeader = true }: Readonly<PublicationViewProps>) {
   const {
     publicationType,
     adminTitle,
@@ -133,22 +134,24 @@ export default function CreatePublicationsView({ data, mode = 'create' }: Readon
 
   return (
     <>
-      <DividedHeader
-        originUrl={PUBLICATIONS_BASE_PATH}
-        rightActionsComponent={
-          publicationType === 'media' ? (
-            <HeaderRightActions
-              mode="edit"
-              onPublish={() => handleMenuAction(MenuActionId.PUBLISH)}
-              onMenuOpen={handleOpen}
-            />
-          ) : (
-            <HeaderRightActions mode="create" onEdit={onEdit} />
-          )
-        }
-      >
-        <Typography variant="customBold20Tight">{`${mode === 'edit' ? 'Редагування' : 'Створення'} ${PAGE_TITLES[publicationType]}`}</Typography>
-      </DividedHeader>
+      {showHeader && (
+        <DividedHeader
+          originUrl={PUBLICATIONS_BASE_PATH}
+          rightActionsComponent={
+            publicationType === 'media' ? (
+              <HeaderRightActions
+                mode="edit"
+                onPublish={() => handleMenuAction(MenuActionId.PUBLISH)}
+                onMenuOpen={handleOpen}
+              />
+            ) : (
+              <HeaderRightActions mode="create" onEdit={onEdit} />
+            )
+          }
+        >
+          <Typography variant="customBold20Tight">{`${mode === 'edit' ? 'Редагування' : 'Створення'} ${PAGE_TITLES[publicationType]}`}</Typography>
+        </DividedHeader>
+      )}
       <Box sx={styles.contentWrapper}>
         <SeoCollapsibleBlock
           title="Деталі"

--- a/app/(logged_in)/publications/[type]/create/CreatePublicationsView.tsx
+++ b/app/(logged_in)/publications/[type]/create/CreatePublicationsView.tsx
@@ -28,13 +28,10 @@ import { BaseContentStatuses } from '~/types/enums/common.enums';
 
 interface PublicationViewProps {
   data: ReturnType<typeof useUpsertPublication>;
-  mode?: 'edit' | 'create';
-  showHeader?: boolean;
+  mode?: 'edit' | 'create' | 'seo';
 }
 
-
-
-export default function CreatePublicationsView({ data, mode = 'create', showHeader = true }: Readonly<PublicationViewProps>) {
+export default function CreatePublicationsView({ data, mode = 'create' }: Readonly<PublicationViewProps>) {
   const {
     publicationType,
     adminTitle,
@@ -127,6 +124,7 @@ export default function CreatePublicationsView({ data, mode = 'create', showHead
       console.error(`Action ${actionId} failed`, err);
     }
   };
+
   const onEdit = async () => {
     const id = await handleSave(BaseContentStatuses.Draft);
     router.push(`${PUBLICATIONS_BASE_PATH}/${publicationType}/${id}/edit`);
@@ -134,7 +132,7 @@ export default function CreatePublicationsView({ data, mode = 'create', showHead
 
   return (
     <>
-      {showHeader && (
+      {mode !== 'seo' && (
         <DividedHeader
           originUrl={PUBLICATIONS_BASE_PATH}
           rightActionsComponent={


### PR DESCRIPTION
## Description

Fixed a bug where two headers were displayed on the SEO settings page (`/publications/[type]/[id]/seo`). `CreatePublicationsView` rendered its own `DividedHeader` internally, while `seo/page.tsx` already rendered its own header before calling the component — resulting in a duplicate header with incorrect title ("Створення" instead of "Редагування").

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Log in to lf-admin
2. Go to **Publications** page
3. Click **Редагувати** on any news or event
4. In the header, open the language/navigation dropdown and select **SEO Налаштування**
5. Verify only **one** header is shown: "Редагування [type]" with Cancel / Save buttons
6. Navigate to `/publications/[type]/create` and verify the header **still appears** with "Створення [type]"
7. Verify the SEO form (`SeoCollapsibleBlock`) renders correctly on the SEO page

## Video / Screenshots
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/ef5a9802-28ef-4195-8449-e35fd4f454f8" />