### PR TITLE
feat: add edit icon to work lists

### DIFF
--- a/app/(logged_in)/creativity/WorksPageContent.tsx
+++ b/app/(logged_in)/creativity/WorksPageContent.tsx
@@ -10,6 +10,7 @@ import {
   MenuItem,
   Typography
 } from '@mui/material';
+import { alpha } from '@mui/material/styles';
 import { ChevronDown, MoreVertical } from 'lucide-react';
 import Link from 'next/link';
 import { useRef, useState } from 'react';
@@ -360,15 +361,15 @@ function EditAction({ href, label }: Readonly<{ href: string; label: string }>) 
 
   return (
     <Box
-      sx={{
+      sx={(theme) => ({
         width: '40px',
         height: '40px',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        mr: '-12px',
+        mr: theme.spacing(-1.5),
         flexShrink: 0
-      }}
+      })}
     >
       <IconButton
         component={Link}
@@ -376,14 +377,14 @@ function EditAction({ href, label }: Readonly<{ href: string; label: string }>) 
         onClick={handleClick}
         aria-label={label}
         sx={{
-          color: '#190D03',
+          color: colors.black,
           width: '32px',
           height: '32px',
           p: 0,
           borderRadius: '50%',
           '& svg': { width: '18px', height: '18px' },
           '&:hover': {
-            bgcolor: 'rgba(25,13,3,0.08)'
+            bgcolor: alpha(colors.black, 0.08)
           }
         }}
       >

--- a/app/(logged_in)/creativity/WorksPageContent.tsx
+++ b/app/(logged_in)/creativity/WorksPageContent.tsx
@@ -18,6 +18,7 @@ import { StatusWithDate } from './components/StatusWithDate';
 import { useWorksFiltering } from './useWorksFiltering';
 import { type OpusGroup, type UngroupedGroup, WORKS_MOCK_DATA, type WorkStatus } from './works.mock';
 import {
+  WORKS_BASE_PATH,
   WORKS_CREATE_OPTIONS,
   WORKS_EMPTY_STATE_DESCRIPTION,
   WORKS_EMPTY_STATE_NO_RESULTS_DESCRIPTION,
@@ -30,6 +31,7 @@ import {
   type WorksTabValue
 } from '~/constants/creativity';
 import type { FilesSortValue } from '~/constants/sort';
+import PencilIcon from '~/public/icons/pencil.svg';
 import DropdownMenu from '~/shared/components/dropdown-menu/DropdownMenu';
 import { EmptyState } from '~/shared/components/empty-state';
 import { FilteringToolbar, SortSelect } from '~/shared/components/filtering-toolbar';
@@ -49,9 +51,15 @@ const GROUP_GENRE_COLUMN_WIDTH = '220px';
 const GROUP_YEARS_COLUMN_WIDTH = '96px';
 const STATUS_COLUMN_WIDTH = '310px';
 const ACCORDION_ICON_OFFSET = '26px';
-const GROUP_ROW_COLUMNS = `1px ${NUMBER_COLUMN_WIDTH} minmax(220px, 1fr) ${GROUP_GENRE_COLUMN_WIDTH} ${GROUP_YEARS_COLUMN_WIDTH} ${STATUS_COLUMN_WIDTH} 40px`;
-const TABLE_HEADER_COLUMNS = `1px calc(${NUMBER_COLUMN_WIDTH} + ${ACCORDION_ICON_OFFSET}) minmax(220px, 1fr) ${GROUP_GENRE_COLUMN_WIDTH} ${GROUP_YEARS_COLUMN_WIDTH} ${STATUS_COLUMN_WIDTH} 40px`;
-const INDIVIDUAL_WORK_ROW_COLUMNS = `1px minmax(220px, 1fr) ${GROUP_GENRE_COLUMN_WIDTH} ${GROUP_YEARS_COLUMN_WIDTH} ${STATUS_COLUMN_WIDTH} 40px`;
+const ACTIONS_COLUMN_WIDTH = '88px';
+const GROUP_ROW_COLUMNS = `1px ${NUMBER_COLUMN_WIDTH} minmax(220px, 1fr) ${GROUP_GENRE_COLUMN_WIDTH} ${GROUP_YEARS_COLUMN_WIDTH} ${STATUS_COLUMN_WIDTH} ${ACTIONS_COLUMN_WIDTH}`;
+const TABLE_HEADER_COLUMNS = `1px calc(${NUMBER_COLUMN_WIDTH} + ${ACCORDION_ICON_OFFSET}) minmax(220px, 1fr) ${GROUP_GENRE_COLUMN_WIDTH} ${GROUP_YEARS_COLUMN_WIDTH} ${STATUS_COLUMN_WIDTH} ${ACTIONS_COLUMN_WIDTH}`;
+const INDIVIDUAL_WORK_ROW_COLUMNS = `1px minmax(220px, 1fr) ${GROUP_GENRE_COLUMN_WIDTH} ${GROUP_YEARS_COLUMN_WIDTH} ${STATUS_COLUMN_WIDTH} ${ACTIONS_COLUMN_WIDTH}`;
+const ROW_ACTIONS_CELL_SX = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'flex-end'
+} as const;
 const WORK_ROW_GRID_SX = {
   display: 'grid',
   gridTemplateColumns: INDIVIDUAL_WORK_ROW_COLUMNS,
@@ -189,6 +197,10 @@ function formatGroupYears(startDate: string, endDate?: string): string {
   }
 
   return `${startDate} - ${endDate}`;
+}
+
+function getGroupEditHref(groupId: string): string {
+  return `${WORKS_BASE_PATH}/group/${groupId}/edit`;
 }
 
 function sortGroups<T extends { title: string; updatedAt: string }>(
@@ -341,6 +353,46 @@ function ContextMenu({
   );
 }
 
+function EditAction({ href, label }: Readonly<{ href: string; label: string }>) {
+  const handleClick = (event: React.MouseEvent<HTMLAnchorElement>): void => {
+    event.stopPropagation();
+  };
+
+  return (
+    <Box
+      sx={{
+        width: '40px',
+        height: '40px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        mr: '-12px',
+        flexShrink: 0
+      }}
+    >
+      <IconButton
+        component={Link}
+        href={href}
+        onClick={handleClick}
+        aria-label={label}
+        sx={{
+          color: '#190D03',
+          width: '32px',
+          height: '32px',
+          p: 0,
+          borderRadius: '50%',
+          '& svg': { width: '18px', height: '18px' },
+          '&:hover': {
+            bgcolor: 'rgba(25,13,3,0.08)'
+          }
+        }}
+      >
+        <PencilIcon />
+      </IconButton>
+    </Box>
+  );
+}
+
 function WorkRowCells({ title, year }: Readonly<{ title: string; year: string }>) {
   return (
     <>
@@ -348,7 +400,9 @@ function WorkRowCells({ title, year }: Readonly<{ title: string; year: string }>
       <Box sx={GENRE_SPACER_SX} />
       <Typography sx={YEAR_TEXT_SX}>{year}</Typography>
       <Box sx={{ width: STATUS_COLUMN_WIDTH }} />
-      <ContextMenu items={WORK_MENU_ITEMS} triggerLabel={`Дії твору ${title}`} />
+      <Box sx={ROW_ACTIONS_CELL_SX}>
+        <ContextMenu items={WORK_MENU_ITEMS} triggerLabel={`Дії твору ${title}`} />
+      </Box>
     </>
   );
 }
@@ -375,7 +429,7 @@ function WorksTableHeader() {
       <Typography sx={TABLE_HEADER_TEXT_SX}>Жанр</Typography>
       <Typography sx={TABLE_HEADER_TEXT_SX}>Роки</Typography>
       <Typography sx={TABLE_HEADER_TEXT_SX}>Статус</Typography>
-      <Box sx={{ width: '40px' }} />
+      <Box sx={{ width: ACTIONS_COLUMN_WIDTH }} />
     </Box>
   );
 }
@@ -480,7 +534,14 @@ function GroupedRow({
             />
           </Box>
 
-          <ContextMenu items={GROUP_MENU_ITEMS} triggerLabel={`Дії групи ${group.title}`} />
+          <Box sx={ROW_ACTIONS_CELL_SX}>
+            <EditAction
+              href={getGroupEditHref(group.id)}
+              label={`Редагувати групу ${group.title}`}
+            />
+
+            <ContextMenu items={GROUP_MENU_ITEMS} triggerLabel={`Дії групи ${group.title}`} />
+          </Box>
         </Box>
       </AccordionSummary>
 
@@ -527,7 +588,9 @@ function IndividualWorkRow({ work }: Readonly<{ work: IndividualWorkData }>) {
 
       <Box sx={{ width: STATUS_COLUMN_WIDTH }} />
 
-      <ContextMenu items={WORK_MENU_ITEMS} triggerLabel={`Дії твору ${work.title}`} />
+      <Box sx={ROW_ACTIONS_CELL_SX}>
+        <ContextMenu items={WORK_MENU_ITEMS} triggerLabel={`Дії твору ${work.title}`} />
+      </Box>
     </Box>
   );
 }

--- a/app/(logged_in)/creativity/page.test.tsx
+++ b/app/(logged_in)/creativity/page.test.tsx
@@ -16,6 +16,11 @@ jest.mock('next/link', () => {
   return MockLink;
 });
 
+jest.mock('~/public/icons/pencil.svg', () => ({
+  __esModule: true,
+  default: () => <svg data-testid="edit-icon" />
+}));
+
 jest.mock('~/shared/components/dropdown-menu/DropdownMenu', () => ({
   __esModule: true,
   default: ({ open, menuList }: { open: boolean; menuList: React.ReactNode }) =>
@@ -160,5 +165,15 @@ describe('Creativity page', () => {
     expect(within(dropdownMenu).queryByText('Редагувати')).not.toBeInTheDocument();
     expect(within(dropdownMenu).queryByText('Опублікувати')).not.toBeInTheDocument();
     expect(within(dropdownMenu).queryByText('Розгрупувати')).not.toBeInTheDocument();
+  });
+
+  it('renders an edit link for each opus and non-opus group', () => {
+    render(<CreativityPage />);
+
+    const editLinks = screen.getAllByRole('link', { name: /редагувати групу/i });
+    const editHrefs = editLinks.map((link) => link.getAttribute('href'));
+
+    expect(editHrefs).toContain('/creativity/group/opus-1/edit');
+    expect(editHrefs).toContain('/creativity/group/bo-1/edit');
   });
 });


### PR DESCRIPTION
## Description

Added a dedicated pencil edit icon to opus and non-opus group rows on the Creativity page, giving admins  quick access to editing directly from the list instead of going through the context menu.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Open the Creativity page (**Творчість**) while logged in.
 2. Confirm a pencil edit icon appears on every opus group row and every non-opus (ungrouped) group row,  aligned left of the `⋮` context menu per Figma.
 3. Click the edit icon and confirm it navigates to `/creativity/group/{id}/edit` without toggling the group
  accordion. (Note: it will land to 404 page as Edit page is not implemented yet)
 4. Open the `⋮` context menu and confirm its actions still work.
 5. Confirm the list layout and individual work rows show no regressions.

## Video / Screenshots
Opus
<img width="1609" height="1000" alt="opus" src="https://github.com/user-attachments/assets/6f5e7c91-a2af-4656-9665-9d9f8f88f0c9" />

Non-opus
<img width="1625" height="988" alt="no-opus" src="https://github.com/user-attachments/assets/35225fbe-2a4e-4a88-8ef1-93bc2ff09794" />

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
