### PR TITLE
Bugfix/542/fix conflicting status badges

### DIFF
--- a/app/shared/components/content-card/ContentCardBadge.tsx
+++ b/app/shared/components/content-card/ContentCardBadge.tsx
@@ -23,6 +23,9 @@ const ContentCardBadge = ({ type, status, localizations }: ContentCardBadgeProps
     }
   };
 
+
+  console.log(status);
+
   const localizationLabel = getLocalizations(localizations);
   const hasLocalizationLabel = Boolean(localizationLabel);
 
@@ -35,12 +38,13 @@ const ContentCardBadge = ({ type, status, localizations }: ContentCardBadgeProps
         sx={styles.typeBadge(type)}
       ></Chip>
 
+      {status === BaseContentStatuses.Published && 
       <Box
         sx={styles.localizationsBadge(hasLocalizationLabel)}
       >
         <CircleCheckBig size={15} />
         {localizationLabel && <Box>{localizationLabel}</Box>}
-      </Box>
+      </Box>}
 
       {status === BaseContentStatuses.Draft && (
         <Box sx={styles.draftBadge}>

--- a/app/shared/components/content-card/ContentCardBadge.tsx
+++ b/app/shared/components/content-card/ContentCardBadge.tsx
@@ -23,9 +23,6 @@ const ContentCardBadge = ({ type, status, localizations }: ContentCardBadgeProps
     }
   };
 
-
-  console.log(status);
-
   const localizationLabel = getLocalizations(localizations);
   const hasLocalizationLabel = Boolean(localizationLabel);
 


### PR DESCRIPTION
## Description

Fixed incorrect badge logic on Новини, події та медіа cards where items can simultaneously display both Published and Чернетка statuses

## Type of change

- [x] Bug fix

## How to test

1. Go to `/publications` page

2. Check content cards with different statuses:
   - Draft items should display ONLY "Чернетка"
   - Published items should display ONLY published badge (no draft label)

3. Verify that:
   - Draft and published badges are never shown at the same time
   - No duplicate or conflicting status indicators appear on a single card

## Video / Screenshots

<img width="1073" height="457" alt="image" src="https://github.com/user-attachments/assets/b7c2b9c2-7ce8-45a6-a132-0ad9758853a6" />

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [x] Task moved to the review column on the board

---
