### PR TITLE
fix(ui): Remove incorrect borders styles for opus/non-opus group rows

### DIFF
--- a/app/(logged_in)/creativity/WorksPageContent.tsx
+++ b/app/(logged_in)/creativity/WorksPageContent.tsx
@@ -394,8 +394,8 @@ function GroupedRow({
       disableGutters
       elevation={0}
       sx={{
+        border: 'none',
         borderBottom: `1px solid ${HORIZONTAL_ROW_DIVIDER_COLOR}`,
-        borderRadius: 0,
         mb: '4px',
         overflow: 'hidden',
         '&:before': { display: 'none' },
@@ -408,6 +408,7 @@ function GroupedRow({
           px: 0,
           minHeight: '56px',
           flexDirection: 'row-reverse',
+          borderBottom: `1px solid ${HORIZONTAL_ROW_DIVIDER_COLOR}`,
           '& .MuiAccordionSummary-expandIconWrapper': {
             width: '26px',
             height: '26px',


### PR DESCRIPTION
## Description

Fixed a visual regression on the `/creativity` page where both opus and non-opus group rows displayed incorrect outer border styles that did not match the approved design.

The `GroupedRow` component was updated by applying `border: 'none'` and removing `borderRadius` on the `Accordion` to hide default borders. The required bottom border was added directly to the `AccordionSummary` to match the exact Figma design.

fixes https://github.com/Liatoshynsky-Foundation/lf-admin/issues/548

**What was changed:**
- Applied `border: 'none'` and removed `borderRadius` from the `Accordion` component to eliminate default outer borders.
- Added the correct bottom border to the `AccordionSummary` according to the design specifications.
- Verified that both expanded and collapsed states render correctly without any layout shifts or visual regressions.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Log in to lf-admin
2. Navigate to the `/creativity` page.
3. Verify that both opus and non-opus group rows no longer have unexpected borders or background styles.
4. Compare the layout with the approved Figma design to ensure perfect visual alignment.
5. Expand and collapse several groups to confirm that nested works still display and function correctly.

## Video / Screenshots

Fixed result
<img width="1190" height="1126" alt="image" src="https://github.com/user-attachments/assets/036a7610-ad78-41a3-a0eb-01bf50b27d77" />


Design
<img width="1065" height="849" alt="image" src="https://github.com/user-attachments/assets/76d5975e-38dc-4fe4-ba0c-6a4203acde65" />

## Checklist

- [x] Verified component styling matches Figma on responsive layouts
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [x] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
