### PR TITLE
feat: connect gallery tab to cloudflare storage

### DIFF
--- a/app/constants/errors.ts
+++ b/app/constants/errors.ts
@@ -68,6 +68,10 @@ export const EventsErrors = {
   FAILED_TO_UPDATE_STATUS: 'Failed to update event status'
 };
 
+export const galleryErrors = {
+  FAILED_TO_FETCH: 'Upload files failed'
+};
+
 export const MediaMentionsErrors = {
   NETWORK_ERROR_CREATE: 'Network error while creating media mention',
   FAILED_TO_CREATE: 'Failed to create media mention',

--- a/app/shared/components/media-modal/views/gallery-view/GalleryView.test.tsx
+++ b/app/shared/components/media-modal/views/gallery-view/GalleryView.test.tsx
@@ -1,8 +1,11 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import type { GalleryFilters } from '../../flow/MediaModalFlowState';
 import { MockFilterDropdown, MockMediaGrid, MockSearchButton } from '../../test-utils/sharedMocks';
 import { GalleryView } from './GalleryView';
+import { useGalleryFiles } from '~/shared/hooks/use-galllery-photo/useGallery';
+import { useAllAssetsQuery } from '~/types/graphql/generated/graphql';
 
 jest.mock('../../components/search-button/SearchButton', () => ({
   SearchButton: MockSearchButton
@@ -24,123 +27,228 @@ jest.mock('../../components/gallery-card/GalleryCard', () => ({
   )
 }));
 
+jest.mock('~/shared/hooks/use-galllery-photo/useGallery', () => ({
+  useGalleryFiles: jest.fn()
+}));
+
+jest.mock('~/types/graphql/generated/graphql', () => ({
+  AssetType: { Image: 'IMAGE' },
+  useAllAssetsQuery: jest.fn()
+}));
+
+const mockFiles = [
+  {
+    filename: 'piano-studio.jpg',
+    originalName: 'piano-studio.jpg',
+    mimeType: 'image/jpeg',
+    size: 1000,
+    createdAt: '2024-01-03T00:00:00.000Z',
+    url: 'https://example.com/piano-studio.jpg'
+  },
+  {
+    filename: 'composer-portrait.jpg',
+    originalName: 'composer-portrait.jpg',
+    mimeType: 'image/jpeg',
+    size: 1000,
+    createdAt: '2024-01-02T00:00:00.000Z',
+    url: 'https://example.com/composer-portrait.jpg'
+  },
+  {
+    filename: 'archive-documents.jpg',
+    originalName: 'archive-documents.jpg',
+    mimeType: 'image/jpeg',
+    size: 1000,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    url: 'https://example.com/archive-documents.jpg'
+  }
+];
+
 describe('GalleryView', () => {
   const mockOnPick = jest.fn();
   const mockOnFiltersChange = jest.fn();
-  const mockFilters = {
-    search: '',
-    favorites: '',
-    usage: ''
-  };
+  const mockFilters: GalleryFilters = { search: '', favorites: '', usage: '' };
+
+  const renderGalleryView = (filtersOverride: Partial<GalleryFilters> = {}) =>
+    render(
+      <GalleryView
+        selected={null}
+        onPick={mockOnPick}
+        filters={{ ...mockFilters, ...filtersOverride }}
+        onFiltersChange={mockOnFiltersChange}
+      />
+    );
 
   beforeEach(() => {
     mockOnPick.mockClear();
     mockOnFiltersChange.mockClear();
+    (useGalleryFiles as jest.Mock).mockReturnValue({ files: mockFiles, isLoading: false, error: null });
+    (useAllAssetsQuery as jest.Mock).mockReturnValue({ data: undefined, loading: false });
   });
 
   it('should render gallery view with title', () => {
-    render(
-      <GalleryView selected={null} onPick={mockOnPick} filters={mockFilters} onFiltersChange={mockOnFiltersChange} />
-    );
-
+    renderGalleryView();
     expect(screen.getByText('Усі зображення')).toBeInTheDocument();
   });
 
   it('should render search button', () => {
-    render(
-      <GalleryView selected={null} onPick={mockOnPick} filters={mockFilters} onFiltersChange={mockOnFiltersChange} />
-    );
-
+    renderGalleryView();
     expect(screen.getByTestId('GalleryView-search')).toBeInTheDocument();
   });
 
   it('should render filter dropdowns', () => {
-    render(
-      <GalleryView selected={null} onPick={mockOnPick} filters={mockFilters} onFiltersChange={mockOnFiltersChange} />
-    );
-
+    renderGalleryView();
     expect(screen.getByTestId('GalleryView-favoritesFilter')).toBeInTheDocument();
     expect(screen.getByTestId('GalleryView-usageFilter')).toBeInTheDocument();
   });
 
   it('should render media grid with mock assets', () => {
-    render(
-      <GalleryView selected={null} onPick={mockOnPick} filters={mockFilters} onFiltersChange={mockOnFiltersChange} />
-    );
-
+    renderGalleryView();
     expect(screen.getByTestId('mocked-media-grid')).toBeInTheDocument();
   });
 
-  it('should call onPick when card is clicked', async () => {
-    const user = userEvent.setup();
-    render(
-      <GalleryView selected={null} onPick={mockOnPick} filters={mockFilters} onFiltersChange={mockOnFiltersChange} />
-    );
-
-    const firstCard = screen.getByText('piano-studio.jpg');
-    await user.click(firstCard);
-
-    expect(mockOnPick).toHaveBeenCalledWith(
-      expect.objectContaining({
-        kind: 'gallery',
-        fileName: 'piano-studio.jpg',
-        locale: 'uk'
-      })
-    );
-  });
-
-  it('should call onFiltersChange when typing in search', async () => {
-    const user = userEvent.setup();
-    render(
-      <GalleryView selected={null} onPick={mockOnPick} filters={mockFilters} onFiltersChange={mockOnFiltersChange} />
-    );
-
-    const searchInput = screen.getByTestId('GalleryView-search');
-    await user.type(searchInput, 'a');
-
-    expect(mockOnFiltersChange).toHaveBeenCalledWith({ search: 'a' });
-  });
-
   it('should render multiple gallery cards', () => {
-    render(
-      <GalleryView selected={null} onPick={mockOnPick} filters={mockFilters} onFiltersChange={mockOnFiltersChange} />
-    );
-
+    renderGalleryView();
     expect(screen.getByText('piano-studio.jpg')).toBeInTheDocument();
     expect(screen.getByText('composer-portrait.jpg')).toBeInTheDocument();
     expect(screen.getByText('archive-documents.jpg')).toBeInTheDocument();
   });
 
+  it('should call onPick when card is clicked', async () => {
+    const user = userEvent.setup();
+    renderGalleryView();
+
+    await user.click(screen.getByText('piano-studio.jpg'));
+
+    expect(mockOnPick).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'gallery', fileName: 'piano-studio.jpg', locale: 'uk' })
+    );
+  });
+
   it('should handle multiple card clicks', async () => {
     const user = userEvent.setup();
-    render(
-      <GalleryView selected={null} onPick={mockOnPick} filters={mockFilters} onFiltersChange={mockOnFiltersChange} />
-    );
+    renderGalleryView();
 
-    const firstCard = screen.getByText('piano-studio.jpg');
-    const secondCard = screen.getByText('composer-portrait.jpg');
-
-    await user.click(firstCard);
-    await user.click(secondCard);
+    await user.click(screen.getByText('piano-studio.jpg'));
+    await user.click(screen.getByText('composer-portrait.jpg'));
 
     expect(mockOnPick).toHaveBeenCalledTimes(2);
   });
 
+  it('should call onFiltersChange when typing in search', async () => {
+    const user = userEvent.setup();
+    renderGalleryView();
+
+    await user.type(screen.getByTestId('GalleryView-search'), 'a');
+
+    expect(mockOnFiltersChange).toHaveBeenCalledWith({ search: 'a' });
+  });
+
   it('should call onFiltersChange when clearing search', async () => {
     const user = userEvent.setup();
-    const filtersWithSearch = { search: 'test', favorites: '', usage: '' };
     render(
       <GalleryView
         selected={null}
         onPick={mockOnPick}
-        filters={filtersWithSearch}
+        filters={{ search: 'test', favorites: '', usage: '' }}
         onFiltersChange={mockOnFiltersChange}
       />
     );
 
-    const searchInput = screen.getByTestId('GalleryView-search');
-    await user.clear(searchInput);
+    await user.clear(screen.getByTestId('GalleryView-search'));
 
     expect(mockOnFiltersChange).toHaveBeenCalledWith({ search: '' });
+  });
+
+  it('should show loading state when files are loading', () => {
+    (useGalleryFiles as jest.Mock).mockReturnValue({ files: [], isLoading: true, error: null });
+    renderGalleryView();
+
+    expect(screen.getByText('Завантаження...')).toBeInTheDocument();
+    expect(screen.queryByTestId('mocked-media-grid')).not.toBeInTheDocument();
+  });
+
+  it('should show loading state when assets are loading', () => {
+    (useAllAssetsQuery as jest.Mock).mockReturnValue({ data: undefined, loading: true });
+    renderGalleryView();
+
+    expect(screen.getByText('Завантаження...')).toBeInTheDocument();
+  });
+
+  it('should filter out non-starred items when favorites filter is starred', () => {
+    renderGalleryView({ favorites: 'starred' });
+    expect(screen.queryByText('piano-studio.jpg')).not.toBeInTheDocument();
+  });
+
+  it('should show all items when favorites filter is not-starred', () => {
+    renderGalleryView({ favorites: 'not-starred' });
+    expect(screen.getByText('piano-studio.jpg')).toBeInTheDocument();
+    expect(screen.getByText('composer-portrait.jpg')).toBeInTheDocument();
+  });
+
+  it('should show all items when favorites filter is an unknown value', () => {
+    renderGalleryView({ favorites: 'unknown-filter-value' });
+    expect(screen.getByText('piano-studio.jpg')).toBeInTheDocument();
+  });
+
+  it('should show all items when usage filter is unused', () => {
+    renderGalleryView({ usage: 'unused' });
+    expect(screen.getByText('piano-studio.jpg')).toBeInTheDocument();
+    expect(screen.getByText('composer-portrait.jpg')).toBeInTheDocument();
+    expect(screen.getByText('archive-documents.jpg')).toBeInTheDocument();
+  });
+
+  it('should filter out items not matching usage page', () => {
+    renderGalleryView({ usage: 'news' });
+    expect(screen.queryByText('piano-studio.jpg')).not.toBeInTheDocument();
+  });
+
+  it('should show starred items and compute usage locations from asset data', () => {
+    (useAllAssetsQuery as jest.Mock).mockReturnValue({
+      data: {
+        allAssets: [
+          {
+            id: 'asset-1',
+            url: 'https://example.com/piano-studio.jpg',
+            filename: 'piano-studio.jpg',
+            isStarred: true,
+            tags: [],
+            usageRefs: [
+              { pageId: 'news', blockId: null },
+              { pageId: 'unknown-page', blockId: null },
+              { pageId: null, blockId: null }
+            ]
+          }
+        ]
+      },
+      loading: false
+    });
+
+    renderGalleryView({ favorites: 'starred' });
+
+    expect(screen.getByText('piano-studio.jpg')).toBeInTheDocument();
+    expect(screen.queryByText('composer-portrait.jpg')).not.toBeInTheDocument();
+  });
+
+  it('should match items by usage page from asset usageRefs', () => {
+    (useAllAssetsQuery as jest.Mock).mockReturnValue({
+      data: {
+        allAssets: [
+          {
+            id: 'asset-1',
+            url: 'https://example.com/piano-studio.jpg',
+            filename: 'piano-studio.jpg',
+            isStarred: false,
+            tags: [],
+            usageRefs: [{ pageId: 'news', blockId: null }]
+          }
+        ]
+      },
+      loading: false
+    });
+
+    renderGalleryView({ usage: 'news' });
+
+    expect(screen.getByText('piano-studio.jpg')).toBeInTheDocument();
+    expect(screen.queryByText('composer-portrait.jpg')).not.toBeInTheDocument();
   });
 });

--- a/app/shared/components/media-modal/views/gallery-view/GalleryView.tsx
+++ b/app/shared/components/media-modal/views/gallery-view/GalleryView.tsx
@@ -12,6 +12,8 @@ import type { GalleryMedia } from '../../MediaModal.types';
 import { sharedViewStyles } from '../shared-view.styles';
 import { useDebounce } from '~/hooks/use-debounce/useDebounce';
 import { matchesSearch, sortByDateAndName } from '~/lib/utils/filterHelpers';
+import { useGalleryFiles } from '~/shared/hooks/use-galllery-photo/useGallery';
+import { AssetType, useAllAssetsQuery } from '~/types/graphql/generated/graphql';
 
 type Props = Readonly<{
   selected: GalleryMedia | null;
@@ -20,57 +22,15 @@ type Props = Readonly<{
   onFiltersChange: (filters: Partial<GalleryFilters>) => void;
 }>;
 
-type MockAsset = {
-  _id: string;
+type GalleryItem = {
+  id: string;
   filename: string;
   url: string;
   isStarred: boolean;
-  tags: ('page' | 'news' | 'events' | 'opus')[];
-  usageRefs: { pageId: string; blockId?: string }[];
+  tags: string[];
+  usageRefs: { pageId?: string | null; blockId?: string | null }[];
   createdAt: string;
 };
-
-const mockAssets: MockAsset[] = [
-  {
-    _id: '1',
-    filename: 'piano-studio.jpg',
-    url: '/images/foundation-second.png',
-    isStarred: true,
-    tags: ['page', 'opus'],
-    usageRefs: [
-      { pageId: 'about', blockId: 'hero' },
-      { pageId: 'collaboration', blockId: 'partners' }
-    ],
-    createdAt: '2025-01-08T10:30:00Z'
-  },
-  {
-    _id: '2',
-    filename: 'composer-portrait.jpg',
-    url: '/images/foundation-first.png',
-    isStarred: false,
-    tags: ['opus'],
-    usageRefs: [],
-    createdAt: '2025-01-09T14:20:00Z'
-  },
-  {
-    _id: '3',
-    filename: 'archive-documents.jpg',
-    url: '/images/mission-1.png',
-    isStarred: true,
-    tags: ['news', 'events'],
-    usageRefs: [],
-    createdAt: '2025-01-10T09:15:00Z'
-  },
-  {
-    _id: '4',
-    filename: 'concert-hall.jpg',
-    url: '/images/foundation-first.png',
-    isStarred: false,
-    tags: ['events'],
-    usageRefs: [],
-    createdAt: '2025-01-07T16:45:00Z'
-  }
-];
 
 const favoritesFilterOptions = [
   { value: 'starred', label: 'Із зірочкою' },
@@ -86,58 +46,95 @@ const usageFilterOptions = [
   { value: 'unused', label: 'Не використані' }
 ];
 
-const getPageNames = (usageRefs: MockAsset['usageRefs']): string[] => {
+const getPageNames = (usageRefs: GalleryItem['usageRefs']): string[] => {
   const pageNameMap: Record<string, string> = {
     about: 'Про Фундацію',
     collaboration: 'Співпраця',
     news: 'Новини',
     events: 'Події'
   };
-
-  return usageRefs.map((ref) => pageNameMap[ref.pageId] || ref.pageId);
+  return usageRefs.map((ref) => pageNameMap[ref.pageId ?? ''] ?? ref.pageId ?? '');
 };
 
-const matchesFavoritesFilter = (asset: MockAsset, filter: string): boolean => {
+const matchesFavoritesFilter = (item: GalleryItem, filter: string): boolean => {
   if (!filter) return true;
-  if (filter === 'starred') return asset.isStarred;
-  if (filter === 'not-starred') return !asset.isStarred;
+  if (filter === 'starred') return item.isStarred;
+  if (filter === 'not-starred') return !item.isStarred;
   return true;
 };
 
-const matchesUsageFilter = (asset: MockAsset, filter: string): boolean => {
+const matchesUsageFilter = (item: GalleryItem, filter: string): boolean => {
   if (!filter) return true;
-  if (filter === 'unused') return asset.usageRefs.length === 0;
-  return asset.tags.includes(filter as MockAsset['tags'][number]);
+  if (filter === 'unused') return item.usageRefs.length === 0;
+  return item.usageRefs.some((ref) => ref.pageId === filter);
 };
 
 export function GalleryView({ selected: _selected, onPick, filters, onFiltersChange }: Props) {
-  const handleCardClick = (asset: MockAsset) => {
-    const galleryMedia: GalleryMedia = {
-      kind: 'gallery',
-      id: asset._id,
-      fileName: asset.filename,
-      src: asset.url,
-      locale: 'uk'
-    };
+  const { files: r2Files, isLoading: r2Loading } = useGalleryFiles();
 
-    onPick(galleryMedia);
-  };
+  const { data: assetsData, loading: assetsLoading } = useAllAssetsQuery({
+    variables: { filters: { type: AssetType.Image } }
+  });
 
   const debouncedSearchValue = useDebounce(filters.search, 200);
 
-  const filteredAndSortedAssets = useMemo(
+  type AssetMeta = {
+    id: string;
+    filename: string;
+    isStarred: boolean;
+    tags: string[];
+    usageRefs: { pageId?: string | null; blockId?: string | null }[];
+  };
+
+  const assetByUrl = useMemo(() => {
+    const map = new Map<string, AssetMeta>();
+    (assetsData?.allAssets ?? []).forEach((asset) => {
+      if (asset.url) map.set(asset.url, asset as AssetMeta);
+    });
+    return map;
+  }, [assetsData]);
+
+  const galleryItems = useMemo((): GalleryItem[] => {
+    return r2Files
+      .filter((file) => !!file.url)
+      .map((file) => {
+        const asset = assetByUrl.get(file.url!);
+        return {
+          id: asset?.id ?? file.path ?? file.filename,
+          filename: asset?.filename ?? file.filename,
+          url: file.url!,
+          isStarred: asset?.isStarred ?? false,
+          tags: asset?.tags ?? [],
+          usageRefs: asset?.usageRefs ?? [],
+          createdAt: file.createdAt
+        };
+      });
+  }, [r2Files, assetByUrl]);
+
+  const filteredAndSortedItems = useMemo(
     () =>
       sortByDateAndName(
-        mockAssets.filter((asset) => {
-          return (
-            matchesSearch(asset, debouncedSearchValue, ['filename']) &&
-            matchesFavoritesFilter(asset, filters.favorites) &&
-            matchesUsageFilter(asset, filters.usage)
-          );
-        })
+        galleryItems.filter(
+          (item) =>
+            matchesSearch(item, debouncedSearchValue, ['filename']) &&
+            matchesFavoritesFilter(item, filters.favorites) &&
+            matchesUsageFilter(item, filters.usage)
+        )
       ),
-    [debouncedSearchValue, filters.favorites, filters.usage]
+    [galleryItems, debouncedSearchValue, filters.favorites, filters.usage]
   );
+
+  const handleCardClick = (item: GalleryItem) => {
+    onPick({
+      kind: 'gallery',
+      id: item.id,
+      fileName: item.filename,
+      src: item.url,
+      locale: 'uk'
+    });
+  };
+
+  const loading = r2Loading || assetsLoading;
 
   return (
     <Box data-testid="GalleryView" sx={sharedViewStyles.container}>
@@ -151,7 +148,6 @@ export function GalleryView({ selected: _selected, onPick, filters, onFiltersCha
             placeholder="Пошук..."
             testId="GalleryView-search"
           />
-
           <FilterDropdown
             label="Позначення"
             value={filters.favorites}
@@ -159,7 +155,6 @@ export function GalleryView({ selected: _selected, onPick, filters, onFiltersCha
             onChange={(favorites) => onFiltersChange({ favorites })}
             testId="GalleryView-favoritesFilter"
           />
-
           <FilterDropdown
             label="Використання"
             value={filters.usage}
@@ -170,21 +165,25 @@ export function GalleryView({ selected: _selected, onPick, filters, onFiltersCha
         </Box>
       </Box>
 
-      <MediaGrid
-        items={filteredAndSortedAssets}
-        sx={sharedViewStyles.gridContainer}
-        renderCard={(asset: MockAsset) => (
-          <GalleryCard
-            src={asset.url}
-            fileName={asset.filename}
-            isStarred={asset.isStarred}
-            usageLocations={getPageNames(asset.usageRefs)}
-            onClick={() => handleCardClick(asset)}
-            testId={`GalleryCard-${asset._id}`}
-          />
-        )}
-        testIdPrefix="GalleryView"
-      />
+      {loading ? (
+        <Box sx={sharedViewStyles.gridContainer}>Завантаження...</Box>
+      ) : (
+        <MediaGrid
+          items={filteredAndSortedItems}
+          sx={sharedViewStyles.gridContainer}
+          renderCard={(item) => (
+            <GalleryCard
+              src={item.url}
+              fileName={item.filename}
+              isStarred={item.isStarred}
+              usageLocations={getPageNames(item.usageRefs)}
+              onClick={() => handleCardClick(item)}
+              testId={`GalleryCard-${item.id}`}
+            />
+          )}
+          testIdPrefix="GalleryView"
+        />
+      )}
     </Box>
   );
 }

--- a/app/shared/components/media-modal/views/gallery-view/GalleryView.tsx
+++ b/app/shared/components/media-modal/views/gallery-view/GalleryView.tsx
@@ -87,9 +87,9 @@ export function GalleryView({ selected: _selected, onPick, filters, onFiltersCha
   };
 
   const assetByUrl = useMemo(() => {
-    const map = new Map<string, AssetMeta>();
+    const map: Record<string, AssetMeta> = {};
     (assetsData?.allAssets ?? []).forEach((asset) => {
-      if (asset.url) map.set(asset.url, asset as AssetMeta);
+      if (asset.url) map[asset.url] = asset as AssetMeta;
     });
     return map;
   }, [assetsData]);
@@ -98,7 +98,7 @@ export function GalleryView({ selected: _selected, onPick, filters, onFiltersCha
     return r2Files
       .filter((file): file is GalleryFile & { url: string } => Boolean(file.url))
       .map((file) => {
-        const asset = assetByUrl.get(file.url);
+        const asset = assetByUrl[file.url];
         return {
           id: asset?.id ?? file.path ?? file.filename,
           filename: asset?.filename ?? file.filename,

--- a/app/shared/components/media-modal/views/gallery-view/GalleryView.tsx
+++ b/app/shared/components/media-modal/views/gallery-view/GalleryView.tsx
@@ -12,7 +12,7 @@ import type { GalleryMedia } from '../../MediaModal.types';
 import { sharedViewStyles } from '../shared-view.styles';
 import { useDebounce } from '~/hooks/use-debounce/useDebounce';
 import { matchesSearch, sortByDateAndName } from '~/lib/utils/filterHelpers';
-import { useGalleryFiles } from '~/shared/hooks/use-galllery-photo/useGallery';
+import { type GalleryFile, useGalleryFiles } from '~/shared/hooks/use-galllery-photo/useGallery';
 import { AssetType, useAllAssetsQuery } from '~/types/graphql/generated/graphql';
 
 type Props = Readonly<{
@@ -96,13 +96,13 @@ export function GalleryView({ selected: _selected, onPick, filters, onFiltersCha
 
   const galleryItems = useMemo((): GalleryItem[] => {
     return r2Files
-      .filter((file) => !!file.url)
+      .filter((file): file is GalleryFile & { url: string } => Boolean(file.url))
       .map((file) => {
-        const asset = assetByUrl.get(file.url!);
+        const asset = assetByUrl.get(file.url);
         return {
           id: asset?.id ?? file.path ?? file.filename,
           filename: asset?.filename ?? file.filename,
-          url: file.url!,
+          url: file.url,
           isStarred: asset?.isStarred ?? false,
           tags: asset?.tags ?? [],
           usageRefs: asset?.usageRefs ?? [],

--- a/app/shared/components/media-modal/views/used-view/UsedView.test.tsx
+++ b/app/shared/components/media-modal/views/used-view/UsedView.test.tsx
@@ -1,93 +1,31 @@
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 
-import { MockFilterDropdown, MockMediaGrid, MockSearchButton } from '../../test-utils/sharedMocks';
 import { UsedView } from './UsedView';
 
-jest.mock('../../components/used-card/UsedCard', () => ({
-  UsedCard: ({ fileName, onClick, testId }: { fileName: string; onClick: () => void; testId: string }) => (
-    <button data-testid={testId} onClick={onClick}>
-      {fileName}
-    </button>
-  )
-}));
-
-jest.mock('../../components/search-button/SearchButton', () => ({
-  SearchButton: MockSearchButton
-}));
-
-jest.mock('../../components/filter-dropdown/FilterDropdown', () => ({
-  FilterDropdown: MockFilterDropdown
-}));
-
-jest.mock('../../components/media-grid/MediaGrid', () => ({
-  MediaGrid: MockMediaGrid
-}));
-
 describe('UsedView', () => {
-  const mockOnPick = jest.fn();
-  const mockOnFiltersChange = jest.fn();
-  const mockFilters = {
-    search: '',
-    language: ''
+  const defaultProps = {
+    selected: null,
+    onPick: jest.fn(),
+    filters: { search: '', language: '' },
+    onFiltersChange: jest.fn()
   };
 
-  beforeEach(() => {
-    mockOnPick.mockClear();
-    mockOnFiltersChange.mockClear();
-  });
-
   it('should render used view component', () => {
-    render(
-      <UsedView selected={null} onPick={mockOnPick} filters={mockFilters} onFiltersChange={mockOnFiltersChange} />
-    );
+    render(<UsedView {...defaultProps} />);
 
     expect(screen.getByTestId('UsedView')).toBeInTheDocument();
   });
 
   it('should render title', () => {
-    render(
-      <UsedView selected={null} onPick={mockOnPick} filters={mockFilters} onFiltersChange={mockOnFiltersChange} />
-    );
+    render(<UsedView {...defaultProps} />);
 
     expect(screen.getByText('Зображення на сторінці')).toBeInTheDocument();
   });
 
-  it('should render media grid', () => {
-    render(
-      <UsedView selected={null} onPick={mockOnPick} filters={mockFilters} onFiltersChange={mockOnFiltersChange} />
-    );
+  it('should render info alert about tab being temporarily unavailable', () => {
+    render(<UsedView {...defaultProps} />);
 
-    expect(screen.getByTestId('mocked-media-grid')).toBeInTheDocument();
-  });
-
-  it('should render multiple used cards', () => {
-    render(
-      <UsedView selected={null} onPick={mockOnPick} filters={mockFilters} onFiltersChange={mockOnFiltersChange} />
-    );
-
-    const pianoCards = screen.getAllByText('piano-studio.jpg');
-    const composerCards = screen.getAllByText('composer-portrait.jpg');
-
-    expect(pianoCards.length).toBeGreaterThan(0);
-    expect(composerCards.length).toBeGreaterThan(0);
-  });
-
-  it('should call onPick when card is clicked', async () => {
-    const user = userEvent.setup();
-    render(
-      <UsedView selected={null} onPick={mockOnPick} filters={mockFilters} onFiltersChange={mockOnFiltersChange} />
-    );
-
-    const firstCard = screen.getByText('2025-01-10-newest.jpg');
-    await user.click(firstCard);
-
-    expect(mockOnPick).toHaveBeenCalledWith(
-      expect.objectContaining({
-        kind: 'used',
-        fileName: '2025-01-10-newest.jpg',
-        locale: 'uk'
-      })
-    );
+    expect(screen.getByText('Вкладка тимчасово недоступна')).toBeInTheDocument();
+    expect(screen.getByText('Дана вкладка не підключена до джерела даних. В майбутньому цей недолік буде виправлено.')).toBeInTheDocument();
   });
 });

--- a/app/shared/components/media-modal/views/used-view/UsedView.tsx
+++ b/app/shared/components/media-modal/views/used-view/UsedView.tsx
@@ -1,138 +1,26 @@
 'use client';
 
 import { Box } from '@mui/material';
-import { useMemo } from 'react';
 
-import { FilterDropdown } from '../../components/filter-dropdown/FilterDropdown';
-import { MediaGrid } from '../../components/media-grid/MediaGrid';
-import { SearchButton } from '../../components/search-button/SearchButton';
-import { UsedCard } from '../../components/used-card/UsedCard';
-import type { UsedFilters } from '../../flow/MediaModalFlowState';
-import type { UsedMedia } from '../../MediaModal.types';
+import type { UsedRendererProps } from '../../MediaModal.renderers';
 import { sharedViewStyles } from '../shared-view.styles';
-import { useDebounce } from '~/hooks/use-debounce/useDebounce';
-import { matchesSearch, sortByDateAndName } from '~/lib/utils/filterHelpers';
+import Alert from '~/shared/components/design-system/alert/Alert';
 
-type Props = Readonly<{
-  selected: UsedMedia | null;
-  onPick: (selected: UsedMedia) => void;
-  filters: UsedFilters;
-  onFiltersChange: (filters: Partial<UsedFilters>) => void;
-}>;
-
-type MockUsedAsset = {
-  _id: string;
-  filename: string;
-  url: string;
-  locale: 'uk' | 'en';
-  createdAt: string;
-};
-
-const mockUsedAssets: MockUsedAsset[] = [
-  {
-    _id: '1',
-    filename: '2025-01-10-newest.jpg',
-    url: '/images/mission-1.png',
-    locale: 'uk',
-    createdAt: '2025-01-10T10:00:00Z'
-  },
-  {
-    _id: '2',
-    filename: 'piano-studio.jpg',
-    url: '/images/foundation-second.png',
-    locale: 'en',
-    createdAt: '2025-01-09T10:00:00Z'
-  },
-  {
-    _id: '3',
-    filename: 'composer-portrait.jpg',
-    url: '/images/foundation-first.png',
-    locale: 'uk',
-    createdAt: '2025-01-08T10:00:00Z'
-  },
-  {
-    _id: '4',
-    filename: '2025-01-07-oldest.jpg',
-    url: '/images/foundation-first.png',
-    locale: 'en',
-    createdAt: '2025-01-07T10:00:00Z'
-  }
-];
-
-const languageFilterOptions = [
-  { value: 'uk', label: 'Українська' },
-  { value: 'en', label: 'English' }
-];
-
-export function UsedView({ onPick, filters, onFiltersChange }: Props) {
-  const debouncedSearchValue = useDebounce(filters.search, 200);
-
-  const handleCardClick = (asset: MockUsedAsset) => {
-    const usedMedia: UsedMedia = {
-      kind: 'used',
-      id: asset._id,
-      fileName: asset.filename,
-      src: asset.url,
-      locale: asset.locale
-    };
-
-    onPick(usedMedia);
-  };
-
-  const filteredAndSortedAssets = useMemo(
-    () =>
-      sortByDateAndName(
-        mockUsedAssets.filter((asset) => {
-          if (!matchesSearch(asset, debouncedSearchValue, ['filename'])) {
-            return false;
-          }
-
-          if (filters.language && asset.locale !== filters.language) {
-            return false;
-          }
-
-          return true;
-        })
-      ),
-    [debouncedSearchValue, filters.language]
-  );
-
+export function UsedView(_props: UsedRendererProps) {
   return (
     <Box data-testid="UsedView" sx={sharedViewStyles.container}>
       <Box sx={sharedViewStyles.header}>
         <Box sx={sharedViewStyles.title}>Зображення на сторінці</Box>
-
-        <Box sx={sharedViewStyles.controlsGroup}>
-          <SearchButton
-            value={filters.search}
-            onSearch={(search) => onFiltersChange({ search })}
-            placeholder="Пошук..."
-            testId="UsedView-search"
-          />
-          <FilterDropdown
-            label="Мова"
-            value={filters.language}
-            options={languageFilterOptions}
-            onChange={(language) => onFiltersChange({ language })}
-            testId="UsedView-languageFilter"
-          />
-        </Box>
       </Box>
 
-      <MediaGrid
-        items={filteredAndSortedAssets}
-        sx={sharedViewStyles.gridContainer}
-        renderCard={(asset: MockUsedAsset) => (
-          <UsedCard
-            src={asset.url}
-            fileName={asset.filename}
-            locale={asset.locale}
-            onClick={() => handleCardClick(asset)}
-            testId={`UsedCard-${asset._id}`}
-          />
-        )}
-        testIdPrefix="UsedView"
-      />
+      <Box sx={sharedViewStyles.gridContainer}>
+        <Alert
+          severity="info"
+          variant="outlined"
+          title="Вкладка тимчасово недоступна"
+          description="Дана вкладка не підключена до джерела даних. В майбутньому цей недолік буде виправлено."
+        />
+      </Box>
     </Box>
   );
 }

--- a/app/shared/components/media-modal/views/used-view/UsedView.tsx
+++ b/app/shared/components/media-modal/views/used-view/UsedView.tsx
@@ -6,7 +6,7 @@ import type { UsedRendererProps } from '../../MediaModal.renderers';
 import { sharedViewStyles } from '../shared-view.styles';
 import Alert from '~/shared/components/design-system/alert/Alert';
 
-export function UsedView(_props: UsedRendererProps) {
+export function UsedView(_props: Readonly<UsedRendererProps>) {
   return (
     <Box data-testid="UsedView" sx={sharedViewStyles.container}>
       <Box sx={sharedViewStyles.header}>

--- a/app/shared/hooks/use-galllery-photo/useGallery.test.ts
+++ b/app/shared/hooks/use-galllery-photo/useGallery.test.ts
@@ -1,0 +1,120 @@
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { useGalleryFiles } from './useGallery';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+const makeResponse = (body: unknown) =>
+  Promise.resolve({ json: () => Promise.resolve(body) } as Response);
+
+describe('useGalleryFiles', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should start with isLoading=true, empty files and null error', () => {
+    mockFetch.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useGalleryFiles());
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.files).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('should fetch from /api/uploads?folder=photos', async () => {
+    mockFetch.mockReturnValue(makeResponse({ success: true, data: [] }));
+
+    renderHook(() => useGalleryFiles());
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith('/api/uploads?folder=photos');
+    });
+  });
+
+  it('should map files and set isLoading=false on success', async () => {
+    const rawFile = {
+      filename: 'photo.jpg',
+      originalName: 'photo.jpg',
+      mimeType: 'image/jpeg',
+      size: 1024,
+      uploadedAt: '2024-01-15T10:00:00.000Z',
+      url: 'https://r2.example.com/photo.jpg',
+      path: 'photos/photo.jpg'
+    };
+
+    mockFetch.mockReturnValue(makeResponse({ success: true, data: [rawFile] }));
+
+    const { result } = renderHook(() => useGalleryFiles());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.files).toHaveLength(1);
+    expect(result.current.files[0]).toMatchObject({
+      filename: 'photo.jpg',
+      mimeType: 'image/jpeg',
+      createdAt: '2024-01-15T10:00:00.000Z'
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it('should convert uploadedAt Date instance to ISO string', async () => {
+    const date = new Date('2024-03-01T12:00:00.000Z');
+    const rawFile = {
+      filename: 'audio.mp3',
+      originalName: 'audio.mp3',
+      mimeType: 'audio/mpeg',
+      size: 512,
+      uploadedAt: date
+    };
+
+    mockFetch.mockReturnValue(makeResponse({ success: true, data: [rawFile] }));
+
+    const { result } = renderHook(() => useGalleryFiles());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.files[0].createdAt).toBe(date.toISOString());
+  });
+
+  it('should convert uploadedAt string via String()', async () => {
+    const rawFile = {
+      filename: 'doc.pdf',
+      originalName: 'doc.pdf',
+      mimeType: 'application/pdf',
+      size: 2048,
+      uploadedAt: '2024-06-10'
+    };
+
+    mockFetch.mockReturnValue(makeResponse({ success: true, data: [rawFile] }));
+
+    const { result } = renderHook(() => useGalleryFiles());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.files[0].createdAt).toBe('2024-06-10');
+  });
+
+  it('should set error when data.success is false', async () => {
+    mockFetch.mockReturnValue(makeResponse({ success: false }));
+
+    const { result } = renderHook(() => useGalleryFiles());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.error).toBe('Upload files failed');
+    expect(result.current.files).toEqual([]);
+  });
+
+  it('should set error when fetch throws', async () => {
+    mockFetch.mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useGalleryFiles());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.error).toBe('Upload files failed');
+    expect(result.current.files).toEqual([]);
+  });
+});

--- a/app/shared/hooks/use-galllery-photo/useGallery.test.ts
+++ b/app/shared/hooks/use-galllery-photo/useGallery.test.ts
@@ -3,10 +3,9 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { useGalleryFiles } from './useGallery';
 
 const mockFetch = jest.fn();
-global.fetch = mockFetch;
+globalThis.fetch = mockFetch;
 
-const makeResponse = (body: unknown) =>
-  Promise.resolve({ json: () => Promise.resolve(body) } as Response);
+const makeResponse = (body: unknown) => Promise.resolve({ json: () => Promise.resolve(body) } as Response);
 
 describe('useGalleryFiles', () => {
   beforeEach(() => {

--- a/app/shared/hooks/use-galllery-photo/useGallery.ts
+++ b/app/shared/hooks/use-galllery-photo/useGallery.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+
+export type GalleryFile = {
+  filename: string;
+  originalName: string;
+  mimeType: string;
+  size: number;
+  createdAt: string;
+  path?: string;
+  url?: string;
+  directory?: string;
+};
+
+export function useGalleryFiles() {
+  const [files, setFiles] = useState<GalleryFile[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch('/api/uploads?folder=photos')
+      .then((r) => r.json())
+      .then((data) => {
+        if (data.success) {
+          const mapped: GalleryFile[] = data.data.map(
+            (f: { uploadedAt: string | Date } & Omit<GalleryFile, 'createdAt'>) => ({
+              ...f,
+              createdAt: f.uploadedAt instanceof Date ? f.uploadedAt.toISOString() : String(f.uploadedAt)
+            })
+          );
+          setFiles(mapped);
+        } else {
+          setError('Upload files failed');
+        }
+      })
+      .catch(() => setError('Upload files failed'))
+      .finally(() => setIsLoading(false));
+  }, []);
+  return { files, isLoading, error };
+}

--- a/app/shared/hooks/use-galllery-photo/useGallery.ts
+++ b/app/shared/hooks/use-galllery-photo/useGallery.ts
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 
+import { galleryErrors } from '~/constants/errors';
+
 export type GalleryFile = {
   filename: string;
   originalName: string;
@@ -29,10 +31,10 @@ export function useGalleryFiles() {
           );
           setFiles(mapped);
         } else {
-          setError('Upload files failed');
+          setError(galleryErrors.FAILED_TO_FETCH);
         }
       })
-      .catch(() => setError('Upload files failed'))
+      .catch(() => setError(galleryErrors.FAILED_TO_FETCH))
       .finally(() => setIsLoading(false));
   }, []);
   return { files, isLoading, error };

--- a/app/types/graphql/queries/assets.graphql
+++ b/app/types/graphql/queries/assets.graphql
@@ -6,6 +6,7 @@ query AllAssets($filters: AssetsFiltersInput) {
     usageRefs {
       pageId
       blockId
+      locale
     }
     filename
     mimeType

--- a/src/infrastructure/repositories/assetRepository/assetRepository.test.ts
+++ b/src/infrastructure/repositories/assetRepository/assetRepository.test.ts
@@ -128,10 +128,10 @@ describe('AssetRepository', () => {
     it('should build isUsed filter using $exists operator', () => {
       const { buildQuery } = getRepoConfig();
 
-      const usedQuery = buildQuery({ isUsed: true }) as Record<string, unknown>;
+      const usedQuery = buildQuery({ isUsed: true });
       expect(usedQuery['usageRefs.0']).toEqual({ $exists: true });
 
-      const unusedQuery = buildQuery({ isUsed: false }) as Record<string, unknown>;
+      const unusedQuery = buildQuery({ isUsed: false });
       expect(unusedQuery['usageRefs.0']).toEqual({ $exists: false });
     });
   });

--- a/src/infrastructure/repositories/assetRepository/assetRepository.test.ts
+++ b/src/infrastructure/repositories/assetRepository/assetRepository.test.ts
@@ -1,13 +1,11 @@
+import { createStorageAdapter } from '../../../uploads/storage';
 import { createBaseRepository } from '../baseRepository/baseRepository';
 import { AssetRepository } from './assetRepository';
+import logger from '~/src/middleware/logger/logger';
 
 jest.mock('~/src/middleware/logger/logger', () => ({
   __esModule: true,
-  default: {
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn()
-  }
+  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
 }));
 
 jest.mock('../baseRepository/baseRepository', () => ({
@@ -17,128 +15,373 @@ jest.mock('../baseRepository/baseRepository', () => ({
 jest.mock('../../../config', () => ({
   config: { uploads: { storage: { type: 'local' } } }
 }));
+
 jest.mock('../../../uploads/storage', () => ({
   createStorageAdapter: jest.fn(() => ({
     delete: jest.fn().mockResolvedValue({ success: true })
   }))
 }));
 
-describe('AssetRepository', () => {
-  const mockedCreateBaseRepository = createBaseRepository as jest.Mock;
+const mockedCreateBaseRepository = createBaseRepository as jest.Mock;
 
-  beforeEach(() => {
-    mockedCreateBaseRepository.mockClear();
-  });
-
-  it('should pass model and handlers into base repository factory', () => {
-    const model = {};
-
-    AssetRepository({ AssetModel: model as never });
-
-    const config = mockedCreateBaseRepository.mock.calls[0][0] as Record<string, unknown>;
-
-    expect(mockedCreateBaseRepository).toHaveBeenCalledTimes(1);
-    expect(config.model).toBe(model);
-    expect(typeof config.toEntity).toBe('function');
-    expect(typeof config.buildQuery).toBe('function');
-    expect(typeof config.getDefaultSort).toBe('function');
-  });
-
-  it('should map document to entity and safely convert dates', () => {
-    AssetRepository({ AssetModel: {} as never });
-
-    const config = mockedCreateBaseRepository.mock.calls[0][0] as {
-      toEntity: (doc: Record<string, unknown>) => Record<string, unknown>;
-    };
-
-    const doc = {
-      _id: { toString: () => 'asset-id-1' },
-      type: 'image',
-      tags: ['archive'],
-      usageRefs: [{ pageId: 'about-us', blockId: 'hero' }],
-      filename: 'piano.jpg',
-      mimeType: 'image/jpeg',
-      sizeBytes: 2048,
-      url: '/uploads/piano.jpg',
-      createdBy: { toString: () => 'admin-id-1' },
-      description: 'desc',
-      isStarred: true,
-      createdAt: new Date('2026-03-10T10:00:00.000Z'),
-      updatedAt: null
-    };
-
-    const entity = config.toEntity(doc);
-
-    expect(entity.id).toBe('asset-id-1');
-    expect(entity.createdBy).toBe('admin-id-1');
-    expect(entity.createdAt).toBe('2026-03-10T10:00:00.000Z');
-    expect(entity.updatedAt).toBe(new Date(0).toISOString());
-  });
-
-  it('should build query and sort based on filters', () => {
-    AssetRepository({ AssetModel: {} as never });
-
-    const config = mockedCreateBaseRepository.mock.calls[0][0] as {
-      buildQuery: (filters?: Record<string, unknown>) => Record<string, unknown>;
-      getDefaultSort: (filters?: Record<string, unknown>) => Record<string, 1 | -1>;
-    };
-
-    expect(config.buildQuery()).toEqual({});
-
-    const query = config.buildQuery({
-      type: 'pdf',
-      isStarred: false,
-      tag: 'archive',
-      search: '  press  '
-    });
-
-    expect(query.type).toBe('pdf');
-    expect(query.isStarred).toBe(false);
-    expect(query.tags).toBe('archive');
-    expect(query.filename).toBeInstanceOf(RegExp);
-    expect((query.filename as RegExp).test('press-kit.pdf')).toBe(true);
-
-    expect(config.getDefaultSort()).toEqual({ createdAt: -1 });
-    expect(config.getDefaultSort({ sortBy: 'filename', sortOrder: 'asc' })).toEqual({ filename: 1 });
-  });
-});
-
-describe('deleteAsset', () => {
-  const mockAssetModel = {
-    findById: jest.fn(),
-    findByIdAndDelete: jest.fn()
+const getRepoConfig = () => {
+  mockedCreateBaseRepository.mockClear();
+  AssetRepository({ AssetModel: {} as never });
+  return mockedCreateBaseRepository.mock.calls[0][0] as {
+    toEntity: (doc: Record<string, unknown>) => Record<string, unknown>;
+    buildQuery: (filters?: Record<string, unknown>) => Record<string, unknown>;
+    getDefaultSort: (filters?: Record<string, unknown>) => Record<string, 1 | -1>;
   };
+};
 
-  const repository = AssetRepository({ AssetModel: mockAssetModel as never });
+describe('AssetRepository', () => {
+  describe('createBaseRepository config', () => {
+    it('should pass model and handlers into base repository factory', () => {
+      const model = {};
+      mockedCreateBaseRepository.mockClear();
+      AssetRepository({ AssetModel: model as never });
 
-  it('should throw an error if the asset is not found', async () => {
-    mockAssetModel.findById.mockResolvedValueOnce(null);
+      const config = mockedCreateBaseRepository.mock.calls[0][0] as Record<string, unknown>;
 
-    await expect(repository.deleteAsset('fake-id')).rejects.toThrow('Файл не знайдено');
+      expect(mockedCreateBaseRepository).toHaveBeenCalledTimes(1);
+      expect(config.model).toBe(model);
+      expect(typeof config.toEntity).toBe('function');
+      expect(typeof config.buildQuery).toBe('function');
+      expect(typeof config.getDefaultSort).toBe('function');
+    });
   });
 
-  it('should throw an error if the asset is used on the site', async () => {
-    mockAssetModel.findById.mockResolvedValueOnce({
-      _id: 'fake-id',
-      usageRefs: [{ pageId: 'some-page-id' }]
+  describe('toEntity', () => {
+    it('should map document to entity, convert Date fields to ISO and handle null updatedAt', () => {
+      const { toEntity } = getRepoConfig();
+      const doc = {
+        _id: { toString: () => 'asset-id-1' },
+        type: 'image',
+        tags: ['archive'],
+        usageRefs: [{ pageId: 'about-us', blockId: 'hero' }],
+        filename: 'piano.jpg',
+        mimeType: 'image/jpeg',
+        sizeBytes: 2048,
+        url: '/uploads/piano.jpg',
+        createdBy: { toString: () => 'admin-id-1' },
+        description: 'desc',
+        isStarred: true,
+        createdAt: new Date('2026-03-10T10:00:00.000Z'),
+        updatedAt: null
+      };
+
+      const entity = toEntity(doc);
+
+      expect(entity.id).toBe('asset-id-1');
+      expect(entity.createdBy).toBe('admin-id-1');
+      expect(entity.createdAt).toBe('2026-03-10T10:00:00.000Z');
+      expect(entity.updatedAt).toBe(new Date(0).toISOString());
     });
 
-    await expect(repository.deleteAsset('fake-id')).rejects.toThrow('Cannot delete: file is in use on the site.');
-    expect(mockAssetModel.findByIdAndDelete).not.toHaveBeenCalled();
+    it('should return string createdAt as-is, convert Date updatedAt and handle missing createdBy', () => {
+      const { toEntity } = getRepoConfig();
+      const doc = {
+        _id: { toString: () => 'asset-id-2' },
+        type: 'pdf',
+        tags: [],
+        usageRefs: [],
+        filename: 'document.pdf',
+        mimeType: 'application/pdf',
+        sizeBytes: 512,
+        url: '/uploads/document.pdf',
+        isStarred: false,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: new Date('2026-01-02T00:00:00.000Z')
+      };
+
+      const entity = toEntity(doc);
+
+      expect(entity.createdBy).toBeUndefined();
+      expect(entity.createdAt).toBe('2026-01-01T00:00:00.000Z');
+      expect(entity.updatedAt).toBe('2026-01-02T00:00:00.000Z');
+    });
   });
 
-  it('should successfully delete asset from storage and DB if not in use', async () => {
-    mockAssetModel.findById.mockResolvedValueOnce({
-      _id: 'fake-id',
-      filename: 'test-image.png',
-      type: 'image',
-      usageRefs: []
+  describe('buildQuery', () => {
+    it('should return empty query when no filters are given', () => {
+      const { buildQuery } = getRepoConfig();
+      expect(buildQuery()).toEqual({});
+      expect(buildQuery(undefined)).toEqual({});
     });
-    mockAssetModel.findByIdAndDelete.mockResolvedValueOnce({});
 
-    const result = await repository.deleteAsset('fake-id');
+    it('should build query from type, isStarred, tag and search filters', () => {
+      const { buildQuery } = getRepoConfig();
+      const query = buildQuery({ type: 'pdf', isStarred: false, tag: 'archive', search: '  press  ' });
 
-    expect(result).toBe(true);
-    expect(mockAssetModel.findByIdAndDelete).toHaveBeenCalledWith('fake-id');
+      expect(query.type).toBe('pdf');
+      expect(query.isStarred).toBe(false);
+      expect(query.tags).toBe('archive');
+      expect(query.filename).toBeInstanceOf(RegExp);
+      expect((query.filename as RegExp).test('press-kit.pdf')).toBe(true);
+    });
+
+    it('should set isStarred: true filter', () => {
+      const { buildQuery } = getRepoConfig();
+      expect(buildQuery({ isStarred: true }).isStarred).toBe(true);
+    });
+
+    it('should build isUsed filter using $exists operator', () => {
+      const { buildQuery } = getRepoConfig();
+
+      const usedQuery = buildQuery({ isUsed: true }) as Record<string, unknown>;
+      expect(usedQuery['usageRefs.0']).toEqual({ $exists: true });
+
+      const unusedQuery = buildQuery({ isUsed: false }) as Record<string, unknown>;
+      expect(unusedQuery['usageRefs.0']).toEqual({ $exists: false });
+    });
+  });
+
+  describe('getDefaultSort', () => {
+    it('should return createdAt descending by default', () => {
+      const { getDefaultSort } = getRepoConfig();
+      expect(getDefaultSort()).toEqual({ createdAt: -1 });
+      expect(getDefaultSort({ sortOrder: 'desc' })).toEqual({ createdAt: -1 });
+    });
+
+    it('should return sort by custom field and direction', () => {
+      const { getDefaultSort } = getRepoConfig();
+      expect(getDefaultSort({ sortBy: 'filename', sortOrder: 'asc' })).toEqual({ filename: 1 });
+      expect(getDefaultSort({ sortBy: 'updatedAt', sortOrder: 'desc' })).toEqual({ updatedAt: -1 });
+    });
+  });
+
+  describe('repository methods', () => {
+    const mockAssetModel = {
+      findById: jest.fn(),
+      findByIdAndDelete: jest.fn(),
+      findByIdAndUpdate: jest.fn(),
+      findOneAndUpdate: jest.fn(),
+      create: jest.fn()
+    };
+
+    const repository = AssetRepository({ AssetModel: mockAssetModel as never });
+
+    let mockStorageDelete: jest.Mock;
+
+    beforeAll(() => {
+      mockStorageDelete = (createStorageAdapter as jest.Mock).mock.results[0].value.delete;
+    });
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockStorageDelete.mockResolvedValue({ success: true });
+    });
+
+    describe('deleteAsset', () => {
+      it('should throw if asset is not found', async () => {
+        mockAssetModel.findById.mockResolvedValueOnce(null);
+        await expect(repository.deleteAsset('fake-id')).rejects.toThrow('Файл не знайдено');
+      });
+
+      it('should throw and skip deletion if asset is in use', async () => {
+        mockAssetModel.findById.mockResolvedValueOnce({ usageRefs: [{ pageId: 'some-page' }] });
+
+        await expect(repository.deleteAsset('fake-id')).rejects.toThrow(
+          'Cannot delete: file is in use on the site.'
+        );
+        expect(mockAssetModel.findByIdAndDelete).not.toHaveBeenCalled();
+      });
+
+      it('should log warning and throw when storage delete fails', async () => {
+        mockAssetModel.findById.mockResolvedValueOnce({
+          _id: 'fake-id',
+          filename: 'test.jpg',
+          type: 'image',
+          usageRefs: []
+        });
+        mockStorageDelete.mockResolvedValueOnce({ success: false, error: 'R2 error' });
+
+        await expect(repository.deleteAsset('fake-id')).rejects.toThrow(
+          'The file was not deleted from cloud storage. Please try again later.'
+        );
+        expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('R2 error'));
+        expect(mockAssetModel.findByIdAndDelete).not.toHaveBeenCalled();
+      });
+
+      it('should delete asset and return true when asset has no URL', async () => {
+        mockAssetModel.findById.mockResolvedValueOnce({
+          _id: 'fake-id',
+          filename: 'test-image.png',
+          type: 'image',
+          usageRefs: []
+        });
+        mockAssetModel.findByIdAndDelete.mockResolvedValueOnce({});
+
+        const result = await repository.deleteAsset('fake-id');
+
+        expect(result).toBe(true);
+        expect(mockStorageDelete).toHaveBeenCalledWith('test-image.png', 'uploads');
+        expect(mockAssetModel.findByIdAndDelete).toHaveBeenCalledWith('fake-id');
+      });
+
+      it('should extract filename and folder from a valid absolute URL', async () => {
+        mockAssetModel.findById.mockResolvedValueOnce({
+          _id: 'fake-id',
+          filename: 'piano.jpg',
+          type: 'image',
+          url: 'https://example.com/photos/piano.jpg',
+          usageRefs: []
+        });
+        mockAssetModel.findByIdAndDelete.mockResolvedValueOnce({});
+
+        await repository.deleteAsset('fake-id');
+
+        expect(mockStorageDelete).toHaveBeenCalledWith('piano.jpg', 'photos');
+      });
+
+      it('should use empty folder when filename is at the root of a valid URL', async () => {
+        mockAssetModel.findById.mockResolvedValueOnce({
+          _id: 'fake-id',
+          filename: 'piano.jpg',
+          type: 'image',
+          url: 'https://example.com/piano.jpg',
+          usageRefs: []
+        });
+        mockAssetModel.findByIdAndDelete.mockResolvedValueOnce({});
+
+        await repository.deleteAsset('fake-id');
+
+        expect(mockStorageDelete).toHaveBeenCalledWith('piano.jpg', '');
+      });
+
+      it.each([
+        ['image', 'photo.jpg', 'photos'],
+        ['audio', 'song.mp3', 'compositions'],
+        ['pdf', 'doc.pdf', 'uploads']
+      ])(
+        'should use type-based folder for invalid URL (type=%s → folder=%s)',
+        async (type, filename, expectedFolder) => {
+          mockAssetModel.findById.mockResolvedValueOnce({
+            _id: 'fake-id',
+            filename,
+            type,
+            url: '/relative/invalid-url',
+            usageRefs: []
+          });
+          mockAssetModel.findByIdAndDelete.mockResolvedValueOnce({});
+
+          await repository.deleteAsset('fake-id');
+
+          expect(mockStorageDelete).toHaveBeenCalledWith(filename, expectedFolder);
+        }
+      );
+    });
+
+    describe('updateAsset', () => {
+      const updatedDoc = {
+        _id: { toString: () => 'asset-id' },
+        type: 'image' as const,
+        tags: [],
+        usageRefs: [],
+        filename: 'updated.jpg',
+        mimeType: 'image/jpeg',
+        sizeBytes: 1024,
+        url: 'https://example.com/updated.jpg',
+        isStarred: false,
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-01-01T00:00:00.000Z')
+      };
+
+      it('should preserve the original file extension when renaming', async () => {
+        mockAssetModel.findById.mockResolvedValueOnce({ filename: 'original.jpg' });
+        mockAssetModel.findByIdAndUpdate.mockResolvedValueOnce(updatedDoc);
+
+        await repository.updateAsset('asset-id', { filename: 'new-name' });
+
+        expect(mockAssetModel.findByIdAndUpdate).toHaveBeenCalledWith(
+          'asset-id',
+          { $set: { filename: 'new-name.jpg' } },
+          { new: true }
+        );
+      });
+
+      it('should keep the provided filename unchanged when existing doc is not found', async () => {
+        mockAssetModel.findById.mockResolvedValueOnce(null);
+        mockAssetModel.findByIdAndUpdate.mockResolvedValueOnce(updatedDoc);
+
+        await repository.updateAsset('asset-id', { filename: 'new-name.png' });
+
+        expect(mockAssetModel.findByIdAndUpdate).toHaveBeenCalledWith(
+          'asset-id',
+          { $set: { filename: 'new-name.png' } },
+          { new: true }
+        );
+      });
+
+      it('should not call findById when filename is not in the update data', async () => {
+        mockAssetModel.findByIdAndUpdate.mockResolvedValueOnce(updatedDoc);
+
+        await repository.updateAsset('asset-id', { isStarred: true });
+
+        expect(mockAssetModel.findById).not.toHaveBeenCalled();
+      });
+
+      it('should return null when the document is not found', async () => {
+        mockAssetModel.findByIdAndUpdate.mockResolvedValueOnce(null);
+
+        const result = await repository.updateAsset('asset-id', { isStarred: true });
+
+        expect(result).toBeNull();
+      });
+
+      it('should return entity when document is updated successfully', async () => {
+        mockAssetModel.findByIdAndUpdate.mockResolvedValueOnce(updatedDoc);
+
+        const result = await repository.updateAsset('asset-id', { isStarred: false });
+
+        expect(result?.id).toBe('asset-id');
+      });
+    });
+
+    describe('createAsset', () => {
+      it('should create asset with default fields and return mapped entity', async () => {
+        const newDoc = {
+          _id: { toString: () => 'new-asset-id' },
+          type: 'image' as const,
+          tags: [],
+          usageRefs: [],
+          filename: 'new-image.jpg',
+          mimeType: 'image/jpeg',
+          sizeBytes: 1024,
+          url: 'https://example.com/new-image.jpg',
+          isStarred: false,
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+          updatedAt: new Date('2026-01-01T00:00:00.000Z')
+        };
+        mockAssetModel.create.mockResolvedValueOnce(newDoc);
+
+        const result = await repository.createAsset({
+          filename: 'new-image.jpg',
+          mimeType: 'image/jpeg',
+          sizeBytes: 1024,
+          url: 'https://example.com/new-image.jpg',
+          type: 'image'
+        });
+
+        expect(mockAssetModel.create).toHaveBeenCalledWith(
+          expect.objectContaining({ isStarred: false, tags: [], usageRefs: [] })
+        );
+        expect(result.id).toBe('new-asset-id');
+        expect(result.isStarred).toBe(false);
+      });
+    });
+
+    describe('addUsageRef', () => {
+      it('should call findOneAndUpdate with $addToSet on usageRefs', async () => {
+        mockAssetModel.findOneAndUpdate.mockResolvedValueOnce({});
+
+        await repository.addUsageRef('https://example.com/photo.jpg', { pageId: 'about', blockId: 'hero' });
+
+        expect(mockAssetModel.findOneAndUpdate).toHaveBeenCalledWith(
+          { url: 'https://example.com/photo.jpg' },
+          { $addToSet: { usageRefs: { pageId: 'about', blockId: 'hero' } } }
+        );
+      });
+    });
   });
 });

--- a/src/infrastructure/repositories/assetRepository/assetRepository.ts
+++ b/src/infrastructure/repositories/assetRepository/assetRepository.ts
@@ -11,6 +11,7 @@ type AssetType = 'image' | 'pdf' | 'audio' | 'document' | 'spreadsheet' | 'video
 type AssetUsageRef = {
   pageId?: string;
   blockId?: string;
+  locale?: string;
 };
 
 export type AssetEntity = {
@@ -32,6 +33,7 @@ export type AssetEntity = {
 export type AssetFilters = {
   type?: AssetType;
   isStarred?: boolean;
+  isUsed?: boolean;
   tag?: string;
   search?: string;
   sortBy?: 'createdAt' | 'updatedAt' | 'filename';
@@ -101,6 +103,10 @@ const buildAssetQuery = (
 
   if (typeof filters.isStarred === 'boolean') {
     query.isStarred = filters.isStarred;
+  }
+
+  if (typeof filters.isUsed === 'boolean') {
+    (query as Record<string, unknown>)['usageRefs.0'] = { $exists: filters.isUsed };
   }
 
   if (filters.tag) {
@@ -220,10 +226,15 @@ export const AssetRepository = ({ AssetModel }: AssetRepoDeps) => {
     return true;
   };
 
+  const addUsageRef = async (url: string, ref: AssetUsageRef): Promise<void> => {
+    await AssetModel.findOneAndUpdate({ url }, { $addToSet: { usageRefs: ref } });
+  };
+
   return {
     ...baseRepo,
     updateAsset,
     createAsset,
-    deleteAsset
+    deleteAsset,
+    addUsageRef
   };
 };

--- a/src/interfaces/graphql/resolvers/assets/Query.ts
+++ b/src/interfaces/graphql/resolvers/assets/Query.ts
@@ -8,6 +8,7 @@ export interface AllAssetsArgs {
   filters: {
     type?: AssetType;
     isStarred?: boolean;
+    isUsed?: boolean;
     sortBy?: AssetSortBy;
     sortOrder?: SortOrder;
     limit?: number;

--- a/src/interfaces/graphql/resolvers/events/eventsMutation.test.ts
+++ b/src/interfaces/graphql/resolvers/events/eventsMutation.test.ts
@@ -141,7 +141,7 @@ describe('EventsMutation Resolvers', () => {
         content: {
           uk: { blocks: [{ src: 'https://cdn.example.com/uk-img.jpg', type: 'image' }] },
           en: { blocks: [] }
-        } as never
+        }
       });
       (mockRepo.create as jest.Mock).mockResolvedValue(createMockEntity({ id: 'evt-http' }));
 
@@ -231,7 +231,7 @@ describe('EventsMutation Resolvers', () => {
     it('should call syncImagesCrops for content when updating event', async () => {
       const id = '456';
       const updateInput: UpdateEventInput = {
-        content: { uk: { blocks: [] }, en: { blocks: [] } } as EventsEntity['content']
+        content: { uk: { blocks: [] }, en: { blocks: [] } }
       };
       (mockRepo.update as jest.Mock).mockResolvedValue(createMockEntity({ id }));
 

--- a/src/interfaces/graphql/resolvers/events/eventsMutation.test.ts
+++ b/src/interfaces/graphql/resolvers/events/eventsMutation.test.ts
@@ -3,6 +3,7 @@ import { LocalizedImage } from '~/domain/entities/BaseContent';
 import { EventsEntity } from '~/domain/entities/Events';
 import type { CreateEventInput, IEventsRepository, UpdateEventInput } from '~/domain/repositories/eventsRepository';
 import { createMockContext } from '~/interfaces/graphql/resolvers/testUtils';
+import { generateUniqueSlug } from '~/src/shared/utils/slugGenerator/slugGenerator';
 import { EventStatus } from '~/types/enums/common.enums';
 
 jest.mock('mongoose');
@@ -43,7 +44,7 @@ describe('EventsMutation Resolvers', () => {
     allowIndexation: { uk: true, en: true },
     slug: 'slug-test',
     content: { uk: { blocks: [] }, en: { blocks: [] } } as EventsEntity['content'],
-    coverImage: { src:'', alt: { uk: '', en: '' }, caption: { uk: '', en: '' } },
+    coverImage: { src: '', alt: { uk: '', en: '' }, caption: { uk: '', en: '' } },
     status: EventStatus.Draft,
     meta: { views: 0 },
     createdAt: '2024-01-01',
@@ -70,12 +71,29 @@ describe('EventsMutation Resolvers', () => {
     ...overrides
   } as Omit<CreateEventInput, 'slug'>);
 
-  beforeEach(() => jest.clearAllMocks());
+  const mockSlugWithCheckExists = () => {
+    (generateUniqueSlug as jest.Mock).mockImplementationOnce(
+      async (title: string, { checkExists }: { checkExists: (s: string) => Promise<boolean> }) => {
+        await checkExists(`slug-${title}`);
+        return `slug-${title.toLowerCase()}`;
+      }
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (mockRepo.findBySlug as jest.Mock).mockResolvedValue(null);
+  });
 
   describe('Security/Authentication', () => {
-    it('should throw UNAUTHENTICATED error message if context.admin is false', async () => {
+    it('should throw UNAUTHENTICATED error if context.admin is false for createEvent', async () => {
       const input = createMockInput();
       await expect(EventsMutation.createEvent({}, { input }, userContext))
+        .rejects.toThrow('You must be logged in to access this resource.');
+    });
+
+    it('should throw UNAUTHENTICATED error for updateEvent if not admin', async () => {
+      await expect(EventsMutation.updateEvent({}, { id: '1', input: {} }, userContext))
         .rejects.toThrow('You must be logged in to access this resource.');
     });
   });
@@ -83,7 +101,6 @@ describe('EventsMutation Resolvers', () => {
   describe('Business Logic', () => {
     it('should create event with correct slug and status and call syncImagesCrops', async () => {
       const input = createMockInput();
-      (mockRepo.findBySlug as jest.Mock).mockResolvedValue(null);
       (mockRepo.create as jest.Mock).mockResolvedValue(createMockEntity({ id: 'event-1', slug: 'slug-подія' }));
 
       const result = await EventsMutation.createEvent({}, { input }, adminContext);
@@ -94,25 +111,87 @@ describe('EventsMutation Resolvers', () => {
       expect(helpers.syncImagesCrops).toHaveBeenCalledWith('event-1', input.content);
     });
 
+    it('should throw TITLE_REQUIRED_FOR_SLUG if title.uk is missing', async () => {
+      const input = createMockInput({ title: { en: 'Only English' } as never });
+      await expect(EventsMutation.createEvent({}, { input }, adminContext))
+        .rejects.toThrow('TITLE_REQUIRED_FOR_SLUG');
+    });
+
+    it('should invoke checkExists and call findBySlug during createEvent slug generation', async () => {
+      const input = createMockInput();
+      (mockRepo.create as jest.Mock).mockResolvedValue(createMockEntity({ id: 'evt-slug' }));
+      mockSlugWithCheckExists();
+
+      await EventsMutation.createEvent({}, { input }, adminContext);
+
+      expect(mockRepo.findBySlug).toHaveBeenCalled();
+    });
+
+    it('should call addUsageRef for http coverImage src and http content src', async () => {
+      const mockAddUsageRef = jest.fn().mockResolvedValue(undefined);
+      const ctxWithAssets = {
+        admin: true,
+        requestContainer: {
+          cradle: { eventsRepository: mockRepo, assetsRepository: { addUsageRef: mockAddUsageRef } }
+        }
+      } as never;
+
+      const input = createMockInput({
+        coverImage: { src: 'https://cdn.example.com/photo.jpg', alt: { uk: '', en: '' }, caption: { uk: '', en: '' } },
+        content: {
+          uk: { blocks: [{ src: 'https://cdn.example.com/uk-img.jpg', type: 'image' }] },
+          en: { blocks: [] }
+        } as never
+      });
+      (mockRepo.create as jest.Mock).mockResolvedValue(createMockEntity({ id: 'evt-http' }));
+
+      await EventsMutation.createEvent({}, { input }, ctxWithAssets);
+
+      expect(mockAddUsageRef).toHaveBeenCalledWith('https://cdn.example.com/photo.jpg', expect.objectContaining({ locale: 'uk' }));
+      expect(mockAddUsageRef).toHaveBeenCalledWith('https://cdn.example.com/photo.jpg', expect.objectContaining({ locale: 'en' }));
+      expect(mockAddUsageRef).toHaveBeenCalledWith('https://cdn.example.com/uk-img.jpg', expect.objectContaining({ locale: 'uk' }));
+    });
+
+    it('should not call syncImagesCrops for content when content is absent in createEvent', async () => {
+      const input = { ...createMockInput(), content: undefined } as never;
+      (mockRepo.create as jest.Mock).mockResolvedValue(createMockEntity({ id: 'no-content-evt' }));
+
+      await EventsMutation.createEvent({}, { input }, adminContext);
+
+      expect(helpers.syncImagesCrops).toHaveBeenCalledTimes(1);
+    });
+
+    it('should default to Draft status if no status is provided', async () => {
+      const input = createMockInput();
+      const { status: _status, ...inputWithoutStatus } = input;
+      const finalInput = inputWithoutStatus as unknown as CreateEventArgs['input'];
+
+      (mockRepo.create as jest.Mock).mockResolvedValue(createMockEntity({ status: EventStatus.Draft }));
+
+      await EventsMutation.createEvent({}, { input: finalInput }, adminContext);
+
+      expect(mockRepo.create).toHaveBeenCalledWith(expect.objectContaining({
+        status: EventStatus.Draft
+      }));
+    });
+
     it('should update event and call syncImagesCrops only for provided fields', async () => {
       const id = '123';
       const updateInput: UpdateEventInput = {
         title: { uk: 'Нова Назва', en: 'New Name' },
         coverImage: {
-          src:'updated.jpg',
+          src: 'updated.jpg',
           alt: { uk: 'оновлено', en: 'updated' },
           crop: { x: 1, y: 1, width: 1, height: 1 }
         } as LocalizedImage
       };
 
-      (mockRepo.findBySlug as jest.Mock).mockResolvedValue(null);
       (mockRepo.update as jest.Mock).mockResolvedValue(createMockEntity({ id, slug: 'slug-нова-назва' }));
 
       const result = await EventsMutation.updateEvent({}, { id, input: updateInput }, adminContext);
 
       expect(result.slug).toBe('slug-нова-назва');
       expect(helpers.syncImagesCrops).toHaveBeenCalledWith(id, updateInput.coverImage, { isCoverImage: true });
-      expect(helpers.syncImagesCrops).not.toHaveBeenCalledWith(id, undefined);
       expect(helpers.syncImagesCrops).toHaveBeenCalledTimes(1);
     });
 
@@ -128,18 +207,48 @@ describe('EventsMutation Resolvers', () => {
       expect(mockRepo.update).toHaveBeenCalled();
     });
 
-    it('should default to Draft status if no status is provided', async () => {
-      const input = createMockInput();
-      const { status: _status, ...inputWithoutStatus } = input;
-      const finalInput = inputWithoutStatus as unknown as CreateEventArgs['input'];
+    it('should invoke checkExists and call findBySlug during updateEvent slug generation', async () => {
+      const id = '999';
+      const updateInput: UpdateEventInput = { title: { uk: 'Тест', en: 'Test' } };
+      (mockRepo.findBySlug as jest.Mock).mockResolvedValue(createMockEntity({ id: 'other-id' }));
+      (mockRepo.update as jest.Mock).mockResolvedValue(createMockEntity({ id }));
+      mockSlugWithCheckExists();
 
-      (mockRepo.create as jest.Mock).mockResolvedValue(createMockEntity({ status: EventStatus.Draft }));
+      await EventsMutation.updateEvent({}, { id, input: updateInput }, adminContext);
 
-      await EventsMutation.createEvent({}, { input: finalInput }, adminContext);
+      expect(mockRepo.findBySlug).toHaveBeenCalled();
+    });
 
-      expect(mockRepo.create).toHaveBeenCalledWith(expect.objectContaining({
-        status: EventStatus.Draft
-      }));
+    it('should throw EVENT_NOT_FOUND if repo.update returns null', async () => {
+      const id = '123';
+      (mockRepo.update as jest.Mock).mockResolvedValue(null);
+
+      await expect(
+        EventsMutation.updateEvent({}, { id, input: { title: { uk: 'x', en: 'x' } } }, adminContext)
+      ).rejects.toThrow('EVENT_NOT_FOUND');
+    });
+
+    it('should call syncImagesCrops for content when updating event', async () => {
+      const id = '456';
+      const updateInput: UpdateEventInput = {
+        content: { uk: { blocks: [] }, en: { blocks: [] } } as EventsEntity['content']
+      };
+      (mockRepo.update as jest.Mock).mockResolvedValue(createMockEntity({ id }));
+
+      await EventsMutation.updateEvent({}, { id, input: updateInput }, adminContext);
+
+      expect(helpers.syncImagesCrops).toHaveBeenCalledWith(id, updateInput.content);
+    });
+
+    it('should preserve meta.views and skip slug generation when title.uk is absent', async () => {
+      const id = '789';
+      const updateInput: UpdateEventInput = { meta: { views: 42 } };
+      (mockRepo.update as jest.Mock).mockResolvedValue(createMockEntity({ id }));
+
+      await EventsMutation.updateEvent({}, { id, input: updateInput }, adminContext);
+
+      expect(generateUniqueSlug).not.toHaveBeenCalled();
+      expect(mockRepo.update).toHaveBeenCalledWith(id, expect.objectContaining({ meta: { views: 42 } }));
     });
   });
 

--- a/src/interfaces/graphql/resolvers/events/eventsMutation.ts
+++ b/src/interfaces/graphql/resolvers/events/eventsMutation.ts
@@ -6,6 +6,42 @@ import {
 } from '../helpers';
 import { GraphQLContext } from '~/back-shared/types/container/types';
 import { graphqlErrors } from '~/constants/errors';
+
+type UsageRepo = { addUsageRef: (url: string, ref: { pageId?: string; blockId?: string; locale?: string }) => Promise<void> };
+
+const extractHttpSrcs = (value: unknown, srcs: Set<string>): void => {
+  if (!value || typeof value !== 'object') return;
+  if (Array.isArray(value)) { value.forEach((v) => extractHttpSrcs(v, srcs)); return; }
+  const obj = value as Record<string, unknown>;
+  if (typeof obj.src === 'string' && obj.src.startsWith('http')) srcs.add(obj.src);
+  Object.values(obj).forEach((v) => extractHttpSrcs(v, srcs));
+};
+
+const markImagesAsUsed = async (
+  repo: UsageRepo,
+  content: { uk?: unknown; en?: unknown } | null | undefined,
+  coverImage: { src?: string } | null | undefined,
+  pageId: string,
+  blockId: string
+): Promise<void> => {
+  const ukSrcs = new Set<string>();
+  const enSrcs = new Set<string>();
+
+  if (content?.uk) extractHttpSrcs(content.uk, ukSrcs);
+  if (content?.en) extractHttpSrcs(content.en, enSrcs);
+
+  const promises: Promise<void>[] = [
+    ...Array.from(ukSrcs).map((url) => repo.addUsageRef(url, { pageId, blockId, locale: 'uk' })),
+    ...Array.from(enSrcs).map((url) => repo.addUsageRef(url, { pageId, blockId, locale: 'en' }))
+  ];
+
+  if (coverImage?.src?.startsWith('http')) {
+    promises.push(repo.addUsageRef(coverImage.src, { pageId, blockId, locale: 'uk' }));
+    promises.push(repo.addUsageRef(coverImage.src, { pageId, blockId, locale: 'en' }));
+  }
+
+  await Promise.all(promises);
+};
 import { EventsEntity } from '~/domain/entities/Events';
 import { CreateEventInput, UpdateEventInput } from '~/domain/repositories/eventsRepository';
 import { generateUniqueSlug } from '~/src/shared/utils/slugGenerator/slugGenerator';
@@ -57,6 +93,9 @@ export const EventsMutation = {
       await syncImagesCrops(res.id, input.content);
     }
 
+    const assetsRepo = context.requestContainer.cradle.assetsRepository;
+    await markImagesAsUsed(assetsRepo, input.content, input.coverImage, 'events', res.id);
+
     return res;
   },
 
@@ -91,6 +130,9 @@ export const EventsMutation = {
     if (input.content) {
       await syncImagesCrops(res.id, input.content);
     }
+
+    const assetsRepo = context.requestContainer.cradle.assetsRepository;
+    await markImagesAsUsed(assetsRepo, input.content, input.coverImage, 'events', res.id);
 
     return res;
   },

--- a/src/interfaces/graphql/resolvers/events/eventsMutation.ts
+++ b/src/interfaces/graphql/resolvers/events/eventsMutation.ts
@@ -2,46 +2,11 @@ import { GraphQLError } from 'graphql';
 
 import {
   endpointRepositoryHandler,
+  markImagesAsUsed,
   syncImagesCrops
 } from '../helpers';
 import { GraphQLContext } from '~/back-shared/types/container/types';
 import { graphqlErrors } from '~/constants/errors';
-
-type UsageRepo = { addUsageRef: (url: string, ref: { pageId?: string; blockId?: string; locale?: string }) => Promise<void> };
-
-const extractHttpSrcs = (value: unknown, srcs: Set<string>): void => {
-  if (!value || typeof value !== 'object') return;
-  if (Array.isArray(value)) { value.forEach((v) => extractHttpSrcs(v, srcs)); return; }
-  const obj = value as Record<string, unknown>;
-  if (typeof obj.src === 'string' && obj.src.startsWith('http')) srcs.add(obj.src);
-  Object.values(obj).forEach((v) => extractHttpSrcs(v, srcs));
-};
-
-const markImagesAsUsed = async (
-  repo: UsageRepo,
-  content: { uk?: unknown; en?: unknown } | null | undefined,
-  coverImage: { src?: string } | null | undefined,
-  pageId: string,
-  blockId: string
-): Promise<void> => {
-  const ukSrcs = new Set<string>();
-  const enSrcs = new Set<string>();
-
-  if (content?.uk) extractHttpSrcs(content.uk, ukSrcs);
-  if (content?.en) extractHttpSrcs(content.en, enSrcs);
-
-  const promises: Promise<void>[] = [
-    ...Array.from(ukSrcs).map((url) => repo.addUsageRef(url, { pageId, blockId, locale: 'uk' })),
-    ...Array.from(enSrcs).map((url) => repo.addUsageRef(url, { pageId, blockId, locale: 'en' }))
-  ];
-
-  if (coverImage?.src?.startsWith('http')) {
-    promises.push(repo.addUsageRef(coverImage.src, { pageId, blockId, locale: 'uk' }));
-    promises.push(repo.addUsageRef(coverImage.src, { pageId, blockId, locale: 'en' }));
-  }
-
-  await Promise.all(promises);
-};
 import { EventsEntity } from '~/domain/entities/Events';
 import { CreateEventInput, UpdateEventInput } from '~/domain/repositories/eventsRepository';
 import { generateUniqueSlug } from '~/src/shared/utils/slugGenerator/slugGenerator';

--- a/src/interfaces/graphql/resolvers/helpers.ts
+++ b/src/interfaces/graphql/resolvers/helpers.ts
@@ -179,3 +179,39 @@ function normalizeCropId(src: string): string {
   } catch {}
   return src;
 }
+
+type UsageRepo = { addUsageRef: (url: string, ref: { pageId?: string; blockId?: string; locale?: string }) => Promise<void> };
+
+const extractHttpSrcs = (value: unknown, srcs: Set<string>): void => {
+  if (!value || typeof value !== 'object') return;
+  if (Array.isArray(value)) { value.forEach((v) => extractHttpSrcs(v, srcs)); return; }
+  const obj = value as Record<string, unknown>;
+  if (typeof obj.src === 'string' && obj.src.startsWith('http')) srcs.add(obj.src);
+  Object.values(obj).forEach((v) => extractHttpSrcs(v, srcs));
+};
+
+export const markImagesAsUsed = async (
+  repo: UsageRepo,
+  content: { uk?: unknown; en?: unknown } | null | undefined,
+  coverImage: { src?: string } | null | undefined,
+  pageId: string,
+  blockId: string
+): Promise<void> => {
+  const ukSrcs = new Set<string>();
+  const enSrcs = new Set<string>();
+
+  if (content?.uk) extractHttpSrcs(content.uk, ukSrcs);
+  if (content?.en) extractHttpSrcs(content.en, enSrcs);
+
+  const promises: Promise<void>[] = [
+    ...Array.from(ukSrcs).map((url) => repo.addUsageRef(url, { pageId, blockId, locale: 'uk' })),
+    ...Array.from(enSrcs).map((url) => repo.addUsageRef(url, { pageId, blockId, locale: 'en' }))
+  ];
+
+  if (coverImage?.src?.startsWith('http')) {
+    promises.push(repo.addUsageRef(coverImage.src, { pageId, blockId, locale: 'uk' }));
+    promises.push(repo.addUsageRef(coverImage.src, { pageId, blockId, locale: 'en' }));
+  }
+
+  await Promise.all(promises);
+};

--- a/src/interfaces/graphql/resolvers/helpers.ts
+++ b/src/interfaces/graphql/resolvers/helpers.ts
@@ -209,8 +209,10 @@ export const markImagesAsUsed = async (
   ];
 
   if (coverImage?.src?.startsWith('http')) {
-    promises.push(repo.addUsageRef(coverImage.src, { pageId, blockId, locale: 'uk' }));
-    promises.push(repo.addUsageRef(coverImage.src, { pageId, blockId, locale: 'en' }));
+    promises.push(
+      repo.addUsageRef(coverImage.src, { pageId, blockId, locale: 'uk' }),
+      repo.addUsageRef(coverImage.src, { pageId, blockId, locale: 'en' })
+    );
   }
 
   await Promise.all(promises);

--- a/src/interfaces/graphql/resolvers/news/newsMutation.ts
+++ b/src/interfaces/graphql/resolvers/news/newsMutation.ts
@@ -3,47 +3,12 @@ import { GraphQLError } from 'graphql';
 import {
   endpointRepositoryHandler,
   extractTitleForSlug,
+  markImagesAsUsed,
   processSlugUpdate,
   syncImagesCrops
 } from '../helpers';
 import { processNewsContent } from './processNewsContent/processNewsContent';
 import type { GraphQLContext } from '~/back-shared/types/container/types';
-
-type UsageRepo = { addUsageRef: (url: string, ref: { pageId?: string; blockId?: string; locale?: string }) => Promise<void> };
-
-const extractHttpSrcs = (value: unknown, srcs: Set<string>): void => {
-  if (!value || typeof value !== 'object') return;
-  if (Array.isArray(value)) { value.forEach((v) => extractHttpSrcs(v, srcs)); return; }
-  const obj = value as Record<string, unknown>;
-  if (typeof obj.src === 'string' && obj.src.startsWith('http')) srcs.add(obj.src);
-  Object.values(obj).forEach((v) => extractHttpSrcs(v, srcs));
-};
-
-const markImagesAsUsed = async (
-  repo: UsageRepo,
-  content: { uk?: unknown; en?: unknown } | null | undefined,
-  coverImage: { src?: string } | null | undefined,
-  pageId: string,
-  blockId: string
-): Promise<void> => {
-  const ukSrcs = new Set<string>();
-  const enSrcs = new Set<string>();
-
-  if (content?.uk) extractHttpSrcs(content.uk, ukSrcs);
-  if (content?.en) extractHttpSrcs(content.en, enSrcs);
-
-  const promises: Promise<void>[] = [
-    ...Array.from(ukSrcs).map((url) => repo.addUsageRef(url, { pageId, blockId, locale: 'uk' })),
-    ...Array.from(enSrcs).map((url) => repo.addUsageRef(url, { pageId, blockId, locale: 'en' }))
-  ];
-
-  if (coverImage?.src?.startsWith('http')) {
-    promises.push(repo.addUsageRef(coverImage.src, { pageId, blockId, locale: 'uk' }));
-    promises.push(repo.addUsageRef(coverImage.src, { pageId, blockId, locale: 'en' }));
-  }
-
-  await Promise.all(promises);
-};
 import { graphqlErrors } from '~/constants/errors';
 import {LocalizedBoolean, LocalizedContent, LocalizedImage, LocalizedString} from '~/domain/entities/BaseContent';
 import type { News } from '~/domain/entities/News';

--- a/src/interfaces/graphql/resolvers/news/newsMutation.ts
+++ b/src/interfaces/graphql/resolvers/news/newsMutation.ts
@@ -8,6 +8,42 @@ import {
 } from '../helpers';
 import { processNewsContent } from './processNewsContent/processNewsContent';
 import type { GraphQLContext } from '~/back-shared/types/container/types';
+
+type UsageRepo = { addUsageRef: (url: string, ref: { pageId?: string; blockId?: string; locale?: string }) => Promise<void> };
+
+const extractHttpSrcs = (value: unknown, srcs: Set<string>): void => {
+  if (!value || typeof value !== 'object') return;
+  if (Array.isArray(value)) { value.forEach((v) => extractHttpSrcs(v, srcs)); return; }
+  const obj = value as Record<string, unknown>;
+  if (typeof obj.src === 'string' && obj.src.startsWith('http')) srcs.add(obj.src);
+  Object.values(obj).forEach((v) => extractHttpSrcs(v, srcs));
+};
+
+const markImagesAsUsed = async (
+  repo: UsageRepo,
+  content: { uk?: unknown; en?: unknown } | null | undefined,
+  coverImage: { src?: string } | null | undefined,
+  pageId: string,
+  blockId: string
+): Promise<void> => {
+  const ukSrcs = new Set<string>();
+  const enSrcs = new Set<string>();
+
+  if (content?.uk) extractHttpSrcs(content.uk, ukSrcs);
+  if (content?.en) extractHttpSrcs(content.en, enSrcs);
+
+  const promises: Promise<void>[] = [
+    ...Array.from(ukSrcs).map((url) => repo.addUsageRef(url, { pageId, blockId, locale: 'uk' })),
+    ...Array.from(enSrcs).map((url) => repo.addUsageRef(url, { pageId, blockId, locale: 'en' }))
+  ];
+
+  if (coverImage?.src?.startsWith('http')) {
+    promises.push(repo.addUsageRef(coverImage.src, { pageId, blockId, locale: 'uk' }));
+    promises.push(repo.addUsageRef(coverImage.src, { pageId, blockId, locale: 'en' }));
+  }
+
+  await Promise.all(promises);
+};
 import { graphqlErrors } from '~/constants/errors';
 import {LocalizedBoolean, LocalizedContent, LocalizedImage, LocalizedString} from '~/domain/entities/BaseContent';
 import type { News } from '~/domain/entities/News';
@@ -100,6 +136,9 @@ export const NewsMutation = {
       await syncImagesCrops(res.id, input.content);
     }
 
+    const assetsRepo = context.requestContainer.cradle.assetsRepository;
+    await markImagesAsUsed(assetsRepo, processedInput.content, processedInput.coverImage, 'news', res.id);
+
     return res;
   },
 
@@ -144,6 +183,9 @@ export const NewsMutation = {
     if (input.content) {
       await syncImagesCrops(res.id, input.content);
     }
+
+    const assetsRepo = context.requestContainer.cradle.assetsRepository;
+    await markImagesAsUsed(assetsRepo, updateData.content, updateData.coverImage, 'news', res.id);
 
     return res;
   },

--- a/src/interfaces/graphql/schemas/assets.graphql
+++ b/src/interfaces/graphql/schemas/assets.graphql
@@ -17,6 +17,7 @@ enum AssetSortBy {
 type AssetUsageRef {
   pageId: String
   blockId: String
+  locale: String
 }
 
 type Asset {
@@ -38,6 +39,7 @@ type Asset {
 input AssetsFiltersInput {
   type: AssetType
   isStarred: Boolean
+  isUsed: Boolean
   tag: String
   search: String
   sortBy: AssetSortBy


### PR DESCRIPTION
## DESCRIPTION

When loading a photo, we open a modal in which we can choose the photo data source - GALLERY, UPLOAD (from the user's local computer) or from USED. The code of this request pool connects the GALLERY tab to the cloudflare r2 storage. We temporarily mark the USED tab using the ALERT component as one that cannot be used to select a photo.

## TYPE OF CHANGES

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [x] Other: <!-- specify -->

## HOW TO TEST


## VIDEP / SCREENSHOTS

BEFORE CONNECT CLOUDFLARE STORAGE

<img width="2560" height="1528" alt="image" src="https://github.com/user-attachments/assets/9eb156a8-fb67-4ee0-9d3d-874f71b3cbc1" />

AFTER CONNECT CLOUDFLARE STORAGE

<img width="1377" height="1179" alt="image" src="https://github.com/user-attachments/assets/c4af9226-f870-49d9-bb6c-2aa2fceac9c7" />

<img width="1371" height="1178" alt="image" src="https://github.com/user-attachments/assets/b4047c42-f935-4df2-81f8-adb7a7bc2f4f" />
<img width="2560" height="1528" alt="image" src="https://github.com/user-attachments/assets/d5fdfbf1-81e0-485a-bd8d-3a01e521038e" />


## CHECKLIST

1. Ideally, it would be good to first run the code from the pull request https://github.com/Liatoshynsky-Foundation/lf-client/pull/1340 on the client. This is necessary so that you can check that the photos that the user uploads when editing or creating a news item are displayed on the news cards. But this order is not critical
2. Go to the admin panel to the NEWS AND EVENTS page
3. You can create a news item or select an already created one and go to the content editing page by clicking the EDIT button
4. From the drop-down menu in the header, select SEO SETTINGS
5. In the photo selection block, click the CHANGE IMAGE button
6. Go to the USED tab to make sure there is a warning message about the temporary absence of the ability to select photos from this tab
7. Go to the GALLERY tab and select any photo
8. If you are creating a news item, you need to fill in all the required fields and click the SAVE button. If you are editing a previously created news item, all the required fields are already filled in, so you can save the changes immediately
9. Then go back to the NEWS AND EVENTS page, click the EDIT button on the news card you created/edited
10. After that, the user will be taken to the content editing page where in the header they need to click the PUBLISH button. This item is needed if the user wants to check whether the photo will be displayed on the news card on the client side
11. You can also check the news record in the database. The coverImage -> src field should contain the path to the image in the repository
12. To check the DOWNLOAD tab, you need to repeat steps 7 to 11 with this tab.

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

Closed  https://github.com/Liatoshynsky-Foundation/lf-admin/issues/520
