### PR TITLE
feat: create main page base structure and routing

### DIFF
--- a/app/(logged_in)/main-page/MainPageContent.tsx
+++ b/app/(logged_in)/main-page/MainPageContent.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { Box, Button, Typography } from '@mui/material';
+import Link from 'next/link';
+
+import { PageHeader, PageHeaderTab } from '~/shared/components/page-header/PageHeader';
+
+type MainPagesContentProps = Readonly<{
+  activeTab: string;
+}>;
+
+const MAIN_PAGE_TABS: readonly PageHeaderTab[] = [
+  { value: 'all', label: 'Всі', href: '/main-pages/all' },
+  { value: 'foundation', label: 'Фундація', href: '/main-pages/foundation' }
+];
+
+export function MainPagesContent({ activeTab }: MainPagesContentProps) {
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: '32px' }}>
+      <PageHeader title="Основні сторінки" activeTab={activeTab} tabs={MAIN_PAGE_TABS} />
+
+      {activeTab === 'foundation' && (
+        <Box sx={{ p: '24px' }}>
+          <Typography variant="body1" sx={{ mb: '16px' }}>
+            Керування сторінкою &quot;Про нас&quot;:
+          </Typography>
+
+          <Button component={Link} href="/about-us" variant="contained" color="primary">
+            Перейти до редагування &quot;Про нас&quot;
+          </Button>
+        </Box>
+      )}
+
+      {activeTab === 'all' && (
+        <Box>
+          <Typography>Тут згодом буде список усіх сторінок</Typography>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/app/(logged_in)/main-page/MainPageContent.tsx
+++ b/app/(logged_in)/main-page/MainPageContent.tsx
@@ -10,8 +10,8 @@ type MainPagesContentProps = Readonly<{
 }>;
 
 const MAIN_PAGE_TABS: readonly PageHeaderTab[] = [
-  { value: 'all', label: 'Всі', href: '/main-pages/all' },
-  { value: 'foundation', label: 'Фундація', href: '/main-pages/foundation' }
+  { value: 'all', label: 'Всі', href: '/main-page/all' },
+  { value: 'foundation', label: 'Фундація', href: '/main-page' }
 ];
 
 export function MainPagesContent({ activeTab }: MainPagesContentProps) {

--- a/app/(logged_in)/main-page/[tab]/page.tsx
+++ b/app/(logged_in)/main-page/[tab]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from 'next/navigation';
 
 import { MainPagesContent } from '../MainPageContent';
 
-const validTabs = ['all', 'foundation'];
+const validTabs = new Set(['all', 'foundation']);
 
 type MainPagesTabProps = Readonly<{
   params: Promise<{
@@ -14,7 +14,7 @@ type MainPagesTabProps = Readonly<{
 export default async function MainPagesTabPage({ params }: MainPagesTabProps) {
   const { tab } = await params;
 
-  if (!validTabs.includes(tab)) {
+  if (!validTabs.has(tab)) {
     notFound();
   }
 

--- a/app/(logged_in)/main-page/[tab]/page.tsx
+++ b/app/(logged_in)/main-page/[tab]/page.tsx
@@ -1,0 +1,26 @@
+import { Box } from '@mui/material';
+import { notFound } from 'next/navigation';
+
+import { MainPagesContent } from '../MainPageContent';
+
+const validTabs = ['all', 'foundation'];
+
+type MainPagesTabProps = Readonly<{
+  params: Promise<{
+    tab: string;
+  }>;
+}>;
+
+export default async function MainPagesTabPage({ params }: MainPagesTabProps) {
+  const { tab } = await params;
+
+  if (!validTabs.includes(tab)) {
+    notFound();
+  }
+
+  return (
+    <Box sx={{ width: '100%', maxWidth: '100%', boxSizing: 'border-box', p: '32px' }}>
+      <MainPagesContent activeTab={tab} />
+    </Box>
+  );
+}

--- a/app/(logged_in)/main-page/page.test.tsx
+++ b/app/(logged_in)/main-page/page.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import MainPagesPage from './page';
+
+jest.mock('./MainPageContent', () => ({
+  MainPagesContent: ({ activeTab }: { activeTab: string }) => (
+    <div data-testid="mock-content">Passed tab: {activeTab}</div>
+  )
+}));
+
+describe('MainPagesPage', () => {
+  it('renders foundation tab by default when searchParams is empty', async () => {
+    const ui = await MainPagesPage({ searchParams: Promise.resolve({}) });
+    render(ui);
+
+    expect(screen.getByTestId('mock-content')).toHaveTextContent('Passed tab: foundation');
+  });
+
+  it('passes the correct tab from searchParams when provided as a string', async () => {
+    const ui = await MainPagesPage({ searchParams: Promise.resolve({ tab: 'all' }) });
+    render(ui);
+
+    expect(screen.getByTestId('mock-content')).toHaveTextContent('Passed tab: all');
+  });
+
+  it('falls back to foundation tab if searchParams.tab is an array', async () => {
+    const ui = await MainPagesPage({
+      searchParams: Promise.resolve({ tab: ['all', 'foundation'] })
+    });
+    render(ui);
+
+    expect(screen.getByTestId('mock-content')).toHaveTextContent('Passed tab: foundation');
+  });
+});

--- a/app/(logged_in)/main-page/page.test.tsx
+++ b/app/(logged_in)/main-page/page.test.tsx
@@ -1,7 +1,13 @@
 import { render, screen } from '@testing-library/react';
+import { notFound } from 'next/navigation';
 import React from 'react';
 
+import MainPagesTabPage from './[tab]/page';
 import MainPagesPage from './page';
+
+jest.mock('next/navigation', () => ({
+  notFound: jest.fn()
+}));
 
 jest.mock('./MainPageContent', () => ({
   MainPagesContent: ({ activeTab }: { activeTab: string }) => (
@@ -9,27 +15,28 @@ jest.mock('./MainPageContent', () => ({
   )
 }));
 
-describe('MainPagesPage', () => {
-  it('renders foundation tab by default when searchParams is empty', async () => {
-    const ui = await MainPagesPage({ searchParams: Promise.resolve({}) });
+describe('MainPage Routing & Pages', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('root page renders "foundation" tab by default', async () => {
+    const ui = await MainPagesPage();
     render(ui);
 
     expect(screen.getByTestId('mock-content')).toHaveTextContent('Passed tab: foundation');
   });
 
-  it('passes the correct tab from searchParams when provided as a string', async () => {
-    const ui = await MainPagesPage({ searchParams: Promise.resolve({ tab: 'all' }) });
+  it('dynamic page renders the correct tab from params', async () => {
+    const ui = await MainPagesTabPage({ params: Promise.resolve({ tab: 'all' }) });
     render(ui);
 
     expect(screen.getByTestId('mock-content')).toHaveTextContent('Passed tab: all');
   });
 
-  it('falls back to foundation tab if searchParams.tab is an array', async () => {
-    const ui = await MainPagesPage({
-      searchParams: Promise.resolve({ tab: ['all', 'foundation'] })
-    });
-    render(ui);
+  it('dynamic page triggers notFound for invalid tab parameters', async () => {
+    await MainPagesTabPage({ params: Promise.resolve({ tab: 'some-garbage-route' }) });
 
-    expect(screen.getByTestId('mock-content')).toHaveTextContent('Passed tab: foundation');
+    expect(notFound).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/(logged_in)/main-page/page.tsx
+++ b/app/(logged_in)/main-page/page.tsx
@@ -1,0 +1,18 @@
+import { Box } from '@mui/material';
+
+import { MainPagesContent } from './MainPageContent';
+
+export default async function MainPagesPage({
+  searchParams
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+  const resolvedParams = await searchParams;
+  const activeTab = typeof resolvedParams.tab === 'string' ? resolvedParams.tab : 'foundation';
+
+  return (
+    <Box sx={{ width: '100%', maxWidth: '100%', boxSizing: 'border-box', p: '32px' }}>
+      <MainPagesContent activeTab={activeTab} />
+    </Box>
+  );
+}

--- a/app/(logged_in)/main-page/page.tsx
+++ b/app/(logged_in)/main-page/page.tsx
@@ -2,17 +2,10 @@ import { Box } from '@mui/material';
 
 import { MainPagesContent } from './MainPageContent';
 
-type MainPagesPageProps = Readonly<{
-  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
-}>;
-
-export default async function MainPagesPage({ searchParams }: MainPagesPageProps) {
-  const resolvedParams = await searchParams;
-  const activeTab = typeof resolvedParams.tab === 'string' ? resolvedParams.tab : 'foundation';
-
+export default async function MainPagesPage() {
   return (
     <Box sx={{ width: '100%', maxWidth: '100%', boxSizing: 'border-box', p: '32px' }}>
-      <MainPagesContent activeTab={activeTab} />
+      <MainPagesContent activeTab="foundation" />
     </Box>
   );
 }

--- a/app/(logged_in)/main-page/page.tsx
+++ b/app/(logged_in)/main-page/page.tsx
@@ -2,11 +2,11 @@ import { Box } from '@mui/material';
 
 import { MainPagesContent } from './MainPageContent';
 
-export default async function MainPagesPage({
-  searchParams
-}: {
+type MainPagesPageProps = Readonly<{
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
-}) {
+}>;
+
+export default async function MainPagesPage({ searchParams }: MainPagesPageProps) {
   const resolvedParams = await searchParams;
   const activeTab = typeof resolvedParams.tab === 'string' ? resolvedParams.tab : 'foundation';
 

--- a/app/shared/components/side-navigation/SideNavigation.consts.ts
+++ b/app/shared/components/side-navigation/SideNavigation.consts.ts
@@ -2,16 +2,14 @@ export const NAVIGATION_DATA = {
   main: [{ title: 'Головна', iconSrc: 'house', href: '/' }],
   content: [
     {
-      element: { title: 'Основні сторінки', iconSrc: 'file-text' },
-      // TEMPORARY
-      collapseElements: [
-        { title: 'Про Фундацію', href: '/about-us' }
-      ]
+      title: 'Основні сторінки',
+      iconSrc: 'file-text',
+      href: '/main-page'
     },
     {
       title: 'Новини та події',
       iconSrc: 'news',
-      href: '/publications',
+      href: '/publications'
     },
     {
       element: { title: 'Каталоги', iconSrc: 'book-marked' },


### PR DESCRIPTION
## Description

This PR implements the base structure and dynamic routing for the new "Основні сторінки" section

## Type of change

- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. Check the sidebar: verify that "Основні сторінки" is now a single clickable link, not a dropdown.

2. Click "Основні сторінки" and verify it opens /main-page (displaying the "Фундація" tab).

3. Check the page header: verify the presence of "Всі" and "Фундація" tabs, and ensure navigation between them updates the URL correctly (/main-page/all and /main-page).

4. On the "Фундація" tab, verify the "Перейти до редагування Про нас" button works and redirects to /about-us.

Closes: https://github.com/Liatoshynsky-Foundation/lf-admin/issues/551