### PR TITLE
fix(ui): Change chevron directions in opus accordion rows

### DIFF
--- a/app/(logged_in)/creativity/WorksPageContent.tsx
+++ b/app/(logged_in)/creativity/WorksPageContent.tsx
@@ -10,7 +10,7 @@ import {
   MenuItem,
   Typography
 } from '@mui/material';
-import { ChevronDown, MoreVertical } from 'lucide-react';
+import { ChevronDown, ChevronRight, MoreVertical } from 'lucide-react';
 import Link from 'next/link';
 import { useRef, useState } from 'react';
 
@@ -403,7 +403,7 @@ function GroupedRow({
       }}
     >
       <AccordionSummary
-        expandIcon={<ChevronDown size={18} />}
+        expandIcon={<ChevronRight size={18} />}
         sx={{
           px: 0,
           minHeight: '56px',
@@ -424,6 +424,9 @@ function GroupedRow({
             my: '12px',
             minWidth: 0,
             width: '100%'
+          },
+          '&.Mui-expanded .MuiAccordionSummary-expandIconWrapper': {
+            transform: 'rotate(90deg)', 
           }
         }}
       >


### PR DESCRIPTION
## Description

Fixed the accordion chevron directions on the `/creativity` page table. The icon rotation logic has been updated to align with the approved UX/UI Figma specifications. The closed accordions has chevrons point to the right (`▶`)  and opened is point to the bottom (`▼`).

fixes #553 

**What was changed:**

-  Replaced the `ChevronDown` icon with `ChevronRight` inside the `AccordionSummary` component.
-  Added CSS logic to automatically rotate the chevron wrapper by 90 degrees clockwise whenever the accordion transitions into its expanded state (`.Mui-expanded`).

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Log in to lf-admin
2. Navigate to the `/creativity` page.
3. Observe the table containing the Opus and non-Opus group rows.
4. Ensure all chevrons natively point to the **right** (`▶`) when accordions are closed.
5. Click on a row to expand the accordion. 
6. Ensure the chevron rotates 90 degrees to point to the **bottom** (`▼`).


## Video / Screenshots

https://github.com/user-attachments/assets/1cf170f9-ceae-4d88-9f16-5cf2a959d8da

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
