### PR TITLE
fix: add about us link to sidebar

### DIFF
--- a/app/shared/components/side-navigation/SideNavigation.consts.ts
+++ b/app/shared/components/side-navigation/SideNavigation.consts.ts
@@ -2,7 +2,7 @@ export const NAVIGATION_DATA = {
   main: [{ title: 'Головна', iconSrc: 'house', href: '/' }],
   content: [
     {
-      element: { title: 'Основні сторінки', href: '/about-us', iconSrc: 'file-text' },
+      element: { title: 'Основні сторінки', iconSrc: 'file-text' },
       collapseElements: [
         { title: 'Про нас', href: '/about-us' }
       ]

--- a/app/shared/components/side-navigation/SideNavigation.consts.ts
+++ b/app/shared/components/side-navigation/SideNavigation.consts.ts
@@ -3,8 +3,9 @@ export const NAVIGATION_DATA = {
   content: [
     {
       element: { title: 'Основні сторінки', iconSrc: 'file-text' },
+      // TEMPORARY
       collapseElements: [
-        { title: 'Про нас', href: '/about-us' }
+        { title: 'Про Фундацію', href: '/about-us' }
       ]
     },
     {

--- a/app/shared/components/side-navigation/SideNavigation.consts.ts
+++ b/app/shared/components/side-navigation/SideNavigation.consts.ts
@@ -2,9 +2,10 @@ export const NAVIGATION_DATA = {
   main: [{ title: 'Головна', iconSrc: 'house', href: '/' }],
   content: [
     {
-      title: 'Основні сторінки',
-      href: '',
-      disabled: true
+      element: { title: 'Основні сторінки', href: '/about-us', iconSrc: 'file-text' },
+      collapseElements: [
+        { title: 'Про нас', href: '/about-us' }
+      ]
     },
     {
       title: 'Новини та події',

--- a/app/shared/components/side-navigation/collapse-list-navigation/CollapeListNavigation.styles.ts
+++ b/app/shared/components/side-navigation/collapse-list-navigation/CollapeListNavigation.styles.ts
@@ -12,7 +12,7 @@ export const linkStyles = {
 
 export const styles = {
   listBox: {
-    alignSelf: 'center'
+    display: 'flex'
   },
   collapse: {
     transition: 'ease-in 0.3s',

--- a/app/shared/components/side-navigation/collapse-list-navigation/CollapeListNavigation.styles.ts
+++ b/app/shared/components/side-navigation/collapse-list-navigation/CollapeListNavigation.styles.ts
@@ -16,7 +16,7 @@ export const styles = {
   },
   collapse: {
     transition: 'ease-in 0.3s',
-    '& ul>div>div': {
+    '& .MuiListItemText-root': {
       pl: '32px'
     }
   }

--- a/app/shared/components/side-navigation/collapse-list-navigation/CollapseListNavigation.tsx
+++ b/app/shared/components/side-navigation/collapse-list-navigation/CollapseListNavigation.tsx
@@ -50,9 +50,9 @@ export const CollapseListNavigation: React.FC<CollapseListNavigationProps> = ({
           }}
         >
           {isSubmenuOpen ? (
-            <Image src="/icons/chevronDown.svg" alt="open list" width={24} height={24} />
+            <Image src="/icons/chevronDown.svg" alt="open list" width={20} height={20} />
           ) : (
-            <Image src="/icons/chevronRight.svg" alt="close list" width={24} height={24} />
+            <Image src="/icons/chevronRight.svg" alt="close list" width={20} height={20} />
           )}
         </Box>
       </ListElement>


### PR DESCRIPTION
## Description
The /about-us page was not accessible in UI before. 
I added the correct configuration for this in the side navigation. 

Closes #528

## Type of change

- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement

## How to test

1. Login into admin page
2. Click on "Основні сторінки"
3. Click on "Про фундацію"
4. Wait for page to render
5. Ensure that you can see /about-us page 

## Video / Screenshots

<img width="265" height="654" alt="image" src="https://github.com/user-attachments/assets/9a35e71f-d5dd-49eb-8079-214786fcd3e8" />
<img width="1916" height="980" alt="image" src="https://github.com/user-attachments/assets/7859b0b7-5ec0-4a5b-8ac7-408a8238e97e" />


## Checklist

- [X] Code compiles and runs correctly
- [X] Tests pass successfully
- [X] Linting checks are clean
- [X] No Sonar issues
- [X] Linked issue/task included
- [ ] Task moved to the review column on the board

---
