### PR TITLE
feat(ui): implement direct file download from sidebar

### DIFF
--- a/app/(logged_in)/files/FilesPageContent.tsx
+++ b/app/(logged_in)/files/FilesPageContent.tsx
@@ -63,6 +63,7 @@ type FilesPageFileItem = FilesCardsLayoutItem & {
   createdAtRaw?: string;
   size?: string;
   previewUrl?: string;
+  downloadUrl?: string;
   addedBy?: { name: string; avatarUrl?: string };
   usage: FileUsageLink[];
 };
@@ -230,6 +231,7 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
       createdAtRaw: asset.createdAt,
       isStarred: asset.isStarred,
       usageLinks: asset.usageRefs.length,
+      downloadUrl: asset.url,
       imageSrc: asset.type === AssetType.Image ? asset.url : undefined,
       previewUrl: asset.type === AssetType.Image ? asset.url : undefined,
       format: formatFromMimeType(asset.mimeType, asset.filename),
@@ -285,7 +287,8 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
       size: selectedFile.size,
       usageLinks: selectedFile.usage,
       description: selectedFile.description,
-      isStarred: selectedFile.isStarred
+      isStarred: selectedFile.isStarred,
+      downloadUrl: selectedFile.downloadUrl
     }
     : null;
 

--- a/app/shared/components/file-info-sidebar/FileInfoSidebar.test.tsx
+++ b/app/shared/components/file-info-sidebar/FileInfoSidebar.test.tsx
@@ -18,10 +18,13 @@ jest.mock('~/shared/components/design-system/text-field/TextField', () => ({
   CustomTextField: ({
     fullWidth: _f,
     minRows: _m,
+    multiline: _ml,
     ...props
-  }: React.TextareaHTMLAttributes<HTMLTextAreaElement> & { fullWidth?: boolean; minRows?: number }) => (
-    <textarea data-testid="desc" {...props} />
-  )
+  }: React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
+    fullWidth?: boolean;
+    minRows?: number;
+    multiline?: boolean;
+  }) => <textarea data-testid="desc" {...props} />
 }));
 
 jest.mock('~/lib/utils/formatUsageCount', () => ({

--- a/app/shared/components/file-info-sidebar/FileInfoSidebar.test.tsx
+++ b/app/shared/components/file-info-sidebar/FileInfoSidebar.test.tsx
@@ -81,6 +81,7 @@ describe('FileInfoSidebar', () => {
     type: 'image',
     filename: 'cat.png',
     previewUrl: '/cat.png',
+    downloadUrl: 'https://example.com/cat.png',
     addedBy: { name: 'Alice', avatarUrl: '/a.png' },
     addedAt: '2025-01-01',
     format: 'png',

--- a/app/shared/components/file-info-sidebar/FileInfoSidebar.test.tsx
+++ b/app/shared/components/file-info-sidebar/FileInfoSidebar.test.tsx
@@ -15,7 +15,11 @@ jest.mock('../design-system/tooltip/Tooltip', () => ({
 
 jest.mock('~/shared/components/design-system/text-field/TextField', () => ({
   __esModule: true,
-  CustomTextField: (props: React.TextareaHTMLAttributes<HTMLTextAreaElement>) => (
+  CustomTextField: ({
+    fullWidth: _f,
+    minRows: _m,
+    ...props
+  }: React.TextareaHTMLAttributes<HTMLTextAreaElement> & { fullWidth?: boolean; minRows?: number }) => (
     <textarea data-testid="desc" {...props} />
   )
 }));

--- a/app/shared/components/file-info-sidebar/FileInfoSidebar.tsx
+++ b/app/shared/components/file-info-sidebar/FileInfoSidebar.tsx
@@ -1,5 +1,6 @@
-import { Avatar, Box, IconButton, Link, Typography } from '@mui/material';
+import { Avatar, Box, CircularProgress, IconButton, Link, Typography } from '@mui/material';
 import React, { useCallback, useState } from 'react';
+import toast from 'react-hot-toast';
 
 import TooltipCustom from '../design-system/tooltip/Tooltip';
 import { styles } from './FileInfoSidebar.styles';
@@ -33,7 +34,7 @@ export type FileDetailsSidebarFile = {
   type: 'image' | 'pdf' | 'audio' | 'document' | 'spreadsheet' | 'video' | 'archive';
   filename: string;
   previewUrl?: string;
-
+  downloadUrl?: string;
   addedBy?: { name: string; avatarUrl?: string };
   addedAt?: string;
 
@@ -95,6 +96,34 @@ export function FileInfoSidebar({ file, onClose, onDescriptionSave, onRequestAct
   const TypeIcon = file?.type ? TYPE_ICON[file.type] : PictureIcon;
 
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+  const [isDownloading, setIsDownloading] = useState(false);
+  const handleDownload = useCallback(async () => {
+    if (!file?.downloadUrl || !filename) return;
+
+    try {
+      setIsDownloading(true);
+
+      const response = await fetch(file.downloadUrl, { cache: 'no-store' });
+      if (!response.ok) throw new Error('Помилка завантаження');
+
+      const blob = await response.blob();
+      const blobUrl = window.URL.createObjectURL(blob);
+
+      const link = document.createElement('a');
+      link.href = blobUrl;
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+
+      document.body.removeChild(link);
+      window.URL.revokeObjectURL(blobUrl);
+      toast.success('Файл завантажено');
+    } catch {
+      toast.error('Не вдалося завантажити файл');
+    } finally {
+      setIsDownloading(false);
+    }
+  }, [file?.downloadUrl, filename]);
 
   const openPreview = useCallback(() => {
     if (isImagePreview) setIsPreviewOpen(true);
@@ -186,15 +215,32 @@ export function FileInfoSidebar({ file, onClose, onDescriptionSave, onRequestAct
           </IconButton>
         </TooltipCustom>
 
-        <TooltipCustom title="Завантажити" showArrow>
-          <IconButton
-            sx={styles.actionBtn}
-            onClick={() => requestAction('download')}
-            aria-label="Завантажити"
-            disabled={!canEdit}
-          >
-            <DownloadOutlinedIcon fontSize="small" />
-          </IconButton>
+        <TooltipCustom title={isDownloading ? 'Завантаження...' : 'Завантажити'} showArrow>
+          <span>
+            <IconButton
+              onClick={handleDownload}
+              sx={styles.actionBtn}
+              aria-label="Завантажити"
+              disabled={!canEdit || !file?.downloadUrl || isDownloading}
+            >
+              {isDownloading ? (
+                <Box
+                  component="span"
+                  sx={{
+                    display: 'flex',
+                    width: '20px',
+                    height: '20px',
+                    alignItems: 'center',
+                    justifyContent: 'center'
+                  }}
+                >
+                  <CircularProgress size={16} color="inherit" />
+                </Box>
+              ) : (
+                <DownloadOutlinedIcon fontSize="small" />
+              )}
+            </IconButton>
+          </span>
         </TooltipCustom>
       </Box>
 

--- a/app/shared/components/file-info-sidebar/FileInfoSidebar.tsx
+++ b/app/shared/components/file-info-sidebar/FileInfoSidebar.tsx
@@ -116,7 +116,7 @@ export function FileInfoSidebar({ file, onClose, onDescriptionSave, onRequestAct
       if (!response.ok) throw new Error('Помилка завантаження');
 
       const blob = await response.blob();
-      const blobUrl = window.URL.createObjectURL(blob);
+      const blobUrl = globalThis.URL.createObjectURL(blob);
 
       const link = document.createElement('a');
       link.href = blobUrl;
@@ -124,8 +124,8 @@ export function FileInfoSidebar({ file, onClose, onDescriptionSave, onRequestAct
       document.body.appendChild(link);
       link.click();
 
-      document.body.removeChild(link);
-      window.URL.revokeObjectURL(blobUrl);
+      link.remove();
+      globalThis.URL.revokeObjectURL(blobUrl);
       toast.success('Файл завантажено');
     } catch {
       toast.error('Не вдалося завантажити файл');

--- a/app/shared/components/file-info-sidebar/FileInfoSidebar.tsx
+++ b/app/shared/components/file-info-sidebar/FileInfoSidebar.tsx
@@ -99,7 +99,7 @@ export function FileInfoSidebar({ file, onClose, onDescriptionSave, onRequestAct
   const [isDownloading, setIsDownloading] = useState(false);
   const handleDownload = useCallback(async () => {
     if (!file?.downloadUrl || !filename) return;
-
+    requestAction('download');
     try {
       setIsDownloading(true);
 

--- a/app/shared/components/file-info-sidebar/FileInfoSidebar.tsx
+++ b/app/shared/components/file-info-sidebar/FileInfoSidebar.tsx
@@ -97,6 +97,15 @@ export function FileInfoSidebar({ file, onClose, onDescriptionSave, onRequestAct
 
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
   const [isDownloading, setIsDownloading] = useState(false);
+
+  const requestAction = useCallback(
+    (type: FileSidebarAction['type']) => {
+      if (!fileId) return;
+      onRequestAction?.({ type, fileId });
+    },
+    [fileId, onRequestAction]
+  );
+
   const handleDownload = useCallback(async () => {
     if (!file?.downloadUrl || !filename) return;
     requestAction('download');
@@ -123,7 +132,7 @@ export function FileInfoSidebar({ file, onClose, onDescriptionSave, onRequestAct
     } finally {
       setIsDownloading(false);
     }
-  }, [file?.downloadUrl, filename]);
+  }, [file?.downloadUrl, filename, requestAction]);
 
   const openPreview = useCallback(() => {
     if (isImagePreview) setIsPreviewOpen(true);
@@ -141,14 +150,6 @@ export function FileInfoSidebar({ file, onClose, onDescriptionSave, onRequestAct
     debounceMs: AUTOSAVE_DEBOUNCE_MS,
     onSave: onDescriptionSave
   });
-
-  const requestAction = useCallback(
-    (type: FileSidebarAction['type']) => {
-      if (!fileId) return;
-      onRequestAction?.({ type, fileId });
-    },
-    [fileId, onRequestAction]
-  );
 
   const [updateAsset, { loading: isUpdatingStar }] = useUpdateAssetMutation();
 


### PR DESCRIPTION
## Description

Implemented direct file downloads to the user's local device from the media library sidebar.


## How to Test
1. Go to the Media Library (Files page).
2. Click on any recently uploaded file (e.g., an image) to open the `FileInfoSidebar` on the right.
3. Click the "Download" (Завантажити) button.
4. Verify that the button shows a loading spinner briefly and the file is successfully downloaded to your local device.

**⚠️ Important Note for QA / Reviewers:** Some older mock files or manually created DB entries (like legacy PDFs or test images) might fail to download if they don't physically exist on the Cloudflare R2 bucket or lack proper CORS headers. Please test the download feature with **newly uploaded files** to ensure correct behavior.

## Expected Result
Users can successfully download any file directly to their local device via the sidebar download button without the browser opening it in a new tab.
## Video / Screenshots

https://github.com/user-attachments/assets/a9694406-b306-422a-a1d8-c3cc5fe171e8



Closes: https://github.com/Liatoshynsky-Foundation/lf-admin/issues/490