### PR TITLE
fix(ui): prevent modal from closing on outside click 

### DIFF
--- a/app/shared/components/media-modal/components/container/MediaModalContainer.tsx
+++ b/app/shared/components/media-modal/components/container/MediaModalContainer.tsx
@@ -37,7 +37,10 @@ export function MediaModalContainer({
   return (
     <Dialog
       open={open}
-      onClose={onClose}
+      onClose={(_, reason: 'backdropClick' | 'escapeKeyDown') => {
+        if (reason === 'backdropClick') return;
+        onClose();
+      }}
       disableScrollLock
       sx={styles.dialog}
       maxWidth={false}


### PR DESCRIPTION
## Description

Clicking outside of the modal on publications/news/create caused an incorrect UX for the user (the modal just closes). 
I have adjusted the logic for the onClose prop in the Dialog component rendered within the MediaModalFlow component. 
Currently, only UI buttons can close the modal. 

Closes #500

## Type of change

- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test
1. Login into admin.
2. Press “Новини та події” in navigation bar.
3. Press to “Create” dropdown and choose a “News” item.
4. Click “Change image” button.
5. Select an image from gallery or local storage.
6. Click “Apply” button.
7. Click “Редагувати” button.
8. Click behind the modal.

(or you can simply press one of "Редагувати" buttons) 

## Video / Screenshots

https://github.com/user-attachments/assets/b6734a3e-88b6-494b-9f41-f3566b346868





## Checklist

- [X] Code compiles and runs correctly
- [X] Tests pass successfully
- [X] Linting checks are clean
- [X] No Sonar issues
- [X] Linked issue/task included
- [ ] Task moved to the review column on the board

---
