### PR TITLE
fix(#530): align sidebar chevron vertically with navigation text

### DIFF
--- a/app/shared/components/side-navigation/collapse-list-navigation/CollapeListNavigation.styles.ts
+++ b/app/shared/components/side-navigation/collapse-list-navigation/CollapeListNavigation.styles.ts
@@ -12,7 +12,9 @@ export const linkStyles = {
 
 export const styles = {
   listBox: {
-    alignSelf: 'center'
+    alignSelf: 'center',
+    display: 'flex',
+    alignItems: 'center'
   },
   collapse: {
     transition: 'ease-in 0.3s',


### PR DESCRIPTION
## Summary
The chevron icon in the main sidebar navigation was vertically misaligned and appeared higher than the navigation text.

## Fix
Added `display: flex` and `alignItems: center` to the `listBox` style in `CollapeListNavigation.styles.ts`, which contains the chevron SVG image. This ensures the Image element inside the Box is vertically centered with the adjacent `ListItemText`.

## Before/After
- Before: Chevron appeared slightly above the text baseline
- After: Chevron is vertically centered with the navigation text
