### PR TITLE
feat(ui): add tooltip for truncated publication titles

### DIFF
--- a/app/shared/components/content-card/ContentCard.tsx
+++ b/app/shared/components/content-card/ContentCard.tsx
@@ -2,13 +2,14 @@ import { Box, Card, CardContent, CardMedia, Typography } from '@mui/material';
 import { EllipsisVertical } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef,useState } from 'react';
 
 import DeleteCardModal from '../delete-card-modal/DeleteCardModal';
 import Button from '../design-system/button/Button';
 import styles from './ContentCard.styles';
 import ContentCardBadge from './ContentCardBadge';
 import ContentCardMenu from './ContentCardMenu';
+import TooltipCustom from '~/ds-components/tooltip/Tooltip';
 import { getStatus } from '~/lib/utils/getStatus';
 import { useDeleteEvent } from '~/shared/hooks/use-events/useEvents';
 import { useDeleteMediaMention } from '~/shared/hooks/use-media-mentions/useMediaMentions';
@@ -67,6 +68,18 @@ const ContentCard = ({
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+
+  const titleRef = useRef<HTMLHeadingElement | null>(null);
+  const [isTitleTruncated, setIsTitleTruncated] = useState(false);
+
+  useEffect(() => {
+    const element = titleRef.current;
+
+    if (!element) return;
+
+    setIsTitleTruncated(element.scrollHeight > element.clientHeight);
+  }, [titleText]);
+
   useEffect(() => {
     setImageSrc(coverImage.src || FALLBACK_IMAGE_SRC);
   }, [coverImage.src]);
@@ -112,9 +125,16 @@ const ContentCard = ({
       <CardContent sx={styles.cardContent}>
         <ContentCardBadge type={type} status={status} localizations={localizedKeys}></ContentCardBadge>
         <Box sx={styles.mainInfo}>
-          <Typography variant="subtitle1" component="h3" sx={styles.title}>
-            {titleText}
-          </Typography>
+          <TooltipCustom title={isTitleTruncated ? titleText : ''}>
+            <Typography
+              ref={titleRef}
+              variant="subtitle1"
+              component="h3"
+              sx={styles.title}
+            >
+              {titleText}
+            </Typography>
+          </TooltipCustom>
           <Box data-testid="menu-button" sx={{ cursor: 'pointer' }} onClick={handleMenuClick}>
             <EllipsisVertical size={20} />
             {anchorEl && (


### PR DESCRIPTION
## Description

Add a tooltip for truncated news/publication card titles on the /publications page.

### Changes made:
- Added tooltip for publication/news card titles
- Tooltip is displayed only when the title is truncated
- Preserved existing two-line truncation behavior
- Ensured card layout remains unchanged

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Run the application locally
2. Open /publications
3. Verify that long card titles remain truncated to two lines
4. Hover over a truncated title and confirm that a tooltip with the full title appears
5. Verify that short titles do not show a tooltip
6. Confirm that card layout and styling remain unchanged

## Video / Screenshots

<img width="372" height="371" alt="Screenshot 2026-05-29 at 14 48 22" src="https://github.com/user-attachments/assets/15a60988-75f1-4ba9-827d-3ce869dbad52" />

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
