### PR TITLE
fix(ui): fix sidebar devider above content

### DIFF
--- a/app/shared/components/side-navigation/SideNavigation.tsx
+++ b/app/shared/components/side-navigation/SideNavigation.tsx
@@ -82,6 +82,7 @@ export const SideBarNavigation = () => {
           <Box sx={styles.spacer(open)} />
           <List sx={styles.list}>
             {renderItems(NAVIGATION_DATA.main)}
+            <Divider sx={styles.divider} />
             {open && <ListSubheader sx={styles.subheader}>Контент</ListSubheader>}
             {renderItems(NAVIGATION_DATA.content)}
             <Divider sx={styles.divider} />


### PR DESCRIPTION
## Description

Add a visual divider line above the "Контент" section in the side navigation bar.  Fixes #532.

## Type of change

- [x] Bug fix

1. Log in to the admin side.
2. Observe the side navigation bar.
3. Verify that a horizontal divider is clearly visible directly above the "Контент" section header.
4. Check that the styling, margins, and alignment match the divider above the "Інше" section.

## Video / Screenshots

| Before (Current) | After (Expected) |
| --- | --- |
| 
<img width="369" height="611" alt="image" src="https://github.com/user-attachments/assets/c0961f32-7a20-42be-8ea0-79c70df4e4ac" />|<img width="358" height="653" alt="image" src="https://github.com/user-attachments/assets/c26aa3b0-9144-4891-a782-e57a915614dd" />|

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [x] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board