### PR TITLE
feat(assets): implement backend logic for Asset deletion

### DIFF
--- a/app/api/blob-url/route.ts
+++ b/app/api/blob-url/route.ts
@@ -5,6 +5,8 @@ import { errorResponse } from '~/utils/apiResponse';
 import { validateWithZod } from '~/utils/validateRequestData';
 import { zBlobQuerySchema } from '~/validators/queryParams.schema';
 
+export const dynamic = 'force-dynamic';
+
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const validationResult = validateWithZod(

--- a/app/api/blob-url/route.ts
+++ b/app/api/blob-url/route.ts
@@ -5,8 +5,6 @@ import { errorResponse } from '~/utils/apiResponse';
 import { validateWithZod } from '~/utils/validateRequestData';
 import { zBlobQuerySchema } from '~/validators/queryParams.schema';
 
-export const dynamic = 'force-dynamic';
-
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const validationResult = validateWithZod(

--- a/src/infrastructure/models/imageCrop.model.ts
+++ b/src/infrastructure/models/imageCrop.model.ts
@@ -1,4 +1,4 @@
-import { type InferSchemaType, type Model, model, Schema, Types } from 'mongoose';
+import { type InferSchemaType, type Model, model, models, Schema, Types } from 'mongoose';
 
 export type Locale = 'uk' | 'en';
 
@@ -36,16 +36,12 @@ const imageCropSchema = new Schema(
   }
 );
 
-imageCropSchema.index(
-  { imageAssetId: 1, pageId: 1, locale: 1 },
-  { unique: true, sparse: true }
-);
+imageCropSchema.index({ imageAssetId: 1, pageId: 1, locale: 1 }, { unique: true, sparse: true });
 
 export type ImageCropDocument = InferSchemaType<typeof imageCropSchema> & {
   _id: Types.ObjectId;
 };
 
-export const ImageCropModel: Model<ImageCropDocument> = model<ImageCropDocument>(
-  'ImageCrop',
-  imageCropSchema
-) as unknown as Model<ImageCropDocument>;
+export const ImageCropModel: Model<ImageCropDocument> =
+  (models.ImageCrop as unknown as Model<ImageCropDocument>) ||
+  (model<ImageCropDocument>('ImageCrop', imageCropSchema) as unknown as Model<ImageCropDocument>);

--- a/src/infrastructure/repositories/assetRepository/assetRepository.test.ts
+++ b/src/infrastructure/repositories/assetRepository/assetRepository.test.ts
@@ -1,6 +1,15 @@
 import { createBaseRepository } from '../baseRepository/baseRepository';
 import { AssetRepository } from './assetRepository';
 
+jest.mock('~/src/middleware/logger/logger', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn()
+  }
+}));
+
 jest.mock('../baseRepository/baseRepository', () => ({
   createBaseRepository: jest.fn((config) => config)
 }));

--- a/src/infrastructure/repositories/assetRepository/assetRepository.test.ts
+++ b/src/infrastructure/repositories/assetRepository/assetRepository.test.ts
@@ -5,6 +5,15 @@ jest.mock('../baseRepository/baseRepository', () => ({
   createBaseRepository: jest.fn((config) => config)
 }));
 
+jest.mock('../../../config', () => ({
+  config: { uploads: { storage: { type: 'local' } } }
+}));
+jest.mock('../../../uploads/storage', () => ({
+  createStorageAdapter: jest.fn(() => ({
+    delete: jest.fn().mockResolvedValue({ success: true })
+  }))
+}));
+
 describe('AssetRepository', () => {
   const mockedCreateBaseRepository = createBaseRepository as jest.Mock;
 
@@ -82,5 +91,45 @@ describe('AssetRepository', () => {
 
     expect(config.getDefaultSort()).toEqual({ createdAt: -1 });
     expect(config.getDefaultSort({ sortBy: 'filename', sortOrder: 'asc' })).toEqual({ filename: 1 });
+  });
+});
+
+describe('deleteAsset', () => {
+  const mockAssetModel = {
+    findById: jest.fn(),
+    findByIdAndDelete: jest.fn()
+  };
+
+  const repository = AssetRepository({ AssetModel: mockAssetModel as never });
+
+  it('should throw an error if the asset is not found', async () => {
+    mockAssetModel.findById.mockResolvedValueOnce(null);
+
+    await expect(repository.deleteAsset('fake-id')).rejects.toThrow('Файл не знайдено');
+  });
+
+  it('should throw an error if the asset is used on the site', async () => {
+    mockAssetModel.findById.mockResolvedValueOnce({
+      _id: 'fake-id',
+      usageRefs: [{ pageId: 'some-page-id' }]
+    });
+
+    await expect(repository.deleteAsset('fake-id')).rejects.toThrow('Cannot delete: file is in use on the site.');
+    expect(mockAssetModel.findByIdAndDelete).not.toHaveBeenCalled();
+  });
+
+  it('should successfully delete asset from storage and DB if not in use', async () => {
+    mockAssetModel.findById.mockResolvedValueOnce({
+      _id: 'fake-id',
+      filename: 'test-image.png',
+      type: 'image',
+      usageRefs: []
+    });
+    mockAssetModel.findByIdAndDelete.mockResolvedValueOnce({});
+
+    const result = await repository.deleteAsset('fake-id');
+
+    expect(result).toBe(true);
+    expect(mockAssetModel.findByIdAndDelete).toHaveBeenCalledWith('fake-id');
   });
 });

--- a/src/infrastructure/repositories/assetRepository/assetRepository.ts
+++ b/src/infrastructure/repositories/assetRepository/assetRepository.ts
@@ -212,6 +212,7 @@ export const AssetRepository = ({ AssetModel }: AssetRepoDeps) => {
 
     if (!storageResult.success) {
       logger.warn(`Failed to delete file from Cloudflare: ${storageResult.error}`);
+      throw new Error('The file was not deleted from cloud storage. Please try again later.');
     }
 
     await AssetModel.findByIdAndDelete(id);

--- a/src/infrastructure/repositories/assetRepository/assetRepository.ts
+++ b/src/infrastructure/repositories/assetRepository/assetRepository.ts
@@ -1,7 +1,10 @@
 import { FilterQuery, Model, Types } from 'mongoose';
 import * as path from 'node:path';
 
+import { config } from '../../../config';
+import { createStorageAdapter } from '../../../uploads/storage';
 import { createBaseRepository } from '../baseRepository/baseRepository';
+import logger from '~/src/middleware/logger/logger';
 
 type AssetType = 'image' | 'pdf' | 'audio' | 'document' | 'spreadsheet' | 'video' | 'archive';
 
@@ -56,6 +59,8 @@ type DbAsset = {
 type AssetRepoDeps = Readonly<{
   AssetModel: Model<DbAsset>;
 }>;
+
+const storage = createStorageAdapter(config.uploads.storage);
 
 const dateToIso = (date?: Date | string | null): string => {
   if (!date) {
@@ -154,6 +159,7 @@ export const AssetRepository = ({ AssetModel }: AssetRepoDeps) => {
 
     return updatedDoc ? toEntity(updatedDoc) : null;
   };
+
   const createAsset = async (data: CreateAssetData): Promise<AssetEntity> => {
     const newDoc = await AssetModel.create({
       ...data,
@@ -167,9 +173,54 @@ export const AssetRepository = ({ AssetModel }: AssetRepoDeps) => {
     return toEntity(newDoc);
   };
 
+  const deleteAsset = async (id: string): Promise<boolean> => {
+    const asset = await AssetModel.findById(id);
+
+    if (!asset) {
+      throw new Error('Файл не знайдено');
+    }
+
+    if (asset.usageRefs && asset.usageRefs.length > 0) {
+      throw new Error('Cannot delete: file is in use on the site.');
+    }
+
+    let targetFolder = 'uploads';
+    let cloudFilename = asset.filename;
+
+    try {
+      if (asset.url) {
+        const urlObj = new URL(asset.url);
+        const pathParts = urlObj.pathname.split('/').filter(Boolean);
+
+        if (pathParts.length > 0) {
+          cloudFilename = pathParts.pop() || asset.filename;
+
+          if (pathParts.length > 0) {
+            targetFolder = pathParts.join('/');
+          } else {
+            targetFolder = '';
+          }
+        }
+      }
+    } catch {
+      if (asset.type === 'image') targetFolder = 'photos';
+      if (asset.type === 'audio') targetFolder = 'compositions';
+    }
+
+    const storageResult = await storage.delete(cloudFilename, targetFolder);
+
+    if (!storageResult.success) {
+      logger.warn(`Failed to delete file from Cloudflare: ${storageResult.error}`);
+    }
+    await AssetModel.findByIdAndDelete(id);
+
+    return true;
+  };
+
   return {
     ...baseRepo,
     updateAsset,
-    createAsset
+    createAsset,
+    deleteAsset
   };
 };

--- a/src/infrastructure/repositories/assetRepository/assetRepository.ts
+++ b/src/infrastructure/repositories/assetRepository/assetRepository.ts
@@ -173,6 +173,28 @@ export const AssetRepository = ({ AssetModel }: AssetRepoDeps) => {
     return toEntity(newDoc);
   };
 
+  const getCloudStoragePath = (asset: DbAsset) => {
+    let folder = 'uploads';
+    let filename = asset.filename;
+
+    try {
+      if (asset.url) {
+        const urlObj = new URL(asset.url);
+        const pathParts = urlObj.pathname.split('/').filter(Boolean);
+
+        if (pathParts.length > 0) {
+          filename = pathParts.pop() || asset.filename;
+          folder = pathParts.length > 0 ? pathParts.join('/') : '';
+        }
+      }
+    } catch {
+      if (asset.type === 'image') folder = 'photos';
+      if (asset.type === 'audio') folder = 'compositions';
+    }
+
+    return { filename, folder };
+  };
+
   const deleteAsset = async (id: string): Promise<boolean> => {
     const asset = await AssetModel.findById(id);
 
@@ -184,34 +206,14 @@ export const AssetRepository = ({ AssetModel }: AssetRepoDeps) => {
       throw new Error('Cannot delete: file is in use on the site.');
     }
 
-    let targetFolder = 'uploads';
-    let cloudFilename = asset.filename;
+    const { filename, folder } = getCloudStoragePath(asset);
 
-    try {
-      if (asset.url) {
-        const urlObj = new URL(asset.url);
-        const pathParts = urlObj.pathname.split('/').filter(Boolean);
-
-        if (pathParts.length > 0) {
-          cloudFilename = pathParts.pop() || asset.filename;
-
-          if (pathParts.length > 0) {
-            targetFolder = pathParts.join('/');
-          } else {
-            targetFolder = '';
-          }
-        }
-      }
-    } catch {
-      if (asset.type === 'image') targetFolder = 'photos';
-      if (asset.type === 'audio') targetFolder = 'compositions';
-    }
-
-    const storageResult = await storage.delete(cloudFilename, targetFolder);
+    const storageResult = await storage.delete(filename, folder);
 
     if (!storageResult.success) {
       logger.warn(`Failed to delete file from Cloudflare: ${storageResult.error}`);
     }
+
     await AssetModel.findByIdAndDelete(id);
 
     return true;

--- a/src/interfaces/graphql/resolvers/assets/Query.ts
+++ b/src/interfaces/graphql/resolvers/assets/Query.ts
@@ -32,6 +32,9 @@ export interface CreateAssetArgs {
     description?: string;
   };
 }
+export interface DeleteAssetArgs {
+  id: string;
+}
 
 const endpointHandler = endpointRepositoryHandler('assetsRepository');
 
@@ -45,5 +48,8 @@ export const AssetsMutation = {
   }),
   createAsset: endpointHandler<CreateAssetArgs, unknown>(async ({ args: { input }, repo }) => {
     return repo.createAsset(input);
+  }),
+  deleteAsset: endpointHandler<DeleteAssetArgs, unknown>(async ({ args: { id }, repo }) => {
+    return repo.deleteAsset(id);
   })
 };

--- a/src/interfaces/graphql/schemas/assets.graphql
+++ b/src/interfaces/graphql/schemas/assets.graphql
@@ -56,10 +56,6 @@ input UpdateAssetInput {
   description: String
 }
 
-extend type Mutation {
-  updateAsset(id: ID!, input: UpdateAssetInput!): Asset!
-}
-
 input CreateAssetInput {
   filename: String!
   mimeType: String!
@@ -70,5 +66,7 @@ input CreateAssetInput {
 }
 
 extend type Mutation {
+  updateAsset(id: ID!, input: UpdateAssetInput!): Asset!
   createAsset(input: CreateAssetInput!): Asset!
+  deleteAsset(id: ID!): Boolean!
 }

--- a/src/uploads/storage/__tests__/cloudStorage.test.ts
+++ b/src/uploads/storage/__tests__/cloudStorage.test.ts
@@ -63,53 +63,66 @@ describe('createCloudStorage', () => {
   });
 
   describe('initialization', () => {
-    it('should create AWS storage successfully', () => {
+    it('should create AWS storage successfully', async () => {
       const options = createAwsOptions({ region: 'us-east-1' });
-
       const storage = createCloudStorage(options);
 
+      mockSend.mockResolvedValueOnce({});
+      await storage.exists('test.txt');
+
       expect(storage).toBeDefined();
-      expect(MockS3Client).toHaveBeenCalledWith({
-        region: 'us-east-1',
-        credentials: {
-          accessKeyId: 'test-key',
-          secretAccessKey: 'test-secret'
-        }
-      });
+      expect(MockS3Client).toHaveBeenCalledWith(
+        expect.objectContaining({
+          region: 'us-east-1',
+          credentials: {
+            accessKeyId: 'test-key',
+            secretAccessKey: 'test-secret'
+          }
+        })
+      );
     });
 
-    it('should create Cloudflare R2 storage successfully', () => {
+    it('should create Cloudflare R2 storage successfully', async () => {
       const options = createCloudflareOptions();
-
       const storage = createCloudStorage(options);
 
+      mockSend.mockResolvedValueOnce({});
+      await storage.exists('test.txt');
+
       expect(storage).toBeDefined();
-      expect(MockS3Client).toHaveBeenCalledWith({
-        region: 'auto',
-        credentials: {
-          accessKeyId: 'test-key',
-          secretAccessKey: 'test-secret'
-        },
-        endpoint: 'https://abc123.r2.cloudflarestorage.com'
-      });
+      expect(MockS3Client).toHaveBeenCalledWith(
+        expect.objectContaining({
+          region: 'auto',
+          credentials: {
+            accessKeyId: 'test-key',
+            secretAccessKey: 'test-secret'
+          },
+          endpoint: 'https://abc123.r2.cloudflarestorage.com'
+        })
+      );
     });
 
-    it('should throw error if AWS credentials are missing', () => {
+    it('should throw error if AWS credentials are missing', async () => {
       const options = createAwsOptions({ credentials: {} });
+      const storage = createCloudStorage(options);
 
-      expect(() => createCloudStorage(options)).toThrow('aws storage requires accessKeyId and secretAccessKey');
+      await expect(storage.exists('test.txt')).rejects.toThrow('aws storage requires accessKeyId and secretAccessKey');
     });
 
-    it('should throw error if Cloudflare credentials are missing', () => {
+    it('should throw error if Cloudflare credentials are missing', async () => {
       const options = createCloudflareOptions({ credentials: {} });
+      const storage = createCloudStorage(options);
 
-      expect(() => createCloudStorage(options)).toThrow('cloudflare storage requires accessKeyId and secretAccessKey');
+      await expect(storage.exists('test.txt')).rejects.toThrow(
+        'cloudflare storage requires accessKeyId and secretAccessKey'
+      );
     });
 
-    it('should throw error if Cloudflare endpoint is missing', () => {
+    it('should throw error if Cloudflare endpoint is missing', async () => {
       const options = createCloudflareOptions({ endpoint: undefined });
+      const storage = createCloudStorage(options);
 
-      expect(() => createCloudStorage(options)).toThrow('Cloudflare R2 storage requires endpoint configuration');
+      await expect(storage.exists('test.txt')).rejects.toThrow('Cloudflare R2 storage requires endpoint configuration');
     });
   });
 

--- a/src/uploads/storage/__tests__/cloudStorage.test.ts
+++ b/src/uploads/storage/__tests__/cloudStorage.test.ts
@@ -102,27 +102,34 @@ describe('createCloudStorage', () => {
       );
     });
 
-    it('should throw error if AWS credentials are missing', async () => {
+    it('should return error if AWS credentials are missing', async () => {
       const options = createAwsOptions({ credentials: {} });
       const storage = createCloudStorage(options);
 
-      await expect(storage.exists('test.txt')).rejects.toThrow('aws storage requires accessKeyId and secretAccessKey');
+      const result = await storage.delete('test.txt');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('aws storage requires accessKeyId and secretAccessKey');
     });
 
-    it('should throw error if Cloudflare credentials are missing', async () => {
+    it('should return error if Cloudflare credentials are missing', async () => {
       const options = createCloudflareOptions({ credentials: {} });
       const storage = createCloudStorage(options);
 
-      await expect(storage.exists('test.txt')).rejects.toThrow(
-        'cloudflare storage requires accessKeyId and secretAccessKey'
-      );
+      const result = await storage.delete('test.txt');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('cloudflare storage requires accessKeyId and secretAccessKey');
     });
 
-    it('should throw error if Cloudflare endpoint is missing', async () => {
+    it('should return error if Cloudflare endpoint is missing', async () => {
       const options = createCloudflareOptions({ endpoint: undefined });
       const storage = createCloudStorage(options);
 
-      await expect(storage.exists('test.txt')).rejects.toThrow('Cloudflare R2 storage requires endpoint configuration');
+      const result = await storage.delete('test.txt');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Cloudflare R2 storage requires endpoint configuration');
     });
   });
 

--- a/src/uploads/storage/cloudStorage.ts
+++ b/src/uploads/storage/cloudStorage.ts
@@ -31,26 +31,34 @@ export const createCloudStorage = (options: CloudStorageOptions): StorageAdapter
 
   let s3Client: S3Client | null = null;
 
-  if (provider === 'aws' || provider === 'cloudflare') {
-    if (!credentials?.accessKeyId || !credentials?.secretAccessKey) {
-      throw new Error(UPLOAD_ERRORS.CLOUD_STORAGE_REQUIRES_CREDENTIALS(provider));
+  const getS3Client = (): S3Client => {
+    if (s3Client) return s3Client;
+
+    if (provider === 'aws' || provider === 'cloudflare') {
+      if (!credentials?.accessKeyId || !credentials?.secretAccessKey) {
+        throw new Error(UPLOAD_ERRORS.CLOUD_STORAGE_REQUIRES_CREDENTIALS(provider));
+      }
+
+      const clientConfig = {
+        region: region || 'auto',
+        credentials: {
+          accessKeyId: credentials.accessKeyId,
+          secretAccessKey: credentials.secretAccessKey
+        },
+        endpoint: provider === 'cloudflare' ? endpoint : undefined
+      };
+
+      if (provider === 'cloudflare' && !endpoint) {
+        throw new Error(UPLOAD_ERRORS.CLOUDFLARE_ENDPOINT_REQUIRED);
+      }
+
+      s3Client = new S3Client(clientConfig);
+      return s3Client;
     }
 
-    const clientConfig = {
-      region: region || 'auto',
-      credentials: {
-        accessKeyId: credentials.accessKeyId,
-        secretAccessKey: credentials.secretAccessKey
-      },
-      endpoint: provider === 'cloudflare' ? endpoint : undefined
-    };
+    throw new Error(UPLOAD_ERRORS.CLOUD_STORAGE_NOT_IMPLEMENTED(provider));
+  };
 
-    if (provider === 'cloudflare' && !endpoint) {
-      throw new Error(UPLOAD_ERRORS.CLOUDFLARE_ENDPOINT_REQUIRED);
-    }
-
-    s3Client = new S3Client(clientConfig);
-  }
 
   const getTargetKey = (filename: string, folder?: string, metadataDir?: unknown): string => {
     const targetFolder = folder || (typeof metadataDir === 'string' ? metadataDir : folderPrefix);
@@ -64,13 +72,7 @@ export const createCloudStorage = (options: CloudStorageOptions): StorageAdapter
     metadata: Record<string, unknown> = {}
   ): Promise<StorageResult> => {
     try {
-      if (provider !== 'aws' && provider !== 'cloudflare') {
-        throw new Error(UPLOAD_ERRORS.CLOUD_STORAGE_NOT_IMPLEMENTED(provider));
-      }
-
-      if (!s3Client) {
-        throw new Error(UPLOAD_ERRORS.S3_CLIENT_NOT_INITIALIZED);
-      }
+      const client = getS3Client();
 
       const key = getTargetKey(filename, undefined, metadata.directory);
 
@@ -78,19 +80,19 @@ export const createCloudStorage = (options: CloudStorageOptions): StorageAdapter
         ? metadata.originalName
         : filename;
 
-      await s3Client.send(new PutObjectCommand({
-        Bucket: bucket,
-        Key: key,
-        Body: buffer,
-        ContentType: mimeType,
-        Metadata: {
-          originalName,
-          uploadedAt: new Date().toISOString(),
-          ...Object.fromEntries(
-            Object.entries(metadata).map(([k, v]) => [k, String(v)])
-          )
-        }
-      }));
+      await client.send(
+        new PutObjectCommand({
+          Bucket: bucket,
+          Key: key,
+          Body: buffer,
+          ContentType: mimeType,
+          Metadata: {
+            originalName,
+            uploadedAt: new Date().toISOString(),
+            ...Object.fromEntries(Object.entries(metadata).map(([k, v]) => [k, String(v)]))
+          }
+        })
+      );
 
       return {
         success: true,
@@ -133,10 +135,10 @@ export const createCloudStorage = (options: CloudStorageOptions): StorageAdapter
   const retrieve = async (filename: string, folder?: string): Promise<Buffer | null> => {
     try {
       if (provider !== 'aws' && provider !== 'cloudflare') return null;
-      if (!s3Client) throw new Error(UPLOAD_ERRORS.S3_CLIENT_NOT_INITIALIZED);
+      const client = getS3Client();
 
       const key = getTargetKey(filename, folder);
-      const response = await s3Client.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
+      const response = await client.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
 
       if (!response.Body) return null;
       const chunks: Uint8Array[] = [];
@@ -154,9 +156,9 @@ export const createCloudStorage = (options: CloudStorageOptions): StorageAdapter
       if (provider !== 'aws' && provider !== 'cloudflare') {
         throw new Error(UPLOAD_ERRORS.CLOUD_STORAGE_NOT_IMPLEMENTED(provider));
       }
-      if (!s3Client) throw new Error(UPLOAD_ERRORS.S3_CLIENT_NOT_INITIALIZED);
+      const client = getS3Client();
 
-      await s3Client.send(new DeleteObjectCommand({ Bucket: bucket, Key: getTargetKey(filename, folder) }));
+      await client.send(new DeleteObjectCommand({ Bucket: bucket, Key: getTargetKey(filename, folder) }));
       return { success: true };
     } catch (error) {
       return { success: false, error: error instanceof Error ? error.message : UPLOAD_ERRORS.UNKNOWN_ERROR_OCCURRED };
@@ -166,9 +168,9 @@ export const createCloudStorage = (options: CloudStorageOptions): StorageAdapter
   const exists = async (filename: string, folder?: string): Promise<boolean> => {
     try {
       if (provider !== 'aws' && provider !== 'cloudflare') return false;
-      if (!s3Client) throw new Error(UPLOAD_ERRORS.S3_CLIENT_NOT_INITIALIZED);
+      const client = getS3Client();
 
-      await s3Client.send(new HeadObjectCommand({ Bucket: bucket, Key: getTargetKey(filename, folder) }));
+      await client.send(new HeadObjectCommand({ Bucket: bucket, Key: getTargetKey(filename, folder) }));
       return true;
     } catch {
       return false;
@@ -178,10 +180,10 @@ export const createCloudStorage = (options: CloudStorageOptions): StorageAdapter
   const getMetadata = async (filename: string, folder?: string): Promise<StorageMetadata | null> => {
     try {
       if (provider !== 'aws' && provider !== 'cloudflare') return null;
-      if (!s3Client) throw new Error(UPLOAD_ERRORS.S3_CLIENT_NOT_INITIALIZED);
+      const client = getS3Client();
 
       const key = getTargetKey(filename, folder);
-      const response = await s3Client.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
+      const response = await client.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
 
       const mimeType = response.ContentType || 'application/octet-stream';
       const originalName = response.Metadata?.originalName || filename;
@@ -206,14 +208,14 @@ export const createCloudStorage = (options: CloudStorageOptions): StorageAdapter
 
   const list = async (folder?: string): Promise<StorageMetadata[]> => {
     try {
-      if (!s3Client) return [];
+      const client = getS3Client();
 
       let prefix = '';
       if (folder) {
         prefix = folder.endsWith('/') ? folder : `${folder}/`;
       }
 
-      const response = await s3Client.send(new ListObjectsV2Command({ Bucket: bucket, Prefix: prefix }));
+      const response = await client.send(new ListObjectsV2Command({ Bucket: bucket, Prefix: prefix }));
 
       return (response.Contents || []).map((item) => {
         const itemKey = item.Key || '';


### PR DESCRIPTION
## Description

This PR implements the backend logic for securely deleting assets from the system. It introduces the deleteAsset GraphQL mutation, which includes a safety validation step to ensure files currently in use (having entries in usageRefs) cannot be deleted, preventing broken links on the frontend. Additionally, it accurately parses the asset's URL to locate and delete the physical file from the appropriate Cloudflare R2 bucket directory before removing its metadata from MongoDB. Unit tests are also included.
## Type of change

- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

Part 1: Setup and Authorization

1. Open the admin panel locally so the client authenticates.
2. Open DevTools (F12), go to the Network tab, and find any graphql request.
3. In the Request Headers, find the Cookie string and copy the accessToken (in the format accessToken=eyJhbG...).
4. Open your local database (e.g., via MongoDB Compass), open the assets collection, and copy the _id of a file you want to delete.

Part 2: Testing Successful Deletion in Postman

5. Open Postman and create a new POST request with the URL: http://localhost:3000/api/graphql
6. Go to the Headers tab and add two keys:

- Key: Cookie, Value: accessToken=YOUR_COPIED_TOKEN
- Key: apollo-require-preflight, Value: true

7. Go to the Body tab, select GraphQL, and paste the following mutation into the Query field:

`GraphQL`
```
mutation DeleteAsset($id: ID!) {
  deleteAsset(id: $id)
}
```
8. In the GraphQL Variables section, paste the copied asset ID:

`JSON`
```
{
  "id": "YOUR_ASSET_ID"
}
```
9. Click Send and check the database/Cloudflare R2 to ensure the file was removed.

Part 3: Testing Usage Validation (Negative Case)

10. In MongoDB Compass, find another existing asset and manually add an item to its usageRefs array (e.g., [{ "pageId": "test-id" }]). Save the document and copy its _id.
11. Go back to Postman, replace the id in the GraphQL Variables with this new ID, and click Send.
12. Verify that the response contains an error blocking the deletion.

## Expected result: 
1. Successful Deletion: Calling the mutation on an unused file returns { "data": { "deleteAsset": true } }. The file is permanently removed from both Cloudflare R2 storage and the MongoDB collection.
2. Validation Block: Calling the mutation on a file that is in use (has usageRefs) returns a GraphQL error with the message "Видалення неможливе: файл використовується на сайті." The file remains completely intact in both the database and cloud storage.

Closes: https://github.com/Liatoshynsky-Foundation/lf-admin/issues/516