### PR TITLE
feat: implement 3-dot dropdown menu for file assets

### DIFF
--- a/app/(logged_in)/files/FilesPageContent.tsx
+++ b/app/(logged_in)/files/FilesPageContent.tsx
@@ -3,6 +3,7 @@
 import { Box, Button } from '@mui/material';
 import { Upload } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
+import toast from 'react-hot-toast';
 
 import {
   FILE_TABS,
@@ -28,6 +29,7 @@ import {
   type FilesTabValue
 } from '~/constants/files';
 import FavouriteStarIcon from '~/public/icons/favourite-star.svg';
+import DeleteFileModal from '~/shared/components/delete-file-modal/DeleteFileModal';
 import { colors } from '~/shared/components/design-system/button/Button.styles';
 import { EmptyState } from '~/shared/components/empty-state';
 import {
@@ -55,7 +57,8 @@ import { RenameFileModal } from '~/shared/components/rename-file-modal/RenameFil
 import { ViewToggle } from '~/shared/components/view-toggle';
 import { useAllAssets } from '~/shared/hooks/use-assets/useAssets';
 import { useFilesFiltering } from '~/shared/hooks/use-files';
-import { AssetType, useCreateAssetMutation } from '~/types/graphql/generated/graphql';
+import { AssetType, useCreateAssetMutation , useDeleteAssetMutation } from '~/types/graphql/generated/graphql';
+
 
 type FilesPageFileItem = FilesCardsLayoutItem & {
   description?: string;
@@ -166,6 +169,10 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
   const [selectedFileId, setSelectedFileId] = useState<string | null>(null);
   const [hasInitializedSelection, setHasInitializedSelection] = useState(false);
   const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
+  const [deleteModalState, setDeleteModalState] = useState<{ open: boolean; fileId: string | null }>({
+    open: false,
+    fileId: null
+  });
   const [uploadModalInitial, setUploadModalInitial] = useState<MediaModalOpenState | undefined>(undefined);
   const [renameModalState, setRenameModalState] = useState<{ open: boolean; fileId: string; currentFilename: string }>({
     open: false,
@@ -174,6 +181,7 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
   });
   const { data, loading, error, refetch } = useAllAssets();
   const [createAsset] = useCreateAssetMutation();
+  const [deleteAsset, { loading: isDeleting }] = useDeleteAssetMutation();
 
   const handleOpenUploadFlow = () => {
     setUploadModalInitial({ tab: 'UPLOAD' });
@@ -245,6 +253,71 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
       description: asset.description ?? undefined
     }));
   }, [data?.allAssets]);
+
+  const handleDownload = async (fileUrl: string, filename: string) => {
+    try {
+      const response = await fetch(fileUrl, { cache: 'no-store' });
+      if (!response.ok) throw new Error('Помилка завантаження');
+
+      const blob = await response.blob();
+      const blobUrl = globalThis.URL.createObjectURL(blob);
+
+      const link = document.createElement('a');
+      link.href = blobUrl;
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+
+      link.remove();
+      globalThis.URL.revokeObjectURL(blobUrl);
+      toast.success('Файл завантажено');
+    } catch {
+      toast.error('Не вдалося завантажити файл');
+    }
+  };
+
+  const handleItemAction = (action: 'rename' | 'delete' | 'download', item: FilesCardsLayoutItem) => {
+    if (action === 'rename') {
+      setRenameModalState({ open: true, fileId: item.id, currentFilename: item.name });
+    } else if (action === 'delete') {
+      setDeleteModalState({ open: true, fileId: item.id });
+    } else if (action === 'download') {
+      const file = allFiles.find((f) => f.id === item.id);
+      if (file?.downloadUrl) {
+        handleDownload(file.downloadUrl, file.name);
+      } else {
+        toast.error('Посилання на завантаження відсутнє');
+      }
+    }
+  };
+
+  const handleDeleteConfirm = async (id: string) => {
+    try {
+      await deleteAsset({
+        variables: { id },
+        update: (cache) => {
+          cache.evict({ id: cache.identify({ __typename: 'Asset', id }) });
+          cache.gc();
+        }
+      });
+      toast.success('Файл успішно видалено');
+      setDeleteModalState({ open: false, fileId: null });
+      if (selectedFileId === id) setSelectedFileId(null);
+    } catch (error: any) {
+      toast.error(error.message || 'Не вдалося видалити файл. Спробуйте пізніше.');
+    }
+  };
+
+  const fileForDeleteModal = useMemo(() => {
+    if (!deleteModalState.fileId) return null;
+    const file = allFiles.find((f) => f.id === deleteModalState.fileId);
+    if (!file) return null;
+    return {
+      id: file.id,
+      filename: file.name,
+      usageRefs: file.usage.map((u) => ({ pageId: u.label, blockId: '' }))
+    };
+  }, [deleteModalState.fileId, allFiles]);
 
   const { filteredFiles, toolbarProps, sortProps } = useFilesFiltering(allFiles, activeTab);
 
@@ -349,7 +422,12 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
       {!loading && error && <EmptyState title={FILES_ERROR_STATE_TITLE} description={FILES_ERROR_STATE_DESCRIPTION} />}
 
       {!loading && !error && filteredFiles.length > 0 && (
-        <FilesCardsLayout view={view} items={filteredFiles} onItemClick={(item) => setSelectedFileId(item.id)} />
+        <FilesCardsLayout
+          view={view}
+          items={filteredFiles}
+          onItemClick={(item) => setSelectedFileId(item.id)}
+          onItemAction={handleItemAction}
+        />
       )}
 
       {hasNoFiles && isFavoritesTab && !hasActiveCriteria && (
@@ -397,6 +475,14 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
         fileId={renameModalState.fileId}
         currentFilename={renameModalState.currentFilename}
         onClose={() => setRenameModalState((prev) => ({ ...prev, open: false }))}
+      />
+      <DeleteFileModal
+        disableScrollLock
+        open={deleteModalState.open}
+        onClose={() => setDeleteModalState({ open: false, fileId: null })}
+        onConfirm={handleDeleteConfirm}
+        file={fileForDeleteModal}
+        isDeleting={isDeleting}
       />
     </Box>
   );

--- a/app/(logged_in)/files/FilesPageContent.tsx
+++ b/app/(logged_in)/files/FilesPageContent.tsx
@@ -28,6 +28,7 @@ import {
   FILES_UPLOAD_FAILED_ERROR,
   type FilesTabValue
 } from '~/constants/files';
+import { downloadFile } from '~/lib/utils/downloadFile';
 import FavouriteStarIcon from '~/public/icons/favourite-star.svg';
 import DeleteFileModal from '~/shared/components/delete-file-modal/DeleteFileModal';
 import { colors } from '~/shared/components/design-system/button/Button.styles';
@@ -57,8 +58,7 @@ import { RenameFileModal } from '~/shared/components/rename-file-modal/RenameFil
 import { ViewToggle } from '~/shared/components/view-toggle';
 import { useAllAssets } from '~/shared/hooks/use-assets/useAssets';
 import { useFilesFiltering } from '~/shared/hooks/use-files';
-import { AssetType, useCreateAssetMutation , useDeleteAssetMutation } from '~/types/graphql/generated/graphql';
-
+import { AssetType, useCreateAssetMutation, useDeleteAssetMutation } from '~/types/graphql/generated/graphql';
 
 type FilesPageFileItem = FilesCardsLayoutItem & {
   description?: string;
@@ -255,25 +255,7 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
   }, [data?.allAssets]);
 
   const handleDownload = async (fileUrl: string, filename: string) => {
-    try {
-      const response = await fetch(fileUrl, { cache: 'no-store' });
-      if (!response.ok) throw new Error('Помилка завантаження');
-
-      const blob = await response.blob();
-      const blobUrl = globalThis.URL.createObjectURL(blob);
-
-      const link = document.createElement('a');
-      link.href = blobUrl;
-      link.download = filename;
-      document.body.appendChild(link);
-      link.click();
-
-      link.remove();
-      globalThis.URL.revokeObjectURL(blobUrl);
-      toast.success('Файл завантажено');
-    } catch {
-      toast.error('Не вдалося завантажити файл');
-    }
+    await downloadFile(fileUrl, filename);
   };
 
   const handleItemAction = (action: 'rename' | 'delete' | 'download', item: FilesCardsLayoutItem) => {

--- a/app/(logged_in)/files/page.test.tsx
+++ b/app/(logged_in)/files/page.test.tsx
@@ -28,7 +28,8 @@ jest.mock('~/types/graphql/generated/graphql', () => ({
     Spreadsheet: 'Spreadsheet'
   },
   useUpdateAssetMutation: () => [jest.fn(), { loading: false }],
-  useCreateAssetMutation: () => [jest.fn(), { loading: false }]
+  useCreateAssetMutation: () => [jest.fn(), { loading: false }],
+  useDeleteAssetMutation: jest.fn().mockReturnValue([jest.fn(), { loading: false }])
 }));
 
 jest.mock('~/shared/components/file-info-sidebar/FileInfoSidebar', () => ({

--- a/app/lib/utils/downloadFile.ts
+++ b/app/lib/utils/downloadFile.ts
@@ -1,0 +1,23 @@
+import toast from 'react-hot-toast';
+
+export const downloadFile = async (fileUrl: string, filename: string): Promise<void> => {
+  try {
+    const response = await fetch(fileUrl, { cache: 'no-store' });
+    if (!response.ok) throw new Error('Помилка завантаження');
+
+    const blob = await response.blob();
+    const blobUrl = globalThis.URL.createObjectURL(blob);
+
+    const link = document.createElement('a');
+    link.href = blobUrl;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+
+    link.remove();
+    globalThis.URL.revokeObjectURL(blobUrl);
+    toast.success('Файл завантажено');
+  } catch {
+    toast.error('Не вдалося завантажити файл');
+  }
+};

--- a/app/shared/components/dropdown-menu/FileMenuActions.styles.ts
+++ b/app/shared/components/dropdown-menu/FileMenuActions.styles.ts
@@ -1,0 +1,30 @@
+import { mainHexPallete } from '~/shared/theme/colors';
+
+export const styles = {
+  menuItem: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '16px',
+    padding: '8px 12px',
+    borderRadius: '8px',
+    width: '242px',
+    boxSizing: 'border-box',
+    '&:hover': {
+      backgroundColor: 'rgba(25, 13, 3, 0.06)'
+    }
+  },
+  menuText: {
+    fontSize: '16px',
+    fontWeight: 500,
+    lineHeight: '150%',
+    color: mainHexPallete.black
+  },
+  icon: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '24px',
+    height: '24px',
+    color: mainHexPallete.black
+  }
+};

--- a/app/shared/components/dropdown-menu/FileMenuActions.test.tsx
+++ b/app/shared/components/dropdown-menu/FileMenuActions.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { FileMenuActions } from './FileMenuActions';
+
+jest.mock('lucide-react', () => ({ Info: () => <svg data-testid="InfoIcon" /> }));
+jest.mock('~/public/icons/pen-line.svg', () => ({ __esModule: true, default: () => <svg data-testid="EditIcon" /> }));
+jest.mock('~/public/icons/small-star.svg', () => ({
+  __esModule: true,
+  default: () => <svg data-testid="StarIcon" />
+}));
+jest.mock('~/public/icons/download.svg', () => ({
+  __esModule: true,
+  default: () => <svg data-testid="DownloadIcon" />
+}));
+jest.mock('~/public/icons/empty-trash.svg', () => ({
+  __esModule: true,
+  default: () => <svg data-testid="DeleteIcon" />
+}));
+
+describe('FileMenuActions', () => {
+  const defaultProps = {
+    isStarred: false,
+    onCloseMenu: jest.fn(),
+    onOpenDetails: jest.fn(),
+    onRename: jest.fn(),
+    onToggleStar: jest.fn(),
+    onDownload: jest.fn(),
+    onDelete: jest.fn()
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders all menu items with correct text', () => {
+    render(<FileMenuActions {...defaultProps} />);
+
+    expect(screen.getByText('Відкрити деталі')).toBeInTheDocument();
+    expect(screen.getByText('Перейменувати')).toBeInTheDocument();
+    expect(screen.getByText('Додати в обрані')).toBeInTheDocument();
+    expect(screen.getByText('Завантажити')).toBeInTheDocument();
+    expect(screen.getByText('Видалити')).toBeInTheDocument();
+  });
+
+  it('renders "Забрати з обраних" when file is starred', () => {
+    render(<FileMenuActions {...defaultProps} isStarred={true} />);
+    expect(screen.getByText('Забрати з обраних')).toBeInTheDocument();
+  });
+
+  it('calls correct action and onCloseMenu when an item is clicked', () => {
+    render(<FileMenuActions {...defaultProps} />);
+
+    fireEvent.click(screen.getByText('Відкрити деталі'));
+    expect(defaultProps.onOpenDetails).toHaveBeenCalledTimes(1);
+    expect(defaultProps.onCloseMenu).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByText('Перейменувати'));
+    expect(defaultProps.onRename).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByText('Видалити'));
+    expect(defaultProps.onDelete).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByText('Додати в обрані'));
+    expect(defaultProps.onToggleStar).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/shared/components/dropdown-menu/FileMenuActions.tsx
+++ b/app/shared/components/dropdown-menu/FileMenuActions.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { Box, CircularProgress, MenuItem, Typography } from '@mui/material';
+import { Info } from 'lucide-react';
+import Image from 'next/image';
+import React from 'react';
+
+import { styles } from './FileMenuActions.styles';
+
+export interface FileMenuActionsProps {
+  isStarred?: boolean;
+  onCloseMenu: () => void;
+  isStarLoading?: boolean;
+  onOpenDetails: () => void;
+  onRename: () => void;
+  onToggleStar: () => void;
+  onDownload: () => void;
+  onDelete: () => void;
+}
+
+export const FileMenuActions: React.FC<FileMenuActionsProps> = ({
+  isStarred = false,
+  isStarLoading = false,
+  onCloseMenu,
+  onOpenDetails,
+  onRename,
+  onToggleStar,
+  onDownload,
+  onDelete
+}) => {
+  const handleAction = (action: () => void, e: React.MouseEvent) => {
+    e.stopPropagation();
+    action();
+    onCloseMenu();
+  };
+
+  const handleStarAction = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (isStarLoading) return;
+    onToggleStar();
+  };
+
+  return (
+    <>
+      <MenuItem onClick={(e) => handleAction(onOpenDetails, e)} sx={styles.menuItem}>
+        <Box sx={styles.icon}>
+          <Info size={24} strokeWidth={1.5} />
+        </Box>
+        <Typography sx={styles.menuText}>Відкрити деталі</Typography>
+      </MenuItem>
+
+      <MenuItem onClick={(e) => handleAction(onRename, e)} sx={styles.menuItem}>
+        <Box sx={styles.icon}>
+          <Image src="/icons/pen-line.svg" width={18} height={17} alt="Rename" />{' '}
+        </Box>
+        <Typography sx={styles.menuText}>Перейменувати</Typography>
+      </MenuItem>
+
+      <MenuItem
+        onClick={handleStarAction}
+        sx={{
+          ...styles.menuItem,
+          opacity: isStarLoading ? 0.6 : 1,
+          cursor: isStarLoading ? 'wait' : 'pointer'
+        }}
+      >
+        <Box sx={styles.icon}>
+          {isStarLoading ? (
+            <CircularProgress size={20} color="inherit" />
+          ) : isStarred ? (
+            <Image src="/icons/star-slash.svg" width={20} height={20} alt="Unstar" />
+          ) : (
+            <Image src="/icons/small-star.svg" width={20} height={20} alt="Star" />
+          )}
+        </Box>
+        <Typography sx={styles.menuText}>{isStarred ? 'Забрати з обраних' : 'Додати в обрані'}</Typography>
+      </MenuItem>
+
+      <MenuItem onClick={(e) => handleAction(onDownload, e)} sx={styles.menuItem}>
+        <Box sx={styles.icon}>
+          <Image src="/icons/download.svg" width={18} height={18} alt="Download" />{' '}
+        </Box>
+        <Typography sx={styles.menuText}>Завантажити</Typography>
+      </MenuItem>
+
+      <MenuItem onClick={(e) => handleAction(onDelete, e)} sx={styles.menuItem}>
+        <Box sx={styles.icon}>
+          <Image src="/icons/empty-trash.svg" width={18} height={20} alt="Delete" />{' '}
+        </Box>
+        <Typography sx={styles.menuText}>Видалити</Typography>
+      </MenuItem>
+    </>
+  );
+};

--- a/app/shared/components/dropdown-menu/FileMenuActions.tsx
+++ b/app/shared/components/dropdown-menu/FileMenuActions.tsx
@@ -40,6 +40,16 @@ export const FileMenuActions: React.FC<FileMenuActionsProps> = ({
     onToggleStar();
   };
 
+  const renderStarIcon = () => {
+    if (isStarLoading) {
+      return <CircularProgress size={20} color="inherit" />;
+    }
+    if (isStarred) {
+      return <Image src="/icons/star-slash.svg" width={20} height={20} alt="Unstar" />;
+    }
+    return <Image src="/icons/small-star.svg" width={20} height={20} alt="Star" />;
+  };
+
   return (
     <>
       <MenuItem onClick={(e) => handleAction(onOpenDetails, e)} sx={styles.menuItem}>
@@ -64,15 +74,7 @@ export const FileMenuActions: React.FC<FileMenuActionsProps> = ({
           cursor: isStarLoading ? 'wait' : 'pointer'
         }}
       >
-        <Box sx={styles.icon}>
-          {isStarLoading ? (
-            <CircularProgress size={20} color="inherit" />
-          ) : isStarred ? (
-            <Image src="/icons/star-slash.svg" width={20} height={20} alt="Unstar" />
-          ) : (
-            <Image src="/icons/small-star.svg" width={20} height={20} alt="Star" />
-          )}
-        </Box>
+        <Box sx={styles.icon}>{renderStarIcon()}</Box>
         <Typography sx={styles.menuText}>{isStarred ? 'Забрати з обраних' : 'Додати в обрані'}</Typography>
       </MenuItem>
 

--- a/app/shared/components/file-card/FileCard.tsx
+++ b/app/shared/components/file-card/FileCard.tsx
@@ -1,8 +1,11 @@
 'use client';
 import { Box, IconButton, Paper, Stack, Typography } from '@mui/material';
 import Image from 'next/image';
-import { MouseEvent, useState } from 'react';
+import { MouseEvent,useState } from 'react';
+import toast from 'react-hot-toast';
 
+import DropdownMenu from '../dropdown-menu/DropdownMenu';
+import { FileMenuActions } from '../dropdown-menu/FileMenuActions';
 import { styles } from './FileCard.styles';
 import TooltipCustom from '~/ds-components/tooltip/Tooltip';
 import { formatUsageCount } from '~/lib/utils/formatUsageCount';
@@ -36,20 +39,37 @@ export interface FileCardProps {
   fileType: FileType;
   fileData: FileCardData;
   onClick?: () => void;
+  onAction?: (action: 'rename' | 'delete' | 'download', fileId: string) => void;
 }
 
-const FileCard = ({ fileType, fileData, onClick }: FileCardProps) => {
+const FileCard = ({ fileType, fileData, onClick, onAction }: FileCardProps) => {
   const [isTooltipOpen, setIsTooltipOpen] = useState(false);
-  const { id, name, dateAdded, isStarred = false, usageLinks, imageSrc } = fileData;
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
+  const [menuDirection, setMenuDirection] = useState<'left' | 'right'>('right');
+
+  const { id, name, dateAdded, isStarred = false, usageLinks, imageSrc } = fileData;
   const [updateAsset, { loading: isUpdatingStar }] = useUpdateAssetMutation();
 
   const handleMenuClick = (e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
+    setAnchorEl(e.currentTarget);
+
+    const rect = e.currentTarget.getBoundingClientRect();
+    const spaceOnRight = window.innerWidth - rect.right;
+
+    if (spaceOnRight < 400) {
+      setMenuDirection('left');
+    } else {
+      setMenuDirection('right');
+    }
   };
 
-  const handleStarClick = async (e: MouseEvent<HTMLDivElement>) => {
-    e.stopPropagation();
+  const handleCloseMenu = () => {
+    setAnchorEl(null);
+  };
+
+  const handleToggleStar = async () => {
     try {
       await updateAsset({
         variables: {
@@ -57,10 +77,18 @@ const FileCard = ({ fileType, fileData, onClick }: FileCardProps) => {
           input: { isStarred: !isStarred }
         }
       });
-    } catch {}
+    } catch {
+      toast.error('');
+    }
+  };
+
+  const handleStarClick = (e: MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+    handleToggleStar();
   };
 
   const fileTypeIcon = FILE_TYPES[fileType] || FILE_TYPES.image;
+  const isMenuOpen = Boolean(anchorEl);
 
   return (
     <Paper variant="outlined" sx={styles.container} onClick={onClick}>
@@ -88,10 +116,50 @@ const FileCard = ({ fileType, fileData, onClick }: FileCardProps) => {
           </Typography>
         </Stack>
 
-        <IconButton size="small" aria-label="Open file menu" onClick={handleMenuClick}>
+        <IconButton
+          sx={{
+            backgroundColor: isMenuOpen ? 'rgba(0, 0, 0, 0.08)' : 'transparent',
+            '&:hover': { backgroundColor: 'rgba(0, 0, 0, 0.08)' }
+          }}
+          size="small"
+          aria-label="Open file menu"
+          onClick={handleMenuClick}
+        >
           <Image src="/icons/menu.svg" width={ICON_SIZE_2} height={32} alt="Menu icon" aria-hidden />
         </IconButton>
       </Stack>
+
+      <DropdownMenu
+        disableScrollLock
+        transitionDuration={0}
+        disableAutoFocus
+        disableEnforceFocus
+        disableRestoreFocus
+        anchorEl={anchorEl}
+        open={isMenuOpen}
+        onClose={handleCloseMenu}
+        onClick={(e) => e.stopPropagation()}
+        anchorOrigin={{
+          vertical: 'top',
+          horizontal: menuDirection === 'left' ? 'left' : 'right'
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: menuDirection === 'left' ? 'right' : 'left'
+        }}
+        menuList={
+          <FileMenuActions
+            isStarred={isStarred}
+            onCloseMenu={handleCloseMenu}
+            isStarLoading={isUpdatingStar}
+            onOpenDetails={() => onClick?.()}
+            onRename={() => onAction?.('rename', id)}
+            onDelete={() => onAction?.('delete', id)}
+            onDownload={() => onAction?.('download', id)}
+            onToggleStar={handleToggleStar}
+          />
+        }
+      />
 
       <Stack sx={styles.metadataSection}>
         <Typography variant="customItalic14" color="text.secondary">

--- a/app/shared/components/file-info-sidebar/FileInfoSidebar.tsx
+++ b/app/shared/components/file-info-sidebar/FileInfoSidebar.tsx
@@ -8,6 +8,7 @@ import TooltipCustom from '../design-system/tooltip/Tooltip';
 import { styles } from './FileInfoSidebar.styles';
 import { ImagePreviewModal } from './image-preview-modal/ImagePreviewModal';
 import { useAutosavedDescription } from './useAutosavedDescription';
+import { downloadFile } from '~/lib/utils/downloadFile';
 import { formatUsageCount } from '~/lib/utils/formatUsageCount';
 import CloseIcon from '~/public/icons/close.svg';
 import DocIcon from '~/public/icons/doc.svg';
@@ -23,7 +24,7 @@ import XlsIcon from '~/public/icons/xls.svg';
 import ArchiveIcon from '~/public/icons/zip.svg';
 import ZoomIn from '~/public/icons/zoom-in.svg';
 import { CustomTextField } from '~/shared/components/design-system/text-field/TextField';
-import { useDeleteAssetMutation,useUpdateAssetMutation } from '~/types/graphql/generated/graphql';
+import { useDeleteAssetMutation, useUpdateAssetMutation } from '~/types/graphql/generated/graphql';
 
 export type FileUsageLink = {
   id: string;
@@ -113,29 +114,10 @@ export function FileInfoSidebar({ file, onClose, onDescriptionSave, onRequestAct
   const handleDownload = useCallback(async () => {
     if (!file?.downloadUrl || !filename) return;
     requestAction('download');
-    try {
-      setIsDownloading(true);
 
-      const response = await fetch(file.downloadUrl, { cache: 'no-store' });
-      if (!response.ok) throw new Error('Помилка завантаження');
-
-      const blob = await response.blob();
-      const blobUrl = globalThis.URL.createObjectURL(blob);
-
-      const link = document.createElement('a');
-      link.href = blobUrl;
-      link.download = filename;
-      document.body.appendChild(link);
-      link.click();
-
-      link.remove();
-      globalThis.URL.revokeObjectURL(blobUrl);
-      toast.success('Файл завантажено');
-    } catch {
-      toast.error('Не вдалося завантажити файл');
-    } finally {
-      setIsDownloading(false);
-    }
+    setIsDownloading(true);
+    await downloadFile(file.downloadUrl, filename);
+    setIsDownloading(false);
   }, [file?.downloadUrl, filename, requestAction]);
 
   const openPreview = useCallback(() => {

--- a/app/shared/components/files-cards-layout/FilesCardsLayout.tsx
+++ b/app/shared/components/files-cards-layout/FilesCardsLayout.tsx
@@ -20,6 +20,7 @@ type FilesCardsLayoutProps = Readonly<{
   view: FilesCardsLayoutView;
   items: FilesCardsLayoutItem[];
   onItemClick?: (item: FilesCardsLayoutItem) => void;
+  onItemAction?: (action: 'rename' | 'delete' | 'download', item: FilesCardsLayoutItem) => void;
 }>;
 
 const minimizedTypeMap: Record<FileType, 'img' | 'audio' | 'pdf' | 'doc' | 'xls' | 'video-file' | 'archive'> = {
@@ -32,7 +33,7 @@ const minimizedTypeMap: Record<FileType, 'img' | 'audio' | 'pdf' | 'doc' | 'xls'
   archive: 'archive'
 };
 
-export function FilesCardsLayout({ view, items, onItemClick }: FilesCardsLayoutProps) {
+export function FilesCardsLayout({ view, items, onItemClick, onItemAction }: FilesCardsLayoutProps) {
   if (view === 'list') {
     return (
       <Box sx={styles.root} data-testid="FilesCardsLayout-list">
@@ -47,6 +48,7 @@ export function FilesCardsLayout({ view, items, onItemClick }: FilesCardsLayoutP
                 name={item.name}
                 date={item.dateAdded}
                 onClick={() => onItemClick?.(item)}
+                onAction={(action) => onItemAction?.(action, item)}
               />
             </Box>
           ))}
@@ -71,6 +73,7 @@ export function FilesCardsLayout({ view, items, onItemClick }: FilesCardsLayoutP
                 imageSrc: item.imageSrc
               }}
               onClick={() => onItemClick?.(item)}
+              onAction={(action) => onItemAction?.(action, item)}
             />
           </Box>
         ))}

--- a/app/shared/components/minimized-file-card/MinimizedFileCard.tsx
+++ b/app/shared/components/minimized-file-card/MinimizedFileCard.tsx
@@ -1,8 +1,11 @@
+'use client';
 import { Box, IconButton, Paper, Stack, Typography } from '@mui/material';
 import Image from 'next/image';
-import { MouseEvent } from 'react';
+import { MouseEvent, useEffect,useState } from 'react';
 
-import { styles } from '~/components/minimized-file-card/MinimizedFileCard.styles';
+import DropdownMenu from '../dropdown-menu/DropdownMenu';
+import { FileMenuActions } from '../dropdown-menu/FileMenuActions';
+import { styles } from '~/shared/components/minimized-file-card/MinimizedFileCard.styles';
 import { useUpdateAssetMutation } from '~/types/graphql/generated/graphql';
 
 const ICON_SIZE = 21;
@@ -27,6 +30,7 @@ interface MinimizedFileCardProps {
   name: string;
   date: string;
   onClick?: () => void;
+  onAction?: (action: 'rename' | 'delete' | 'download', fileId: string) => void;
   onMenuClick?: (e: MouseEvent<HTMLButtonElement>) => void;
 }
 
@@ -38,17 +42,39 @@ const MinimizedFileCard = ({
   name,
   date,
   onClick,
+  onAction,
   onMenuClick
 }: MinimizedFileCardProps) => {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [updateAsset, { loading: isUpdatingStar }] = useUpdateAssetMutation();
+
+  useEffect(() => {
+    const handleResizeOrScroll = () => {
+      if (anchorEl) {
+        setAnchorEl(null);
+      }
+    };
+
+    window.addEventListener('resize', handleResizeOrScroll);
+    window.addEventListener('scroll', handleResizeOrScroll, true);
+
+    return () => {
+      window.removeEventListener('resize', handleResizeOrScroll);
+      window.removeEventListener('scroll', handleResizeOrScroll, true);
+    };
+  }, [anchorEl]);
 
   const handleMenuClick = (e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
+    setAnchorEl(e.currentTarget);
     onMenuClick?.(e);
   };
 
-  const handleStarClick = async (e: MouseEvent<HTMLDivElement>) => {
-    e.stopPropagation();
+  const handleCloseMenu = () => {
+    setAnchorEl(null);
+  };
+
+  const handleToggleStar = async () => {
     try {
       await updateAsset({
         variables: {
@@ -58,6 +84,13 @@ const MinimizedFileCard = ({
       });
     } catch {}
   };
+
+  const handleStarClick = (e: MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+    handleToggleStar();
+  };
+
+  const isMenuOpen = Boolean(anchorEl);
 
   return (
     <Paper variant="outlined" sx={styles.container} onClick={onClick}>
@@ -92,12 +125,52 @@ const MinimizedFileCard = ({
       <Stack direction="row" sx={styles.content} alignItems="center">
         <Typography variant="customItalic16">{date}</Typography>
 
-        <IconButton size="small" aria-label="Open file menu" onClick={handleMenuClick}>
+        <IconButton
+          sx={{
+            backgroundColor: isMenuOpen ? 'rgba(0, 0, 0, 0.08)' : 'transparent',
+            '&:hover': { backgroundColor: 'rgba(0, 0, 0, 0.08)' }
+          }}
+          size="small"
+          aria-label="Open file menu"
+          onClick={handleMenuClick}
+        >
           <Image src="/icons/menu.svg" width={ICON_SIZE} height={ICON_SIZE} alt="Menu icon" aria-hidden />
         </IconButton>
       </Stack>
+
+      <DropdownMenu
+        disableScrollLock
+        transitionDuration={0}
+        disableAutoFocus
+        disableEnforceFocus
+        disableRestoreFocus
+        anchorEl={anchorEl}
+        open={isMenuOpen}
+        onClose={handleCloseMenu}
+        onClick={(e) => e.stopPropagation()}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        slotProps={{
+          paper: {
+            sx: {
+              mt: '-1px'
+            }
+          }
+        }}
+        menuList={
+          <FileMenuActions
+            isStarred={starred}
+            isStarLoading={isUpdatingStar}
+            onCloseMenu={handleCloseMenu}
+            onOpenDetails={() => onClick?.()}
+            onRename={() => onAction?.('rename', id)}
+            onDelete={() => onAction?.('delete', id)}
+            onDownload={() => onAction?.('download', id)}
+            onToggleStar={handleToggleStar}
+          />
+        }
+      />
     </Paper>
   );
 };
-
 export default MinimizedFileCard;

--- a/public/icons/star-slash.svg
+++ b/public/icons/star-slash.svg
@@ -1,0 +1,3 @@
+<svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7.09 7.09009L0.75 8.02009L5.75 12.8901L4.57 19.7501L10.75 16.5201L16.93 19.7501L16.34 16.3201M17.1701 11.51L20.7501 8.02L13.8401 7.02L10.7501 0.75L9.31006 3.66M0.75 0.75L20.75 20.75" stroke="#131414" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## Description

Implemented a 3-dot dropdown context menu for file assets in both Grid View (Cards) and List View (Rows). Fixed SonarQube code duplication by extracting download logic to a shared utility.
## Type of change

- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Navigate to the Files dashboard.
2. In Grid View, click the 3-dot menu icon on any file card.
3. Test all menu actions: Відкрити деталі, Перейменувати, Завантажити, Видалити, and Додати/Забрати з обраних.
4. Switch to List View and test the 3-dot menu row actions again.

## Video / Screenshots

<img width="312" height="284" alt="image" src="https://github.com/user-attachments/assets/aa3a71e9-dd76-4906-9791-017c07207046" />

## Expected result: 
1. Dropdown menu layout, paddings, and hovers match the Figma design 1:1.
2. All actions work seamlessly: opens sidebar, triggers modals, or starts file download.
3. Clicking the "Favorite" star icon shows a loading spinner inside the menu, updates the UI state dynamically, and does not close the dropdown prematurely.


Closes: https://github.com/Liatoshynsky-Foundation/lf-admin/issues/524