### PR TITLE
fix: simplify news edit actions dropdown

### DIFF
--- a/app/(logged_in)/publications/[type]/[id]/edit/EditPublicationsView.test.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/edit/EditPublicationsView.test.tsx
@@ -155,7 +155,7 @@ describe('EditPublicationsView Component', () => {
     fireEvent.click(screen.getByText('Опублікувати і вийти'));
 
     expect(mockOnAction).toHaveBeenCalledTimes(1);
-    expect(mockOnAction).toHaveBeenCalledWith(MenuActionId.UPDATE_AND_EXIT);
+    expect(mockOnAction).toHaveBeenCalledWith(MenuActionId.PUBLICATE_AND_EXIT);
   });
 
   it('should handle the quick publish button from HeaderRightActions directly', () => {

--- a/app/(logged_in)/publications/[type]/[id]/edit/EditPublicationsView.test.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/edit/EditPublicationsView.test.tsx
@@ -155,7 +155,7 @@ describe('EditPublicationsView Component', () => {
     fireEvent.click(screen.getByText('Опублікувати і вийти'));
 
     expect(mockOnAction).toHaveBeenCalledTimes(1);
-    expect(mockOnAction).toHaveBeenCalledWith(MenuActionId.SAVE_AND_EXIT);
+    expect(mockOnAction).toHaveBeenCalledWith(MenuActionId.UPDATE_AND_EXIT);
   });
 
   it('should handle the quick publish button from HeaderRightActions directly', () => {

--- a/app/(logged_in)/publications/[type]/[id]/edit/EditPublicationsView.test.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/edit/EditPublicationsView.test.tsx
@@ -152,10 +152,10 @@ describe('EditPublicationsView Component', () => {
     render(<EditPublicationsView {...defaultProps} />);
     
     fireEvent.click(screen.getByTestId('mock-publish-menu-btn'));
-    fireEvent.click(screen.getByText('Зберегти зміни'));
+    fireEvent.click(screen.getByText('Опублікувати і вийти'));
 
     expect(mockOnAction).toHaveBeenCalledTimes(1);
-    expect(mockOnAction).toHaveBeenCalledWith(MenuActionId.SAVE_DRAFT);
+    expect(mockOnAction).toHaveBeenCalledWith(MenuActionId.SAVE_AND_EXIT);
   });
 
   it('should handle the quick publish button from HeaderRightActions directly', () => {

--- a/app/(logged_in)/publications/[type]/[id]/edit/page.test.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/edit/page.test.tsx
@@ -59,7 +59,7 @@ jest.mock('./EditPublicationsView', () => ({
         }
       />
       <button data-testid="trigger-publish" onClick={() => props.onAction(MenuActionId.PUBLISH)} />
-      <button data-testid="trigger-save-exit" onClick={() => props.onAction(MenuActionId.SAVE_AND_EXIT)} />
+      <button data-testid="trigger-save-exit" onClick={() => props.onAction(MenuActionId.UPDATE_AND_EXIT)} />
       <button data-testid="trigger-delete" onClick={() => props.onAction(MenuActionId.DELETE_DRAFT)} />
       <button data-testid="trigger-seo" onClick={props.onSeoClick} />
     </div>
@@ -153,7 +153,7 @@ describe('EditPublicationsPage Container', () => {
     });
   });
 
-  it('should handle SAVE_AND_EXIT action and redirect router', async () => {
+  it('should handle UPDATE_AND_EXIT action and redirect router', async () => {
     render(<EditPublicationsPage />);
 
     fireEvent.click(screen.getByTestId('trigger-save-exit'));

--- a/app/(logged_in)/publications/[type]/[id]/edit/page.test.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/edit/page.test.tsx
@@ -59,7 +59,7 @@ jest.mock('./EditPublicationsView', () => ({
         }
       />
       <button data-testid="trigger-publish" onClick={() => props.onAction(MenuActionId.PUBLISH)} />
-      <button data-testid="trigger-save-exit" onClick={() => props.onAction(MenuActionId.UPDATE_AND_EXIT)} />
+      <button data-testid="trigger-save-exit" onClick={() => props.onAction(MenuActionId.PUBLICATE_AND_EXIT)} />
       <button data-testid="trigger-delete" onClick={() => props.onAction(MenuActionId.DELETE_DRAFT)} />
       <button data-testid="trigger-seo" onClick={props.onSeoClick} />
     </div>
@@ -153,7 +153,7 @@ describe('EditPublicationsPage Container', () => {
     });
   });
 
-  it('should handle UPDATE_AND_EXIT action and redirect router', async () => {
+  it('should handle PUBLICATE_AND_EXIT action and redirect router', async () => {
     render(<EditPublicationsPage />);
 
     fireEvent.click(screen.getByTestId('trigger-save-exit'));

--- a/app/(logged_in)/publications/[type]/[id]/edit/page.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/edit/page.tsx
@@ -68,12 +68,6 @@ export default function EditPublicationsPage() {
         break;
       }
 
-      case MenuActionId.SAVE_DRAFT: {
-        const { data } = await manager.updateResource(BaseContentStatuses.Draft, contentPayload);
-        if (data) toast.success(CONTENT_MUTATION_RESULTS.draftSaved);
-        break;
-      }
-
       case MenuActionId.SAVE_AND_EXIT: {
         const { data } = await manager.updateResource(BaseContentStatuses.Draft, contentPayload);
         if (data) {

--- a/app/(logged_in)/publications/[type]/[id]/edit/page.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/edit/page.tsx
@@ -68,7 +68,7 @@ export default function EditPublicationsPage() {
         break;
       }
 
-      case MenuActionId.UPDATE_AND_EXIT: {
+      case MenuActionId.PUBLICATE_AND_EXIT: {
         const { data } = await manager.updateResource(BaseContentStatuses.Draft, contentPayload);
         if (data) {
           toast.success(CONTENT_MUTATION_RESULTS.draftSaved);

--- a/app/(logged_in)/publications/[type]/[id]/edit/page.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/edit/page.tsx
@@ -68,7 +68,7 @@ export default function EditPublicationsPage() {
         break;
       }
 
-      case MenuActionId.SAVE_AND_EXIT: {
+      case MenuActionId.UPDATE_AND_EXIT: {
         const { data } = await manager.updateResource(BaseContentStatuses.Draft, contentPayload);
         if (data) {
           toast.success(CONTENT_MUTATION_RESULTS.draftSaved);

--- a/app/(logged_in)/publications/[type]/create/CreatePublicationsView.tsx
+++ b/app/(logged_in)/publications/[type]/create/CreatePublicationsView.tsx
@@ -110,7 +110,7 @@ export default function CreatePublicationsView({ data, mode = 'create' }: Readon
         break;
       }
 
-      case MenuActionId.SAVE_AND_EXIT: {
+      case MenuActionId.UPDATE_AND_EXIT: {
         const id = await handleSave(BaseContentStatuses.Draft);
         if (id) {
           toast.success(CONTENT_MUTATION_RESULTS.draftSaved);

--- a/app/(logged_in)/publications/[type]/create/CreatePublicationsView.tsx
+++ b/app/(logged_in)/publications/[type]/create/CreatePublicationsView.tsx
@@ -110,7 +110,7 @@ export default function CreatePublicationsView({ data, mode = 'create' }: Readon
         break;
       }
 
-      case MenuActionId.UPDATE_AND_EXIT: {
+      case MenuActionId.PUBLICATE_AND_EXIT: {
         const id = await handleSave(BaseContentStatuses.Draft);
         if (id) {
           toast.success(CONTENT_MUTATION_RESULTS.draftSaved);

--- a/app/constants/publications.ts
+++ b/app/constants/publications.ts
@@ -152,7 +152,7 @@ export const PublicationsChipLabels: Record<PublicationsItemType, string> = {
 export enum MenuActionId {
   PUBLISH = 'PUBLISH',
   SAVE_DRAFT = 'SAVE_DRAFT',
-  SAVE_AND_EXIT = 'SAVE_AND_EXIT',
+  UPDATE_AND_EXIT = 'UPDATE_AND_EXIT',
   DELETE_DRAFT = 'DELETE_DRAFT'
 }
 
@@ -166,7 +166,7 @@ export type HEADER_MENU_OPTIONS_TYPE = Record<string, ReadonlyArray<ACTIONS_TYPE
 export const HEADER_MENU_OPTIONS: HEADER_MENU_OPTIONS_TYPE = {
   baseActions: [
     { id: MenuActionId.PUBLISH, label: 'Опублікувати' },
-    { id: MenuActionId.SAVE_AND_EXIT, label: 'Опублікувати і вийти' },
+    { id: MenuActionId.UPDATE_AND_EXIT, label: 'Опублікувати і вийти' },
     { id: MenuActionId.DELETE_DRAFT, label: 'Видалити чернетку' }
   ]
 } as const;

--- a/app/constants/publications.ts
+++ b/app/constants/publications.ts
@@ -166,8 +166,7 @@ export type HEADER_MENU_OPTIONS_TYPE = Record<string, ReadonlyArray<ACTIONS_TYPE
 export const HEADER_MENU_OPTIONS: HEADER_MENU_OPTIONS_TYPE = {
   baseActions: [
     { id: MenuActionId.PUBLISH, label: 'Опублікувати' },
-    { id: MenuActionId.SAVE_DRAFT, label: 'Зберегти зміни' },
-    { id: MenuActionId.SAVE_AND_EXIT, label: 'Зберегти зміни і вийти' },
+    { id: MenuActionId.SAVE_AND_EXIT, label: 'Опублікувати і вийти' },
     { id: MenuActionId.DELETE_DRAFT, label: 'Видалити чернетку' }
   ]
 } as const;

--- a/app/constants/publications.ts
+++ b/app/constants/publications.ts
@@ -152,7 +152,7 @@ export const PublicationsChipLabels: Record<PublicationsItemType, string> = {
 export enum MenuActionId {
   PUBLISH = 'PUBLISH',
   SAVE_DRAFT = 'SAVE_DRAFT',
-  UPDATE_AND_EXIT = 'UPDATE_AND_EXIT',
+  PUBLICATE_AND_EXIT = 'PUBLICATE_AND_EXIT',
   DELETE_DRAFT = 'DELETE_DRAFT'
 }
 
@@ -166,7 +166,7 @@ export type HEADER_MENU_OPTIONS_TYPE = Record<string, ReadonlyArray<ACTIONS_TYPE
 export const HEADER_MENU_OPTIONS: HEADER_MENU_OPTIONS_TYPE = {
   baseActions: [
     { id: MenuActionId.PUBLISH, label: 'Опублікувати' },
-    { id: MenuActionId.UPDATE_AND_EXIT, label: 'Опублікувати і вийти' },
+    { id: MenuActionId.PUBLICATE_AND_EXIT, label: 'Опублікувати і вийти' },
     { id: MenuActionId.DELETE_DRAFT, label: 'Видалити чернетку' }
   ]
 } as const;


### PR DESCRIPTION
## Description

Simplified the actions dropdown on the edit page according to the updated design review decision.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Open publications edit page
2. Open the dropdown and verify it contains only:
- Опублікувати і вийти
- Видалити чернетку
3. Verify that "Зберегти зміни" is no longer present
4. Verify that the edit page header/actions layout has no visual regressions

## Video / Screenshots

<img width="342" height="213" alt="image" src="https://github.com/user-attachments/assets/8f186da4-12d0-48c6-8565-0f2bb3d5a453" />

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
