### PR TITLE
feat(logs): add configurable retention and manual cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ MONGO_PORT=
 JWT_ACCESS_TOKEN_SECRET=
 JWT_REFRESH_TOKEN_SECRET=
 
+# Logs retention (in seconds) — controls how long application logs live in MongoDB.
+# Defaults to 7 days (604800) when unset or invalid.
+LOG_RETENTION_SECONDS=604800
+
 # Storage Environment - determines the environment context
 # Set to 'production' for production, 'development' (default) for development
 STORAGE_ENV=development
@@ -218,12 +222,6 @@ formData.append('fileType', 'image'); // Optional: image, document, video, audio
 formData.append('validationRules', JSON.stringify({ maxSize: 5242880 })); // Optional
 formData.append('metadata', JSON.stringify({ author: 'Admin' })); // Optional
 
-### Logs History
-
-- Application logs are written by Winston to MongoDB when `MONGO_URL` is configured.
-- Logs are stored in the same MongoDB database as the application, in the `logger` collection.
-- The logs page reads data through `GET /api/logs`, which fetches documents directly from the `logger` collection.
-
 const response = await fetch('/api/uploads/single', {
   method: 'POST',
   body: formData
@@ -232,6 +230,20 @@ const response = await fetch('/api/uploads/single', {
 const result = await response.json();
 // Returns: { success: true, data: { filename, originalName, url, size, mimeType, metadata } }
 ```
+
+### Logs History
+
+- Application logs are written by Winston to MongoDB when `MONGO_URL` is configured.
+- Logs are stored in the same MongoDB database as the application, in the `logger` collection.
+- The logs page reads data through `GET /api/logs`, which fetches documents directly from the `logger` collection.
+
+#### Retention and cleanup
+
+- Logs auto-expire via a MongoDB TTL index on the `timestamp` field. The index is created by `winston-mongodb` on the first write.
+- Retention period is controlled by `LOG_RETENTION_SECONDS` (defaults to `604800` — 7 days). Set it in `.env` to change how long logs are kept.
+- Manual cleanup is available on the `/logs` admin page: an admin can clear all logs or only logs of the currently selected level (a confirmation dialog protects against accidental clicks).
+- The manual clear is exposed as `DELETE /api/logs` (optional `?level=error|warn|info|debug`) and requires a valid admin access token cookie.
+- Changing `LOG_RETENTION_SECONDS` only affects future writes; MongoDB will update the TTL index lazily — to apply a new value immediately, drop the existing index from the `logger` collection and let it be re-created on the next log write.
 
 #### Configuration Examples
 

--- a/app/(logged_in)/logs/LogsPageClient.tsx
+++ b/app/(logged_in)/logs/LogsPageClient.tsx
@@ -207,6 +207,8 @@ const LogsPageClient = () => {
 
       setPage(1);
       setReloadKey((value) => value + 1);
+    } catch (error) {
+      console.warn(error);
     } finally {
       setDialogOpen(false);
       setClearing(false);

--- a/app/(logged_in)/logs/LogsPageClient.tsx
+++ b/app/(logged_in)/logs/LogsPageClient.tsx
@@ -6,14 +6,20 @@ import {
   AccordionDetails,
   AccordionSummary,
   Box,
+  Button,
   Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
   Pagination,
   Stack,
   Tab,
   Tabs,
   Typography
 } from '@mui/material';
-import { type SyntheticEvent, useEffect, useState } from 'react';
+import { type SyntheticEvent, useCallback, useEffect, useState } from 'react';
 
 import type { LogEntry, LogLevel, LogsResponse } from '~/back-shared/types/logs';
 
@@ -133,6 +139,9 @@ const LogsPageClient = () => {
   const [items, setItems] = useState<LogEntry[]>([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(false);
+  const [reloadKey, setReloadKey] = useState(0);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [clearing, setClearing] = useState(false);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -162,7 +171,7 @@ const LogsPageClient = () => {
 
     loadLogs();
     return () => controller.abort();
-  }, [level, page]);
+  }, [level, page, reloadKey]);
 
   const totalPages = Math.max(1, Math.ceil(total / 20));
   const hasItems = items.length > 0;
@@ -172,6 +181,41 @@ const LogsPageClient = () => {
     setLevel(value);
     setPage(1);
   };
+
+  const openClearDialog = (): void => setDialogOpen(true);
+  const closeClearDialog = (): void => {
+    if (!clearing) {
+      setDialogOpen(false);
+    }
+  };
+
+  const confirmClear = useCallback(async (): Promise<void> => {
+    setClearing(true);
+
+    try {
+      const params = new URLSearchParams();
+      if (level !== 'all') params.set('level', level);
+
+      const response = await fetch(`/api/logs?${params.toString()}`, {
+        method: 'DELETE',
+        credentials: 'include'
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to clear logs');
+      }
+
+      setPage(1);
+      setReloadKey((value) => value + 1);
+    } finally {
+      setDialogOpen(false);
+      setClearing(false);
+    }
+  }, [level]);
+
+  const noLogs = total === 0;
+  const capitalizedLevel = level === 'all' ? '' : `${level[0].toUpperCase()}${level.slice(1)}`;
+  const clearLabel = level === 'all' ? 'Видалити всі логи' : `Видалити ${capitalizedLevel} логи`;
 
   let content: React.ReactNode;
   if (loading) {
@@ -196,15 +240,35 @@ const LogsPageClient = () => {
     );
   }
 
+  const clearDialogTitle = level === 'all' ? 'Видалити всі логи?' : `Видалити логи рівня "${level.toUpperCase()}"?`;
+  const clearDialogText =
+    level === 'all'
+      ? 'Усі записи з колекції logger буде видалено без можливості відновлення.'
+      : 'Записи поточної вкладки буде видалено без можливості відновлення.';
+
   return (
     <Stack spacing={2.5}>
-      <Stack spacing={0.5}>
-        <Typography variant="h4" sx={{ fontWeight: 800 }}>
-          Logs
-        </Typography>
-        <Typography variant="body2" color="text.secondary">
-          Логи з MongoDB. Деталі відкриваються по кліку на запис.
-        </Typography>
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5} alignItems={{ xs: 'flex-start', sm: 'flex-start' }} justifyContent="space-between">
+        <Stack spacing={0.5}>
+          <Typography variant="h4" sx={{ fontWeight: 800 }}>
+            Logs
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Логи з MongoDB. Деталі відкриваються по кліку на запис.
+          </Typography>
+        </Stack>
+        <Button
+          variant="contained"
+          onClick={openClearDialog}
+          disabled={loading || clearing || noLogs}
+          sx={{
+            backgroundColor: 'common.black',
+            color: 'common.white',
+            '&:hover': { backgroundColor: 'common.black' }
+          }}
+        >
+          {clearLabel}
+        </Button>
       </Stack>
 
       <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
@@ -222,6 +286,21 @@ const LogsPageClient = () => {
       {content}
 
       {hasItems && totalPages > 1 ? <Pagination count={totalPages} page={page} onChange={(_, value) => setPage(value)} /> : null}
+
+      <Dialog open={dialogOpen} onClose={closeClearDialog}>
+        <DialogTitle>{clearDialogTitle}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>{clearDialogText}</DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={closeClearDialog} disabled={clearing}>
+            Скасувати
+          </Button>
+          <Button onClick={confirmClear} color="error" variant="contained" disabled={clearing} autoFocus>
+            {clearing ? 'Видалення...' : 'Видалити'}
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Stack>
   );
 };

--- a/app/api/logs/route.test.ts
+++ b/app/api/logs/route.test.ts
@@ -1,7 +1,10 @@
 import 'whatwg-fetch';
+import type { NextRequest } from 'next/server';
 
-import { GET } from './route';
-import { getLogs } from '~/infrastructure/repositories/logRepository/logRepository';
+import { DELETE, GET } from './route';
+import { deleteLogs, getLogs } from '~/infrastructure/repositories/logRepository/logRepository';
+
+const verifyAccessTokenMock = jest.fn();
 
 jest.mock('next/server', () => ({
   __esModule: true,
@@ -12,8 +15,27 @@ jest.mock('next/server', () => ({
 
 jest.mock('~/infrastructure/repositories/logRepository/logRepository', () => ({
   __esModule: true,
-  getLogs: jest.fn()
+  getLogs: jest.fn(),
+  deleteLogs: jest.fn()
 }));
+
+jest.mock('~/src/application/use-cases/tokenService/createToken.service', () => ({
+  __esModule: true,
+  createTokenService: () => ({
+    verifyAccessToken: verifyAccessTokenMock
+  })
+}));
+
+const buildRequest = (url: string, cookies: Record<string, string> = {}): NextRequest => {
+  const parsedUrl = new URL(url);
+
+  return {
+    nextUrl: parsedUrl,
+    cookies: {
+      get: (name: string) => (name in cookies ? { name, value: cookies[name] } : undefined)
+    }
+  } as unknown as NextRequest;
+};
 
 describe('GET /api/logs', () => {
   beforeEach(() => {
@@ -26,7 +48,7 @@ describe('GET /api/logs', () => {
       pagination: { page: 1, limit: 20, total: 0 }
     });
 
-    const request = new Request('http://localhost/api/logs?level=error&page=2&limit=15&from=2026-05-12T00:00:00.000Z');
+    const request = buildRequest('http://localhost/api/logs?level=error&page=2&limit=15&from=2026-05-12T00:00:00.000Z');
     const response = await GET(request);
 
     expect(getLogs).toHaveBeenCalledWith({
@@ -50,7 +72,7 @@ describe('GET /api/logs', () => {
       pagination: { page: 1, limit: 20, total: 0 }
     });
 
-    const request = new Request('http://localhost/api/logs?level=invalid');
+    const request = buildRequest('http://localhost/api/logs?level=invalid');
     await GET(request);
 
     expect(getLogs).toHaveBeenCalledWith({
@@ -60,5 +82,65 @@ describe('GET /api/logs', () => {
       from: undefined,
       to: undefined
     });
+  });
+});
+
+describe('DELETE /api/logs', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects requests without an access token cookie', async () => {
+    const request = buildRequest('http://localhost/api/logs');
+    const response = await DELETE(request);
+
+    expect(response.status).toBe(401);
+    expect(deleteLogs).not.toHaveBeenCalled();
+  });
+
+  it('rejects requests with an invalid access token', async () => {
+    verifyAccessTokenMock.mockImplementation(() => {
+      throw new Error('Invalid token');
+    });
+
+    const request = buildRequest('http://localhost/api/logs', { accessToken: 'bad-token' });
+    const response = await DELETE(request);
+
+    expect(response.status).toBe(401);
+    expect(deleteLogs).not.toHaveBeenCalled();
+  });
+
+  it('clears all logs when no level is provided', async () => {
+    verifyAccessTokenMock.mockReturnValue({ id: 'admin-1', type: 'admin' });
+    (deleteLogs as jest.Mock).mockResolvedValue(10);
+
+    const request = buildRequest('http://localhost/api/logs', { accessToken: 'valid-token' });
+    const response = await DELETE(request);
+
+    expect(deleteLogs).toHaveBeenCalledWith(undefined);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ deletedCount: 10 });
+  });
+
+  it('clears logs of a specific level when provided', async () => {
+    verifyAccessTokenMock.mockReturnValue({ id: 'admin-1', type: 'admin' });
+    (deleteLogs as jest.Mock).mockResolvedValue(3);
+
+    const request = buildRequest('http://localhost/api/logs?level=error', { accessToken: 'valid-token' });
+    const response = await DELETE(request);
+
+    expect(deleteLogs).toHaveBeenCalledWith('error');
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ deletedCount: 3 });
+  });
+
+  it('ignores invalid level values and clears all', async () => {
+    verifyAccessTokenMock.mockReturnValue({ id: 'admin-1', type: 'admin' });
+    (deleteLogs as jest.Mock).mockResolvedValue(0);
+
+    const request = buildRequest('http://localhost/api/logs?level=invalid', { accessToken: 'valid-token' });
+    await DELETE(request);
+
+    expect(deleteLogs).toHaveBeenCalledWith(undefined);
   });
 });

--- a/app/api/logs/route.ts
+++ b/app/api/logs/route.ts
@@ -1,7 +1,9 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
 import type { LogLevel } from '~/back-shared/types/logs';
-import { getLogs } from '~/infrastructure/repositories/logRepository/logRepository';
+import { deleteLogs, getLogs } from '~/infrastructure/repositories/logRepository/logRepository';
+import { createTokenService } from '~/src/application/use-cases/tokenService/createToken.service';
+import { ACCESS_TOKEN_COOKIE_NAME } from '~/src/constants';
 
 const parsePositiveInteger = (value: string | null, fallback: number): number => {
   const parsed = Number.parseInt(value ?? '', 10);
@@ -15,26 +17,54 @@ const isLogLevel = (value: string): value is LogLevel => LOG_LEVELS.has(value as
 const parseLevel = (value: string | null): LogLevel | 'all' | undefined => {
   if (!value) return undefined;
   if (value === 'all') return 'all';
+
   if (isLogLevel(value)) {
     return value;
   }
+
   return undefined;
 };
 
-export async function GET(request: Request) {
+export async function GET(request: NextRequest) {
   try {
-    const url = new URL(request.url);
-    const level = parseLevel(url.searchParams.get('level'));
-    const page = parsePositiveInteger(url.searchParams.get('page'), 1);
-    const limit = parsePositiveInteger(url.searchParams.get('limit'), 20);
-    const from = url.searchParams.get('from') ?? undefined;
-    const to = url.searchParams.get('to') ?? undefined;
+    const { searchParams } = request.nextUrl;
+    const level = parseLevel(searchParams.get('level'));
+    const page = parsePositiveInteger(searchParams.get('page'), 1);
+    const limit = parsePositiveInteger(searchParams.get('limit'), 20);
+    const from = searchParams.get('from') ?? undefined;
+    const to = searchParams.get('to') ?? undefined;
 
     const data = await getLogs({ level, page, limit, from, to });
 
     return NextResponse.json(data);
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to load logs';
+    return NextResponse.json({ message }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: NextRequest): Promise<Response> {
+  const accessToken = request.cookies.get(ACCESS_TOKEN_COOKIE_NAME)?.value;
+
+  if (!accessToken) {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    createTokenService().verifyAccessToken(accessToken);
+  } catch {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const level = parseLevel(request.nextUrl.searchParams.get('level'));
+    const levelFilter = level && level !== 'all' ? level : undefined;
+
+    const deletedCount = await deleteLogs(levelFilter);
+
+    return NextResponse.json({ deletedCount });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to clear logs';
     return NextResponse.json({ message }, { status: 500 });
   }
 }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -2,6 +2,7 @@ import {
   StorageConfig,
   StorageType
 } from '../uploads/storage/types';
+import { SEVEN_DAYS_IN_SECONDS } from '~/constants/index';
 
 export const mongoUrl = process.env.MONGO_URL ?? '';
 
@@ -9,6 +10,8 @@ export const getJWT = {
   JWT_ACCESS_TOKEN_SECRET: process.env.JWT_ACCESS_TOKEN_SECRET ?? 'your-access-secret',
   JWT_REFRESH_TOKEN_SECRET: process.env.JWT_REFRESH_TOKEN_SECRET ?? 'your-refresh-secret'
 };
+
+export const logRetentionSeconds = Number.parseInt(process.env.LOG_RETENTION_SECONDS ?? String(SEVEN_DAYS_IN_SECONDS), 10);
 
 export type CloudProvider = 'aws' | 'gcp' | 'azure' | 'cloudflare';
 

--- a/src/infrastructure/repositories/logRepository/logRepository.test.ts
+++ b/src/infrastructure/repositories/logRepository/logRepository.test.ts
@@ -5,6 +5,7 @@ const skipMock = jest.fn(() => ({ limit: limitMock }));
 const sortMock = jest.fn(() => ({ skip: skipMock }));
 const findMock = jest.fn(() => ({ sort: sortMock }));
 const countDocumentsMock = jest.fn();
+const deleteManyMock = jest.fn();
 
 jest.doMock('~/infrastructure/db/connect', () => ({
   __esModule: true,
@@ -18,7 +19,8 @@ jest.doMock('mongoose', () => ({
       db: {
         collection: jest.fn(() => ({
           find: findMock,
-          countDocuments: countDocumentsMock
+          countDocuments: countDocumentsMock,
+          deleteMany: deleteManyMock
         }))
       }
     }
@@ -86,6 +88,29 @@ describe('logRepository', () => {
       ],
       pagination: { page: 2, limit: 10, total: 1 }
     });
+  });
+
+  it('deletes all logs when no level is provided', async () => {
+    const { deleteLogs } = await import('./logRepository');
+
+    deleteManyMock.mockResolvedValue({ deletedCount: 42 });
+
+    const result = await deleteLogs();
+
+    expect(mockDbConnect).toHaveBeenCalled();
+    expect(deleteManyMock).toHaveBeenCalledWith({});
+    expect(result).toBe(42);
+  });
+
+  it('deletes logs for a specific level when provided', async () => {
+    const { deleteLogs } = await import('./logRepository');
+
+    deleteManyMock.mockResolvedValue({ deletedCount: 5 });
+
+    const result = await deleteLogs('error');
+
+    expect(deleteManyMock).toHaveBeenCalledWith({ level: 'error' });
+    expect(result).toBe(5);
   });
 
   it('returns warn logs when warn filter is requested', async () => {

--- a/src/infrastructure/repositories/logRepository/logRepository.ts
+++ b/src/infrastructure/repositories/logRepository/logRepository.ts
@@ -103,6 +103,27 @@ const normalizePagination = (page?: number, limit?: number) => ({
   limit: Math.min(MAX_LIMIT, Math.max(1, limit ?? DEFAULT_LIMIT))
 });
 
+export const deleteLogs = async (level?: LogLevel): Promise<number> => {
+  await dbConnect();
+
+  const db = mongoose.connection.db;
+
+  if (!db) {
+    throw new Error('Database connection is not available');
+  }
+
+  const filters: Record<string, unknown> = {};
+
+  if (level && isAllowedLevel(level)) {
+    filters.level = level;
+  }
+
+  const collection = db.collection<RawLogDocument>('logger');
+  const result = await collection.deleteMany(filters);
+
+  return result.deletedCount ?? 0;
+};
+
 export const getLogs = async (query: Partial<LogsQuery> = {}): Promise<LogsResponse> => {
   await dbConnect();
 

--- a/src/middleware/logger/logger.test.ts
+++ b/src/middleware/logger/logger.test.ts
@@ -38,7 +38,8 @@ jest.mock('winston-mongodb', () => ({
 
 jest.mock('../../config', () => ({
   __esModule: true,
-  mongoUrl: 'mongodb://localhost:27017/test-logs'
+  mongoUrl: 'mongodb://localhost:27017/test-logs',
+  logRetentionSeconds: 60 * 60 * 24 * 3
 }));
 
 const getMongoDBMock = (): jest.Mock => jest.requireMock('winston-mongodb').MongoDB as jest.Mock;
@@ -81,6 +82,20 @@ describe('Logger', () => {
       expect.objectContaining({
         level: 'debug',
         collection: 'logger'
+      })
+    );
+  });
+
+  it('passes configurable retention to MongoDB transport', async () => {
+    jest.resetModules();
+    const MongoDBMock = getMongoDBMock();
+    MongoDBMock.mockClear();
+
+    await import('./logger');
+
+    expect(MongoDBMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expireAfterSeconds: 60 * 60 * 24 * 3
       })
     );
   });

--- a/src/middleware/logger/logger.ts
+++ b/src/middleware/logger/logger.ts
@@ -3,8 +3,7 @@ import { createLogger, format, transports } from 'winston';
 import { MongoDB } from 'winston-mongodb';
 import type Transport from 'winston-transport';
 
-import { mongoUrl } from '../../config';
-import { SEVEN_DAYS_IN_SECONDS } from '~/constants';
+import { logRetentionSeconds, mongoUrl } from '../../config';
 
 const { combine, timestamp, printf, errors, json } = format;
 
@@ -38,7 +37,7 @@ if (mongoUrl) {
       level: 'debug',
       db: mongoUrl,
       collection: 'logger',
-      expireAfterSeconds: SEVEN_DAYS_IN_SECONDS,
+      expireAfterSeconds: logRetentionSeconds,
       format: combine(errors({ stack: true }), timestamp(), json())
     })
   );


### PR DESCRIPTION
## Description

Adds a retention/cleanup strategy for application logs so the MongoDB `logger` collection no longer grows  without limits.
  - **Configurable TTL** via `LOG_RETENTION_SECONDS` env var (defaults to `604800` — 7 days). The
  `winston-mongodb` transport creates a TTL index on `timestamp` so MongoDB auto-expires old logs in the
  background.
  - **Manual clear action** on the `/logs` admin page: a single black "Видалити …" button whose label and scope
  adapt to the active tab ("Видалити всі логи" on the *Усі* tab, "Видалити Error логи" / "Видалити Warn логи" /
  etc. on a level tab). Confirmation dialog, disabled when the visible list is empty.
  - **`DELETE /api/logs`** endpoint backing the action; optional `?level=` filter; gated by access-token cookie
  verification using the same `createTokenService` pattern as the GraphQL context.
  - **README** updated with the new env var, the auto-expiry behavior, and a note that an existing TTL index isn't  auto-updated on retention changes (collection/index must be dropped or `collMod`'d).

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Setup — start the app against any MongoDB instance you have access to. Defaults give 7-day retention; set
  `LOG_RETENTION_SECONDS` in your env to override. 
2. Manual clear (Phase 1) — log in, use the app to generate some logs, open `/logs` page.  Verify:
    - On the "Усі" tab the button reads "Видалити всі логи" and clears the entire collection.
    - On a level tab (Error / Warn / Info / Debug) the button reads "Видалити  логи" and clears only that level.
    - The button is disabled when the visible list is empty.
    - The action requires a valid admin session (DELETE returns 401 otherwise).
  3. TTL retention (Phase 2) — set LOG_RETENTION_SECONDS=60, drop the existing logger collection so MongoDB
  recreates the TTL index with the new value, restart the app, write a few logs. Within ~60–120 s the collection
  empties on its own and /logs shows no records.
  4. Reset — restore LOG_RETENTION_SECONDS to your normal value before continuing other work.

## Video / Screenshots

Manual logs deletetion from admin panel
https://github.com/user-attachments/assets/45debc49-2981-4e98-ad92-c6e887069b72

Automatic logs retention (retention period set to 60 seconds)
https://github.com/user-attachments/assets/e07489d9-0798-4f1a-a445-bebf62ce710c



## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [x] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
Issue: [540](https://github.com/Liatoshynsky-Foundation/lf-admin/issues/540)