### PR TITLE
fix(ui): scrolling background is able when modal is active

### DIFF
--- a/app/shared/components/media-modal/components/container/MediaModalContainer.tsx
+++ b/app/shared/components/media-modal/components/container/MediaModalContainer.tsx
@@ -37,7 +37,10 @@ export function MediaModalContainer({
   return (
     <Dialog
       open={open}
-      onClose={onClose}
+      onClose={(_, reason: 'backdropClick' | 'escapeKeyDown') => {
+        if (reason === 'backdropClick') return;
+        onClose();
+      }}
       disableScrollLock
       sx={styles.dialog}
       maxWidth={false}

--- a/app/shared/components/media-modal/components/container/MediaModalContainer.tsx
+++ b/app/shared/components/media-modal/components/container/MediaModalContainer.tsx
@@ -41,7 +41,6 @@ export function MediaModalContainer({
         if (reason === 'backdropClick') return;
         onClose();
       }}
-      disableScrollLock
       sx={styles.dialog}
       maxWidth={false}
       data-testid={baseTestId}

--- a/app/shared/theme/theme.ts
+++ b/app/shared/theme/theme.ts
@@ -1297,7 +1297,16 @@ export const createAdminTheme = () =>
             color: tooltipColors.defaultBg
           }
         }
-      }
+      },
+      MuiDialog: {
+        styleOverrides: {
+          root: {
+            'html:has(&)': {
+              overflow: 'hidden'
+            }
+          }
+        }
+      },
     }
   });
 

--- a/app/shared/theme/theme.ts
+++ b/app/shared/theme/theme.ts
@@ -1302,6 +1302,7 @@ export const createAdminTheme = () =>
         styleOverrides: {
           root: {
             'html:has(&)': {
+              scrollbarGutter: 'stable',
               overflow: 'hidden'
             }
           }


### PR DESCRIPTION
## Description

Scrolling the page when the modal on publications/news/create caused an incorrect UX.
I have adjusted the theme.ts file for global theme MUI styles to use the correct overflow property in MuiDialog styles.
Currently, no scroll on the page when the modal is opened.

Closes #501 

## Type of change

- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test
1. Login into admin.
2. Press “Новини та події” in navigation bar.
3. Press to “Create” dropdown and choose a “News” item.
4. Click “Change image” button.
5. Modal is opened.
6. Try to scroll behind the modal.
7. Verify that you cannot scroll 

## Video / Screenshots


## Checklist

- [X] Code compiles and runs correctly
- [X] Tests pass successfully
- [X] Linting checks are clean
- [X] No Sonar issues
- [X] Branch is up to date with the target branch
- [X] Linked issue/task included
- [ ] Task moved to the review column on the board

---
