### PR TITLE
fix(ui): close content card dropdown on scroll

### DIFF
--- a/app/shared/components/content-card/ContentCard.tsx
+++ b/app/shared/components/content-card/ContentCard.tsx
@@ -2,7 +2,7 @@ import { Box, Card, CardContent, CardMedia, Typography } from '@mui/material';
 import { EllipsisVertical } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useEffect, useRef,useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import DeleteCardModal from '../delete-card-modal/DeleteCardModal';
 import Button from '../design-system/button/Button';
@@ -97,6 +97,20 @@ const ContentCard = ({
   const handleMenuClose = () => {
     setAnchorEl(null);
   };
+
+  useEffect(() => {
+    if (!anchorEl) return;
+
+    const handleScroll = () => {
+      setAnchorEl(null);
+    };
+
+    window.addEventListener('scroll', handleScroll, true);
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll, true);
+    };
+  }, [anchorEl]);
 
   async function handleDelete() {
     try {


### PR DESCRIPTION
## Description

Fixed the content card dropdown behavior during page scroll.

Previously, when the user opened the "More options" dropdown on a content card and scrolled the page, the dropdown stayed fixed in the viewport and detached from the card. Now the dropdown automatically closes when scrolling starts.

Closes [#565](https://github.com/Liatoshynsky-Foundation/lf-admin/issues/565)

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Navigate to the Publications page.
2. Click the "More options" icon on any content card.
3. Scroll the page up or down using the mouse wheel or trackpad.
4. Verify that the dropdown menu closes as soon as scrolling starts.

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [ ] Task moved to the review column on the board

---
