### PR TITLE
refactor(ui): create reusable badge component

### DIFF
--- a/app/(logged_in)/creativity/components/StatusWithDate.tsx
+++ b/app/(logged_in)/creativity/components/StatusWithDate.tsx
@@ -1,15 +1,12 @@
-import { Box, Chip, Typography } from '@mui/material';
-import { CircleCheckBig } from 'lucide-react';
+import { Box, Typography } from '@mui/material';
 
 import { formatDate } from '~/lib/utils/formatDate';
+import Badge from '~/shared/components/badge/Badge';
 import contentCardStyles from '~/shared/components/content-card/ContentCard.styles';
-import contentCardBadgeStyles from '~/shared/components/content-card/ContentCardBadge.styles';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
 
 type StatusChipStatus = typeof BaseContentStatuses.Draft | typeof BaseContentStatuses.Published;
 type StatusWithDateStatus = typeof BaseContentStatuses[keyof typeof BaseContentStatuses];
-
-type StatusChipProps = Readonly<{ status: StatusChipStatus }>;
 
 type StatusWithDateProps = Readonly<{
   status: StatusWithDateStatus;
@@ -19,43 +16,6 @@ type StatusWithDateProps = Readonly<{
   dividerColor: string;
 }>;
 
-function StatusChip({ status }: StatusChipProps) {
-  if (status === BaseContentStatuses.Published) {
-    return (
-      <Box
-        sx={{
-          width: '24px',
-          height: '24px',
-          borderRadius: '12px',
-          display: 'inline-flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          backgroundColor: 'green.600',
-          color: 'white',
-          flexShrink: 0
-        }}
-      >
-        <CircleCheckBig size={14} />
-      </Box>
-    );
-  }
-
-  return (
-    <Chip
-      label="Чернетка"
-      size="small"
-      sx={{
-        backgroundColor: contentCardBadgeStyles.draftBadge.backgroundColor,
-        color: 'black',
-        typography: contentCardBadgeStyles.draftBadge.typography,
-        height: '24px',
-        '& .MuiChip-label': {
-          color: 'black'
-        }
-      }}
-    />
-  );
-}
 
 export function StatusWithDate({
   status,
@@ -95,7 +55,7 @@ export function StatusWithDate({
         minWidth: 0
       }}
     >
-      <StatusChip status={normalizedStatus} />
+      <Badge variant={normalizedStatus}/>
       {statusText && (
         <Typography
           variant="body2"

--- a/app/(logged_in)/publications/[type]/[id]/edit/EditPublicationsView.styles.ts
+++ b/app/(logged_in)/publications/[type]/[id]/edit/EditPublicationsView.styles.ts
@@ -1,16 +1,3 @@
-import { chipsColors } from '~/shared/theme/colors';
-
-type ChipColorType = 'draft' | 'published' | 'news' | 'events' | 'media';
-
-const publicationsChipsColors: Record<ChipColorType, string> = {
-  published: chipsColors.published,
-  draft: chipsColors.draft,
-  news: chipsColors.newsChipBg,
-  events: chipsColors.eventChipBg,
-  media: chipsColors.mediaChipBg
-};
-
-
 export const styles = {
   container: {
     width: '100%',
@@ -58,27 +45,5 @@ export const styles = {
       maxWidth: '1136px',
       bgcolor: 'white'
     }
-  },
-  chip: (color: ChipColorType) => ({
-    pointerEvents: 'none',
-    cursor: 'default',
-    userSelect: 'none',
-
-    '&:hover': {
-      bgcolor: 'inherit'
-    },
-    '&:active': {
-      boxShadow: 'none'
-    },
-
-    '& .MuiTouchRipple-root': {
-      display: 'none'
-    },
-
-    bgcolor: publicationsChipsColors[color],
-    height: 28,
-    '& .MuiChip-root': {
-      p: '4px 8px'
-    }
-  })
+  }
 };

--- a/app/(logged_in)/publications/[type]/[id]/edit/EditPublicationsView.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/edit/EditPublicationsView.tsx
@@ -1,4 +1,4 @@
-import { Box, Chip, Divider, ListSubheader, Menu, MenuItem, Typography } from '@mui/material';
+import { Box, Divider, ListSubheader, Menu, MenuItem, Typography } from '@mui/material';
 import { MouseEvent, useState } from 'react';
 
 import { styles } from './EditPublicationsView.styles';
@@ -13,6 +13,7 @@ import {
   PublicationsChipLabels,
   PublicationsItemType
 } from '~/constants/publications';
+import Badge from '~/shared/components/badge/Badge';
 import { ContentEditor, isContentEmpty, SerializedContent } from '~/shared/components/content-editor';
 import DividedHeader from '~/shared/components/divided-header/DividedHeader';
 import HeaderRightActions from '~/shared/components/divided-header/header-right-actions/HeaderRightActions';
@@ -94,8 +95,8 @@ export function EditPublicationsView({
             onMenuOpen={(e) => handleOpen(e, 'navigation')}
           />
         )}
-        <Chip sx={styles.chip(type)} label={PublicationsChipLabels[type]} />
-        <Chip sx={styles.chip('draft')} label="Чернетка" />
+        <Badge variant={type} label={PublicationsChipLabels[type]} />
+        <Badge variant='draft' />
       </DividedHeader>
 
       <Box sx={styles.mainContent}>

--- a/app/shared/components/badge/Badge.stories.tsx
+++ b/app/shared/components/badge/Badge.stories.tsx
@@ -1,0 +1,106 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Badge from './Badge';
+
+const meta = {
+  title: 'Shared/Badge',
+  component: Badge,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'radio',
+      options: ['news', 'events', 'media', 'draft', 'published']
+    },
+    localizations: {
+      control: 'radio',
+      options: ['uk', 'en'],
+    }
+  },
+  args: {
+    localizations: ['uk', 'en']
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: 'Reusable badge for admin card on news & events page.'
+      }
+    }
+  },
+  decorators: [
+    (Story) => (
+      <Story />
+    )
+  ]
+} satisfies Meta<typeof Badge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const DraftBadge: Story = {
+  args: {
+    variant: 'draft',
+    label: 'Чернетка',
+  }
+};
+export const DraftBadgeLocalised: Story = {
+  args: {
+    variant: 'draft',
+    label: 'Чернетка',
+    localizations: ['uk']
+  }
+};
+
+export const PublishedBadge: Story = {
+  args: {
+    variant: 'published',
+  }
+};
+export const PublishedBadgeLocalised: Story = {
+  args: {
+    variant: 'published',
+    localizations: ['uk']
+  }
+};
+
+
+export const NewsBadge: Story = {
+  args: {
+    variant: 'news',
+  }
+};
+
+export const NewsBadgeLocalised: Story = {
+  args: {
+    variant: 'news',
+    localizations: ['uk']
+  }
+};
+
+export const EventBadge: Story = {
+  args: {
+    variant: 'events',
+  }
+};
+export const EventBadgeLocalised: Story = {
+  args: {
+    variant: 'events',
+    localizations: ['uk']
+  }
+};
+
+export const MediaBadge: Story = {
+  args: {
+    variant: 'media',
+  }
+};
+
+export const MediaBadgeLocalised: Story = {
+  args: {
+    variant: 'media',
+    localizations: ['uk']
+  }
+};
+
+
+
+

--- a/app/shared/components/badge/Badge.styles.ts
+++ b/app/shared/components/badge/Badge.styles.ts
@@ -1,0 +1,41 @@
+import { SxProps } from '@mui/material';
+
+import { BadgeVariant } from './Badge';
+import { chipsColors } from '~/shared/theme/colors';
+
+export const badgeColors = {
+  news: chipsColors.newsChipBg,
+  events: chipsColors.eventChipBg,
+  media: chipsColors.mediaChipBg,
+  draft: chipsColors.draft,
+  published: chipsColors.published
+};
+
+const styles = {
+  typeBadge: (type: BadgeVariant, hasLabel: boolean): SxProps => ({
+    display:'inline-flex',
+    justifyContent: 'center',
+    alignItems:'center',
+    gap: '4px',
+    height: '28px',
+    flexShrink: 0,
+    padding: hasLabel  ? '5px 8px' : '6px', 
+    
+    typography: 'subtitle2',
+    color: type === 'published' ? 'adminBlue.50' : 'black',
+    borderRadius: type === 'published' ? '15px' : '20px',
+    backgroundColor: badgeColors[type],
+    
+    '& svg': {
+      color: 'inherit'
+    }
+  }),
+
+  news:{},
+  events: {},
+  media: {}, 
+  draft: {}, 
+  published: {}
+};
+
+export default styles;

--- a/app/shared/components/badge/Badge.styles.ts
+++ b/app/shared/components/badge/Badge.styles.ts
@@ -11,31 +11,32 @@ export const badgeColors = {
   published: chipsColors.published
 };
 
-const styles = {
-  typeBadge: (type: BadgeVariant, hasLabel: boolean): SxProps => ({
-    display:'inline-flex',
-    justifyContent: 'center',
-    alignItems:'center',
-    gap: '4px',
-    height: '28px',
-    flexShrink: 0,
-    padding: hasLabel  ? '5px 8px' : '6px', 
-    
-    typography: 'subtitle2',
-    color: type === 'published' ? 'adminBlue.50' : 'black',
-    borderRadius: type === 'published' ? '15px' : '20px',
-    backgroundColor: badgeColors[type],
-    
-    '& svg': {
-      color: 'inherit'
-    }
-  }),
-
-  news:{},
-  events: {},
-  media: {}, 
-  draft: {}, 
-  published: {}
+const badgeConfigs: Partial<Record<BadgeVariant, SxProps>> = {
+  published: { color: 'adminBlue.50', borderRadius: '15px' },
 };
 
-export default styles;
+const baseBadgeStyles = {
+  display:'inline-flex',
+  justifyContent: 'center',
+  alignItems:'center',
+  gap: '4px',
+  height: '28px',
+  flexShrink: 0,
+  typography: 'subtitle2',
+  '& svg': {
+    color: 'inherit'
+  },
+  color: 'black', 
+  borderRadius: '20px'
+};
+
+const getBadgeStyles = (type: BadgeVariant, hasLabel: boolean): SxProps => 
+  ({
+    ...baseBadgeStyles,
+    padding: hasLabel ? '5px 8px' : '6px', 
+    backgroundColor: badgeColors[type],
+    ...badgeConfigs[type],
+  });
+
+
+export default getBadgeStyles;

--- a/app/shared/components/badge/Badge.test.tsx
+++ b/app/shared/components/badge/Badge.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+
+import Badge from './Badge';
+
+describe('Badge Component', () => {
+  describe('Rendering Variants', ()=>{
+    it('should render the correct label for the news variant', () => {
+      render(<Badge variant="news" localizations={['uk']} />);
+      expect(screen.getByText('Новина')).toBeInTheDocument();
+    });
+
+    it('should render the correct label for the draft variant', () => {
+      render(<Badge variant="draft" localizations={['uk']} />);
+      expect(screen.getByText('Чернетка')).toBeInTheDocument();
+    });
+
+    it('should render the correct label for the events variant', () => {
+      render(<Badge variant="events" localizations={['uk']} />);
+      expect(screen.getByText('Подія')).toBeInTheDocument();
+    });
+    it('should render the correct label for the media variant', () => {
+      render(<Badge variant="media" localizations={['uk']} />);
+      expect(screen.getByText('Ми у ЗМІ')).toBeInTheDocument();
+    });
+  });
+
+  describe('Localization Labels', () => {
+    it('should display "EN" label when only english localization is provided', () => {
+      render(<Badge variant="news" localizations={['en']} />);
+      expect(screen.getByText('Новина EN')).toBeInTheDocument();
+    });
+
+    it('should display "UK" label when only ukrainian localization is provided', () => {
+      render(<Badge variant="news" localizations={['uk']} />);
+      expect(screen.getByText('Новина UK')).toBeInTheDocument();
+    });
+
+    it('should not display a text label when both localizations are provided', () => {
+      render(<Badge variant="news" localizations={['uk', 'en']} />);
+      expect(screen.queryByText('UK')).not.toBeInTheDocument();
+      expect(screen.queryByText('EN')).not.toBeInTheDocument();
+    });
+  });
+
+
+  describe('Custom props', () => {
+    it('should display correct custom label when provided', () => {
+      render(<Badge variant="news" label='Custom label' localizations={['uk']} />);
+      expect(screen.getByText('Custom label')).toBeInTheDocument();
+    });
+
+    it('should display correct styles for a badge when sx prop provided', ()=>{
+      render(<Badge variant="news" sx={{gap: '32px'}} localizations={['uk']} />);
+      const badge = screen.getByTestId('badge');
+      expect(badge).toHaveStyle({
+        gap: '32px'
+      });
+    });
+  });
+});

--- a/app/shared/components/badge/Badge.test.tsx
+++ b/app/shared/components/badge/Badge.test.tsx
@@ -1,26 +1,17 @@
 import { render, screen } from '@testing-library/react';
 
-import Badge from './Badge';
+import Badge, { BadgeVariant } from './Badge';
 
 describe('Badge Component', () => {
   describe('Rendering Variants', ()=>{
-    it('should render the correct label for the news variant', () => {
-      render(<Badge variant="news" localizations={['uk']} />);
-      expect(screen.getByTestId('badge')).toHaveTextContent('Новина');
-    });
-
-    it('should render the correct label for the draft variant', () => {
-      render(<Badge variant="draft" localizations={['uk']} />);
-      expect(screen.getByTestId('badge')).toHaveTextContent('Чернетка');
-    });
-
-    it('should render the correct label for the events variant', () => {
-      render(<Badge variant="events" localizations={['uk']} />);
-      expect(screen.getByTestId('badge')).toHaveTextContent('Подія');
-    });
-    it('should render the correct label for the media variant', () => {
-      render(<Badge variant="media" localizations={['uk']} />);
-      expect(screen.getByTestId('badge')).toHaveTextContent('Ми у ЗМІ');
+    it.each([
+      { variant: 'news', expected: 'Новина' },
+      { variant: 'draft', expected: 'Чернетка' },
+      { variant: 'events', expected: 'Подія' },
+      { variant: 'media', expected: 'Ми у ЗМІ' },
+    ])('should render $expected for $variant variant', ({ variant, expected }) => {
+      render(<Badge variant={variant as BadgeVariant} localizations={['uk']} />);
+      expect(screen.getByTestId('badge')).toHaveTextContent(expected);
     });
   });
 

--- a/app/shared/components/badge/Badge.test.tsx
+++ b/app/shared/components/badge/Badge.test.tsx
@@ -6,39 +6,40 @@ describe('Badge Component', () => {
   describe('Rendering Variants', ()=>{
     it('should render the correct label for the news variant', () => {
       render(<Badge variant="news" localizations={['uk']} />);
-      expect(screen.getByText('Новина')).toBeInTheDocument();
+      expect(screen.getByTestId('badge')).toHaveTextContent('Новина');
     });
 
     it('should render the correct label for the draft variant', () => {
       render(<Badge variant="draft" localizations={['uk']} />);
-      expect(screen.getByText('Чернетка')).toBeInTheDocument();
+      expect(screen.getByTestId('badge')).toHaveTextContent('Чернетка');
     });
 
     it('should render the correct label for the events variant', () => {
       render(<Badge variant="events" localizations={['uk']} />);
-      expect(screen.getByText('Подія')).toBeInTheDocument();
+      expect(screen.getByTestId('badge')).toHaveTextContent('Подія');
     });
     it('should render the correct label for the media variant', () => {
       render(<Badge variant="media" localizations={['uk']} />);
-      expect(screen.getByText('Ми у ЗМІ')).toBeInTheDocument();
+      expect(screen.getByTestId('badge')).toHaveTextContent('Ми у ЗМІ');
     });
   });
 
   describe('Localization Labels', () => {
-    it('should display "EN" label when only english localization is provided', () => {
+    it('should display "EN" label when only English localization is provided', () => {
       render(<Badge variant="news" localizations={['en']} />);
-      expect(screen.getByText('Новина EN')).toBeInTheDocument();
+      expect(screen.getByTestId('badge')).toHaveTextContent('EN');
     });
 
-    it('should display "UK" label when only ukrainian localization is provided', () => {
+    it('should display "UK" label when only Ukrainian localization is provided', () => {
       render(<Badge variant="news" localizations={['uk']} />);
-      expect(screen.getByText('Новина UK')).toBeInTheDocument();
+      expect(screen.getByTestId('badge')).toHaveTextContent('UK');
     });
 
     it('should not display a text label when both localizations are provided', () => {
       render(<Badge variant="news" localizations={['uk', 'en']} />);
-      expect(screen.queryByText('UK')).not.toBeInTheDocument();
-      expect(screen.queryByText('EN')).not.toBeInTheDocument();
+      const badge = screen.getByTestId('badge');
+      expect(badge).not.toHaveTextContent('UK');
+      expect(badge).not.toHaveTextContent('EN');
     });
   });
 
@@ -46,7 +47,7 @@ describe('Badge Component', () => {
   describe('Custom props', () => {
     it('should display correct custom label when provided', () => {
       render(<Badge variant="news" label='Custom label' localizations={['uk']} />);
-      expect(screen.getByText('Custom label')).toBeInTheDocument();
+      expect(screen.getByTestId('badge')).toHaveTextContent('Custom label');
     });
 
     it('should display correct styles for a badge when sx prop provided', ()=>{

--- a/app/shared/components/badge/Badge.tsx
+++ b/app/shared/components/badge/Badge.tsx
@@ -1,0 +1,54 @@
+import { Box } from '@mui/material';
+import { CircleCheckBig } from 'lucide-react';
+import { ReactElement } from 'react';
+
+import styles from './Badge.styles';
+import { getLocalizations } from '~/lib/utils/localizations';
+
+export type BadgeVariant = 'published' | 'draft' | 'news' | 'events' | 'media'
+
+type BadgeProps = {
+  variant: BadgeVariant;
+  label?: string;
+  sx?: object;
+  localizations: Array<string>
+}
+
+const iconMapping: Record<BadgeVariant, ReactElement<SVGSVGElement> | null> = {
+  published: <CircleCheckBig size={16} />,
+  draft: null,
+  news: null,
+  events: null,
+  media: null,
+};
+
+const labelMapping: Record<BadgeVariant, string | null> = {
+  published: null,
+  draft: 'Чернетка',
+  news: 'Новина',
+  events: 'Подія',
+  media: 'Ми у ЗМІ',
+};
+
+const Badge = ({ variant, label, sx, localizations }: BadgeProps) => {
+  const localizationLabel = getLocalizations(localizations);
+  const hasLocalizationLabel = Boolean(localizationLabel);
+  const hasLabel = hasLocalizationLabel || Boolean(label);
+
+  return (
+    <Box
+      data-testid="badge"
+      sx={{ ...styles.typeBadge(variant, hasLabel), ...styles[variant], ...sx }}
+    >
+      {iconMapping[variant] ? iconMapping[variant] : undefined}
+      {
+        (label || labelMapping[variant]) && (
+          <Box>{label ? label : labelMapping[variant]}</Box>
+        )
+      }
+      {localizationLabel && <Box>{localizationLabel}</Box>}</Box>
+  );
+};
+
+
+export default Badge;

--- a/app/shared/components/badge/Badge.tsx
+++ b/app/shared/components/badge/Badge.tsx
@@ -33,8 +33,8 @@ const labelMapping: Record<BadgeVariant, string | null> = {
 const Badge = ({ variant, label, sx, localizations=['uk', 'en'] }: BadgeProps) => {
   const localizationLabel = getLocalizations(localizations);
   const hasLocalizationLabel = Boolean(localizationLabel);
-  const hasLabel = hasLocalizationLabel || Boolean(label);
-  
+  const hasLabel = hasLocalizationLabel || Boolean(label) || Boolean(labelMapping[variant]);
+
   return (
     <Box
       data-testid="badge"

--- a/app/shared/components/badge/Badge.tsx
+++ b/app/shared/components/badge/Badge.tsx
@@ -11,7 +11,7 @@ type BadgeProps = {
   variant: BadgeVariant;
   label?: string;
   sx?: object;
-  localizations: Array<string>
+  localizations?: Array<string>
 }
 
 const iconMapping: Record<BadgeVariant, ReactElement<SVGSVGElement> | null> = {
@@ -30,20 +30,20 @@ const labelMapping: Record<BadgeVariant, string | null> = {
   media: 'Ми у ЗМІ',
 };
 
-const Badge = ({ variant, label, sx, localizations }: BadgeProps) => {
+const Badge = ({ variant, label, sx, localizations=['uk', 'en'] }: BadgeProps) => {
   const localizationLabel = getLocalizations(localizations);
   const hasLocalizationLabel = Boolean(localizationLabel);
   const hasLabel = hasLocalizationLabel || Boolean(label);
-
+  
   return (
     <Box
       data-testid="badge"
       sx={{ ...styles.typeBadge(variant, hasLabel), ...styles[variant], ...sx }}
     >
-      {iconMapping[variant] ? iconMapping[variant] : undefined}
+      {iconMapping[variant] ?? iconMapping[variant]}
       {
         (label || labelMapping[variant]) && (
-          <Box>{label ? label : labelMapping[variant]}</Box>
+          <Box>{label ?? labelMapping[variant]}</Box>
         )
       }
       {localizationLabel && <Box>{localizationLabel}</Box>}</Box>

--- a/app/shared/components/badge/Badge.tsx
+++ b/app/shared/components/badge/Badge.tsx
@@ -2,7 +2,7 @@ import { Box } from '@mui/material';
 import { CircleCheckBig } from 'lucide-react';
 import { ReactElement } from 'react';
 
-import styles from './Badge.styles';
+import getBadgeStyles from './Badge.styles';
 import { getLocalizations } from '~/lib/utils/localizations';
 
 export type BadgeVariant = 'published' | 'draft' | 'news' | 'events' | 'media'
@@ -38,9 +38,9 @@ const Badge = ({ variant, label, sx, localizations=['uk', 'en'] }: BadgeProps) =
   return (
     <Box
       data-testid="badge"
-      sx={{ ...styles.typeBadge(variant, hasLabel), ...styles[variant], ...sx }}
+      sx={{ ...getBadgeStyles(variant, hasLabel), ...sx }}
     >
-      {iconMapping[variant] ?? iconMapping[variant]}
+      {iconMapping[variant]}
       {
         (label || labelMapping[variant]) && (
           <Box>{label ?? labelMapping[variant]}</Box>

--- a/app/shared/components/content-card/ContentCardBadge.styles.ts
+++ b/app/shared/components/content-card/ContentCardBadge.styles.ts
@@ -1,52 +1,9 @@
-import { SxProps } from '@mui/material';
-
-import { ContentType } from './ContentCard';
-import { chipsColors } from '~/shared/theme/colors';
-
-export const badgeColors: Record<ContentType, string> = {
-  news: chipsColors.newsChipBg,
-  events: chipsColors.eventChipBg,
-  media: chipsColors.mediaChipBg
-};
-
 export const styles = {
   badgeContainer: {
     display: 'flex',
     alignItems: 'center',
     gap: '2px'
   },
-
-  typeBadge: (type: ContentType): SxProps => ({
-    backgroundColor: badgeColors[type],
-    padding: '5.5px 8px'
-  }),
-
-  localizationsBadge: (hasLabel: boolean): SxProps => ({
-    backgroundColor: 'green.600',
-    color: 'adminBlue.50',
-
-    display: 'flex',
-    alignItems: 'center',
-    borderRadius: '15px',
-    gap: '4px',
-    typography: 'subtitle2',
-
-    padding: hasLabel ? '4px 8px' : '7px',
-
-    '& svg': {
-      color: 'inherit'
-    }
-  }),
-
-  draftBadge: {
-    backgroundColor: 'red.200',
-
-    display: 'flex',
-    padding: '4px 8px',
-    borderRadius: '15px',
-    gap: '4px',
-    typography: 'subtitle2'
-  }
 };
 
 export default styles;

--- a/app/shared/components/content-card/ContentCardBadge.tsx
+++ b/app/shared/components/content-card/ContentCardBadge.tsx
@@ -1,9 +1,8 @@
-import { Box, Chip } from '@mui/material';
-import { CircleCheckBig } from 'lucide-react';
+import { Box } from '@mui/material';
 
+import Badge from '../badge/Badge';
 import { ContentType } from './ContentCard';
 import { styles } from './ContentCardBadge.styles';
-import { getLocalizations } from '~/lib/utils/localizations';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
 interface ContentCardBadgeProps {
   type: ContentType;
@@ -12,42 +11,15 @@ interface ContentCardBadgeProps {
 }
 
 const ContentCardBadge = ({ type, status, localizations }: ContentCardBadgeProps) => {
-  const getContentTypeLabel = (contentType: ContentType): string => {
-    switch (contentType) {
-    case 'news':
-      return 'Новина';
-    case 'events':
-      return 'Подія';
-    case 'media':
-      return 'Ми у ЗМІ';
-    }
-  };
-
-  const localizationLabel = getLocalizations(localizations);
-  const hasLocalizationLabel = Boolean(localizationLabel);
-
   return (
     <Box sx={styles.badgeContainer}>
-      <Chip
-        label={getContentTypeLabel(type)}
-        size="small"
-        variant="filled"
-        sx={styles.typeBadge(type)}
-      ></Chip>
+      <Badge variant={type} localizations={localizations}/>
 
-      {status === BaseContentStatuses.Published && 
-      <Box
-        sx={styles.localizationsBadge(hasLocalizationLabel)}
-      >
-        <CircleCheckBig size={15} />
-        {localizationLabel && <Box>{localizationLabel}</Box>}
-      </Box>}
+      {status === BaseContentStatuses.Published &&
+        <Badge variant='published' localizations={localizations} />
+      }
 
-      {status === BaseContentStatuses.Draft && (
-        <Box sx={styles.draftBadge}>
-          {`Чернетка ${localizationLabel || ''}`.trim()}
-        </Box>
-      )}
+      {status === BaseContentStatuses.Draft && <Badge variant='draft' localizations={localizations} /> }
     </Box>
   );
 };

--- a/app/shared/theme/colors.ts
+++ b/app/shared/theme/colors.ts
@@ -229,7 +229,7 @@ export const chipsColors = {
   outlineDisabledText: mainHexPalette.blue[700],
 
   published: mainHexPalette.green[600],
-  draft: mainHexPalette.red[100],
+  draft: mainHexPalette.red[200],
   newsChipBg: 'rgb(182, 208, 247)',
   eventChipBg: 'rgb(247, 182, 225)',
   mediaChipBg: 'rgb(182, 247, 207)'


### PR DESCRIPTION
## Description
This PR introduces a centralized, reusable Badge component to standardize the display of status and category labels
across the application. It refactors existing scattered badge logic in StatusWithDate and ContentCardBadge to use this
new component, improving maintainability and UI consistency.

* Created a flexible Badge component in app/shared/components/badge/ that supports five variants: news, events, media, draft, and published.
* Replaced the custom StatusChip in StatusWithDate.tsx.
* Simplified ContentCardBadge.tsx by removing local styles and logic, delegating everything to the new Badge component.
* Updated the draft badge color to a correct red [200].
* Added a full suite of Jest tests covering rendering variants, localization logic, and custom prop overrides
* Added Storybook stories to visualize all badge states and variants in isolation
* Check with Figma to ensure all styles are correctly implemented


Closes #541 

## Type of change

- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [X] Refactoring / Tech debt
- [ ] CI/CD improvement

## How to test

1. Go to the /creativity page
2. Ensure that each item has correct badges with correct text & styles
3. Go to the /publications page
4. Look at each card type and ensure all correct badges are presented with correct labels & styles
5. Click on "Редагувати" on a card 
6. Look at the top of the page publications/events/:id/edit and ensure all correct labels are presented
7. Additionally: 
    * run Storybook via npm run storybook and look at Badge component stories
    * run test cases for both the new Badge component & the updated (e.g. ContentCardBadge)

## Video / Screenshots
<img width="256" height="108" alt="image" src="https://github.com/user-attachments/assets/b527a0a3-36e0-424f-aa81-4d1ba374fd46" />
<img width="724" height="97" alt="image" src="https://github.com/user-attachments/assets/829d0907-1d1f-440e-97b9-a57d21480a9e" />
<img width="399" height="357" alt="image" src="https://github.com/user-attachments/assets/8fc9249c-6c2c-4fac-8dee-b40f35588436" />
<img width="280" height="100" alt="image" src="https://github.com/user-attachments/assets/b9d025e2-9988-42ce-823b-5943f4d356cb" />
<img width="781" height="337" alt="image" src="https://github.com/user-attachments/assets/c25df2c3-1084-4619-af73-039177e7c377" />
<img width="777" height="316" alt="image" src="https://github.com/user-attachments/assets/81a4bf6d-d22c-421d-a96f-0d53cdd78cdc" />


## Checklist

- [X] Reusable Badge component is created
- [X] Component supports variants for different badge types/states
- [X] Existing badges on Новини, події та медіа cards use the new component
- [X] Badge UI matches the current design
- [X] No visual regressions on cards
- [X] Component can be extended with new variants in the future

- [X] Code compiles and runs correctly
- [X] Tests pass successfully
- [X] Linting checks are clean
- [X] No Sonar issues
- [X] Linked issue/task included
- [ ] Task moved to the review column on the board

---
