### PR TITLE
(SP: 0.5) fix(ui): Align navigation chevron vertically with text

### DIFF
--- a/app/shared/components/side-navigation/collapse-list-navigation/CollapeListNavigation.styles.ts
+++ b/app/shared/components/side-navigation/collapse-list-navigation/CollapeListNavigation.styles.ts
@@ -12,7 +12,7 @@ export const linkStyles = {
 
 export const styles = {
   listBox: {
-    alignSelf: 'center'
+    display: 'flex'
   },
   collapse: {
     transition: 'ease-in 0.3s',

--- a/app/shared/components/side-navigation/collapse-list-navigation/CollapseListNavigation.tsx
+++ b/app/shared/components/side-navigation/collapse-list-navigation/CollapseListNavigation.tsx
@@ -50,9 +50,9 @@ export const CollapseListNavigation: React.FC<CollapseListNavigationProps> = ({
           }}
         >
           {isSubmenuOpen ? (
-            <Image src="/icons/chevronDown.svg" alt="open list" width={24} height={24} />
+            <Image src="/icons/chevronDown.svg" alt="open list" width={20} height={20} />
           ) : (
-            <Image src="/icons/chevronRight.svg" alt="close list" width={24} height={24} />
+            <Image src="/icons/chevronRight.svg" alt="close list" width={20} height={20} />
           )}
         </Box>
       </ListElement>


### PR DESCRIPTION
## Description

Fixed an alignment issue where chevron icons in the main sidebar navigation were positioned slightly above the vertical center of the navigation text. This caused a visually unbalanced appearance, especially on hover.
Updated CollapseListNavigation.styles.ts by applying display: 'flex' to the listBox container to properly align the icon and text within the same layout context.
Also adjusted the chevron icon size in CollapseListNavigation.tsx by setting the Image component width and height to 20px to match the design.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Log in to lf-admin
2. Click on a sidebar navigation item that has a chevron icon (e.g. Каталоги)
3. Verify that the chevron icon is vertically centered relative to the navigation label
4. Hover over the item and confirm the alignment remains consistent

## Video / Screenshots

https://github.com/user-attachments/assets/8313a66a-d94c-46c3-85ec-2737aa4a1618

## Checklist

- [ ] Code compiles and runs correctly
- [ ] Tests pass successfully
- [ ] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [ ] Linked issue/task included
- [ ] Task moved to the review column on the board

---
