### PR TITLE
feat(auth): implement reset password flow and update login validation

### DIFF
--- a/app/constants/errors.ts
+++ b/app/constants/errors.ts
@@ -12,9 +12,25 @@ export const loginErrors = {
   INVALID_CREDENTIALS: 'Неправильний логін або пароль',
   EMPTY_USERNAME: 'Логін не може бути порожнім',
   EMPTY_PASSWORD: 'Пароль не може бути порожнім', //NOSONAR
-  UNEXPECTED_ERROR: 'Непередбачена помилка. Спробуйте ще раз.'
+  UNEXPECTED_ERROR: 'Непередбачена помилка. Спробуйте ще раз.',
+  INVALID_PASSWORD: 'Неправильний пароль',
+  EMPTY_EMAIL: 'Будь ласка, вкажіть вашу електронну адресу',
+  INVALID_EMAIL: 'Введіть коректну електронну пошту'
 };
 
+export const forgotPasswordErrors = {
+  SUCCESS_MESSAGE:
+    'Якщо обліковий запис із цією електронною адресою існує, ми надіслали інструкції для відновлення пароля.',
+  RATE_LIMIT: 'Ви перевищили кількість спроб. Спробуйте через 15 хвилин.'
+};
+
+export const resetPasswordErrors = {
+  TOKEN_EXPIRED:
+    'Посилання для відновлення пароля вже було використано або втратило чинність. Будь ласка, створіть новий запит на відновлення пароля.',
+  REQUIREMENTS_NOT_MET: 'Пароль не відповідає вимогам безпеки.',
+  PASSWORDS_MISMATCH: 'Паролі не збігаються.',
+  EMPTY_PASSWORD: 'Введіть новий пароль'
+};
 export const cropperErrors = {
   NO_FRAME: 'Оберіть необхідну зону'
 };

--- a/app/constants/styles.ts
+++ b/app/constants/styles.ts
@@ -1,0 +1,3 @@
+export const placeholderStyle = {
+  '& .MuiInputBase-input::placeholder': { color: '#1A1A1A', opacity: 1 }
+};

--- a/app/forgot-password/layout.tsx
+++ b/app/forgot-password/layout.tsx
@@ -1,9 +1,8 @@
 import '../globals.css';
 
-import BodyProvider, { metadata as LayoutMetadata } from '~/providers/body-provider/BodyProvider';
+import BodyProvider from '~/providers/body-provider/BodyProvider';
+export { metadata } from '~/providers/body-provider/BodyProvider';
 import { Toaster } from '~/shared/components/toaster/Toaster';
-
-export const metadata = LayoutMetadata;
 
 export default async function ForgotPasswordLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (

--- a/app/forgot-password/layout.tsx
+++ b/app/forgot-password/layout.tsx
@@ -5,7 +5,7 @@ import { Toaster } from '~/shared/components/toaster/Toaster';
 
 export const metadata = LayoutMetadata;
 
-export default async function LoginLayout({ children }: Readonly<{ children: React.ReactNode }>) {
+export default async function ForgotPasswordLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
     <BodyProvider>
       {children}

--- a/app/forgot-password/page.stories.tsx
+++ b/app/forgot-password/page.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, within } from '@storybook/test';
+import { graphql, HttpResponse } from 'msw';
+
+import { withMswHandlers } from '../../.storybook/msw';
+import ForgotPasswordPage from './page';
+
+const meta = {
+  title: 'Pages/ForgotPasswordPage',
+  component: ForgotPasswordPage,
+  parameters: {
+    layout: 'fullscreen',
+    nextNavigation: { pathname: '/forgot-password' }
+  }
+} satisfies Meta<typeof ForgotPasswordPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+async function submitEmail(canvasElement: HTMLElement, email: string) {
+  const canvas = within(canvasElement);
+  await userEvent.type(await canvas.findByLabelText(/Електронна адреса/i), email);
+  await userEvent.click(await canvas.findByRole('button', { name: /Відновити пароль/i }));
+  return canvas;
+}
+
+export const Default: Story = {};
+
+export const SuccessfulRequest: Story = {
+  parameters: {
+    ...withMswHandlers(
+      graphql.mutation('RequestPasswordReset', () =>
+        HttpResponse.json({
+          data: { requestPasswordReset: { success: true } }
+        })
+      )
+    )
+  },
+  async play({ canvasElement }) {
+    await submitEmail(canvasElement, 'admin@example.com');
+
+    const expectedMessage =
+      'Якщо обліковий запис із цією електронною адресою існує, ми надіслали інструкції для відновлення пароля.';
+    await expect(await within(canvasElement).findByText(expectedMessage)).toBeInTheDocument();
+  }
+};
+
+export const ServerError: Story = {
+  parameters: {
+    ...withMswHandlers(graphql.mutation('RequestPasswordReset', () => new HttpResponse(null, { status: 500 })))
+  },
+  async play({ canvasElement }) {
+    await submitEmail(canvasElement, 'admin@example.com');
+    await expect(await within(canvasElement).findByText(/Сталася помилка/i)).toBeInTheDocument();
+  }
+};

--- a/app/forgot-password/page.test.tsx
+++ b/app/forgot-password/page.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+
+import ForgotPasswordPage from './page';
+
+jest.mock('~/shared/components/forgot-password-form/ForgotPasswordForm', () => {
+  return function MockedForm() {
+    return <div data-testid="mock-forgot-form">Mock Form</div>;
+  };
+});
+
+describe('ForgotPasswordPage', () => {
+  it('renders the ForgotPasswordForm component', () => {
+    render(<ForgotPasswordPage />);
+    expect(screen.getByTestId('mock-forgot-form')).toBeInTheDocument();
+  });
+});

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+import ForgotPasswordForm from '~/shared/components/forgot-password-form/ForgotPasswordForm';
+
+export default function ForgotPasswordPage() {
+  return <ForgotPasswordForm />;
+}

--- a/app/lib/utils/renderHelperText.test.tsx
+++ b/app/lib/utils/renderHelperText.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+
+import { renderHelperText } from './renderHelperText';
+
+describe('renderHelperText', () => {
+  it('returns null if text is null', () => {
+    const { container } = render(<>{renderHelperText(null)}</>);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders error text', () => {
+    render(<>{renderHelperText('Введіть пароль')}</>);
+    expect(screen.getByText('Введіть пароль')).toBeInTheDocument();
+  });
+
+  it('renders AlertCircle icon', () => {
+    const { container } = render(<>{renderHelperText('Помилка')}</>);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+});

--- a/app/lib/utils/renderHelperText.tsx
+++ b/app/lib/utils/renderHelperText.tsx
@@ -1,0 +1,12 @@
+import { Box } from '@mui/material';
+import { AlertCircle } from 'lucide-react';
+
+export const renderHelperText = (text: string | null) => {
+  if (!text) return null;
+  return (
+    <Box component="span" sx={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+      <AlertCircle size={14} />
+      {text}
+    </Box>
+  );
+};

--- a/app/lib/utils/validateEmail.test.ts
+++ b/app/lib/utils/validateEmail.test.ts
@@ -1,0 +1,15 @@
+import { validateEmail } from './validateEmail';
+
+describe('validateEmail', () => {
+  it('returns error if email is empty', () => {
+    expect(validateEmail('')).toBe('Введіть електронну пошту');
+  });
+
+  it('returns error if email is invalid', () => {
+    expect(validateEmail('notanemail')).toBe('Введіть коректну електронну пошту');
+  });
+
+  it('returns null if email is valid', () => {
+    expect(validateEmail('test@example.com')).toBeNull();
+  });
+});

--- a/app/lib/utils/validateEmail.ts
+++ b/app/lib/utils/validateEmail.ts
@@ -1,6 +1,7 @@
 export const validateEmail = (email: string): string | null => {
-  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  const emailRegex = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i;
   if (!email.trim()) return 'Введіть електронну пошту';
+  if (email.length > 254) return 'Електронна пошта занадто довга';
   if (!emailRegex.test(email)) return 'Введіть коректну електронну пошту';
   return null;
 };

--- a/app/lib/utils/validateEmail.ts
+++ b/app/lib/utils/validateEmail.ts
@@ -1,0 +1,6 @@
+export const validateEmail = (email: string): string | null => {
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!email.trim()) return 'Введіть електронну пошту';
+  if (!emailRegex.test(email)) return 'Введіть коректну електронну пошту';
+  return null;
+};

--- a/app/login/page.test.tsx
+++ b/app/login/page.test.tsx
@@ -1,8 +1,10 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { act } from 'react';
+import toast from 'react-hot-toast';
 import { v4 as uuidv4 } from 'uuid';
 
 import LoginPage from './page';
+import { loginErrors } from '~/constants/errors';
 import { type LoginMutation, useLoginMutation } from '~/types/graphql/generated/graphql';
 
 const mockSuccessMutationResponse: LoginMutation = {
@@ -34,6 +36,11 @@ jest.mock('next/navigation', () => ({
   useRouter: () => ({
     push: routerMockPush
   })
+}));
+
+jest.mock('react-hot-toast', () => ({
+  success: jest.fn(),
+  error: jest.fn()
 }));
 
 jest.mock('~/public/icons/eye.svg', () => {
@@ -109,30 +116,37 @@ describe('LoginPage', () => {
     });
   });
 
-  it('should handle successful login and redirect', () => {
+  it('should handle successful login and redirect', async () => {
     mockedUseLoginMutation.mockImplementation(({ onCompleted }) => mockLoginWithSuccess(onCompleted));
     const test = uuidv4();
 
     submitFormHelper(test);
 
-    expect(routerMockPush).toHaveBeenCalledWith('/');
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith('Ви успішно увійшли до адмін панелі!');
+      expect(routerMockPush).toHaveBeenCalledWith('/');
+    });
   });
 
-  it('should handle login failure and display error message', () => {
+  it('should handle login failure and display error message', async () => {
     mockedUseLoginMutation.mockImplementation(({ onCompleted }) => mockLoginWithError(onCompleted));
     const test = uuidv4();
 
     submitFormHelper(test);
 
-    expect(screen.getByText('Invalid credentials')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(loginErrors.INVALID_CREDENTIALS || 'Invalid credentials');
+    });
   });
 
-  it('should handle unexpected errors gracefully', () => {
+  it('should handle unexpected errors gracefully', async () => {
     mockedUseLoginMutation.mockImplementation(({ onError }) => mockLoginWithNetworkError(onError));
     const test = uuidv4();
 
     submitFormHelper(test);
 
-    expect(screen.getByText('Непередбачена помилка. Спробуйте ще раз.')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(loginErrors.UNEXPECTED_ERROR);
+    });
   });
 });

--- a/app/login/page.test.tsx
+++ b/app/login/page.test.tsx
@@ -72,7 +72,7 @@ const mockLoginWithNetworkError = (onError: (err: Error) => void) => {
 const submitFormHelper = (password: string) => {
   render(<LoginPage />);
 
-  const emailInput = screen.getByLabelText(/Логін/i);
+  const emailInput = screen.getByLabelText(/Електронна пошта/i);
   const passwordInput = screen.getByLabelText(/Пароль/i);
   const submitButton = screen.getByRole('button', { name: 'Увійти' });
 
@@ -89,7 +89,7 @@ describe('LoginPage', () => {
 
   it('should render the login modal with all fields and button', () => {
     render(<LoginPage />);
-    expect(screen.getByLabelText(/Логін/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Електронна пошта/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/Пароль/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Увійти' })).toBeInTheDocument();
   });

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -11,7 +11,7 @@ import { useLoginMutation } from '~/types/graphql/generated/graphql';
 
 export default function LoginPage() {
   const router = useRouter();
-  const [loginError, setLoginError] = useState<string | null>(null);
+  const [triggerErrorClear, setTriggerErrorClear] = useState<number>(0);
 
   const [loginMutation] = useLoginMutation({
     onCompleted: (data) => {
@@ -23,18 +23,20 @@ export default function LoginPage() {
         return;
       }
       if (result.__typename === 'ErrorPayload') {
-        setLoginError(result.message);
+        setTriggerErrorClear(Date.now());
+        toast.error(loginErrors.INVALID_CREDENTIALS || result.message);
         return;
       }
-      setLoginError(loginErrors.UNEXPECTED_ERROR);
+      toast.error(loginErrors.UNEXPECTED_ERROR);
+      setTriggerErrorClear(Date.now());
     },
     onError: () => {
-      setLoginError(loginErrors.UNEXPECTED_ERROR);
+      toast.error(loginErrors.UNEXPECTED_ERROR);
+      setTriggerErrorClear(Date.now());
     }
   });
 
   const handleLoginSubmit = (data: LoginSubmitData) => {
-    setLoginError(null);
     loginMutation({
       variables: {
         email: data.login,
@@ -43,5 +45,5 @@ export default function LoginPage() {
     });
   };
 
-  return <LoginModal onSubmit={handleLoginSubmit} submitError={loginError} />;
+  return <LoginModal onSubmit={handleLoginSubmit} submitError={triggerErrorClear.toString()} />;
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
+import toast from 'react-hot-toast';
 
 import { loginErrors } from '~/constants/errors';
 import LoginModal from '~/shared/components/login-modal/LoginModal';
@@ -17,11 +18,12 @@ export default function LoginPage() {
       const result = data.login;
 
       if (result.__typename === 'LoginPayload' && result.success) {
+        toast.success('Ви успішно увійшли до адмін панелі!');
         router.push('/');
         return;
       }
       if (result.__typename === 'ErrorPayload') {
-        setLoginError(result.message || loginErrors.INVALID_CREDENTIALS);
+        setLoginError(result.message);
         return;
       }
       setLoginError(loginErrors.UNEXPECTED_ERROR);

--- a/app/reset-password/layout.tsx
+++ b/app/reset-password/layout.tsx
@@ -5,7 +5,7 @@ import { Toaster } from '~/shared/components/toaster/Toaster';
 
 export const metadata = LayoutMetadata;
 
-export default async function LoginLayout({ children }: Readonly<{ children: React.ReactNode }>) {
+export default async function ResetPasswordLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
     <BodyProvider>
       {children}

--- a/app/reset-password/layout.tsx
+++ b/app/reset-password/layout.tsx
@@ -1,9 +1,9 @@
 import '../globals.css';
 
-import BodyProvider, { metadata as LayoutMetadata } from '~/providers/body-provider/BodyProvider';
 import { Toaster } from '~/shared/components/toaster/Toaster';
 
-export const metadata = LayoutMetadata;
+export { metadata } from '~/providers/body-provider/BodyProvider';
+import BodyProvider from '~/providers/body-provider/BodyProvider';
 
 export default async function ResetPasswordLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (

--- a/app/reset-password/page.stories.tsx
+++ b/app/reset-password/page.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, within } from '@storybook/test';
+import { graphql, HttpResponse } from 'msw';
+
+import { getRouter } from '../../.storybook/mocks/next-navigation';
+import { withMswHandlers } from '../../.storybook/msw';
+import ResetPasswordPage from './page';
+
+const meta = {
+  title: 'Pages/ResetPasswordPage',
+  component: ResetPasswordPage,
+  args: {
+    searchParams: Promise.resolve({ token: 'valid-token-123' })
+  },
+  parameters: {
+    layout: 'fullscreen',
+    nextNavigation: {
+      pathname: '/reset-password'
+    }
+  }
+  // ... решта коду
+} satisfies Meta<typeof ResetPasswordPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+async function fillResetForm(canvasElement: HTMLElement, pass1: string, pass2: string) {
+  const canvas = within(canvasElement);
+  await userEvent.type(await canvas.findByLabelText(/^Новий пароль/i), pass1);
+  await userEvent.type(await canvas.findByLabelText(/Підтвердження паролю/i), pass2);
+  await userEvent.click(await canvas.findByRole('button', { name: /Змінити пароль/i }));
+  return canvas;
+}
+
+export const Default: Story = {};
+
+export const SuccessfulReset: Story = {
+  parameters: {
+    ...withMswHandlers(
+      graphql.mutation('ResetPassword', () =>
+        HttpResponse.json({
+          data: { resetPassword: { success: true } }
+        })
+      )
+    )
+  },
+  async play({ canvasElement }) {
+    await fillResetForm(canvasElement, 'Pass123456!', 'Pass123456!');
+    // Очікуємо редірект на логін
+    await expect(getRouter().push).toHaveBeenCalledWith('/login');
+  }
+};
+
+export const PasswordMismatch: Story = {
+  async play({ canvasElement }) {
+    await fillResetForm(canvasElement, 'Pass123456!', 'WrongPass!');
+    await expect(await within(canvasElement).findByText(/Паролі не збігаються/i)).toBeInTheDocument();
+  }
+};

--- a/app/reset-password/page.test.tsx
+++ b/app/reset-password/page.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+
+import ResetPasswordPage from './page';
+
+jest.mock('~/shared/components/reset-password-form/ResetPasswordForm', () => {
+  return {
+    __esModule: true,
+    default: function MockedForm({ token }: { token: string }) {
+      return <div data-testid="mock-reset-form">Form for token: {token}</div>;
+    }
+  };
+});
+
+jest.mock('~/shared/components/auth-card/AuthCardLayout', () => {
+  return {
+    __esModule: true,
+    AuthCardLayout: function MockedLayout({ title, children }: { title: string; children: React.ReactNode }) {
+      return (
+        <div data-testid="mock-layout">
+          <h1>{title}</h1>
+          {children}
+        </div>
+      );
+    }
+  };
+});
+
+describe('ResetPasswordPage (Server Component)', () => {
+  it('renders error if no token is provided', async () => {
+    const searchParams = Promise.resolve({});
+
+    const UI = await ResetPasswordPage({ searchParams });
+    render(UI);
+
+    expect(screen.getByText('Помилка')).toBeInTheDocument();
+    expect(screen.getByText('Будь ласка, перейдіть за посиланням з вашого листа.')).toBeInTheDocument();
+  });
+
+  it('renders the form when token is provided', async () => {
+    const searchParams = Promise.resolve({ token: 'valid-token-123' });
+
+    const UI = await ResetPasswordPage({ searchParams });
+    render(UI);
+
+    expect(screen.getByTestId('mock-reset-form')).toHaveTextContent('Form for token: valid-token-123');
+  });
+
+  it('renders error if token is invalid', async () => {
+    const searchParams = Promise.resolve({ token: 'invalid-fake-token' });
+
+    const UI = await ResetPasswordPage({ searchParams });
+    render(UI);
+
+    expect(screen.getByText('Помилка')).toBeInTheDocument();
+    expect(screen.getByText(/Посилання для відновлення пароля вже було використано/i)).toBeInTheDocument();
+  });
+});

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -1,0 +1,41 @@
+import { Typography } from '@mui/material';
+import React from 'react';
+
+import { AuthCardLayout } from '~/shared/components/auth-card/AuthCardLayout';
+import ResetPasswordForm from '~/shared/components/reset-password-form/ResetPasswordForm';
+
+type ResetPasswordPageProps = {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+};
+
+async function verifyToken(token: string): Promise<boolean> {
+  // here will be fetch to back
+  return token === 'valid-token-123';
+}
+
+export default async function ResetPasswordPage({ searchParams }: ResetPasswordPageProps) {
+  const params = await searchParams;
+  const token = typeof params.token === 'string' ? params.token : '';
+  if (!token) {
+    return (
+      <AuthCardLayout title="Помилка" subtitle="Посилання недійсне">
+        <Typography align="center">Будь ласка, перейдіть за посиланням з вашого листа.</Typography>
+      </AuthCardLayout>
+    );
+  }
+
+  const isTokenValid = await verifyToken(token);
+
+  if (!isTokenValid) {
+    return (
+      <AuthCardLayout title="Помилка" subtitle="Посилання недійсне">
+        <Typography align="center">
+          Посилання для відновлення пароля вже було використано або втратило чинність. Будь ласка, створіть новий запит
+          на відновлення пароля.
+        </Typography>
+      </AuthCardLayout>
+    );
+  }
+
+  return <ResetPasswordForm token={token} />;
+}

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -13,7 +13,7 @@ async function verifyToken(token: string): Promise<boolean> {
   return token === 'valid-token-123';
 }
 
-export default async function ResetPasswordPage({ searchParams }: ResetPasswordPageProps) {
+export default async function ResetPasswordPage({ searchParams }: Readonly<ResetPasswordPageProps>) {
   const params = await searchParams;
   const token = typeof params.token === 'string' ? params.token : '';
   if (!token) {

--- a/app/shared/components/auth-card/AuthCardLayout.styles.ts
+++ b/app/shared/components/auth-card/AuthCardLayout.styles.ts
@@ -1,0 +1,40 @@
+export const styles = {
+  outerContainer: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    flexDirection: 'column',
+    minHeight: '100vh',
+    width: '100%',
+    backgroundColor: '#F5F6F8'
+  },
+  container: {
+    background: '#FFFFFF',
+    borderRadius: '16px',
+    padding: '32px 24px',
+    maxWidth: '432px',
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '40px'
+  },
+  header: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+    width: '100%'
+  },
+  TitleAndSubtitle: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px'
+  },
+  title: {
+    textAlign: 'center'
+  },
+  subtitle: {
+    fontWeight: 400,
+    textAlign: 'center',
+    color: 'adminBlue.800'
+  }
+};

--- a/app/shared/components/auth-card/AuthCardLayout.test.tsx
+++ b/app/shared/components/auth-card/AuthCardLayout.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+
+import { AuthCardLayout } from './AuthCardLayout';
+
+describe('AuthCardLayout', () => {
+  it('renders title, subtitle, and children correctly', () => {
+    render(
+      <AuthCardLayout title="Тестовий заголовок" subtitle="Тестовий підзаголовок">
+        <div data-testid="child-element">Форма</div>
+      </AuthCardLayout>
+    );
+
+    expect(screen.getByText('Тестовий заголовок')).toBeInTheDocument();
+    expect(screen.getByText('Тестовий підзаголовок')).toBeInTheDocument();
+
+    expect(screen.getByTestId('child-element')).toBeInTheDocument();
+  });
+});

--- a/app/shared/components/auth-card/AuthCardLayout.tsx
+++ b/app/shared/components/auth-card/AuthCardLayout.tsx
@@ -1,0 +1,36 @@
+import { Box, Typography } from '@mui/material';
+import Image from 'next/image';
+import React from 'react';
+
+import { styles } from './AuthCardLayout.styles';
+
+interface AuthCardLayoutProps {
+  title: string;
+  subtitle: string;
+  children: React.ReactNode;
+}
+
+export const AuthCardLayout = ({ title, subtitle, children }: AuthCardLayoutProps) => {
+  return (
+    <Box sx={styles.outerContainer}>
+      <Box sx={styles.container}>
+        <Box sx={styles.header}>
+          <Box sx={{ display: 'flex', justifyContent: 'center', width: '100%' }}>
+            <Image src="./icons/logo.svg" alt="logo" width={96} height={80} />
+          </Box>
+
+          <Box sx={styles.TitleAndSubtitle}>
+            <Typography sx={styles.title} variant="h6">
+              {title}
+            </Typography>
+            <Typography sx={styles.subtitle} variant="textMd">
+              {subtitle}
+            </Typography>
+          </Box>
+        </Box>
+
+        {children}
+      </Box>
+    </Box>
+  );
+};

--- a/app/shared/components/design-system/password-field/PasswordField.test.tsx
+++ b/app/shared/components/design-system/password-field/PasswordField.test.tsx
@@ -1,5 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
+import { fireEvent,render, screen } from '@testing-library/react';
 
 import PasswordField from './PasswordField';
 
@@ -18,33 +17,31 @@ jest.mock('~/public/icons/eye-closed.svg', () => {
 describe('PasswordField', () => {
   it('renders the password field with label', () => {
     render(<PasswordField helperText={null} />);
-    expect(screen.getByLabelText('Пароль')).toBeInTheDocument();
+    expect(screen.getByLabelText('Пароль *')).toBeInTheDocument();
   });
 
   it('renders helper text when provided', () => {
-    const helperText = 'Пароль має містити щонайменше 6 символів';
-    render(<PasswordField helperText={helperText} />);
-    expect(screen.getByText(helperText)).toBeInTheDocument();
-  });
-
-  it('does not render helper text when not provided', () => {
-    render(<PasswordField helperText={null} />);
-    expect(screen.queryByText('Пароль має містити щонайменше 6 символів')).toBeNull();
+    render(<PasswordField helperText="Обов'язкове поле" />);
+    expect(screen.getByText('Обов\'язкове поле')).toBeInTheDocument();
   });
 
   it('toggles password visibility when the visibility button is clicked', () => {
     render(<PasswordField helperText={null} />);
-    const passwordInput = screen.getByLabelText('Пароль');
-    const toggleButton = screen.getByRole('button', { name: 'display the password' });
+
+    const passwordInput = screen.getByLabelText('Пароль *');
+    const toggleButton = screen.getByRole('button', { name: /display the password/i });
 
     expect(passwordInput).toHaveAttribute('type', 'password');
 
     fireEvent.click(toggleButton);
     expect(passwordInput).toHaveAttribute('type', 'text');
-    expect(toggleButton).toHaveAttribute('aria-label', 'hide the password');
 
-    fireEvent.click(toggleButton);
+    fireEvent.click(screen.getByRole('button', { name: /hide the password/i }));
     expect(passwordInput).toHaveAttribute('type', 'password');
-    expect(toggleButton).toHaveAttribute('aria-label', 'display the password');
+  });
+
+  it('renders with custom label if provided', () => {
+    render(<PasswordField label="Новий пароль *" helperText={null} />);
+    expect(screen.getByLabelText('Новий пароль *')).toBeInTheDocument();
   });
 });

--- a/app/shared/components/design-system/password-field/PasswordField.tsx
+++ b/app/shared/components/design-system/password-field/PasswordField.tsx
@@ -17,10 +17,10 @@ import VisibilityOn from '~/public/icons/eye.svg';
 import VisibilityOff from '~/public/icons/eye-closed.svg';
 
 interface PasswordFieldProps extends OutlinedInputProps {
-  helperText: string | null;
+  helperText: React.ReactNode;
 }
 
-const PasswordField = ({ helperText, sx, ...props }: PasswordFieldProps) => {
+const PasswordField = ({ helperText, sx, label = 'Пароль *', ...props }: PasswordFieldProps) => {
   const [showPassword, setShowPassword] = React.useState(false);
 
   const handleClickShowPassword = () => setShowPassword((show) => !show);
@@ -35,11 +35,11 @@ const PasswordField = ({ helperText, sx, ...props }: PasswordFieldProps) => {
 
   return (
     <Box sx={styles}>
-      <FormControl variant="outlined" fullWidth>
-        <InputLabel htmlFor="outlined-adornment-password">Пароль</InputLabel>
+      <FormControl variant="outlined" fullWidth error={props.error}>
+        <InputLabel htmlFor="outlined-adornment-password">{label}</InputLabel>
         <OutlinedInput
           id="outlined-adornment-password"
-          label="Пароль"
+          label={label}
           type={showPassword ? 'text' : 'password'}
           endAdornment={
             <InputAdornment position="end">
@@ -57,7 +57,7 @@ const PasswordField = ({ helperText, sx, ...props }: PasswordFieldProps) => {
           sx={sx}
           {...props}
         />
-        {helperText && <FormHelperText error>{helperText}</FormHelperText>}
+        {helperText && <FormHelperText error={!!props.error}>{helperText}</FormHelperText>}{' '}
       </FormControl>
     </Box>
   );

--- a/app/shared/components/forgot-password-form/ForgotPasswordForm.styles.ts
+++ b/app/shared/components/forgot-password-form/ForgotPasswordForm.styles.ts
@@ -1,0 +1,21 @@
+import { mainHexPalette } from '~/shared/theme/colors';
+
+export const styles = {
+  form: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '24px'
+  },
+  buttonSubmit: {
+    background: mainHexPalette.yellow[500],
+    color: '#1A1A1A',
+    fontWeight: 600,
+    padding: '8px 24px',
+    textTransform: 'none',
+    boxShadow: 'none',
+    '&:hover': {
+      backgroundColor: mainHexPalette.yellow[600],
+      boxShadow: 'none'
+    }
+  }
+};

--- a/app/shared/components/forgot-password-form/ForgotPasswordForm.test.tsx
+++ b/app/shared/components/forgot-password-form/ForgotPasswordForm.test.tsx
@@ -1,0 +1,31 @@
+import { fireEvent,render, screen } from '@testing-library/react';
+
+import ForgotPasswordForm from './ForgotPasswordForm';
+
+describe('ForgotPasswordForm', () => {
+  it('shows error for invalid email format', () => {
+    render(<ForgotPasswordForm />);
+
+    const emailInput = screen.getByPlaceholderText('Введіть електронну пошту');
+    const submitButton = screen.getByRole('button', { name: /надіслати інструкції/i });
+
+    fireEvent.change(emailInput, { target: { value: 'invalid-email' } });
+    fireEvent.click(submitButton);
+
+    expect(screen.getByText('Введіть коректну електронну пошту')).toBeInTheDocument();
+  });
+
+  it('removes error when user starts typing again', () => {
+    render(<ForgotPasswordForm />);
+
+    const emailInput = screen.getByPlaceholderText('Введіть електронну пошту');
+    const submitButton = screen.getByRole('button', { name: /надіслати інструкції/i });
+
+    fireEvent.change(emailInput, { target: { value: 'invalid' } });
+    fireEvent.click(submitButton);
+    expect(screen.getByText('Введіть коректну електронну пошту')).toBeInTheDocument();
+
+    fireEvent.change(emailInput, { target: { value: 'valid@mail.com' } });
+    expect(screen.queryByText('Введіть коректну електронну пошту')).not.toBeInTheDocument();
+  });
+});

--- a/app/shared/components/forgot-password-form/ForgotPasswordForm.tsx
+++ b/app/shared/components/forgot-password-form/ForgotPasswordForm.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { Box, Button, InputAdornment, Typography } from '@mui/material';
+import { Mail } from 'lucide-react';
+import React, { useState } from 'react';
+import toast from 'react-hot-toast';
+
+import { styles } from './ForgotPasswordForm.styles';
+import { placeholderStyle } from '~/constants/styles';
+import { CustomTextField } from '~/ds-components/text-field/TextField';
+import { renderHelperText } from '~/lib/utils/renderHelperText';
+import { validateEmail } from '~/lib/utils/validateEmail';
+import { AuthCardLayout } from '~/shared/components/auth-card/AuthCardLayout';
+
+export default function ForgotPasswordForm() {
+  const [email, setEmail] = useState('');
+  const [emailError, setEmailError] = useState<string | null>(null);
+  const [isSubmitted, setIsSubmitted] = useState(false);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setEmail(e.target.value);
+    setEmailError(null);
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const error = validateEmail(email);
+    setEmailError(error);
+    if (!error) {
+      setIsSubmitted(true);
+      toast.success('Лист для відновлення надіслано');
+    }
+  };
+
+  if (isSubmitted) {
+    return (
+      <AuthCardLayout title="Відновлення паролю" subtitle="">
+        <Typography align="center">
+          Якщо обліковий запис із цією електронною адресою існує, ми надіслали інструкції для відновлення пароля.
+        </Typography>
+      </AuthCardLayout>
+    );
+  }
+
+  return (
+    <AuthCardLayout
+      title="Відновлення паролю"
+      subtitle="Введіть свою електронну адресу, і ми надішлемо вам інструкції з відновлення."
+    >
+      <Box component="form" onSubmit={handleSubmit} sx={styles.form}>
+        <CustomTextField
+          label="Електронна пошта *"
+          value={email}
+          onChange={handleChange}
+          error={!!emailError}
+          helperText={renderHelperText(emailError)}
+          placeholder="Введіть електронну пошту"
+          fullWidth
+          sx={placeholderStyle}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <Mail size={20} strokeWidth={1.75} style={{ color: '#4E5061' }} />
+              </InputAdornment>
+            )
+          }}
+        />
+
+        <Button variant="contained" sx={styles.buttonSubmit} type="submit" fullWidth>
+          Надіслати інструкції
+        </Button>
+      </Box>
+    </AuthCardLayout>
+  );
+}

--- a/app/shared/components/login-modal/LoginModal.test.tsx
+++ b/app/shared/components/login-modal/LoginModal.test.tsx
@@ -1,10 +1,14 @@
-import { fireEvent,render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import LoginModal from './LoginModal';
 import { loginErrors } from '~/constants/errors';
 
 jest.mock('next/link', () => {
-  const MockedLink = ({ children }: { children: React.ReactNode }) => <a>{children}</a>;
+  const MockedLink = ({ children, ...props }: { children: React.ReactNode; [key: string]: any }) => (
+    <a href="#" {...props}>
+      {children}
+    </a>
+  );
   MockedLink.displayName = 'MockedLink';
   return MockedLink;
 });

--- a/app/shared/components/login-modal/LoginModal.test.tsx
+++ b/app/shared/components/login-modal/LoginModal.test.tsx
@@ -4,8 +4,8 @@ import LoginModal from './LoginModal';
 import { loginErrors } from '~/constants/errors';
 
 jest.mock('next/link', () => {
-  const MockedLink = ({ children, ...props }: { children: React.ReactNode; [key: string]: any }) => (
-    <a href="#" {...props}>
+  const MockedLink = ({ children, href, ...props }: { children: React.ReactNode; [key: string]: any }) => (
+    <a href={href || '/'} {...props}>
       {children}
     </a>
   );

--- a/app/shared/components/login-modal/LoginModal.test.tsx
+++ b/app/shared/components/login-modal/LoginModal.test.tsx
@@ -1,13 +1,12 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
-import { v4 as uuidv4 } from 'uuid';
+import { fireEvent,render, screen } from '@testing-library/react';
 
 import LoginModal from './LoginModal';
+import { loginErrors } from '~/constants/errors';
 
-jest.mock('~/public/icons/logo.svg', () => {
-  const Logo = () => <img alt="logo" />;
-  Logo.displayName = 'Logo';
-  return Logo;
+jest.mock('next/link', () => {
+  const MockedLink = ({ children }: { children: React.ReactNode }) => <a>{children}</a>;
+  MockedLink.displayName = 'MockedLink';
+  return MockedLink;
 });
 
 jest.mock('~/public/icons/eye.svg', () => {
@@ -26,100 +25,46 @@ describe('LoginModal', () => {
   const mockOnSubmit = jest.fn();
 
   beforeEach(() => {
-    mockOnSubmit.mockClear();
-
-    render(<LoginModal onSubmit={mockOnSubmit} />);
-
-    const usernameInput = screen.getByLabelText('Логін');
-    fireEvent.change(usernameInput, { target: { value: '  ' } });
-
-    const passwordInput = screen.getByLabelText('Пароль');
-    fireEvent.change(passwordInput, { target: { value: '  ' } });
+    jest.clearAllMocks();
   });
 
-  it('should render all elements correctly', () => {
-    expect(screen.getByAltText('logo')).toBeInTheDocument();
-    expect(screen.getByText('Вхід до адмін-панелі')).toBeInTheDocument();
-    expect(screen.getByText('Для редагування сайту увійдіть у свій обліковий запис.')).toBeInTheDocument();
-    expect(screen.getByLabelText('Логін')).toBeInTheDocument();
-    expect(screen.getByLabelText('Пароль')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Увійти' })).toBeInTheDocument();
+  it('renders all inputs and buttons', () => {
+    render(<LoginModal onSubmit={mockOnSubmit} submitError={null} />);
+    expect(screen.getByPlaceholderText('Введіть електронну пошту')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Введіть пароль')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /увійти/i })).toBeInTheDocument();
   });
 
-  it('should disable the submit button when either is empty', () => {
-    const usernameInput = screen.getByLabelText('Логін');
-    const passwordInput = screen.getByLabelText('Пароль');
+  it('shows validation errors when submitting empty fields', () => {
+    render(<LoginModal onSubmit={mockOnSubmit} submitError={null} />);
 
-    fireEvent.change(usernameInput, { target: { value: '' } });
-    fireEvent.change(passwordInput, { target: { value: 'password123' } });
-
-    const submitButton = screen.getByRole('button', { name: 'Увійти' });
-    expect(submitButton).toBeDisabled();
-
-    fireEvent.change(usernameInput, { target: { value: 'username' } });
-    fireEvent.change(passwordInput, { target: { value: '' } });
-
-    expect(submitButton).toBeDisabled();
-
-    fireEvent.change(usernameInput, { target: { value: 'username' } });
-    fireEvent.change(passwordInput, { target: { value: 'password123' } });
-
-    expect(submitButton).toBeEnabled();
-  });
-
-  it('should show an error when the username is spaces', () => {
-    const submitButton = screen.getByRole('button', { name: 'Увійти' });
+    const submitButton = screen.getByRole('button', { name: /увійти/i });
     fireEvent.click(submitButton);
 
-    expect(screen.getByText('Логін не може бути порожнім')).toBeInTheDocument();
+    expect(screen.getByText(loginErrors.EMPTY_EMAIL)).toBeInTheDocument();
+    expect(screen.getByText(loginErrors.EMPTY_PASSWORD)).toBeInTheDocument();
     expect(mockOnSubmit).not.toHaveBeenCalled();
   });
 
-  it('should show an error when the password is spaces', () => {
-    const usernameInput = screen.getByLabelText('Логін');
-    fireEvent.change(usernameInput, { target: { value: 'testuser' } });
+  it('calls onSubmit with correct data when form is valid', () => {
+    render(<LoginModal onSubmit={mockOnSubmit} submitError={null} />);
 
-    const submitButton = screen.getByRole('button', { name: 'Увійти' });
-    fireEvent.click(submitButton);
+    const emailInput = screen.getByPlaceholderText('Введіть електронну пошту');
+    const passwordInput = screen.getByPlaceholderText('Введіть пароль');
+    const submitButton = screen.getByRole('button', { name: /увійти/i });
 
-    expect(screen.getByText('Пароль не може бути порожнім')).toBeInTheDocument();
-    expect(mockOnSubmit).not.toHaveBeenCalled();
-  });
-
-  it('should call onSubmit with correct data when inputs are valid', () => {
-    const usernameInput = screen.getByLabelText('Логін');
-    const passwordInput = screen.getByLabelText('Пароль');
-    const submitButton = screen.getByRole('button', { name: 'Увійти' });
-    const test = uuidv4();
-
-    fireEvent.change(usernameInput, { target: { value: 'testuser' } });
-    fireEvent.change(passwordInput, { target: { value: test } });
+    fireEvent.change(emailInput, { target: { value: 'test@example.com' } });
+    fireEvent.change(passwordInput, { target: { value: 'password123' } });
     fireEvent.click(submitButton);
 
     expect(mockOnSubmit).toHaveBeenCalledWith({
-      login: 'testuser',
-      password: test
+      login: 'test@example.com',
+      password: 'password123'
     });
   });
 
-  it('should login user by pressing Enter', () => {
-    const usernameInput = screen.getByLabelText('Логін');
-    const passwordInput = screen.getByLabelText('Пароль');
-    const test = uuidv4();
-
-    fireEvent.change(usernameInput, { target: { value: 'testuser' } });
-    fireEvent.change(passwordInput, { target: { value: test } });
-
-    const form = passwordInput.closest('form');
-    if (!form) {
-      throw new Error('Form element not found');
-    }
-
-    fireEvent.submit(form);
-
-    expect(mockOnSubmit).toHaveBeenCalledWith({
-      login: 'testuser',
-      password: test
-    });
+  it('displays server submitError if provided', () => {
+    render(<LoginModal onSubmit={mockOnSubmit} submitError="Непередбачена помилка сервера" />);
+    expect(screen.getByText('Непередбачена помилка сервера')).toBeInTheDocument();
   });
 });

--- a/app/shared/components/login-modal/LoginModal.test.tsx
+++ b/app/shared/components/login-modal/LoginModal.test.tsx
@@ -67,8 +67,16 @@ describe('LoginModal', () => {
     });
   });
 
-  it('displays server submitError if provided', () => {
-    render(<LoginModal onSubmit={mockOnSubmit} submitError="Непередбачена помилка сервера" />);
-    expect(screen.getByText('Непередбачена помилка сервера')).toBeInTheDocument();
+  it('clears password field when submitError changes', () => {
+    const { rerender } = render(<LoginModal onSubmit={mockOnSubmit} submitError={null} />);
+
+    const passwordInput = screen.getByPlaceholderText('Введіть пароль');
+    fireEvent.change(passwordInput, { target: { value: 'password123' } });
+
+    expect(passwordInput).toHaveValue('password123');
+
+    rerender(<LoginModal onSubmit={mockOnSubmit} submitError={Date.now().toString()} />);
+
+    expect(passwordInput).toHaveValue('');
   });
 });

--- a/app/shared/components/login-modal/LoginModal.tsx
+++ b/app/shared/components/login-modal/LoginModal.tsx
@@ -1,13 +1,18 @@
 'use client';
 
-import { Box, Button, Typography } from '@mui/material';
-import Image from 'next/image';
-import React, { useState } from 'react';
+import { Box, Button, InputAdornment, Typography } from '@mui/material';
+import { Lock, Mail } from 'lucide-react';
+import Link from 'next/link';
+import React, { useEffect, useState } from 'react';
 
+import { AuthCardLayout } from '../auth-card/AuthCardLayout';
 import PasswordField from '../design-system/password-field/PasswordField';
 import { styles } from './LoginModal.styles';
 import { loginErrors } from '~/constants/errors';
+import { placeholderStyle } from '~/constants/styles';
 import { CustomTextField } from '~/ds-components/text-field/TextField';
+import { renderHelperText } from '~/lib/utils/renderHelperText';
+import { validateEmail } from '~/lib/utils/validateEmail';
 import { LoginModalProps } from '~/types/adminLogin';
 
 const LoginModal = ({ onSubmit, submitError }: LoginModalProps) => {
@@ -15,10 +20,34 @@ const LoginModal = ({ onSubmit, submitError }: LoginModalProps) => {
   const [usernameError, setUsernameError] = useState<string | null>(null);
   const [password, setPassword] = useState('');
   const [passwordError, setPasswordError] = useState<string | null>(null);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (submitError) {
+      const errorText = submitError.toLowerCase();
+
+      if (errorText.includes('email')) {
+        setUsernameError(loginErrors.INVALID_EMAIL || 'Введіть коректну електронну пошту');
+        setServerError(null);
+      } else if (errorText.includes('password')) {
+        setPasswordError(loginErrors.INVALID_PASSWORD || 'Неправильний пароль');
+        setPassword('');
+        setServerError(null);
+      } else {
+        setServerError(submitError);
+        setPassword('');
+      }
+    }
+  }, [submitError]);
 
   const validateUsername = () => {
     if (!username.trim()) {
-      setUsernameError(loginErrors.EMPTY_USERNAME);
+      setUsernameError(loginErrors.EMPTY_EMAIL);
+      return false;
+    }
+    const error = validateEmail(username);
+    if (error) {
+      setUsernameError(loginErrors.INVALID_EMAIL);
       return false;
     }
     setUsernameError(null);
@@ -27,7 +56,8 @@ const LoginModal = ({ onSubmit, submitError }: LoginModalProps) => {
 
   const handleUsernameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setUsername(e.target.value);
-    if (usernameError) validateUsername();
+    setUsernameError(null);
+    setServerError(null);
   };
 
   const validatePassword = () => {
@@ -41,7 +71,8 @@ const LoginModal = ({ onSubmit, submitError }: LoginModalProps) => {
 
   const handlePasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setPassword(e.target.value);
-    if (passwordError) validatePassword();
+    setPasswordError(null);
+    setServerError(null);
   };
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -56,40 +87,61 @@ const LoginModal = ({ onSubmit, submitError }: LoginModalProps) => {
   };
 
   return (
-    <Box sx={styles.outerContainer}>
-      <Image src="./icons/logo.svg" alt="logo" width={96} height={80} />
-      <Box component="form" onSubmit={handleSubmit} sx={styles.container}>
-        <Typography sx={styles.title} variant="h6">
-          Вхід до адмін-панелі
-        </Typography>
-        <Typography sx={styles.subtitle} variant="textMd">
-          Для редагування сайту увійдіть у свій обліковий запис.
-        </Typography>
-        <CustomTextField
-          label="Логін"
-          value={username}
-          onChange={handleUsernameChange}
-          error={!!usernameError}
-          helperText={usernameError}
-          fullWidth
-        />
-        <PasswordField
-          value={password}
-          onChange={handlePasswordChange}
-          error={!!passwordError}
-          helperText={passwordError}
-          fullWidth
-        />
-        {submitError && (
-          <Typography sx={styles.errorText} variant="body2">
-            {submitError}
-          </Typography>
-        )}
-        <Button variant="contained" size='large' sx={styles.button} type="submit" disabled={!username || !password} fullWidth>
-          Увійти
-        </Button>
+    <AuthCardLayout
+      title="Вхід до адмін-панелі"
+      subtitle="Увійдіть щоб отримати доступ до робочого простору вашої фірми."
+    >
+      <Box component="form" onSubmit={handleSubmit}>
+        <Box sx={styles.inputs}>
+          <CustomTextField
+            label="Електронна пошта *"
+            value={username}
+            onChange={handleUsernameChange}
+            error={!!usernameError}
+            helperText={renderHelperText(usernameError)}
+            placeholder="Введіть електронну пошту"
+            fullWidth
+            sx={placeholderStyle}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <Mail size={20} strokeWidth={1.75} style={{ color: '#4E5061' }} />
+                </InputAdornment>
+              )
+            }}
+          />
+          <PasswordField
+            label="Пароль *"
+            value={password}
+            placeholder="Введіть пароль"
+            onChange={handlePasswordChange}
+            error={!!passwordError}
+            helperText={renderHelperText(passwordError)}
+            sx={placeholderStyle}
+            startAdornment={
+              <InputAdornment position="start">
+                <Lock size={20} strokeWidth={1.75} style={{ color: '#4E5061' }} />
+              </InputAdornment>
+            }
+          />
+        </Box>
+        <Box sx={styles.buttonsContainer}>
+          {serverError && (
+            <Box sx={{ mt: 1, mb: 2, mx: 'auto' }}>
+              <Typography variant="body2" sx={{ color: '#d32f2f' }}>
+                {renderHelperText(serverError)}
+              </Typography>
+            </Box>
+          )}
+          <Button variant="contained" sx={styles.buttonLogin} type="submit" fullWidth>
+            Увійти
+          </Button>
+          <Button component={Link} href="/forgot-password" variant="outlined" sx={styles.buttonReset} fullWidth>
+            Забули пароль?
+          </Button>
+        </Box>
       </Box>
-    </Box>
+    </AuthCardLayout>
   );
 };
 

--- a/app/shared/components/login-modal/LoginModal.tsx
+++ b/app/shared/components/login-modal/LoginModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Box, Button, InputAdornment, Typography } from '@mui/material';
+import { Box, Button, InputAdornment } from '@mui/material';
 import { Lock, Mail } from 'lucide-react';
 import Link from 'next/link';
 import React, { useEffect, useState } from 'react';
@@ -20,23 +20,10 @@ const LoginModal = ({ onSubmit, submitError }: LoginModalProps) => {
   const [usernameError, setUsernameError] = useState<string | null>(null);
   const [password, setPassword] = useState('');
   const [passwordError, setPasswordError] = useState<string | null>(null);
-  const [serverError, setServerError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (submitError) {
-      const errorText = submitError.toLowerCase();
-
-      if (errorText.includes('email')) {
-        setUsernameError(loginErrors.INVALID_EMAIL || 'Введіть коректну електронну пошту');
-        setServerError(null);
-      } else if (errorText.includes('password')) {
-        setPasswordError(loginErrors.INVALID_PASSWORD || 'Неправильний пароль');
-        setPassword('');
-        setServerError(null);
-      } else {
-        setServerError(submitError);
-        setPassword('');
-      }
+    if (submitError && submitError !== '0') {
+      setPassword('');
     }
   }, [submitError]);
 
@@ -57,7 +44,6 @@ const LoginModal = ({ onSubmit, submitError }: LoginModalProps) => {
   const handleUsernameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setUsername(e.target.value);
     setUsernameError(null);
-    setServerError(null);
   };
 
   const validatePassword = () => {
@@ -72,7 +58,6 @@ const LoginModal = ({ onSubmit, submitError }: LoginModalProps) => {
   const handlePasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setPassword(e.target.value);
     setPasswordError(null);
-    setServerError(null);
   };
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -126,13 +111,6 @@ const LoginModal = ({ onSubmit, submitError }: LoginModalProps) => {
           />
         </Box>
         <Box sx={styles.buttonsContainer}>
-          {serverError && (
-            <Box sx={{ mt: 1, mb: 2, mx: 'auto' }}>
-              <Typography variant="body2" sx={{ color: '#d32f2f' }}>
-                {renderHelperText(serverError)}
-              </Typography>
-            </Box>
-          )}
           <Button variant="contained" sx={styles.buttonLogin} type="submit" fullWidth>
             Увійти
           </Button>

--- a/app/shared/components/reset-password-form/ResetPasswordForm.styles.ts
+++ b/app/shared/components/reset-password-form/ResetPasswordForm.styles.ts
@@ -1,19 +1,17 @@
 import { mainHexPalette } from '~/shared/theme/colors';
 
 export const styles = {
-  inputs: {
+  form: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '32px'
+  },
+  inputsWrapper: {
     display: 'flex',
     flexDirection: 'column',
     gap: '20px'
   },
-  buttonsContainer: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '12px',
-    width: '100%',
-    marginTop: '32px'
-  },
-  buttonLogin: {
+  buttonSubmit: {
     background: mainHexPalette.yellow[500],
     color: '#1A1A1A',
     fontWeight: 600,
@@ -23,17 +21,6 @@ export const styles = {
     '&:hover': {
       backgroundColor: mainHexPalette.yellow[600],
       boxShadow: 'none'
-    }
-  },
-  buttonReset: {
-    color: '#1A1A1A',
-    fontWeight: 600,
-    textTransform: 'none',
-    padding: '8px 24px',
-    borderColor: '#1A1A1A',
-    '&:hover': {
-      borderColor: '#A9A9A9',
-      backgroundColor: 'rgba(0, 0, 0, 0.04)'
     }
   }
 };

--- a/app/shared/components/reset-password-form/ResetPasswordForm.test.tsx
+++ b/app/shared/components/reset-password-form/ResetPasswordForm.test.tsx
@@ -1,0 +1,49 @@
+import { fireEvent,render, screen } from '@testing-library/react';
+
+import ResetPasswordForm from './ResetPasswordForm';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn()
+  })
+}));
+
+jest.mock('~/public/icons/eye.svg', () => {
+  const Eye = () => <span>eye</span>;
+  Eye.displayName = 'Eye';
+  return Eye;
+});
+
+jest.mock('~/public/icons/eye-closed.svg', () => {
+  const EyeClosed = () => <span>closed eye</span>;
+  EyeClosed.displayName = 'EyeClosed';
+  return EyeClosed;
+});
+
+describe('ResetPasswordForm', () => {
+  it('shows error if passwords do not match', () => {
+    render(<ResetPasswordForm token="" />);
+
+    const newPasswordInput = screen.getByPlaceholderText('Введіть новий пароль');
+    const confirmPasswordInput = screen.getByPlaceholderText('Повторіть пароль');
+    const submitButton = screen.getByRole('button', { name: /змінити пароль/i });
+
+    fireEvent.change(newPasswordInput, { target: { value: 'Password123!' } });
+    fireEvent.change(confirmPasswordInput, { target: { value: 'Password456!' } });
+    fireEvent.click(submitButton);
+
+    expect(screen.getByText('Паролі не збігаються')).toBeInTheDocument();
+  });
+
+  it('shows error if password is too short', () => {
+    render(<ResetPasswordForm token="" />);
+
+    const newPasswordInput = screen.getByPlaceholderText('Введіть новий пароль');
+    const submitButton = screen.getByRole('button', { name: /змінити пароль/i });
+
+    fireEvent.change(newPasswordInput, { target: { value: '123' } });
+    fireEvent.click(submitButton);
+
+    expect(screen.getByText('Пароль не відповідає вимогам безпеки')).toBeInTheDocument();
+  });
+});

--- a/app/shared/components/reset-password-form/ResetPasswordForm.tsx
+++ b/app/shared/components/reset-password-form/ResetPasswordForm.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { Box, Button, InputAdornment, Typography } from '@mui/material';
+import { Lock } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import React, { useState } from 'react';
+import toast from 'react-hot-toast';
+
+import PasswordField from '../design-system/password-field/PasswordField';
+import { styles } from './ResetPasswordForm.styles';
+import { placeholderStyle } from '~/constants/styles';
+import { renderHelperText } from '~/lib/utils/renderHelperText';
+import { AuthCardLayout } from '~/shared/components/auth-card/AuthCardLayout';
+
+interface ResetPasswordFormProps {
+  token: string;
+}
+
+const passwordRegex = /^(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*])/;
+
+const validatePassword = (password: string): string | null => {
+  if (!password.trim()) return 'Введіть новий пароль';
+  if (password.length < 10) return 'Пароль не відповідає вимогам безпеки';
+  if (password.length > 72) return 'Пароль не відповідає вимогам безпеки';
+  if (!passwordRegex.test(password)) return 'Пароль не відповідає вимогам безпеки';
+  return null;
+};
+
+const PASSWORD_HINT =
+  'Пароль має містити щонайменше 10 символів, включаючи велику літеру, цифру та спеціальний символ (наприклад, !@#$%). Максимальна довжина — 72 символи.';
+
+export default function ResetPasswordForm({ token: _token }: ResetPasswordFormProps) {
+  const router = useRouter();
+
+  const [password, setPassword] = useState('');
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [confirmPasswordError, setConfirmPasswordError] = useState<string | null>(null);
+
+  const [isSubmitted, setIsSubmitted] = useState(false);
+
+  const validate = () => {
+    setIsSubmitted(true);
+    const passError = validatePassword(password);
+    setPasswordError(passError);
+
+    let confirmError: string | null = null;
+    if (!confirmPassword.trim()) {
+      confirmError = 'Підтвердіть пароль';
+    } else if (password !== confirmPassword) {
+      confirmError = 'Паролі не збігаються';
+    }
+    setConfirmPasswordError(confirmError);
+
+    return !passError && !confirmError;
+  };
+
+  const handlePasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPassword(e.target.value);
+    if (passwordError) setPasswordError(null);
+  };
+
+  const handleConfirmPasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setConfirmPassword(e.target.value);
+    if (confirmPasswordError) setConfirmPasswordError(null);
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (validate()) {
+      try {
+        // todo backend
+        const responseDataSuccess = true;
+
+        if (responseDataSuccess) {
+          toast.success('Пароль успішно змінено. Увійдіть з новим паролем.');
+          router.push('/login');
+        }
+      } catch {
+        toast.error('Сталася помилка, спробуйте ще раз');
+      }
+    }
+  };
+
+  return (
+    <AuthCardLayout title="Зміна паролю" subtitle="Створіть новий пароль для захисту вашого акаунта">
+      <Box component="form" onSubmit={handleSubmit} sx={styles.form}>
+        <Box sx={styles.inputsWrapper}>
+          <PasswordField
+            label="Новий пароль *"
+            value={password}
+            placeholder="Введіть новий пароль"
+            onChange={handlePasswordChange}
+            error={isSubmitted && !!passwordError}
+            helperText={isSubmitted && passwordError ? renderHelperText(passwordError) : ''}
+            fullWidth
+            sx={placeholderStyle}
+            startAdornment={
+              <InputAdornment position="start">
+                <Lock size={20} strokeWidth={1.75} style={{ color: '#4E5061' }} />
+              </InputAdornment>
+            }
+          />
+          <Box sx={{ mt: -1, mb: 2 }}>
+            <Typography sx={{ fontSize: '12px', color: '#666' }}>{PASSWORD_HINT}</Typography>
+          </Box>
+
+          <PasswordField
+            label="Повторіть пароль *"
+            value={confirmPassword}
+            placeholder="Повторіть пароль"
+            onChange={handleConfirmPasswordChange}
+            error={isSubmitted && !!confirmPasswordError}
+            helperText={isSubmitted && confirmPasswordError ? renderHelperText(confirmPasswordError) : ''}
+            fullWidth
+            sx={placeholderStyle}
+            startAdornment={
+              <InputAdornment position="start">
+                <Lock size={20} strokeWidth={1.75} style={{ color: '#4E5061' }} />
+              </InputAdornment>
+            }
+          />
+        </Box>
+
+        <Button variant="contained" sx={styles.buttonSubmit} type="submit" fullWidth>
+          Змінити пароль
+        </Button>
+      </Box>
+    </AuthCardLayout>
+  );
+}

--- a/app/shared/components/reset-password-form/ResetPasswordForm.tsx
+++ b/app/shared/components/reset-password-form/ResetPasswordForm.tsx
@@ -29,7 +29,7 @@ const validatePassword = (password: string): string | null => {
 const PASSWORD_HINT =
   'Пароль має містити щонайменше 10 символів, включаючи велику літеру, цифру та спеціальний символ (наприклад, !@#$%). Максимальна довжина — 72 символи.';
 
-export default function ResetPasswordForm({ token: _token }: ResetPasswordFormProps) {
+export default function ResetPasswordForm({ token: _token }: Readonly<ResetPasswordFormProps>) {
   const router = useRouter();
 
   const [password, setPassword] = useState('');

--- a/app/shared/components/reset-password-form/ResetPasswordForm.tsx
+++ b/app/shared/components/reset-password-form/ResetPasswordForm.tsx
@@ -70,7 +70,6 @@ export default function ResetPasswordForm({ token: _token }: Readonly<ResetPassw
     e.preventDefault();
     if (validate()) {
       try {
-        // todo backend
         const responseDataSuccess = true;
 
         if (responseDataSuccess) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,13 +3,13 @@ import { NextResponse } from 'next/server';
 
 import { REFRESH_TOKEN_COOKIE_NAME } from './src/constants';
 
-const publicRoutes = ['/login', '/forgot-password', '/reset-password'];
+const publicRoutes = new Set(['/login', '/forgot-password', '/reset-password']);
 
 export function middleware(request: NextRequest) {
   const refreshToken = request.cookies.get(REFRESH_TOKEN_COOKIE_NAME);
   const { pathname } = request.nextUrl;
 
-  if (!refreshToken && !publicRoutes.includes(pathname)) {
+  if (!refreshToken && !publicRoutes.has(pathname)) {
     return NextResponse.redirect(new URL('/login', request.url));
   }
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,10 +3,13 @@ import { NextResponse } from 'next/server';
 
 import { REFRESH_TOKEN_COOKIE_NAME } from './src/constants';
 
+const publicRoutes = ['/login', '/forgot-password', '/reset-password'];
+
 export function middleware(request: NextRequest) {
   const refreshToken = request.cookies.get(REFRESH_TOKEN_COOKIE_NAME);
+  const { pathname } = request.nextUrl;
 
-  if (!refreshToken && request.nextUrl.pathname !== '/login') {
+  if (!refreshToken && !publicRoutes.includes(pathname)) {
     return NextResponse.redirect(new URL('/login', request.url));
   }
 

--- a/src/application/use-cases/loginAdmin/loginAdmin.ts
+++ b/src/application/use-cases/loginAdmin/loginAdmin.ts
@@ -1,6 +1,7 @@
 import bcrypt from 'bcrypt';
 
 import { LoginError } from '~/back-constants/apolloCustomErrors/adminErrors';
+import { errors } from '~/back-constants/errors';
 import { adminTypes } from '~/back-constants/index';
 import { AdminRepository } from '~/domain/repositories/adminRepository';
 import { zEmailSchema } from '~/validators/auth.schema';
@@ -11,10 +12,10 @@ export const loginAdmin = ({ adminRepository }: { adminRepository: AdminReposito
       const validatedEmail = zEmailSchema.parse(email);
 
       const admin = await adminRepository.findByEmail(validatedEmail);
-      if (!admin) throw new LoginError();
+      if (!admin) throw new LoginError(errors.WRONG_EMAIL);
 
       const valid = await bcrypt.compare(password, admin.password);
-      if (!valid) throw new LoginError();
+      if (!valid) throw new LoginError(errors.WRONG_PASSWORD);
 
       return {
         id: admin.id,

--- a/src/application/use-cases/loginAdmin/loginAdmin.ts
+++ b/src/application/use-cases/loginAdmin/loginAdmin.ts
@@ -15,7 +15,7 @@ export const loginAdmin = ({ adminRepository }: { adminRepository: AdminReposito
       if (!admin) throw new LoginError(errors.WRONG_EMAIL);
 
       const valid = await bcrypt.compare(password, admin.password);
-      if (!valid) throw new LoginError(errors.WRONG_PASSWORD);
+      if (!valid) throw new LoginError(errors.WRONG_PASS);
 
       return {
         id: admin.id,

--- a/src/constants/apolloCustomErrors/adminErrors.ts
+++ b/src/constants/apolloCustomErrors/adminErrors.ts
@@ -1,7 +1,7 @@
 import { AuthenticationError } from 'apollo-server-errors';
 
 export class LoginError extends AuthenticationError {
-  constructor() {
-    super('Неправильний логін або пароль');
+  constructor(message: string = 'Неправильний логін або пароль') {
+    super(message);
   }
 }

--- a/src/constants/errors.ts
+++ b/src/constants/errors.ts
@@ -14,7 +14,7 @@ export const errors = {
   INVALID_EMAIL_FORMAT: 'Invalid email format',
   EMAIL_TOO_LONG: 'Email must not exceed 254 characters',
   WRONG_EMAIL: 'WRONG_EMAIL',
-  WRONG_PASSWORD: 'WRONG_PASSWORD'
+  WRONG_PASS: 'WRONG_PASSWORD'
 };
 
 export const utilsErrors = {

--- a/src/constants/errors.ts
+++ b/src/constants/errors.ts
@@ -12,7 +12,9 @@ export const errors = {
   // Validation errors
   EMAIL_REQUIRED: 'Email is required',
   INVALID_EMAIL_FORMAT: 'Invalid email format',
-  EMAIL_TOO_LONG: 'Email must not exceed 254 characters'
+  EMAIL_TOO_LONG: 'Email must not exceed 254 characters',
+  WRONG_EMAIL: 'WRONG_EMAIL',
+  WRONG_PASSWORD: 'WRONG_PASSWORD'
 };
 
 export const utilsErrors = {


### PR DESCRIPTION
## Description

This PR implements the user interface and client-side logic for the Admin Panel authentication flow (Login, Forgot Password, and Reset Password pages).

## Type of change

- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Login Validation:
Navigate to /login.
Leave fields empty and submit to verify validation messages.
Enter invalid email/password formats to verify error handling.

2. Forgot Password Flow:
Click "Забули пароль?" to navigate to /forgot-password.
Submit a valid email address and verify the success toast and confirmation message.

3. Reset Password Flow:
Navigate to /reset-password?token=valid-token-123.
Enter passwords that do not match to verify validation.
Enter a password not meeting security requirements to verify validation.
Enter valid passwords matching the requirements to verify successful submission and redirection 
to /login.

## Video / Screenshots

https://github.com/user-attachments/assets/83acd5bd-d1aa-41b8-ab36-cfeef44279ac




Closes: https://github.com/Liatoshynsky-Foundation/lf-admin/issues/582
