### PR TITLE
fix: prevent grid layout shift on content card

### DIFF
--- a/app/shared/components/content-card/ContentCard.styles.ts
+++ b/app/shared/components/content-card/ContentCard.styles.ts
@@ -32,8 +32,7 @@ const styles: Record<string, SxProps<Theme>> = {
     display: 'flex',
     alignItems: 'flex-start',
     justifyContent: 'space-between',
-    gap: '4px',
-    overflow: 'hidden'
+    gap: '4px'
   },
 
   title: {
@@ -45,6 +44,22 @@ const styles: Record<string, SxProps<Theme>> = {
     WebkitLineClamp: 2,
     WebkitBoxOrient: 'vertical',
     overflow: 'hidden'
+  },
+
+  menuButton: {
+    borderRadius: '50%',
+    color: 'text.secondary',
+    mr: '4px',
+    mt: '2px',
+    transition: 'box-shadow 0.2s ease-in-out, background-color 0.2s ease-in-out',
+    '&:hover': {
+      backgroundColor: 'rgba(0, 0, 0, 0.04)',
+      boxShadow: '0px 0px 8px rgba(0, 0, 0, 0.15)'
+    },
+    '&.active': {
+      backgroundColor: 'rgba(0, 0, 0, 0.04)',
+      boxShadow: '0px 0px 10px rgba(0, 0, 0, 0.15)'
+    }
   },
   
   date: {

--- a/app/shared/components/content-card/ContentCard.test.tsx
+++ b/app/shared/components/content-card/ContentCard.test.tsx
@@ -3,6 +3,20 @@ import type { MouseEventHandler, ReactNode } from 'react';
 
 import ContentCard, { ContentType } from './ContentCard';
 
+jest.mock('./ContentCardMenu', () => ({
+  __esModule: true,
+  default: ({ onClose, setDeleteModalOpen }: { onClose: () => void; setDeleteModalOpen: (v: boolean) => void }) => (
+    <div>
+      <button onClick={onClose} data-testid="menu-close">
+        close menu
+      </button>
+      <button onClick={() => setDeleteModalOpen(true)} data-testid="open-delete">
+        delete
+      </button>
+    </div>
+  )
+}));
+
 jest.mock('~/lib/utils/formatDate', () => ({
   formatDate: (date: string) => `formatted-${date}`
 }));
@@ -46,6 +60,16 @@ jest.mock('../design-system/button/Button', () => ({
 jest.mock('./ContentCardBadge', () => ({
   __esModule: true,
   default: () => <div data-testid="badge" />
+}));
+
+jest.mock('../delete-card-modal/DeleteCardModal', () => ({
+  __esModule: true,
+  default: ({ open, onDelete }: { open: boolean; onDelete: () => void }) =>
+    open ? (
+      <button onClick={onDelete} data-testid="confirm-delete">
+        confirm delete
+      </button>
+    ) : null
 }));
 
 describe('ContentCard', () => {
@@ -149,5 +173,58 @@ describe('ContentCard', () => {
     fireEvent.error(img);
 
     expect(img).toHaveAttribute('src', '/images/image.png');
+  });
+
+  it('should open menu when three dots button is clicked', () => {
+    render(<ContentCard {...defaultProps} />);
+    fireEvent.click(screen.getByTestId('menu-button'));
+    expect(screen.getByTestId('menu-button')).toBeInTheDocument();
+  });
+
+  it('should close menu when clicked again', () => {
+    render(<ContentCard {...defaultProps} />);
+    const menuButton = screen.getByTestId('menu-button');
+    fireEvent.click(menuButton);
+    fireEvent.click(menuButton);
+    expect(screen.getByTestId('menu-button')).toBeInTheDocument();
+  });
+
+  it('should close menu when onClose is called', () => {
+    render(<ContentCard {...defaultProps} />);
+    fireEvent.click(screen.getByTestId('menu-button'));
+    expect(screen.getByTestId('menu-close')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('menu-close'));
+    expect(screen.getByTestId('menu-button')).toBeInTheDocument();
+  });
+
+  it('should open delete modal when delete is clicked', () => {
+    render(<ContentCard {...defaultProps} />);
+    fireEvent.click(screen.getByTestId('menu-button'));
+    fireEvent.click(screen.getByTestId('open-delete'));
+    expect(screen.getByTestId('confirm-delete')).toBeInTheDocument();
+  });
+
+  it('should call deleteNews when delete is confirmed', async () => {
+    render(<ContentCard {...defaultProps} type="news" />);
+    fireEvent.click(screen.getByTestId('menu-button'));
+    fireEvent.click(screen.getByTestId('open-delete'));
+    await fireEvent.click(screen.getByTestId('confirm-delete'));
+    expect(screen.getByTestId('menu-button')).toBeInTheDocument();
+  });
+
+  it('should call deleteEvent when type is events', async () => {
+    render(<ContentCard {...defaultProps} type="events" />);
+    fireEvent.click(screen.getByTestId('menu-button'));
+    fireEvent.click(screen.getByTestId('open-delete'));
+    await fireEvent.click(screen.getByTestId('confirm-delete'));
+    expect(screen.getByTestId('menu-button')).toBeInTheDocument();
+  });
+
+  it('should call deleteMediaMention when type is media', async () => {
+    render(<ContentCard {...defaultProps} type="media" />);
+    fireEvent.click(screen.getByTestId('menu-button'));
+    fireEvent.click(screen.getByTestId('open-delete'));
+    await fireEvent.click(screen.getByTestId('confirm-delete'));
+    expect(screen.getByTestId('menu-button')).toBeInTheDocument();
   });
 });

--- a/app/shared/components/content-card/ContentCard.test.tsx
+++ b/app/shared/components/content-card/ContentCard.test.tsx
@@ -72,6 +72,14 @@ jest.mock('../delete-card-modal/DeleteCardModal', () => ({
     ) : null
 }));
 
+const TEST_IDS = {
+  menuButton: 'menu-button',
+  menuClose: 'menu-close',
+  openDelete: 'open-delete',
+  confirmDelete: 'confirm-delete',
+  badge: 'badge'
+} as const;
+
 describe('ContentCard', () => {
   const defaultProps = {
     id: '1',
@@ -177,54 +185,44 @@ describe('ContentCard', () => {
 
   it('should open menu when three dots button is clicked', () => {
     render(<ContentCard {...defaultProps} />);
-    fireEvent.click(screen.getByTestId('menu-button'));
-    expect(screen.getByTestId('menu-button')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId(TEST_IDS.menuButton));
+    expect(screen.getByTestId(TEST_IDS.menuButton)).toBeInTheDocument();
   });
 
   it('should close menu when clicked again', () => {
     render(<ContentCard {...defaultProps} />);
-    const menuButton = screen.getByTestId('menu-button');
+    const menuButton = screen.getByTestId(TEST_IDS.menuButton);
     fireEvent.click(menuButton);
     fireEvent.click(menuButton);
-    expect(screen.getByTestId('menu-button')).toBeInTheDocument();
+    expect(screen.getByTestId(TEST_IDS.menuButton)).toBeInTheDocument();
   });
 
   it('should close menu when onClose is called', () => {
     render(<ContentCard {...defaultProps} />);
-    fireEvent.click(screen.getByTestId('menu-button'));
+    fireEvent.click(screen.getByTestId(TEST_IDS.menuButton));
     expect(screen.getByTestId('menu-close')).toBeInTheDocument();
     fireEvent.click(screen.getByTestId('menu-close'));
-    expect(screen.getByTestId('menu-button')).toBeInTheDocument();
+    expect(screen.getByTestId(TEST_IDS.menuButton)).toBeInTheDocument();
   });
 
   it('should open delete modal when delete is clicked', () => {
     render(<ContentCard {...defaultProps} />);
-    fireEvent.click(screen.getByTestId('menu-button'));
+    fireEvent.click(screen.getByTestId(TEST_IDS.menuButton));
     fireEvent.click(screen.getByTestId('open-delete'));
     expect(screen.getByTestId('confirm-delete')).toBeInTheDocument();
   });
 
-  it('should call deleteNews when delete is confirmed', async () => {
-    render(<ContentCard {...defaultProps} type="news" />);
-    fireEvent.click(screen.getByTestId('menu-button'));
-    fireEvent.click(screen.getByTestId('open-delete'));
-    await fireEvent.click(screen.getByTestId('confirm-delete'));
-    expect(screen.getByTestId('menu-button')).toBeInTheDocument();
-  });
-
-  it('should call deleteEvent when type is events', async () => {
-    render(<ContentCard {...defaultProps} type="events" />);
-    fireEvent.click(screen.getByTestId('menu-button'));
-    fireEvent.click(screen.getByTestId('open-delete'));
-    await fireEvent.click(screen.getByTestId('confirm-delete'));
-    expect(screen.getByTestId('menu-button')).toBeInTheDocument();
-  });
-
-  it('should call deleteMediaMention when type is media', async () => {
-    render(<ContentCard {...defaultProps} type="media" />);
-    fireEvent.click(screen.getByTestId('menu-button'));
-    fireEvent.click(screen.getByTestId('open-delete'));
-    await fireEvent.click(screen.getByTestId('confirm-delete'));
-    expect(screen.getByTestId('menu-button')).toBeInTheDocument();
+  describe('Deletion flow', () => {
+    it.each([
+      { type: 'news', label: 'deleteNews' },
+      { type: 'events', label: 'deleteEvent' },
+      { type: 'media', label: 'deleteMediaMention' }
+    ])('should handle deletion for $type', async ({ type }) => {
+      render(<ContentCard {...defaultProps} type={type as ContentType} />);
+      fireEvent.click(screen.getByTestId(TEST_IDS.menuButton));
+      fireEvent.click(screen.getByTestId(TEST_IDS.openDelete));
+      await fireEvent.click(screen.getByTestId(TEST_IDS.confirmDelete));
+      expect(screen.getByTestId(TEST_IDS.menuButton)).toBeInTheDocument();
+    });
   });
 });

--- a/app/shared/components/content-card/ContentCard.tsx
+++ b/app/shared/components/content-card/ContentCard.tsx
@@ -1,8 +1,8 @@
-import { Box, Card, CardContent, CardMedia, Typography } from '@mui/material';
+import { Box, Card, CardContent, CardMedia, IconButton,Typography } from '@mui/material';
 import { EllipsisVertical } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useEffect, useRef,useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import DeleteCardModal from '../delete-card-modal/DeleteCardModal';
 import Button from '../design-system/button/Button';
@@ -126,27 +126,26 @@ const ContentCard = ({
         <ContentCardBadge type={type} status={status} localizations={localizedKeys}></ContentCardBadge>
         <Box sx={styles.mainInfo}>
           <TooltipCustom title={isTitleTruncated ? titleText : ''}>
-            <Typography
-              ref={titleRef}
-              variant="subtitle1"
-              component="h3"
-              sx={styles.title}
-            >
+            <Typography ref={titleRef} variant="subtitle1" component="h3" sx={styles.title}>
               {titleText}
             </Typography>
           </TooltipCustom>
-          <Box data-testid="menu-button" sx={{ cursor: 'pointer' }} onClick={handleMenuClick}>
+          <IconButton
+            data-testid="menu-button"
+            onClick={handleMenuClick}
+            sx={styles.menuButton}
+            className={Boolean(anchorEl) ? 'active' : ''}
+          >
             <EllipsisVertical size={20} />
-            {anchorEl && (
-              <ContentCardMenu
-                id={id}
-                type={type}
-                anchorEl={anchorEl}
-                onClose={handleMenuClose}
-                setDeleteModalOpen={setDeleteModalOpen}
-              />
-            )}
-          </Box>
+          </IconButton>
+
+          <ContentCardMenu
+            id={id}
+            type={type}
+            anchorEl={anchorEl}
+            onClose={handleMenuClose}
+            setDeleteModalOpen={setDeleteModalOpen}
+          />
         </Box>
         <Typography variant="caption" sx={styles.date}>
           {getStatus(status, createdAt, updatedAt, publishedAt)}

--- a/app/shared/components/content-card/ContentCard.tsx
+++ b/app/shared/components/content-card/ContentCard.tsx
@@ -1,4 +1,4 @@
-import { Box, Card, CardContent, CardMedia, IconButton,Typography } from '@mui/material';
+import { Box, Card, CardContent, CardMedia, IconButton, Typography } from '@mui/material';
 import { EllipsisVertical } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -134,7 +134,7 @@ const ContentCard = ({
             data-testid="menu-button"
             onClick={handleMenuClick}
             sx={styles.menuButton}
-            className={Boolean(anchorEl) ? 'active' : ''}
+            className={anchorEl ? 'active' : ''}
           >
             <EllipsisVertical size={20} />
           </IconButton>

--- a/app/shared/components/content-card/ContentCardMenu.tsx
+++ b/app/shared/components/content-card/ContentCardMenu.tsx
@@ -23,7 +23,7 @@ const ContentCardMenu = ({ id, type, anchorEl, onClose, setDeleteModalOpen }: Co
   };
 
   return (
-    <Menu anchorEl={anchorEl} open={open} onClose={onClose} sx={styles.menu} disableAutoFocusItem>
+    <Menu anchorEl={anchorEl} open={open} onClose={onClose} sx={styles.menu} disableAutoFocusItem disableScrollLock>
       <MenuItem onClick={() => router.push(href)} sx={styles.menuItem}>
         SEO налаштування
       </MenuItem>


### PR DESCRIPTION
## Description

When clicking the "More options" (⋮) button on any content card, the entire grid shifts horizontally. This was caused by MUI Menu component adding padding-right and overflow: hidden to the body when opened, which removes the scrollbar and causes a layout shift. Added disableScrollLock prop to the Menu component in ContentCardMenu.tsx to prevent this behavior. Also added hover and active shadow effect to the "More options" (⋮) button in ContentCard.styles.ts for better visual feedback when interacting with the menu button

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## Videos/Screenshots

<img width="1920" height="930" alt="image" src="https://github.com/user-attachments/assets/77c6a01e-79a7-4634-b452-700dfed33c09" />

## How to test

1. Login into admin
2. Navigate to "Новини та події"
3. Locate any content card (e.g. "Liatoshynsky Space 2025")
4. Click the "More options" (⋮) button
5. Verify that the grid does not shift horizontally when the dropdown opens

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
Close #563 