### PR TITLE
fix: redirect to undefined on empty keywords

### DIFF
--- a/app/(logged_in)/publications/[type]/create/CreatePublicationsView.tsx
+++ b/app/(logged_in)/publications/[type]/create/CreatePublicationsView.tsx
@@ -127,7 +127,9 @@ export default function CreatePublicationsView({ data, mode = 'create' }: Readon
 
   const onEdit = async () => {
     const id = await handleSave(BaseContentStatuses.Draft);
-    router.push(`${PUBLICATIONS_BASE_PATH}/${publicationType}/${id}/edit`);
+    if (id) {
+      router.push(`${PUBLICATIONS_BASE_PATH}/${publicationType}/${id}/edit`);
+    }
   };
 
   return (

--- a/src/domain/entities/BaseContent.ts
+++ b/src/domain/entities/BaseContent.ts
@@ -37,7 +37,7 @@ export type BaseContentFields = {
       metaTitle?: { uk: string; en: string };
     };
   };
-  keywords: LocalizedString;
+  keywords?: LocalizedString;
   allowIndexation: LocalizedBoolean;
   slug: string;
   coverImage: LocalizedImage;

--- a/src/infrastructure/models/commonSchemas.ts
+++ b/src/infrastructure/models/commonSchemas.ts
@@ -57,6 +57,14 @@ export const localizedImageSchema = new mongoose.Schema(
   { _id: false }
 );
 
+export const optionalTranslatedFieldSchema = new mongoose.Schema(
+  {
+    uk: { type: String, required: false, default: '' },
+    en: { type: String, required: false, default: '' }
+  },
+  { _id: false }
+);
+
 export const baseContentSchemaFields = {
   adminTitle: {
     type: String,
@@ -71,8 +79,8 @@ export const baseContentSchemaFields = {
     required: true
   },
   keywords: {
-    type: translatedFieldSchema,
-    required: true
+    type: optionalTranslatedFieldSchema,
+    required: false
   },
   allowIndexation: {
     type: translatedBooleanSchema,

--- a/src/infrastructure/repositories/newsRepository/newsRepository.ts
+++ b/src/infrastructure/repositories/newsRepository/newsRepository.ts
@@ -14,7 +14,7 @@ export type DbNews = {
   title: News['title'];
   adminTitle: News['adminTitle'];
   description: News['description'];
-  keywords: News['keywords'];
+  keywords?: News['keywords'];
   allowIndexation: News['allowIndexation'];
   content: News['content'];
   slug: string;

--- a/src/interfaces/graphql/resolvers/news/newsMutation.ts
+++ b/src/interfaces/graphql/resolvers/news/newsMutation.ts
@@ -21,7 +21,7 @@ export type CreateNewsGQLInput = {
   adminTitle: string;
   title: LocalizedString;
   description: LocalizedString;
-  keywords: LocalizedString;
+  keywords?: LocalizedString;
   allowIndexation: LocalizedBoolean;
   content: LocalizedContent;
   coverImage: LocalizedImage;

--- a/src/interfaces/graphql/schemas/common.graphql
+++ b/src/interfaces/graphql/schemas/common.graphql
@@ -45,7 +45,7 @@ interface BaseContent {
   adminTitle: String!
   title: LocalizedString!
   description: LocalizedString!
-  keywords: LocalizedString!
+  keywords: LocalizedString
   allowIndexation: LocalizedBoolean!
   slug: String!
   coverImage: LocalizedImage!

--- a/src/interfaces/graphql/schemas/news.graphql
+++ b/src/interfaces/graphql/schemas/news.graphql
@@ -12,7 +12,7 @@ type News implements BaseContent {
   title: LocalizedString!
   slug: String!
   description: LocalizedString!
-  keywords: LocalizedString!
+  keywords: LocalizedString
   content: LocalizedJSON!
   coverImage: LocalizedImage!
   status: NewsStatus!
@@ -58,7 +58,7 @@ input CreateNewsInput {
   adminTitle: String!
   title: JSON!
   description: JSON!
-  keywords: JSON!
+  keywords: JSON
   allowIndexation: JSON!
   content: JSON!
   coverImage: JSON!


### PR DESCRIPTION
## Description

When creating a news item with an empty "Meta keywords" field, the system was redirecting to /publications/news/undefined/edit and displaying a 404 page. This happened because:
MongoDB schema required keywords as a mandatory field, causing GraphQL to return an error and handleSave to return undefined
The frontend was not checking if id exists before redirecting
Fixed by:
- Made keywords optional in MongoDB schema (commonSchemas.ts)
- Made keywords optional in GraphQL schema (news.graphql, BaseContent interface)
- Made keywords optional in TypeScript types (BaseContent.ts, newsRepository.ts, newsMutation.ts)
- Added if (id) guard before redirect in CreatePublicationsView.tsx

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Log in to the admin panel 
2. Navigate to the "Новини та події" section 
3. Click the creation dropdown and select "Новину" to open the creation form
4. Fill in all required fields (Admin Title, Meta Title, Meta Description)
5. Leave the Meta keywords field completely empty 
6. Upload an image 
7. Click the "Редагувати" (Edit / Publish) button in the top right corner

Expected Result:
The system performs a correct redirect to the content editing page of the newly created news
The URL in the browser changes to a valid one: http://localhost:3000/publications/news/[NEWS_ID]/edit (e.g., /news/6a1ff5525822cf2663dae192/edit) instead of the previous broken /undefined/edit
The page loads successfully, displaying the content editor block with the placeholder "Почніть вводити текст..." (Start typing text...) and the status badge "Чернетка" (Draft). The 404 error page no longer appears

## Video / Screenshots

<img width="1280" height="623" alt="image" src="https://github.com/user-attachments/assets/54e94089-8563-4421-b9bc-6be6f1c08e49" />

<img width="1920" height="978" alt="image" src="https://github.com/user-attachments/assets/5c72eaec-4ef7-49ae-8307-3794e80c3e19" />

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---

Close #505 