### PR TITLE
feat(assets): implement delete file modal and integrate graphql mutation

### DIFF
--- a/app/shared/components/delete-file-modal/DeleteFileModal.styles.ts
+++ b/app/shared/components/delete-file-modal/DeleteFileModal.styles.ts
@@ -1,0 +1,69 @@
+import { mainHexPallete } from '~/shared/theme/colors';
+
+export const styles = {
+  dialogPaper: {
+    width: '572px',
+    maxWidth: '100%',
+    borderRadius: '24px',
+    padding: '28px 24px 28px 32px'
+  },
+  closeIcon: {
+    position: 'absolute',
+    top: 24,
+    right: 24,
+    cursor: 'pointer',
+    color: mainHexPallete.black
+  },
+  title: {
+    padding: 0,
+    paddingBottom: '16px',
+    fontSize: '24px',
+    fontWeight: 700,
+    color: mainHexPallete.black
+  },
+  content: {
+    padding: 0
+  },
+  description: {
+    color: mainHexPallete.blue[800],
+    fontSize: '16px',
+    lineHeight: '150%'
+  },
+  filename: {
+    fontWeight: 700,
+    color: mainHexPallete.blue[800]
+  },
+  usageList: {
+    marginTop: '12px',
+    marginBottom: 0,
+    paddingLeft: '24px',
+    color: mainHexPallete.blue[800]
+  },
+  usageItem: {
+    fontSize: '16px',
+    lineHeight: '150%',
+    textDecoration: 'underline',
+    textUnderlineOffset: '2px'
+  },
+  actions: {
+    padding: 0,
+    paddingTop: '40px',
+    display: 'flex',
+    justifyContent: 'flex-start',
+    gap: '16px'
+  },
+  deleteBtn: {
+    backgroundColor: mainHexPallete.red[600],
+    color: mainHexPallete.white,
+    '&:hover': {
+      backgroundColor: mainHexPallete.red[700]
+    }
+  },
+  okBtn: {
+    backgroundColor: mainHexPallete.yellow[500],
+    color: mainHexPallete.black,
+    '&:hover': {
+      backgroundColor: mainHexPallete.yellow[600]
+    }
+  }
+};

--- a/app/shared/components/delete-file-modal/DeleteFileModal.test.tsx
+++ b/app/shared/components/delete-file-modal/DeleteFileModal.test.tsx
@@ -1,0 +1,90 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import DeleteFileModal from './DeleteFileModal';
+
+describe('DeleteFileModal', () => {
+  const mockFileUnused = {
+    id: '1',
+    filename: 'Liatoshynsky_photo.jpg',
+    usageRefs: []
+  };
+
+  const mockFileUsed = {
+    id: '2',
+    filename: 'Important_document.pdf',
+    usageRefs: [
+      { pageId: 'about-us', blockId: 'hero' },
+      { pageId: 'events', blockId: 'block-1' }
+    ]
+  };
+
+  const defaultProps = {
+    open: true,
+    onClose: jest.fn(),
+    onConfirm: jest.fn(),
+    file: mockFileUnused
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should not render when file is null', () => {
+    render(<DeleteFileModal {...defaultProps} file={null} />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  describe('when file is NOT in use (Confirmation State)', () => {
+    it('should render confirmation content', () => {
+      render(<DeleteFileModal {...defaultProps} file={mockFileUnused} />);
+
+      expect(screen.getByText('Підтвердити видалення')).toBeInTheDocument();
+      expect(screen.getByText(/Ви збираєтесь видалити файл/i)).toBeInTheDocument();
+      expect(screen.getByText('Liatoshynsky_photo.jpg')).toBeInTheDocument();
+
+      expect(screen.getByText('Видалити')).toBeInTheDocument();
+      expect(screen.getByText('Скасувати')).toBeInTheDocument();
+    });
+
+    it('should call onConfirm with file id when delete button is clicked', () => {
+      render(<DeleteFileModal {...defaultProps} file={mockFileUnused} />);
+      fireEvent.click(screen.getByText('Видалити'));
+      expect(defaultProps.onConfirm).toHaveBeenCalledWith('1');
+    });
+
+    it('should call onClose when cancel button is clicked', () => {
+      render(<DeleteFileModal {...defaultProps} file={mockFileUnused} />);
+      fireEvent.click(screen.getByText('Скасувати'));
+      expect(defaultProps.onClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('when file IS in use (Blocked State)', () => {
+    it('should render blocking content and list', () => {
+      render(<DeleteFileModal {...defaultProps} file={mockFileUsed} />);
+
+      expect(screen.getByText('Видалення неможливе')).toBeInTheDocument();
+      expect(screen.getByText(/використовується на сайті і привʼязаний у 2 місцях/i)).toBeInTheDocument();
+      expect(screen.getByText('Important_document.pdf')).toBeInTheDocument();
+
+      expect(screen.getByText('about-us/hero')).toBeInTheDocument();
+      expect(screen.getByText('events/block-1')).toBeInTheDocument();
+
+      expect(screen.getByText('Гаразд')).toBeInTheDocument();
+      expect(screen.queryByText('Видалити')).not.toBeInTheDocument();
+    });
+
+    it('should call onClose when OK button is clicked', () => {
+      render(<DeleteFileModal {...defaultProps} file={mockFileUsed} />);
+      fireEvent.click(screen.getByText('Гаразд'));
+      expect(defaultProps.onClose).toHaveBeenCalled();
+    });
+  });
+
+  it('should call onClose when close icon is clicked', () => {
+    render(<DeleteFileModal {...defaultProps} />);
+    const closeIcon = document.querySelector('svg');
+    fireEvent.click(closeIcon!);
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+});

--- a/app/shared/components/delete-file-modal/DeleteFileModal.tsx
+++ b/app/shared/components/delete-file-modal/DeleteFileModal.tsx
@@ -60,13 +60,16 @@ const DeleteFileModal = ({ open, onClose, onConfirm, file, isDeleting, disableSc
             </Typography>
 
             <Box component="ul" sx={styles.usageList}>
-              {blockedRefs.map((ref, index) => (
-                <li key={index}>
-                  <Typography component="span" sx={styles.usageItem}>
-                    {formatUsageRef(ref)}
-                  </Typography>
-                </li>
-              ))}
+              {blockedRefs.map((ref, index) => {
+                const uniqueKey = `${ref.pageId || 'no-page'}-${ref.blockId || 'no-block'}-${index}`;
+                return (
+                  <li key={uniqueKey}>
+                    <Typography component="span" sx={styles.usageItem}>
+                      {formatUsageRef(ref)}
+                    </Typography>
+                  </li>
+                );
+              })}
             </Box>
           </Box>
         ) : (

--- a/app/shared/components/delete-file-modal/DeleteFileModal.tsx
+++ b/app/shared/components/delete-file-modal/DeleteFileModal.tsx
@@ -1,0 +1,111 @@
+import { Box, Dialog, DialogActions, DialogContent, DialogTitle, Typography } from '@mui/material';
+import { X } from 'lucide-react';
+
+import { styles } from './DeleteFileModal.styles';
+import Button from '~/components/design-system/button/Button';
+
+export interface UsageRef {
+  pageId?: string;
+  blockId?: string;
+}
+
+export interface FileAsset {
+  id: string;
+  filename: string;
+  usageRefs?: UsageRef[];
+}
+
+interface DeleteFileModalProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: (id: string) => void;
+  file: FileAsset | null;
+  isDeleting?: boolean;
+  disableScrollLock?: boolean;
+}
+
+const formatUsageRef = (ref: UsageRef) => {
+  const parts = [];
+  if (ref.pageId) parts.push(ref.pageId);
+  if (ref.blockId) parts.push(ref.blockId);
+  return parts.length > 0 ? parts.join('/') : 'Невідомий блок';
+};
+
+const DeleteFileModal = ({ open, onClose, onConfirm, file, isDeleting, disableScrollLock }: DeleteFileModalProps) => {
+  if (!file) return null;
+
+  const blockedRefs = file.usageRefs || [];
+  const isBlocked = blockedRefs.length > 0;
+
+  const placesWord = blockedRefs.length === 1 ? 'місці' : 'місцях';
+
+  return (
+    <Dialog open={open} onClose={onClose} disableScrollLock={disableScrollLock} PaperProps={{ sx: styles.dialogPaper }}>
+      <Box sx={styles.closeIcon} onClick={onClose}>
+        <X />
+      </Box>
+
+      <DialogTitle sx={styles.title}>{isBlocked ? 'Видалення неможливе' : 'Підтвердити видалення'}</DialogTitle>
+
+      <DialogContent sx={styles.content}>
+        {isBlocked ? (
+          <Box>
+            <Typography sx={styles.description}>
+              Файл{' '}
+              <Box component="span" sx={styles.filename}>
+                {file.filename}
+              </Box>{' '}
+              використовується на сайті і привʼязаний у {blockedRefs.length} {placesWord}. Щоб видалити файл відвʼяжіть
+              його, замінивши зображення на інше на відповідних сторінках:
+            </Typography>
+
+            <Box component="ul" sx={styles.usageList}>
+              {blockedRefs.map((ref, index) => (
+                <li key={index}>
+                  <Typography component="span" sx={styles.usageItem}>
+                    {formatUsageRef(ref)}
+                  </Typography>
+                </li>
+              ))}
+            </Box>
+          </Box>
+        ) : (
+          <Typography sx={styles.description}>
+            Ви збираєтесь видалити файл{' '}
+            <Box component="span" sx={styles.filename}>
+              {file.filename}
+            </Box>
+            .
+            <br />
+            Ви впевнені, що хочете продовжити?
+          </Typography>
+        )}
+      </DialogContent>
+
+      <DialogActions sx={styles.actions}>
+        {isBlocked ? (
+          <Button variant="filled" size="medium" sx={styles.okBtn} onClick={onClose}>
+            Гаразд
+          </Button>
+        ) : (
+          <>
+            <Button
+              variant="filled"
+              size="medium"
+              sx={styles.deleteBtn}
+              onClick={() => onConfirm(file.id)}
+              disabled={isDeleting}
+            >
+              Видалити
+            </Button>
+            <Button variant="outlined" size="medium" color="primary" onClick={onClose} disabled={isDeleting}>
+              Скасувати
+            </Button>
+          </>
+        )}
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default DeleteFileModal;

--- a/app/shared/components/file-info-sidebar/FileInfoSidebar.test.tsx
+++ b/app/shared/components/file-info-sidebar/FileInfoSidebar.test.tsx
@@ -5,7 +5,8 @@ import { type FileDetailsSidebarFile, FileInfoSidebar } from './FileInfoSidebar'
 
 jest.mock('~/types/graphql/generated/graphql', () => ({
   ...jest.requireActual('~/types/graphql/generated/graphql'),
-  useUpdateAssetMutation: () => [jest.fn(), { loading: false }]
+  useUpdateAssetMutation: () => [jest.fn(), { loading: false }],
+  useDeleteAssetMutation: () => [jest.fn(), { loading: false }]
 }));
 
 jest.mock('../design-system/tooltip/Tooltip', () => ({
@@ -141,7 +142,7 @@ describe('FileInfoSidebar', () => {
     expect(screen.getByLabelText('Завантажити')).toBeDisabled();
   });
 
-  it('should request rename/delete/download with correct payload', () => {
+  it('should request rename and download, and open delete modal', () => {
     const onRequestAction = jest.fn();
 
     render(<FileInfoSidebar file={baseFile} onClose={jest.fn()} onRequestAction={onRequestAction} />);
@@ -149,13 +150,13 @@ describe('FileInfoSidebar', () => {
     fireEvent.click(screen.getByLabelText('Перейменувати'));
     expect(onRequestAction).toHaveBeenCalledWith({ type: 'rename', fileId: 'f1' });
 
-    fireEvent.click(screen.getByLabelText('Видалити'));
-    expect(onRequestAction).toHaveBeenCalledWith({ type: 'delete', fileId: 'f1' });
-
     fireEvent.click(screen.getByLabelText('Завантажити'));
     expect(onRequestAction).toHaveBeenCalledWith({ type: 'download', fileId: 'f1' });
 
-    expect(onRequestAction).toHaveBeenCalledTimes(3);
+    fireEvent.click(screen.getByLabelText('Видалити'));
+    expect(screen.getByText('Видалення неможливе')).toBeInTheDocument();
+
+    expect(onRequestAction).toHaveBeenCalledTimes(2);
   });
 
   it('should render preview image when previewUrl exists', () => {

--- a/app/shared/components/file-info-sidebar/FileInfoSidebar.tsx
+++ b/app/shared/components/file-info-sidebar/FileInfoSidebar.tsx
@@ -1,7 +1,9 @@
+import { ApolloCache } from '@apollo/client';
 import { Avatar, Box, CircularProgress, IconButton, Link, Typography } from '@mui/material';
 import React, { useCallback, useState } from 'react';
 import toast from 'react-hot-toast';
 
+import DeleteFileModal from '../delete-file-modal/DeleteFileModal';
 import TooltipCustom from '../design-system/tooltip/Tooltip';
 import { styles } from './FileInfoSidebar.styles';
 import { ImagePreviewModal } from './image-preview-modal/ImagePreviewModal';
@@ -21,7 +23,7 @@ import XlsIcon from '~/public/icons/xls.svg';
 import ArchiveIcon from '~/public/icons/zip.svg';
 import ZoomIn from '~/public/icons/zoom-in.svg';
 import { CustomTextField } from '~/shared/components/design-system/text-field/TextField';
-import { useUpdateAssetMutation } from '~/types/graphql/generated/graphql';
+import { useDeleteAssetMutation,useUpdateAssetMutation } from '~/types/graphql/generated/graphql';
 
 export type FileUsageLink = {
   id: string;
@@ -98,6 +100,8 @@ export function FileInfoSidebar({ file, onClose, onDescriptionSave, onRequestAct
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
   const [isDownloading, setIsDownloading] = useState(false);
 
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+
   const requestAction = useCallback(
     (type: FileSidebarAction['type']) => {
       if (!fileId) return;
@@ -152,6 +156,7 @@ export function FileInfoSidebar({ file, onClose, onDescriptionSave, onRequestAct
   });
 
   const [updateAsset, { loading: isUpdatingStar }] = useUpdateAssetMutation();
+  const [deleteAsset, { loading: isDeleting }] = useDeleteAssetMutation();
 
   const handleStarToggle = async () => {
     if (!file?.id) return;
@@ -165,6 +170,34 @@ export function FileInfoSidebar({ file, onClose, onDescriptionSave, onRequestAct
       });
     } catch {}
   };
+
+  const handleDeleteConfirm = async (id: string) => {
+    try {
+      await deleteAsset({
+        variables: { id },
+        update: (cache: ApolloCache<any>) => {
+          cache.evict({ id: cache.identify({ __typename: 'Asset', id }) });
+          cache.gc();
+        }
+      });
+
+      toast.success('Файл успішно видалено');
+      setIsDeleteModalOpen(false);
+      onClose();
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : 'Не вдалося видалити файл. Спробуйте пізніше.';
+
+      toast.error(errorMessage);
+    }
+  };
+
+  const fileForDeleteModal = file
+    ? {
+      id: file.id,
+      filename: file.filename,
+      usageRefs: file.usageLinks?.map((link) => ({ pageId: link.label, blockId: '' })) || []
+    }
+    : null;
 
   return (
     <Box sx={styles.root}>
@@ -208,7 +241,7 @@ export function FileInfoSidebar({ file, onClose, onDescriptionSave, onRequestAct
         <TooltipCustom title="Видалити" showArrow>
           <IconButton
             sx={styles.actionBtn}
-            onClick={() => requestAction('delete')}
+            onClick={() => setIsDeleteModalOpen(true)}
             aria-label="Видалити"
             disabled={!canEdit}
           >
@@ -244,6 +277,15 @@ export function FileInfoSidebar({ file, onClose, onDescriptionSave, onRequestAct
           </span>
         </TooltipCustom>
       </Box>
+
+      <DeleteFileModal
+        disableScrollLock
+        open={isDeleteModalOpen}
+        onClose={() => setIsDeleteModalOpen(false)}
+        onConfirm={handleDeleteConfirm}
+        file={fileForDeleteModal}
+        isDeleting={isDeleting}
+      />
 
       <Box
         sx={{

--- a/app/types/graphql/mutations/assets.graphql
+++ b/app/types/graphql/mutations/assets.graphql
@@ -17,3 +17,7 @@ mutation CreateAsset($input: CreateAssetInput!) {
     type
   }
 }
+
+mutation DeleteAsset($id: ID!) {
+  deleteAsset(id: $id)
+}


### PR DESCRIPTION
## Description

Implemented the frontend logic and UI for the file deletion flow.

## Type of change

- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Open FileInfoSidebar for an unused file and click "Delete". Verify the confirmation modal appears and the file is removed from the list upon confirmation.

2. Open a file that is in use (usageRefs > 0) and click "Delete". Verify the blocking modal displays the list of pages where the file is currently used.

## Video / Screenshots

https://github.com/user-attachments/assets/621b70ea-b06d-45ca-af2b-e617ca8ff857



Closes: https://github.com/Liatoshynsky-Foundation/lf-admin/issues/521
