### PR TITLE
Implement centralized application logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,12 @@ formData.append('fileType', 'image'); // Optional: image, document, video, audio
 formData.append('validationRules', JSON.stringify({ maxSize: 5242880 })); // Optional
 formData.append('metadata', JSON.stringify({ author: 'Admin' })); // Optional
 
+### Logs History
+
+- Application logs are written by Winston to MongoDB when `MONGO_URL` is configured.
+- Logs are stored in the same MongoDB database as the application, in the `logger` collection.
+- The logs page reads data through `GET /api/logs`, which fetches documents directly from the `logger` collection.
+
 const response = await fetch('/api/uploads/single', {
   method: 'POST',
   body: formData

--- a/app/(logged_in)/logs/LogsPageClient.tsx
+++ b/app/(logged_in)/logs/LogsPageClient.tsx
@@ -13,7 +13,7 @@ import {
   Tabs,
   Typography
 } from '@mui/material';
-import { type SyntheticEvent, useEffect, useMemo, useState } from 'react';
+import { type SyntheticEvent, useEffect, useState } from 'react';
 
 import type { LogEntry, LogLevel, LogsResponse } from '~/back-shared/types/logs';
 
@@ -134,8 +134,6 @@ const LogsPageClient = () => {
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(false);
 
-  const currentTab = useMemo(() => level, [level]);
-
   useEffect(() => {
     const controller = new AbortController();
 
@@ -210,7 +208,7 @@ const LogsPageClient = () => {
       </Stack>
 
       <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-        <Tabs value={currentTab} onChange={onLevelChange} variant="scrollable" scrollButtons="auto" allowScrollButtonsMobile>
+        <Tabs value={level} onChange={onLevelChange} variant="scrollable" scrollButtons="auto" allowScrollButtonsMobile>
           {LEVEL_OPTIONS.map((option) => (
             <Tab key={option.value} value={option.value} label={option.label} />
           ))}

--- a/app/(logged_in)/logs/LogsPageClient.tsx
+++ b/app/(logged_in)/logs/LogsPageClient.tsx
@@ -13,7 +13,7 @@ import {
   Tabs,
   Typography
 } from '@mui/material';
-import { type SyntheticEvent,useEffect, useMemo, useState } from 'react';
+import { type SyntheticEvent, useEffect, useMemo, useState } from 'react';
 
 import type { LogEntry, LogLevel, LogsResponse } from '~/back-shared/types/logs';
 
@@ -67,7 +67,9 @@ const JsonBlock = ({ value }: { value?: Record<string, unknown> }) => {
 };
 
 const LogItem = ({ item }: { item: LogEntry }) => {
-  const hasDetails = Boolean(item.meta.method || item.meta.url || item.meta.statusCode || item.meta.stack || item.meta.metadata || item.meta.raw);
+  const hasStatusCode = typeof item.meta.statusCode === 'number';
+  const hasDetails = Boolean(item.meta.method || item.meta.url || hasStatusCode || item.meta.stack || item.meta.metadata || item.meta.raw);
+  const noDetails = !hasDetails;
   const accent = LEVEL_ACCENTS[item.level];
 
   return (
@@ -102,7 +104,7 @@ const LogItem = ({ item }: { item: LogEntry }) => {
               <strong>URL:</strong> {item.meta.url}
             </Typography>
           ) : null}
-          {item.meta.statusCode !== undefined ? (
+          {hasStatusCode ? (
             <Typography variant="body2">
               <strong>Status:</strong> {item.meta.statusCode}
             </Typography>
@@ -114,7 +116,7 @@ const LogItem = ({ item }: { item: LogEntry }) => {
           ) : null}
           <JsonBlock value={item.meta.metadata} />
           <JsonBlock value={item.meta.raw} />
-          {!hasDetails ? (
+          {noDetails ? (
             <Typography variant="body2" color="text.secondary">
               Немає додаткових деталей.
             </Typography>
@@ -165,11 +167,36 @@ const LogsPageClient = () => {
   }, [level, page]);
 
   const totalPages = Math.max(1, Math.ceil(total / 20));
+  const hasItems = items.length > 0;
+  const noItems = items.length === 0;
 
-  const onLevelChange = (_event: SyntheticEvent, value: string) => {
-    setLevel(value as LogLevel | 'all');
+  const onLevelChange = (_event: SyntheticEvent, value: LogLevel | 'all') => {
+    setLevel(value);
     setPage(1);
   };
+
+  let content: React.ReactNode;
+  if (loading) {
+    content = (
+      <Typography variant="body2" color="text.secondary">
+        Завантаження...
+      </Typography>
+    );
+  } else if (noItems) {
+    content = (
+      <Typography variant="body2" color="text.secondary">
+        Логи не знайдено.
+      </Typography>
+    );
+  } else {
+    content = (
+      <Stack spacing={1.5}>
+        {items.map((item) => (
+          <LogItem key={item.id} item={item} />
+        ))}
+      </Stack>
+    );
+  }
 
   return (
     <Stack spacing={2.5}>
@@ -194,23 +221,9 @@ const LogsPageClient = () => {
         {total} записів
       </Typography>
 
-      {loading ? (
-        <Typography variant="body2" color="text.secondary">
-          Завантаження...
-        </Typography>
-      ) : items.length === 0 ? (
-        <Typography variant="body2" color="text.secondary">
-          Логи не знайдено.
-        </Typography>
-      ) : (
-        <Stack spacing={1.5}>
-          {items.map((item) => (
-            <LogItem key={item.id} item={item} />
-          ))}
-        </Stack>
-      )}
+      {content}
 
-      {totalPages > 1 ? <Pagination count={totalPages} page={page} onChange={(_, value) => setPage(value)} /> : null}
+      {hasItems && totalPages > 1 ? <Pagination count={totalPages} page={page} onChange={(_, value) => setPage(value)} /> : null}
     </Stack>
   );
 };

--- a/app/(logged_in)/logs/LogsPageClient.tsx
+++ b/app/(logged_in)/logs/LogsPageClient.tsx
@@ -1,0 +1,218 @@
+'use client';
+
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Chip,
+  Pagination,
+  Stack,
+  Tab,
+  Tabs,
+  Typography
+} from '@mui/material';
+import { type SyntheticEvent,useEffect, useMemo, useState } from 'react';
+
+import type { LogEntry, LogLevel, LogsResponse } from '~/back-shared/types/logs';
+
+const LEVEL_OPTIONS: Array<{ value: LogLevel | 'all'; label: string }> = [
+  { value: 'all', label: 'Усі' },
+  { value: 'error', label: 'Error' },
+  { value: 'warn', label: 'Warn' },
+  { value: 'info', label: 'Info' },
+  { value: 'debug', label: 'Debug' }
+];
+
+const LEVEL_COLORS: Record<LogLevel, 'error' | 'warning' | 'info' | 'default'> = {
+  error: 'error',
+  warn: 'warning',
+  info: 'info',
+  debug: 'default'
+};
+
+const LEVEL_ACCENTS: Record<LogLevel, { border: string; background: string }> = {
+  error: {
+    border: 'rgba(211, 47, 47, 0.28)',
+    background: 'rgba(211, 47, 47, 0.05)'
+  },
+  warn: {
+    border: 'rgba(237, 108, 2, 0.28)',
+    background: 'rgba(237, 108, 2, 0.05)'
+  },
+  info: {
+    border: 'rgba(2, 136, 209, 0.28)',
+    background: 'rgba(2, 136, 209, 0.05)'
+  },
+  debug: {
+    border: 'rgba(97, 97, 97, 0.28)',
+    background: 'rgba(97, 97, 97, 0.05)'
+  }
+};
+
+const formatTimestamp = (value: string) => {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString('uk-UA');
+};
+
+const JsonBlock = ({ value }: { value?: Record<string, unknown> }) => {
+  if (!value || Object.keys(value).length === 0) return null;
+
+  return (
+    <Typography component="pre" sx={{ m: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word', fontSize: 13 }}>
+      {JSON.stringify(value, null, 2)}
+    </Typography>
+  );
+};
+
+const LogItem = ({ item }: { item: LogEntry }) => {
+  const hasDetails = Boolean(item.meta.method || item.meta.url || item.meta.statusCode || item.meta.stack || item.meta.metadata || item.meta.raw);
+  const accent = LEVEL_ACCENTS[item.level];
+
+  return (
+    <Accordion
+      disableGutters
+      sx={{
+        borderRadius: 2,
+        overflow: 'hidden',
+        border: `1px solid ${accent.border}`,
+        backgroundColor: accent.background,
+        '&:before': { display: 'none' }
+      }}
+    >
+      <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ px: 2 }}>
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5} width="100%" alignItems={{ xs: 'flex-start', sm: 'center' }}>
+          <Chip label={item.level.toUpperCase()} color={LEVEL_COLORS[item.level]} size="small" />
+          <Typography sx={{ flexGrow: 1, fontWeight: 700 }}>{item.message}</Typography>
+          <Typography variant="body2" color="text.secondary">
+            {formatTimestamp(item.timestamp)}
+          </Typography>
+        </Stack>
+      </AccordionSummary>
+      <AccordionDetails sx={{ px: 2, pb: 2 }}>
+        <Stack spacing={1}>
+          {item.meta.method ? (
+            <Typography variant="body2">
+              <strong>Method:</strong> {item.meta.method}
+            </Typography>
+          ) : null}
+          {item.meta.url ? (
+            <Typography variant="body2">
+              <strong>URL:</strong> {item.meta.url}
+            </Typography>
+          ) : null}
+          {item.meta.statusCode !== undefined ? (
+            <Typography variant="body2">
+              <strong>Status:</strong> {item.meta.statusCode}
+            </Typography>
+          ) : null}
+          {item.meta.stack ? (
+            <Typography component="pre" sx={{ m: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word', fontSize: 13 }}>
+              {item.meta.stack}
+            </Typography>
+          ) : null}
+          <JsonBlock value={item.meta.metadata} />
+          <JsonBlock value={item.meta.raw} />
+          {!hasDetails ? (
+            <Typography variant="body2" color="text.secondary">
+              Немає додаткових деталей.
+            </Typography>
+          ) : null}
+        </Stack>
+      </AccordionDetails>
+    </Accordion>
+  );
+};
+
+const LogsPageClient = () => {
+  const [level, setLevel] = useState<LogLevel | 'all'>('all');
+  const [page, setPage] = useState(1);
+  const [items, setItems] = useState<LogEntry[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+
+  const currentTab = useMemo(() => level, [level]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    const loadLogs = async () => {
+      setLoading(true);
+
+      try {
+        const params = new URLSearchParams({ page: String(page), limit: '20' });
+        if (level !== 'all') params.set('level', level);
+
+        const response = await fetch(`/api/logs?${params.toString()}`, {
+          signal: controller.signal,
+          credentials: 'include'
+        });
+        const payload = (await response.json()) as LogsResponse;
+
+        setItems(payload.items);
+        setTotal(payload.pagination.total);
+      } catch {
+        setItems([]);
+        setTotal(0);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadLogs();
+    return () => controller.abort();
+  }, [level, page]);
+
+  const totalPages = Math.max(1, Math.ceil(total / 20));
+
+  const onLevelChange = (_event: SyntheticEvent, value: string) => {
+    setLevel(value as LogLevel | 'all');
+    setPage(1);
+  };
+
+  return (
+    <Stack spacing={2.5}>
+      <Stack spacing={0.5}>
+        <Typography variant="h4" sx={{ fontWeight: 800 }}>
+          Logs
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          Логи з MongoDB. Деталі відкриваються по кліку на запис.
+        </Typography>
+      </Stack>
+
+      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+        <Tabs value={currentTab} onChange={onLevelChange} variant="scrollable" scrollButtons="auto" allowScrollButtonsMobile>
+          {LEVEL_OPTIONS.map((option) => (
+            <Tab key={option.value} value={option.value} label={option.label} />
+          ))}
+        </Tabs>
+      </Box>
+
+      <Typography variant="body2" color="text.secondary">
+        {total} записів
+      </Typography>
+
+      {loading ? (
+        <Typography variant="body2" color="text.secondary">
+          Завантаження...
+        </Typography>
+      ) : items.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          Логи не знайдено.
+        </Typography>
+      ) : (
+        <Stack spacing={1.5}>
+          {items.map((item) => (
+            <LogItem key={item.id} item={item} />
+          ))}
+        </Stack>
+      )}
+
+      {totalPages > 1 ? <Pagination count={totalPages} page={page} onChange={(_, value) => setPage(value)} /> : null}
+    </Stack>
+  );
+};
+
+export default LogsPageClient;

--- a/app/(logged_in)/logs/page.tsx
+++ b/app/(logged_in)/logs/page.tsx
@@ -1,0 +1,11 @@
+import { Box } from '@mui/material';
+
+import LogsPageClient from './LogsPageClient';
+
+export default function LogsPage() {
+  return (
+    <Box sx={{ width: '100%', p: '32px' }}>
+      <LogsPageClient />
+    </Box>
+  );
+}

--- a/app/api/health/route.test.ts
+++ b/app/api/health/route.test.ts
@@ -3,7 +3,7 @@ import mongoose from 'mongoose';
 
 import { GET } from './route';
 import { errors } from '~/constants/errors';
-import dbConnect from '~/infrastructure/db/connect';
+import dbConnect, { getLastMongoConnectionErrorMessage } from '~/infrastructure/db/connect';
 
 jest.mock('mongoose', () => {
   const mockDbCommand = jest.fn();
@@ -40,16 +40,19 @@ jest.mock('~/utils/apiResponse', () => ({
 }));
 jest.mock('~/src/infrastructure/db/connect', () => ({
   __esModule: true,
-  default: jest.fn()
+  default: jest.fn(),
+  getLastMongoConnectionErrorMessage: jest.fn()
 }));
 
 const mockDbCommand = mongoose.connection.db!.command as jest.Mock;
 const mockServerStatus = mongoose.connection.db!.admin().serverStatus as jest.Mock;
+const mockGetLastMongoConnectionErrorMessage = getLastMongoConnectionErrorMessage as jest.Mock;
 
 describe('GET /api/health', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (mongoose.connection as any).readyState = 0;
+    mockGetLastMongoConnectionErrorMessage.mockReturnValue(null);
   });
 
   it('should return status UP when database connection is successful', async () => {
@@ -66,7 +69,13 @@ describe('GET /api/health', () => {
     expect(responseJson.status).toBe('UP');
     expect(responseJson.dependencies.database.status).toBe('UP');
     expect(responseJson.dependencies.database.details).toEqual(
-      expect.objectContaining({ connectionStatus: 'CONNECTED' })
+      expect.objectContaining({
+        connectionStatus: 'CONNECTED',
+        readyState: 1,
+        host: 'mock-host',
+        databaseName: 'mock-db-name',
+        lastErrorMessage: null
+      })
     );
   });
 
@@ -80,6 +89,15 @@ describe('GET /api/health', () => {
     const responseJson = await response.json();
     expect(responseJson.status).toBe('DOWN');
     expect(responseJson.dependencies.database.message).toBe('Database connection state is: CONNECTING');
+    expect(responseJson.dependencies.database.details).toEqual(
+      expect.objectContaining({
+        connectionStatus: 'CONNECTING',
+        readyState: 2,
+        host: 'mock-host',
+        databaseName: 'mock-db-name',
+        lastErrorMessage: null
+      })
+    );
     expect(mockDbCommand).not.toHaveBeenCalled();
   });
 
@@ -92,6 +110,15 @@ describe('GET /api/health', () => {
     expect(response.status).toBe(503);
     const responseJson = await response.json();
     expect(responseJson.dependencies.database.message).toBe(errors.FAILED_TO_CONNECT_DB);
+    expect(responseJson.dependencies.database.details).toEqual(
+      expect.objectContaining({
+        connectionStatus: 'DISCONNECTED',
+        readyState: 0,
+        host: 'mock-host',
+        databaseName: 'mock-db-name',
+        lastErrorMessage: 'Connection failed'
+      })
+    );
   });
 
   it('should return status DOWN with 503 if db.command throws an error', async () => {
@@ -105,5 +132,14 @@ describe('GET /api/health', () => {
     expect(response.status).toBe(503);
     const responseJson = await response.json();
     expect(responseJson.dependencies.database.message).toBe(errors.FAILED_TO_CONNECT_DB);
+    expect(responseJson.dependencies.database.details).toEqual(
+      expect.objectContaining({
+        connectionStatus: 'CONNECTED',
+        readyState: 1,
+        host: 'mock-host',
+        databaseName: 'mock-db-name',
+        lastErrorMessage: 'Command failed'
+      })
+    );
   });
 });

--- a/app/api/health/route.test.ts
+++ b/app/api/health/route.test.ts
@@ -47,12 +47,18 @@ jest.mock('~/src/infrastructure/db/connect', () => ({
 const mockDbCommand = mongoose.connection.db!.command as jest.Mock;
 const mockServerStatus = mongoose.connection.db!.admin().serverStatus as jest.Mock;
 const mockGetLastMongoConnectionErrorMessage = getLastMongoConnectionErrorMessage as jest.Mock;
+const originalDb = mongoose.connection.db;
 
 describe('GET /api/health', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (mongoose.connection as any).readyState = 0;
+    (mongoose.connection as any).db = originalDb;
     mockGetLastMongoConnectionErrorMessage.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    (mongoose.connection as any).db = originalDb;
   });
 
   it('should return status UP when database connection is successful', async () => {
@@ -141,5 +147,40 @@ describe('GET /api/health', () => {
         lastErrorMessage: 'Command failed'
       })
     );
+  });
+
+  it('should return UNKNOWN connectionStatus for unrecognized readyState', async () => {
+    (dbConnect as jest.Mock).mockResolvedValue(true);
+    (mongoose.connection as any).readyState = 99;
+
+    const response = await GET();
+
+    expect(response.status).toBe(503);
+    const responseJson = await response.json();
+    expect(responseJson.dependencies.database.details.connectionStatus).toBe('UNKNOWN');
+    expect(responseJson.dependencies.database.message).toBe('Database connection state is: UNKNOWN');
+  });
+
+  it('should throw if db is null when connected', async () => {
+    (dbConnect as jest.Mock).mockResolvedValue(true);
+    (mongoose.connection as any).readyState = 1;
+    (mongoose.connection as any).db = null;
+
+    const response = await GET();
+
+    expect(response.status).toBe(503);
+    const responseJson = await response.json();
+    expect(responseJson.dependencies.database.message).toBe(errors.FAILED_TO_CONNECT_DB);
+  });
+
+  it('should use getLastMongoConnectionErrorMessage fallback when thrown value is not an Error', async () => {
+    (dbConnect as jest.Mock).mockRejectedValue('unexpected string error');
+    mockGetLastMongoConnectionErrorMessage.mockReturnValue('stored error message');
+
+    const response = await GET();
+
+    expect(response.status).toBe(503);
+    const responseJson = await response.json();
+    expect(responseJson.dependencies.database.details.lastErrorMessage).toBe('stored error message');
   });
 });

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -3,11 +3,24 @@ import { NextResponse } from 'next/server';
 
 import { stateNames } from '~/constants';
 import { errors } from '~/constants/errors';
-import dbConnect from '~/infrastructure/db/connect';
+import dbConnect, { getLastMongoConnectionErrorMessage } from '~/infrastructure/db/connect';
 import { successResponse } from '~/utils/apiResponse';
 
 const getMongooseConnectionState = (state: number): string => {
   return stateNames[state] || 'UNKNOWN';
+};
+
+const getDatabaseDetails = (lastErrorMessage: string | null) => {
+  const connection = mongoose.connection;
+  const readyState = connection.readyState;
+
+  return {
+    readyState,
+    connectionStatus: getMongooseConnectionState(readyState),
+    host: connection.host,
+    databaseName: connection.name,
+    lastErrorMessage
+  };
 };
 
 export async function GET() {
@@ -32,12 +45,7 @@ export async function GET() {
     const connectionStatus = getMongooseConnectionState(readyState);
     const isConnected = readyState === 1;
 
-    healthDetails.dependencies.database.details = {
-      connectionStatus: connectionStatus,
-      host: connection.host,
-      port: connection.port,
-      databaseName: connection.name
-    };
+    healthDetails.dependencies.database.details = getDatabaseDetails(getLastMongoConnectionErrorMessage());
 
     if (isConnected) {
       if (!db) throw new Error(errors.FAILED_TO_CONNECT_DB);
@@ -46,6 +54,7 @@ export async function GET() {
 
       healthDetails.dependencies.database.details = {
         ...healthDetails.dependencies.database.details,
+        port: connection.port,
         serverVersion: serverInfo.version,
         collections: stats.collections,
         objects: stats.objects,
@@ -64,8 +73,13 @@ export async function GET() {
       return NextResponse.json(healthDetails, { status: 503 });
     }
   } catch (e) {
+    const caughtErrorMessage = e instanceof Error && e.message ? e.message : null;
+
     healthDetails.dependencies.database.message = errors.FAILED_TO_CONNECT_DB;
-    healthDetails.dependencies.database.details = { e };
+    healthDetails.dependencies.database.details = getDatabaseDetails(
+      caughtErrorMessage ?? getLastMongoConnectionErrorMessage()
+    );
+
     return NextResponse.json(healthDetails, { status: 503 });
   }
 }

--- a/app/api/logs/route.test.ts
+++ b/app/api/logs/route.test.ts
@@ -1,0 +1,55 @@
+import { GET } from './route';
+import { getLogs } from '~/infrastructure/repositories/logRepository/logRepository';
+
+jest.mock('~/infrastructure/repositories/logRepository/logRepository', () => ({
+  __esModule: true,
+  getLogs: jest.fn()
+}));
+
+describe('GET /api/logs', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns logs with pagination and filters', async () => {
+    (getLogs as jest.Mock).mockResolvedValue({
+      items: [],
+      pagination: { page: 1, limit: 20, total: 0 }
+    });
+
+    const request = new Request('http://localhost/api/logs?level=error&page=2&limit=15&from=2026-05-12T00:00:00.000Z');
+    const response = await GET(request);
+
+    expect(getLogs).toHaveBeenCalledWith({
+      level: 'error',
+      page: 2,
+      limit: 15,
+      from: '2026-05-12T00:00:00.000Z',
+      to: undefined
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      items: [],
+      pagination: { page: 1, limit: 20, total: 0 }
+    });
+  });
+
+  it('ignores invalid level values', async () => {
+    (getLogs as jest.Mock).mockResolvedValue({
+      items: [],
+      pagination: { page: 1, limit: 20, total: 0 }
+    });
+
+    const request = new Request('http://localhost/api/logs?level=invalid');
+    await GET(request);
+
+    expect(getLogs).toHaveBeenCalledWith({
+      level: undefined,
+      page: 1,
+      limit: 20,
+      from: undefined,
+      to: undefined
+    });
+  });
+});

--- a/app/api/logs/route.test.ts
+++ b/app/api/logs/route.test.ts
@@ -1,5 +1,14 @@
+import 'whatwg-fetch';
+
 import { GET } from './route';
 import { getLogs } from '~/infrastructure/repositories/logRepository/logRepository';
+
+jest.mock('next/server', () => ({
+  __esModule: true,
+  NextResponse: {
+    json: (body: any, init?: ResponseInit) => new Response(JSON.stringify(body), init)
+  }
+}));
 
 jest.mock('~/infrastructure/repositories/logRepository/logRepository', () => ({
   __esModule: true,

--- a/app/api/logs/route.ts
+++ b/app/api/logs/route.ts
@@ -8,10 +8,15 @@ const parsePositiveInteger = (value: string | null, fallback: number): number =>
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 };
 
+const LOG_LEVELS = new Set<LogLevel>(['error', 'warn', 'info', 'debug']);
+
+const isLogLevel = (value: string): value is LogLevel => LOG_LEVELS.has(value as LogLevel);
+
 const parseLevel = (value: string | null): LogLevel | 'all' | undefined => {
-  if (!value || value === 'all') return value ?? undefined;
-  if (['error', 'warn', 'info', 'debug'].includes(value)) {
-    return value as LogLevel;
+  if (!value) return undefined;
+  if (value === 'all') return 'all';
+  if (isLogLevel(value)) {
+    return value;
   }
   return undefined;
 };

--- a/app/api/logs/route.ts
+++ b/app/api/logs/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+
+import type { LogLevel } from '~/back-shared/types/logs';
+import { getLogs } from '~/infrastructure/repositories/logRepository/logRepository';
+
+const parsePositiveInteger = (value: string | null, fallback: number): number => {
+  const parsed = Number.parseInt(value ?? '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+const parseLevel = (value: string | null): LogLevel | 'all' | undefined => {
+  if (!value || value === 'all') return value ?? undefined;
+  if (['error', 'warn', 'info', 'debug'].includes(value)) {
+    return value as LogLevel;
+  }
+  return undefined;
+};
+
+export async function GET(request: Request) {
+  try {
+    const url = new URL(request.url);
+    const level = parseLevel(url.searchParams.get('level'));
+    const page = parsePositiveInteger(url.searchParams.get('page'), 1);
+    const limit = parsePositiveInteger(url.searchParams.get('limit'), 20);
+    const from = url.searchParams.get('from') ?? undefined;
+    const to = url.searchParams.get('to') ?? undefined;
+
+    const data = await getLogs({ level, page, limit, from, to });
+
+    return NextResponse.json(data);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to load logs';
+    return NextResponse.json({ message }, { status: 500 });
+  }
+}

--- a/app/shared/components/side-navigation/SideNavigation.consts.ts
+++ b/app/shared/components/side-navigation/SideNavigation.consts.ts
@@ -3,7 +3,6 @@ export const NAVIGATION_DATA = {
   content: [
     {
       title: 'Основні сторінки',
-      iconSrc: 'file-text',
       href: '',
       disabled: true
     },

--- a/src/infrastructure/db/connect.test.ts
+++ b/src/infrastructure/db/connect.test.ts
@@ -5,6 +5,15 @@ import { errors } from '~/constants/errors';
 type MongooseGlobalCache = {
   conn: Mongoose | null;
   promise: Promise<Mongoose> | null;
+  listenersAttached: boolean;
+};
+
+const expectedMongoConnectOptions = {
+  bufferCommands: false,
+  connectTimeoutMS: 60000,
+  serverSelectionTimeoutMS: 60000,
+  socketTimeoutMS: 60000,
+  family: 4
 };
 
 const mockConnection = { connection: { readyState: 1 } };
@@ -51,7 +60,7 @@ describe('dbConnect', () => {
 
     const conn = await dbConnect();
 
-    expect(connect).toHaveBeenCalledWith(mongoUrl, { bufferCommands: false });
+    expect(connect).toHaveBeenCalledWith(mongoUrl, expectedMongoConnectOptions);
     expect(loggerMock.info).toHaveBeenCalledWith('✅ Connected to db');
     expect(conn).toStrictEqual(mockConnection);
 
@@ -59,6 +68,22 @@ describe('dbConnect', () => {
     expect(cached).toBeDefined();
     expect(cached?.conn).toStrictEqual(mockConnection);
     expect(cached?.promise).toBeInstanceOf(Promise);
+  });
+
+  it('should reuse cached connection without reconnecting', async () => {
+    const connectMock = jest.fn().mockResolvedValue(mockConnection);
+    const loggerMock = createLoggerMock();
+
+    mockMongoose(connectMock);
+    mockConfig('mongodb://localhost:27017/test-db');
+    mockLoggerModule(loggerMock);
+
+    const { default: dbConnect } = await import('./connect');
+
+    await dbConnect();
+    await dbConnect();
+
+    expect(connectMock).toHaveBeenCalledTimes(1);
   });
 
   it('should log error if connection fails', async () => {
@@ -98,7 +123,7 @@ describe('dbConnect', () => {
 
     const conn = await dbConnect();
 
-    expect(connect).toHaveBeenCalledWith(mongoUrl, { bufferCommands: false });
+    expect(connect).toHaveBeenCalledWith(mongoUrl, expectedMongoConnectOptions);
     expect(loggerMock.info).toHaveBeenCalledWith('✅ Connected to db');
     expect(conn).toStrictEqual(fakeMongoose);
 

--- a/src/infrastructure/db/connect.ts
+++ b/src/infrastructure/db/connect.ts
@@ -7,40 +7,95 @@ import logger from '~/middleware/logger/logger';
 type MongooseGlobalCache = {
   conn: typeof mongoose | null;
   promise: Promise<typeof mongoose> | null;
+  listenersAttached: boolean;
+  lastErrorMessage: string | null;
+};
+
+const toErrorMessage = (error: unknown): string | null => {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return typeof error === 'string' && error.length > 0 ? error : null;
+};
+
+const getEnvNumber = (value: string | undefined, fallback: number) => {
+  const parsed = Number.parseInt(value ?? '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+const mongoConnectTimeoutMs = getEnvNumber(process.env.MONGO_CONNECT_TIMEOUT_MS, 60000);
+const mongoServerSelectionTimeoutMs = getEnvNumber(process.env.MONGO_SERVER_SELECTION_TIMEOUT_MS, 60000);
+const mongoSocketTimeoutMs = getEnvNumber(process.env.MONGO_SOCKET_TIMEOUT_MS, 60000);
+
+const mongoConnectOptions = {
+  bufferCommands: false,
+  connectTimeoutMS: mongoConnectTimeoutMs,
+  serverSelectionTimeoutMS: mongoServerSelectionTimeoutMs,
+  socketTimeoutMS: mongoSocketTimeoutMs,
+  family: 4 as const
 };
 
 const cached: MongooseGlobalCache = (global as { mongoose?: MongooseGlobalCache }).mongoose ?? {
   conn: null,
-  promise: null
+  promise: null,
+  listenersAttached: false,
+  lastErrorMessage: null
 };
 (global as { mongoose?: MongooseGlobalCache }).mongoose = cached;
+
+const attachConnectionListeners = () => {
+  if (cached.listenersAttached || typeof mongoose.connection?.on !== 'function') {
+    return;
+  }
+
+  mongoose.connection.on('connected', () => {
+    cached.lastErrorMessage = null;
+    logger.info('✅ MongoDB connection established');
+  });
+
+  mongoose.connection.on('disconnected', () => {
+    cached.lastErrorMessage = 'MongoDB connection lost';
+    logger.error('❌ MongoDB connection lost');
+  });
+
+  mongoose.connection.on('error', (error) => {
+    cached.lastErrorMessage = toErrorMessage(error);
+    logger.error('❌ MongoDB connection error', error);
+  });
+
+  cached.listenersAttached = true;
+};
 
 async function dbConnect() {
   if (!mongoUrl) {
     throw new Error(errors.MISSING_MONGO_URL);
   }
 
+  attachConnectionListeners();
+
   if (cached.conn) {
     return cached.conn;
   }
   if (!cached.promise) {
-    const opts = {
-      bufferCommands: false
-    };
-    cached.promise = mongoose.connect(mongoUrl, opts).then((mongoose) => {
+    cached.promise = mongoose.connect(mongoUrl, mongoConnectOptions).then((mongoose) => {
       logger.info('✅ Connected to db');
       return mongoose;
     });
   }
   try {
     cached.conn = await cached.promise;
+    cached.lastErrorMessage = null;
   } catch (error) {
     cached.promise = null;
+    cached.lastErrorMessage = toErrorMessage(error);
     logger.error(errors.FAILED_TO_CONNECT_DB, error);
     throw error;
   }
 
   return cached.conn;
 }
+
+export const getLastMongoConnectionErrorMessage = () => cached.lastErrorMessage;
 
 export default dbConnect;

--- a/src/infrastructure/db/connect.ts
+++ b/src/infrastructure/db/connect.ts
@@ -77,12 +77,10 @@ async function dbConnect() {
   if (cached.conn) {
     return cached.conn;
   }
-  if (!cached.promise) {
-    cached.promise = mongoose.connect(mongoUrl, mongoConnectOptions).then((mongoose) => {
-      logger.info('✅ Connected to db');
-      return mongoose;
-    });
-  }
+  cached.promise ??= mongoose.connect(mongoUrl, mongoConnectOptions).then((mongoose) => {
+    logger.info('✅ Connected to db');
+    return mongoose;
+  });
   try {
     cached.conn = await cached.promise;
     cached.lastErrorMessage = null;

--- a/src/infrastructure/repositories/logRepository/logRepository.test.ts
+++ b/src/infrastructure/repositories/logRepository/logRepository.test.ts
@@ -1,5 +1,3 @@
-import { ObjectId } from 'mongodb';
-
 const mockDbConnect = jest.fn();
 const toArrayMock = jest.fn();
 const limitMock = jest.fn(() => ({ toArray: toArrayMock }));
@@ -34,7 +32,7 @@ describe('logRepository', () => {
 
   it('returns paginated logs ordered by newest first with normalized metadata', async () => {
     const { getLogs } = await import('./logRepository');
-    const id = new ObjectId();
+    const id = '507f1f77bcf86cd799439011';
 
     countDocumentsMock.mockResolvedValue(1);
     toArrayMock.mockResolvedValue([
@@ -92,7 +90,7 @@ describe('logRepository', () => {
 
   it('returns warn logs when warn filter is requested', async () => {
     const { getLogs } = await import('./logRepository');
-    const id = new ObjectId();
+    const id = '507f191e810c19729de860ea';
 
     countDocumentsMock.mockResolvedValue(1);
     toArrayMock.mockResolvedValue([

--- a/src/infrastructure/repositories/logRepository/logRepository.test.ts
+++ b/src/infrastructure/repositories/logRepository/logRepository.test.ts
@@ -1,0 +1,127 @@
+import { ObjectId } from 'mongodb';
+
+const mockDbConnect = jest.fn();
+const toArrayMock = jest.fn();
+const limitMock = jest.fn(() => ({ toArray: toArrayMock }));
+const skipMock = jest.fn(() => ({ limit: limitMock }));
+const sortMock = jest.fn(() => ({ skip: skipMock }));
+const findMock = jest.fn(() => ({ sort: sortMock }));
+const countDocumentsMock = jest.fn();
+
+jest.doMock('~/infrastructure/db/connect', () => ({
+  __esModule: true,
+  default: mockDbConnect
+}));
+
+jest.doMock('mongoose', () => ({
+  __esModule: true,
+  default: {
+    connection: {
+      db: {
+        collection: jest.fn(() => ({
+          find: findMock,
+          countDocuments: countDocumentsMock
+        }))
+      }
+    }
+  }
+}));
+
+describe('logRepository', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns paginated logs ordered by newest first with normalized metadata', async () => {
+    const { getLogs } = await import('./logRepository');
+    const id = new ObjectId();
+
+    countDocumentsMock.mockResolvedValue(1);
+    toArrayMock.mockResolvedValue([
+      {
+        _id: id,
+        level: 'error',
+        message: 'Database connection failed',
+        timestamp: '2026-05-12T10:00:00.000Z',
+        meta: {
+          method: 'GET',
+          url: '/api/health',
+          statusCode: 500,
+          stack: 'Error: fail'
+        },
+        requestId: 'req-1'
+      }
+    ]);
+
+    const result = await getLogs({ level: 'error', page: 2, limit: 10, from: '2026-05-12T00:00:00.000Z' });
+
+    expect(mockDbConnect).toHaveBeenCalled();
+    expect(findMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: 'error',
+        timestamp: expect.objectContaining({ $gte: new Date('2026-05-12T00:00:00.000Z') })
+      })
+    );
+    expect(skipMock).toHaveBeenCalledWith(10);
+    expect(limitMock).toHaveBeenCalledWith(10);
+    expect(countDocumentsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: 'error'
+      })
+    );
+    expect(result).toEqual({
+      items: [
+        {
+          id: id.toString(),
+          level: 'error',
+          message: 'Database connection failed',
+          timestamp: '2026-05-12T10:00:00.000Z',
+          meta: {
+            method: 'GET',
+            url: '/api/health',
+            statusCode: 500,
+            stack: 'Error: fail',
+            metadata: { method: 'GET', url: '/api/health', statusCode: 500, stack: 'Error: fail' },
+            raw: { requestId: 'req-1' }
+          }
+        }
+      ],
+      pagination: { page: 2, limit: 10, total: 1 }
+    });
+  });
+
+  it('returns warn logs when warn filter is requested', async () => {
+    const { getLogs } = await import('./logRepository');
+    const id = new ObjectId();
+
+    countDocumentsMock.mockResolvedValue(1);
+    toArrayMock.mockResolvedValue([
+      {
+        _id: id,
+        level: 'warn',
+        message: 'Storage fallback is in use',
+        timestamp: '2026-05-12T11:00:00.000Z'
+      }
+    ]);
+
+    const result = await getLogs({ level: 'warn', page: 1, limit: 20 });
+
+    expect(findMock).toHaveBeenCalledWith({ level: 'warn' });
+    expect(result.items).toEqual([
+      {
+        id: id.toString(),
+        level: 'warn',
+        message: 'Storage fallback is in use',
+        timestamp: '2026-05-12T11:00:00.000Z',
+        meta: {
+          method: undefined,
+          url: undefined,
+          statusCode: undefined,
+          stack: undefined,
+          metadata: undefined,
+          raw: undefined
+        }
+      }
+    ]);
+  });
+});

--- a/src/infrastructure/repositories/logRepository/logRepository.ts
+++ b/src/infrastructure/repositories/logRepository/logRepository.ts
@@ -1,0 +1,149 @@
+import mongoose from 'mongoose';
+
+import type { LogEntry, LogLevel, LogsQuery, LogsResponse } from '~/back-shared/types/logs';
+import dbConnect from '~/infrastructure/db/connect';
+
+type RawLogDocument = {
+  _id: mongoose.Types.ObjectId | string;
+  level?: string;
+  message?: unknown;
+  timestamp?: string | Date;
+  date?: string | Date;
+  method?: string;
+  url?: string;
+  statusCode?: number;
+  stack?: string;
+  meta?: unknown;
+  metadata?: unknown;
+  context?: unknown;
+  [key: string]: unknown;
+};
+
+const ALLOWED_LEVELS: LogLevel[] = ['error', 'warn', 'info', 'debug'];
+const DEFAULT_PAGE = 1;
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+};
+
+const isAllowedLevel = (level: unknown): level is LogLevel => {
+  return typeof level === 'string' && ALLOWED_LEVELS.includes(level as LogLevel);
+};
+
+const toDateString = (value: unknown): string => {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (typeof value === 'string' && value) {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? value : parsed.toISOString();
+  }
+
+  return new Date(0).toISOString();
+};
+
+const normalizeRawMeta = (value: unknown): Record<string, unknown> | undefined => {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  return value;
+};
+
+const pickMetaValue = (sources: Array<Record<string, unknown> | undefined>, key: string): unknown => {
+  for (const source of sources) {
+    if (source && key in source) {
+      return source[key];
+    }
+  }
+
+  return undefined;
+};
+
+const normalizeLogDocument = (doc: RawLogDocument): LogEntry => {
+  const metaSources = [normalizeRawMeta(doc.meta), normalizeRawMeta(doc.metadata), normalizeRawMeta(doc.context)];
+  const raw = Object.fromEntries(
+    Object.entries(doc).filter(([key]) => !['_id', 'level', 'message', 'timestamp', 'date', 'meta', 'metadata', 'context'].includes(key))
+  );
+
+  const method = pickMetaValue(metaSources, 'method') ?? doc.method;
+  const url = pickMetaValue(metaSources, 'url') ?? doc.url;
+  const statusCode = pickMetaValue(metaSources, 'statusCode') ?? doc.statusCode;
+  const stack = pickMetaValue(metaSources, 'stack') ?? doc.stack;
+
+  const metadata = metaSources.find(Boolean);
+
+  return {
+    id: String(doc._id),
+    level: isAllowedLevel(doc.level) ? doc.level : 'info',
+    message: typeof doc.message === 'string' ? doc.message : JSON.stringify(doc.message),
+    timestamp: toDateString(doc.timestamp ?? doc.date),
+    meta: {
+      method: typeof method === 'string' ? method : undefined,
+      url: typeof url === 'string' ? url : undefined,
+      statusCode: typeof statusCode === 'number' ? statusCode : undefined,
+      stack: typeof stack === 'string' ? stack : undefined,
+      metadata,
+      raw: Object.keys(raw).length > 0 ? raw : undefined
+    }
+  };
+};
+
+const parseDateFilter = (value?: string): Date | undefined => {
+  if (!value) return undefined;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+};
+
+const normalizePagination = (page?: number, limit?: number) => ({
+  page: Math.max(DEFAULT_PAGE, page ?? DEFAULT_PAGE),
+  limit: Math.min(MAX_LIMIT, Math.max(1, limit ?? DEFAULT_LIMIT))
+});
+
+export const getLogs = async (query: Partial<LogsQuery> = {}): Promise<LogsResponse> => {
+  await dbConnect();
+
+  const { page, limit } = normalizePagination(query.page, query.limit);
+  const skip = (page - 1) * limit;
+  const db = mongoose.connection.db;
+
+  if (!db) {
+    throw new Error('Database connection is not available');
+  }
+
+  const filters: Record<string, unknown> = {};
+
+  if (query.level && query.level !== 'all') {
+    filters.level = query.level;
+  }
+
+  const from = parseDateFilter(query.from);
+  const to = parseDateFilter(query.to);
+  if (from || to) {
+    filters.timestamp = {};
+    if (from) {
+      (filters.timestamp as Record<string, Date>).$gte = from;
+    }
+    if (to) {
+      (filters.timestamp as Record<string, Date>).$lte = to;
+    }
+  }
+
+  const collection = db.collection<RawLogDocument>('logger');
+  const [items, total] = await Promise.all([
+    collection.find(filters).sort({ timestamp: -1, _id: -1 }).skip(skip).limit(limit).toArray(),
+    collection.countDocuments(filters)
+  ]);
+
+  return {
+    items: items.map(normalizeLogDocument),
+    pagination: {
+      page,
+      limit,
+      total
+    }
+  };
+};

--- a/src/infrastructure/repositories/logRepository/logRepository.ts
+++ b/src/infrastructure/repositories/logRepository/logRepository.ts
@@ -19,7 +19,7 @@ type RawLogDocument = {
   [key: string]: unknown;
 };
 
-const ALLOWED_LEVELS: LogLevel[] = ['error', 'warn', 'info', 'debug'];
+const ALLOWED_LEVELS = new Set<LogLevel>(['error', 'warn', 'info', 'debug']);
 const DEFAULT_PAGE = 1;
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 100;
@@ -29,7 +29,7 @@ const isRecord = (value: unknown): value is Record<string, unknown> => {
 };
 
 const isAllowedLevel = (level: unknown): level is LogLevel => {
-  return typeof level === 'string' && ALLOWED_LEVELS.includes(level as LogLevel);
+  return typeof level === 'string' && ALLOWED_LEVELS.has(level as LogLevel);
 };
 
 const toDateString = (value: unknown): string => {

--- a/src/middleware/logger/logger.test.ts
+++ b/src/middleware/logger/logger.test.ts
@@ -36,6 +36,10 @@ jest.mock('winston-mongodb', () => ({
   MongoDB: jest.fn()
 }));
 
+jest.mock('../../config', () => ({
+  mongoUrl: 'mongodb://localhost:27017/test-logs'
+}));
+
 const MongoDBMock = jest.requireMock('winston-mongodb').MongoDB as jest.Mock;
 
 describe('Logger', () => {

--- a/src/middleware/logger/logger.test.ts
+++ b/src/middleware/logger/logger.test.ts
@@ -41,7 +41,7 @@ jest.mock('../../config', () => ({
   mongoUrl: 'mongodb://localhost:27017/test-logs'
 }));
 
-const MongoDBMock = jest.requireMock('winston-mongodb').MongoDB as jest.Mock;
+const getMongoDBMock = (): jest.Mock => jest.requireMock('winston-mongodb').MongoDB as jest.Mock;
 
 describe('Logger', () => {
   let logger: Logger;
@@ -72,6 +72,7 @@ describe('Logger', () => {
 
   it('stores all log levels in MongoDB transport', async () => {
     jest.resetModules();
+    const MongoDBMock = getMongoDBMock();
     MongoDBMock.mockClear();
 
     await import('./logger');

--- a/src/middleware/logger/logger.test.ts
+++ b/src/middleware/logger/logger.test.ts
@@ -37,6 +37,7 @@ jest.mock('winston-mongodb', () => ({
 }));
 
 jest.mock('../../config', () => ({
+  __esModule: true,
   mongoUrl: 'mongodb://localhost:27017/test-logs'
 }));
 
@@ -69,7 +70,12 @@ describe('Logger', () => {
     expect(hasMongoDB).toBe(true);
   });
 
-  it('stores all log levels in MongoDB transport', () => {
+  it('stores all log levels in MongoDB transport', async () => {
+    jest.resetModules();
+    MongoDBMock.mockClear();
+
+    await import('./logger');
+
     expect(MongoDBMock).toHaveBeenCalledWith(
       expect.objectContaining({
         level: 'debug',

--- a/src/middleware/logger/logger.test.ts
+++ b/src/middleware/logger/logger.test.ts
@@ -36,6 +36,8 @@ jest.mock('winston-mongodb', () => ({
   MongoDB: jest.fn()
 }));
 
+const MongoDBMock = jest.requireMock('winston-mongodb').MongoDB as jest.Mock;
+
 describe('Logger', () => {
   let logger: Logger;
 
@@ -61,6 +63,15 @@ describe('Logger', () => {
   it('includes MongoDB transport', () => {
     const hasMongoDB = logger.transports.some((t) => t.constructor?.name === 'MongoDB');
     expect(hasMongoDB).toBe(true);
+  });
+
+  it('stores all log levels in MongoDB transport', () => {
+    expect(MongoDBMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: 'debug',
+        collection: 'logger'
+      })
+    );
   });
 
   it('formats message with stack and metadata', () => {

--- a/src/middleware/logger/logger.ts
+++ b/src/middleware/logger/logger.ts
@@ -35,7 +35,7 @@ const transportsList: Transport[] = [
 if (mongoUrl) {
   transportsList.push(
     new MongoDB({
-      level: 'error',
+      level: 'debug',
       db: mongoUrl,
       collection: 'logger',
       expireAfterSeconds: SEVEN_DAYS_IN_SECONDS,

--- a/src/shared/types/logs.ts
+++ b/src/shared/types/logs.ts
@@ -1,0 +1,35 @@
+export type LogLevel = 'error' | 'warn' | 'info' | 'debug';
+
+export type LogMeta = {
+  method?: string;
+  url?: string;
+  statusCode?: number;
+  stack?: string;
+  metadata?: Record<string, unknown>;
+  raw?: Record<string, unknown>;
+};
+
+export type LogEntry = {
+  id: string;
+  level: LogLevel;
+  message: string;
+  timestamp: string;
+  meta: LogMeta;
+};
+
+export type LogsQuery = {
+  level?: LogLevel | 'all';
+  page: number;
+  limit: number;
+  from?: string;
+  to?: string;
+};
+
+export type LogsResponse = {
+  items: LogEntry[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+  };
+};


### PR DESCRIPTION
## Description

This PR implements centralized application logging with MongoDB persistence, API access, and an admin logs viewer.

Implemented:
- Added Winston MongoDB transport for application logs
- Logs are stored in MongoDB collection `logger`
- Transport level is set to `debug`, so `error`, `warn`, `info`, and `debug` logs are persisted
- Added API endpoint for reading logs with:
  - filtering by level
  - pagination
  - date range support
  - newest-first sorting
- Added admin logs page at `/logs` with:
  - tabs by log level
  - colored level indicators
  - logs list
  - expandable technical details
  - pagination
- Added log types and basic tests
- Updated README with short logging documentation

Out of scope:
- Sidebar item for logs page
- `/admin/logs` route
- Real-time log streaming
- Export functionality
- Logs retention strategy

## Type of change

- [x] New feature

## How to test

1. Open the logs page:
   ```bash
   /logs
   ```
2. Verify that logs are displayed correctly.
3. Switch between log level tabs.
4. Verify that pagination works.
5. Expand log details and check technical information.
6. Verify that logs are saved in MongoDB collection `logger`.
7. Test filtering by:
   - level
   - page
   - limit
   - from
   - to
8. Run tests.

## Video / Screenshots

<img width="1744" height="1265" alt="Screenshot 2026-05-15 at 17 04 21" src="https://github.com/user-attachments/assets/68ae41c7-49b5-4060-971c-58da72981bdf" />

<img width="1745" height="1272" alt="Screenshot 2026-05-15 at 17 04 34" src="https://github.com/user-attachments/assets/b10c5922-184f-4c41-862e-d1346b5de84b" />

<img width="1444" height="861" alt="Screenshot 2026-05-15 at 17 05 03" src="https://github.com/user-attachments/assets/e60635f9-2233-4815-9aec-27759229089c" />
