### PR TITLE
feat(ui): Replace chevron arrows with hover dropdowns in collapsed state

### DIFF
--- a/app/shared/components/side-navigation/collapse-list-navigation/CollapeListNavigation.styles.ts
+++ b/app/shared/components/side-navigation/collapse-list-navigation/CollapeListNavigation.styles.ts
@@ -19,5 +19,11 @@ export const styles = {
     '& .MuiListItemText-root': {
       pl: '32px'
     }
+  },
+  floatingSubmenu: {
+    position: 'fixed',
+    top: 0,
+    left: 264,
+    zIndex: 2000
   }
 };

--- a/app/shared/components/side-navigation/collapse-list-navigation/CollapeListNavigation.styles.ts
+++ b/app/shared/components/side-navigation/collapse-list-navigation/CollapeListNavigation.styles.ts
@@ -21,9 +21,8 @@ export const styles = {
     }
   },
   floatingSubmenu: {
-    position: 'fixed',
-    top: 0,
-    left: 264,
-    zIndex: 2000
+    zIndex: 1000,
+    maxHeight: 'calc(100vh - 16px)',
+    overflowY: 'auto'
   }
 };

--- a/app/shared/components/side-navigation/collapse-list-navigation/CollapeListNavigation.styles.ts
+++ b/app/shared/components/side-navigation/collapse-list-navigation/CollapeListNavigation.styles.ts
@@ -1,4 +1,6 @@
-import { mainHexPalette } from '~/shared/theme/colors';
+import { alpha } from '@mui/material';
+
+import { mainHexPalette, shadowColors } from '~/shared/theme/colors';
 
 export const linkStyles = {
   mb: '0',
@@ -29,7 +31,7 @@ export const styles = {
     overflowY: 'auto',
     backgroundColor: mainHexPalette.white,
     borderRadius: '8px',
-    boxShadow: '0 4px 8px 0 rgba(78, 80, 97, 0.06), 0 0 4px 0 rgba(78, 80, 97, 0.04)'
+    boxShadow: `0 4px 8px 0 ${alpha(shadowColors.popup, 0.06)}, 0 0 4px 0 ${alpha(shadowColors.popup, 0.04)}`
   },
   subItem: {
     margin: 0,

--- a/app/shared/components/side-navigation/collapse-list-navigation/CollapeListNavigation.styles.ts
+++ b/app/shared/components/side-navigation/collapse-list-navigation/CollapeListNavigation.styles.ts
@@ -1,3 +1,5 @@
+import { mainHexPalette } from '~/shared/theme/colors';
+
 export const linkStyles = {
   mb: '0',
   justifyContent: 'center',
@@ -21,8 +23,12 @@ export const styles = {
     }
   },
   floatingSubmenu: {
-    zIndex: 1000,
     maxHeight: 'calc(100vh - 16px)',
-    overflowY: 'auto'
+    maxWidth: '223px',
+    padding: '8px',
+    overflowY: 'auto',
+    backgroundColor: mainHexPalette.white,
+    borderRadius: '8px',
+    boxShadow: '0 4px 8px 0 rgba(78, 80, 97, 0.06), 0 0 4px 0 rgba(78, 80, 97, 0.04)'
   }
 };

--- a/app/shared/components/side-navigation/collapse-list-navigation/CollapeListNavigation.styles.ts
+++ b/app/shared/components/side-navigation/collapse-list-navigation/CollapeListNavigation.styles.ts
@@ -24,11 +24,19 @@ export const styles = {
   },
   floatingSubmenu: {
     maxHeight: 'calc(100vh - 16px)',
-    maxWidth: '223px',
+    width: '223px',
     padding: '8px',
     overflowY: 'auto',
     backgroundColor: mainHexPalette.white,
     borderRadius: '8px',
     boxShadow: '0 4px 8px 0 rgba(78, 80, 97, 0.06), 0 0 4px 0 rgba(78, 80, 97, 0.04)'
+  },
+  subItem: {
+    margin: 0,
+    padding: '10px 16px',
+    alignItems: 'flex-start',
+    '& .MuiListItemText-root': {
+      margin: 0
+    }
   }
 };

--- a/app/shared/components/side-navigation/collapse-list-navigation/CollapseListNavigation.tsx
+++ b/app/shared/components/side-navigation/collapse-list-navigation/CollapseListNavigation.tsx
@@ -1,4 +1,4 @@
-import { Box, Collapse, List } from '@mui/material';
+import { Box, Collapse, List, Paper, Popper } from '@mui/material';
 import { CollapseListNavigationProps } from 'app/types/sideNavigation';
 import Image from 'next/image';
 import { useEffect, useRef, useState } from 'react';
@@ -15,6 +15,7 @@ export const CollapseListNavigation: React.FC<CollapseListNavigationProps> = ({
 }) => {
   const { element, collapseElements } = elementProps;
   const [isSubmenuOpen, setIsSubmenuOpen] = useState(false);
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const prevOpenNavbarRef = useRef(openNavbar);
 
   const handleClick = () => {
@@ -25,14 +26,16 @@ export const CollapseListNavigation: React.FC<CollapseListNavigationProps> = ({
     }
   };
 
-  const handleMouseEnter = () => {
+  const handleMouseEnter = (event: React.MouseEvent<HTMLElement>) => {
     if (!openNavbar) {
+      setAnchorEl(event.currentTarget);
       setIsSubmenuOpen(true);
     }
   };
 
   const handleMouseLeave = () => {
     if (!openNavbar) {
+      setAnchorEl(null);
       setIsSubmenuOpen(false);
     }
   };
@@ -56,7 +59,7 @@ export const CollapseListNavigation: React.FC<CollapseListNavigationProps> = ({
     <Box sx={{ position: 'relative' }} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
       <ListElement
         element={element}
-        open={shouldShowContent}
+        open={openNavbar}
         handleClick={openNavbar ? handleClick : undefined}
         sxItem={{ mb: '0' }}
       >
@@ -81,11 +84,20 @@ export const CollapseListNavigation: React.FC<CollapseListNavigationProps> = ({
           <List disablePadding>{collapseContent}</List>
         </Collapse>
       ) : null}
-      {!openNavbar && isSubmenuOpen && (
-        <Box sx={styles.floatingSubmenu}>
-          <List disablePadding>{collapseContent}</List>
-        </Box>
-      )}
+      <Popper
+        open={!openNavbar && isSubmenuOpen}
+        anchorEl={anchorEl}
+        placement="right-start"
+        modifiers={[
+          { name: 'preventOverflow', options: { boundary: 'viewport', padding: 8 } },
+          { name: 'flip', options: { fallbackPlacements: ['right-end', 'left-start'] } }
+        ]}
+        sx={{ zIndex: 1000 }}
+      >
+        <Paper sx={styles.floatingSubmenu}>
+          <List disablePadding>{collapseContent}</List>{' '}
+        </Paper>
+      </Popper>
     </Box>
   );
 };

--- a/app/shared/components/side-navigation/collapse-list-navigation/CollapseListNavigation.tsx
+++ b/app/shared/components/side-navigation/collapse-list-navigation/CollapseListNavigation.tsx
@@ -25,6 +25,18 @@ export const CollapseListNavigation: React.FC<CollapseListNavigationProps> = ({
     }
   };
 
+  const handleMouseEnter = () => {
+    if (!openNavbar) {
+      setIsSubmenuOpen(true);
+    }
+  };
+
+  const handleMouseLeave = () => {
+    if (!openNavbar) {
+      setIsSubmenuOpen(false);
+    }
+  };
+
   useEffect(() => {
     if (prevOpenNavbarRef.current !== openNavbar) {
       prevOpenNavbarRef.current = openNavbar;
@@ -41,24 +53,39 @@ export const CollapseListNavigation: React.FC<CollapseListNavigationProps> = ({
   ));
 
   return (
-    <>
-      <ListElement element={element} open={shouldShowContent} handleClick={handleClick} sxItem={{ mb: '0' }}>
-        <Box
-          sx={{
-            ...SideNavigationStyles.hideInClosed(shouldShowContent),
-            ...styles.listBox
-          }}
-        >
-          {isSubmenuOpen ? (
-            <Image src="/icons/chevronDown.svg" alt="open list" width={20} height={20} />
-          ) : (
-            <Image src="/icons/chevronRight.svg" alt="close list" width={20} height={20} />
-          )}
-        </Box>
+    <Box sx={{ position: 'relative' }} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+      <ListElement
+        element={element}
+        open={shouldShowContent}
+        handleClick={openNavbar ? handleClick : undefined}
+        sxItem={{ mb: '0' }}
+      >
+        {openNavbar && (
+          <Box
+            sx={{
+              ...SideNavigationStyles.hideInClosed(shouldShowContent),
+              ...styles.listBox
+            }}
+          >
+            {isSubmenuOpen ? (
+              <Image src="/icons/chevronDown.svg" alt="open list" width={20} height={20} />
+            ) : (
+              <Image src="/icons/chevronRight.svg" alt="close list" width={20} height={20} />
+            )}
+          </Box>
+        )}
       </ListElement>
-      <Collapse in={isSubmenuOpen} timeout="auto" unmountOnExit sx={styles.collapse}>
-        <List disablePadding>{collapseContent}</List>
-      </Collapse>
-    </>
+
+      {openNavbar ? (
+        <Collapse in={isSubmenuOpen} timeout="auto" unmountOnExit sx={styles.collapse}>
+          <List disablePadding>{collapseContent}</List>
+        </Collapse>
+      ) : null}
+      {!openNavbar && isSubmenuOpen && (
+        <Box sx={styles.floatingSubmenu}>
+          <List disablePadding>{collapseContent}</List>
+        </Box>
+      )}
+    </Box>
   );
 };

--- a/app/shared/components/side-navigation/collapse-list-navigation/CollapseListNavigation.tsx
+++ b/app/shared/components/side-navigation/collapse-list-navigation/CollapseListNavigation.tsx
@@ -52,7 +52,12 @@ export const CollapseListNavigation: React.FC<CollapseListNavigationProps> = ({
   const shouldShowContent = openNavbar || isSubmenuOpen;
 
   const collapseContent = collapseElements?.map((item) => (
-    <LinkElement element={item} open={shouldShowContent} key={item.title} sxItem={{ mb: '0' }} />
+    <LinkElement
+      element={item}
+      open={shouldShowContent}
+      key={item.title}
+      sxItem={[{ mb: '0' }, !openNavbar && styles.subItem]}
+    />
   ));
 
   return (

--- a/app/shared/components/side-navigation/collapse-list-navigation/CollapseListNavigation.tsx
+++ b/app/shared/components/side-navigation/collapse-list-navigation/CollapseListNavigation.tsx
@@ -89,13 +89,22 @@ export const CollapseListNavigation: React.FC<CollapseListNavigationProps> = ({
         anchorEl={anchorEl}
         placement="right-start"
         modifiers={[
+          {
+            name: 'offset',
+            options: {
+              offset: [0, -20]
+            }
+          },
           { name: 'preventOverflow', options: { boundary: 'viewport', padding: 8 } },
-          { name: 'flip', options: { fallbackPlacements: ['right-end', 'left-start'] } }
+          {
+            name: 'flip',
+            enabled: false
+          }
         ]}
         sx={{ zIndex: 1000 }}
       >
         <Paper sx={styles.floatingSubmenu}>
-          <List disablePadding>{collapseContent}</List>{' '}
+          <List disablePadding>{collapseContent}</List>
         </Paper>
       </Popper>
     </Box>

--- a/app/shared/components/side-navigation/link-element/LinkElement.tsx
+++ b/app/shared/components/side-navigation/link-element/LinkElement.tsx
@@ -4,12 +4,6 @@ import Link from 'next/link';
 import { ListElement } from '../list-element/ListElement';
 
 export const LinkElement: React.FC<LinkElementProps> = ({ element, open, handleClick, sxItem = {}, children }) => {
-  if (element.disabled) {
-    return (
-      <ListElement element={element} open={open} sxItem={{ cursor: 'not-allowed', color: 'grey.500', ...sxItem }} />
-    );
-  }
-
   return (
     <Link href={element.href ?? '/'} key={element.href}>
       <ListElement element={element} open={open} handleClick={handleClick} sxItem={sxItem} />

--- a/app/shared/components/side-navigation/list-element/ListElement.tsx
+++ b/app/shared/components/side-navigation/list-element/ListElement.tsx
@@ -26,10 +26,19 @@ export const ListElement: React.FC<LinkElementProps> = ({
 }) => {
   const { title, href, iconSrc } = element;
   const pathName = usePathname();
-  const listItemSx: SxProps<Theme> = Array.isArray(sxItem) ? [styles.listItem, ...sxItem] : [styles.listItem, sxItem];
+  const disabled = element.disabled;
+  const listItemSx: SxProps<Theme> = [
+    styles.listItem,
+    ...(Array.isArray(sxItem) ? sxItem : [sxItem]),
+    disabled && {
+      color: 'grey.500',
+      cursor: 'not-allowed',
+      opacity: 0.6
+    }
+  ];
 
   return (
-    <ListItemButton sx={listItemSx} selected={isActivePath(href, pathName)} onClick={handleClick}>
+    <ListItemButton sx={listItemSx} selected={isActivePath(href, pathName)} onClick={handleClick} disabled={disabled}>
       {iconSrc && (
         <ListItemIcon sx={styles.listItemIcon}>
           <Image src={`/icons/${iconSrc}.svg`} alt={title} width={24} height={24} />

--- a/app/shared/components/side-navigation/list-element/ListElement.tsx
+++ b/app/shared/components/side-navigation/list-element/ListElement.tsx
@@ -30,11 +30,7 @@ export const ListElement: React.FC<LinkElementProps> = ({
   const listItemSx: SxProps<Theme> = Array.isArray(sxItem) ? [styles.listItem, ...sxItem] : [styles.listItem, sxItem];
 
   return (
-    <ListItemButton
-      sx={listItemSx}
-      selected={isActivePath(href, pathName)}
-      onClick={handleClick ?? (() => {})}
-    >
+    <ListItemButton sx={listItemSx} selected={isActivePath(href, pathName)} onClick={handleClick}>
       {iconSrc && (
         <ListItemIcon sx={styles.listItemIcon}>
           <Image src={`/icons/${iconSrc}.svg`} alt={title} width={24} height={24} />

--- a/app/shared/components/side-navigation/list-element/ListElement.tsx
+++ b/app/shared/components/side-navigation/list-element/ListElement.tsx
@@ -32,8 +32,11 @@ export const ListElement: React.FC<LinkElementProps> = ({
     ...(Array.isArray(sxItem) ? sxItem : [sxItem]),
     disabled && {
       color: 'grey.500',
-      cursor: 'not-allowed',
-      opacity: 0.6
+      opacity: 0.6,
+      '&.Mui-disabled': {
+        cursor: 'not-allowed',
+        pointerEvents: 'auto'
+      }
     }
   ];
 

--- a/app/shared/components/side-navigation/list-element/ListElement.tsx
+++ b/app/shared/components/side-navigation/list-element/ListElement.tsx
@@ -41,7 +41,6 @@ export const ListElement: React.FC<LinkElementProps> = ({
             primary: styles.listItemText
           }}
           primary={title}
-          inset={!iconSrc}
         />
       )}
       {children}

--- a/app/shared/components/side-navigation/list-element/ListElement.tsx
+++ b/app/shared/components/side-navigation/list-element/ListElement.tsx
@@ -3,7 +3,6 @@ import { LinkElementProps } from 'app/types/sideNavigation';
 import Image from 'next/image';
 import { usePathname } from 'next/navigation';
 
-import { styles as SideNavigationStyles } from '../SideNavigation.styles';
 import { styles } from './ListElement.styles';
 
 const isActivePath = (href: string | undefined, pathName: string | null) => {
@@ -36,14 +35,15 @@ export const ListElement: React.FC<LinkElementProps> = ({
           <Image src={`/icons/${iconSrc}.svg`} alt={title} width={24} height={24} />
         </ListItemIcon>
       )}
-      <ListItemText
-        sx={SideNavigationStyles.hideInClosed(open)}
-        slotProps={{
-          primary: styles.listItemText
-        }}
-        primary={title}
-        inset={!iconSrc}
-      />
+      {open && (
+        <ListItemText
+          slotProps={{
+            primary: styles.listItemText
+          }}
+          primary={title}
+          inset={!iconSrc}
+        />
+      )}
       {children}
     </ListItemButton>
   );

--- a/app/shared/theme/colors.ts
+++ b/app/shared/theme/colors.ts
@@ -384,3 +384,7 @@ export const tooltipColors = {
   defaultText: mainHexPalette.white,
   defaultShadow: 'rgba(0, 0, 0, 0.07)'
 };
+
+export const shadowColors = {
+  popup: 'rgb(78, 80, 97)'
+};


### PR DESCRIPTION
## Description

This PR updates the collapsed sidebar behavior and improves navigation UI consistency.

Changes include:

Implemented collapseContent logic inside CollapseListNavigation.tsx for the hover dropdown menu in collapsed sidebar state.
Hidden chevron icons when the sidebar is collapsed.
Refactored navigation styles to remove layout conflicts in disabled items.
Adjusted styling for disabled states in sidebar items to ensure consistent appearance across main items and sub-items.

The result is a more consistent collapsed sidebar behavior with improved handling of hover dropdowns and cleaner styling for navigation items.

## Type of change

- [x] New feature
- [x] Bug fix
- [ ] Documentation update
- [x] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Log in to lf-admin.
2. Collapse the sidebar by clicking the chevron button on the left.
3. Hover over navigation icons and verify that a floating submenu appears on hover.
4. Click any submenu item (e.g. "Твори") and confirm that the navigation redirects correctly.
5. Ensure the sidebar stays collapsed after navigation and the hover menu closes automatically.

## Video / Screenshots


https://github.com/user-attachments/assets/8d9fb4ca-1459-447e-b96c-b7cf10027e00



## Checklist

- [ ] Code compiles and runs correctly
- [ ] Tests pass successfully
- [ ] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [ ] Linked issue/task included
- [ ] Task moved to the review column on the board

---
