### PR TITLE
fix(ui): isolate cover image crops per locale

### DIFF
--- a/app/(logged_in)/publications/[type]/create/CreatePublicationsView.tsx
+++ b/app/(logged_in)/publications/[type]/create/CreatePublicationsView.tsx
@@ -17,6 +17,7 @@ import {
   PAGE_TITLES,
   PUBLICATIONS_BASE_PATH
 } from '~/constants/publications';
+import { normalizeFetchedCrop } from '~/lib/utils/CropperHelper';
 import DividedHeader from '~/shared/components/divided-header/DividedHeader';
 import HeaderRightActions from '~/shared/components/divided-header/header-right-actions/HeaderRightActions';
 import SeoCollapsibleBlock from '~/shared/components/forms/seo-collapsible-block/SeoCollapsibleBlock';
@@ -160,7 +161,7 @@ export default function CreatePublicationsView({ data, mode = 'create' }: Readon
           showTicketUrl={publicationType === 'events'}
           extraFieldsBeforeKeywords={publicationType === 'media'}
           forceShowErrors={forceShowErrors}
-          crop={crop}
+          crop={normalizeFetchedCrop(crop) ?? undefined}
           onChangeCrop={setCrop}
           value={seoValue}
           onChange={setSeoValue}

--- a/app/constants/publications.ts
+++ b/app/constants/publications.ts
@@ -1,7 +1,7 @@
 import { CONTENT_VERSION, SerializedContent } from '~/shared/components/content-editor/types';
 import { SeoBlockValue } from '~/shared/components/forms/seo-metadata-form/seo-metadata-block/SeoMetadataBlock';
 import type { FilterOption } from '~/shared/components/selector/FilterSelect';
-import { CropRect } from '~/types/common';
+import { CropRect, LocalizedCropRect } from '~/types/common';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
 
 export const PUBLICATIONS_TYPES = ['events', 'news', 'media'] as const;
@@ -232,7 +232,7 @@ export interface FetchedPublicationData {
   coverImage?: {
     src?: string | null;
     alt?: { uk?: string | null; en?: string | null } | null;
-    crop?: CropRect | null;
+    crop?: CropRect | LocalizedCropRect | null;
   } | null;
   allowIndexation?: {
     uk?: boolean | null;

--- a/app/lib/utils/CropperHelper.ts
+++ b/app/lib/utils/CropperHelper.ts
@@ -1,6 +1,7 @@
 import { PixelCrop } from 'react-image-crop';
 
 import { cropperErrors } from '~/constants/errors';
+import { CropRect, LocalizedCropRect } from '~/types/common';
 import { Size } from '~/types/cropper';
 
 export default async function getCroppedImg(
@@ -67,3 +68,59 @@ function createImage(url: string): Promise<HTMLImageElement> {
     image.src = url;
   });
 }
+
+export const isCropRect = (crop: unknown): crop is CropRect => {
+  if (!crop || typeof crop !== 'object') return false;
+  const candidate = crop as Record<string, unknown>;
+  return (
+    typeof candidate.x === 'number' &&
+    typeof candidate.y === 'number' &&
+    typeof candidate.width === 'number' &&
+    typeof candidate.height === 'number'
+  );
+};
+
+export const isLocalizedCropRect = (crop: unknown): crop is LocalizedCropRect => {
+  if (!crop || typeof crop !== 'object') return false;
+  const value = crop as Record<string, unknown>;
+  return 'uk' in value || 'en' in value;
+};
+
+export const buildCoverImageCropPayload = (crop: unknown) => {
+  if (!crop) return {};
+
+  if (isLocalizedCropRect(crop)) {
+    const fallbackCrop = (crop as LocalizedCropRect).uk ?? (crop as LocalizedCropRect).en ?? null;
+    if (!fallbackCrop) return {};
+
+    return {
+      crop: fallbackCrop,
+      localizedCrop: crop
+    };
+  }
+
+  if (isCropRect(crop)) {
+    return { crop };
+  }
+
+  return {};
+};
+
+export const normalizeFetchedCrop = (crop: unknown): LocalizedCropRect | null => {
+  if (!crop) return null;
+
+  if (isLocalizedCropRect(crop)) {
+    const localized = crop as LocalizedCropRect;
+    return {
+      uk: localized.uk ?? null,
+      en: localized.en ?? null
+    };
+  }
+
+  if (isCropRect(crop)) {
+    const rect = crop as CropRect;
+    return { uk: rect, en: rect };
+  }
+
+  return null;
+};

--- a/app/lib/utils/CropperHelper.ts
+++ b/app/lib/utils/CropperHelper.ts
@@ -90,7 +90,7 @@ export const buildCoverImageCropPayload = (crop: unknown) => {
   if (!crop) return {};
 
   if (isLocalizedCropRect(crop)) {
-    const fallbackCrop = (crop as LocalizedCropRect).uk ?? (crop as LocalizedCropRect).en ?? null;
+    const fallbackCrop = crop.uk ?? crop.en ?? null;
     if (!fallbackCrop) return {};
 
     return {
@@ -110,7 +110,7 @@ export const normalizeFetchedCrop = (crop: unknown): LocalizedCropRect | null =>
   if (!crop) return null;
 
   if (isLocalizedCropRect(crop)) {
-    const localized = crop as LocalizedCropRect;
+    const localized = crop;
     return {
       uk: localized.uk ?? null,
       en: localized.en ?? null
@@ -118,7 +118,7 @@ export const normalizeFetchedCrop = (crop: unknown): LocalizedCropRect | null =>
   }
 
   if (isCropRect(crop)) {
-    const rect = crop as CropRect;
+    const rect = crop;
     return { uk: rect, en: rect };
   }
 

--- a/app/shared/components/design-system/photo-block/PhotoBlock.tsx
+++ b/app/shared/components/design-system/photo-block/PhotoBlock.tsx
@@ -29,6 +29,7 @@ interface ImagePreviewBlockProps extends StackProps {
   typographySpacing?: string;
   showAlternativeText?: boolean;
   disabled?: boolean;
+  locale?: 'uk' | 'en';
 }
 
 export const ImagePreviewBlock = ({
@@ -45,7 +46,8 @@ export const ImagePreviewBlock = ({
   showAlternativeText = false,
   altText,
   onChangeAltText,
-  disabled = false
+  disabled = false,
+  locale = 'uk'
 }: ImagePreviewBlockProps) => {
   const [previewImage, setPreviewImage] = useState<string>(imageUrl);
 
@@ -75,7 +77,7 @@ export const ImagePreviewBlock = ({
         id: 'current-image',
         fileName: finalFileName ?? fileName ?? 'image',
         src: previewImage,
-        locale: 'uk'
+        locale: locale
       },
       crop: savedCrop
     });

--- a/app/shared/components/forms/seo-metadata-form/SeoMetadataForm.tsx
+++ b/app/shared/components/forms/seo-metadata-form/SeoMetadataForm.tsx
@@ -167,6 +167,7 @@ export default function SeoMetadataForm({
             }
           })
         }
+        locale={locale}
       />
       <Typography variant="textMd" sx={styles.ogImageHint}>
         {'Оптимальний розмір: 1200×630 px.'}

--- a/app/shared/components/forms/seo-metadata-form/seo-metadata-block/SeoMetadataBlock.tsx
+++ b/app/shared/components/forms/seo-metadata-form/seo-metadata-block/SeoMetadataBlock.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from 'react';
 import type { LocalizedMeta } from '../SeoMetadataForm';
 import SeoMetadataForm from '../SeoMetadataForm';
 import { styles } from '../SeoMetadataForm.styles';
-import { CropRect } from '~/types/common';
+import {LocalizedCropRect } from '~/types/common';
 
 export interface SeoBlockValue {
   meta: { uk: LocalizedMeta; en: LocalizedMeta };
@@ -31,8 +31,8 @@ export interface SeoMetadataBlockProps {
   readonly extraFieldsBeforeKeywords?: boolean;
   readonly forceShowErrors?: boolean;
   readonly value?: SeoBlockValue;
-  readonly crop?: CropRect | null;
-  readonly onChangeCrop?: (newCrop: CropRect | null) => void;
+  readonly crop?: LocalizedCropRect | null;
+  readonly onChangeCrop?: (newCrop: LocalizedCropRect | null) => void;
   readonly onChange?: (value: SeoBlockValue) => void;
   readonly extraFields?: (
     locale: 'uk' | 'en',
@@ -137,8 +137,10 @@ export default function SeoMetadataBlock({
         showAlternativeText={showAlternativeText}
         extraFieldsBeforeKeywords={extraFieldsBeforeKeywords}
         forceShowErrors={forceShowErrors}
-        crop={crop}
-        onChangeCrop={onChangeCrop}
+        crop={crop?.uk ?? null}
+        onChangeCrop={(newUkCrop) => 
+          onChangeCrop?.({ uk: newUkCrop, en: crop?.en ?? null })
+        }
         extraFields={
           showTicketUrl || extraFields
             ? (localeMeta, onLocaleMeta) => buildExtraFields('uk', localeMeta, onLocaleMeta)
@@ -155,8 +157,10 @@ export default function SeoMetadataBlock({
         onIndexingChange={(val) => handleChange({ ...value, allowIndexing: { ...value.allowIndexing, en: val } })}
         showAlternativeText={showAlternativeText}
         extraFieldsBeforeKeywords={extraFieldsBeforeKeywords}
-        crop={crop}
-        onChangeCrop={onChangeCrop}
+        crop={crop?.en ?? null}
+        onChangeCrop={(newEnCrop) => 
+          onChangeCrop?.({ uk: crop?.uk ?? null, en: newEnCrop })
+        }
         extraFields={
           showTicketUrl || extraFields
             ? (localeMeta, onLocaleMeta) => buildExtraFields('en', localeMeta, onLocaleMeta)

--- a/app/shared/hooks/use-upsert-publication/useUpsertPublication.ts
+++ b/app/shared/hooks/use-upsert-publication/useUpsertPublication.ts
@@ -9,6 +9,7 @@ import {
   PUBLICATIONS_TYPES,
   PublicationsItemType
 } from '~/constants/publications';
+import { buildCoverImageCropPayload } from '~/lib/utils/CropperHelper';
 import type { SeoBlockValue } from '~/shared/components/forms/seo-metadata-form/seo-metadata-block/SeoMetadataBlock';
 import { useCreateEvent, useEventById, useUpdateEvent } from '~/shared/hooks/use-events/useEvents';
 import {
@@ -201,7 +202,7 @@ export const useUpsertPublication = ({ type, id }: UseUpsertPublicationProps) =>
         src: seoValue.ogImage || adminTitle,
         alt: { uk: ukMeta.altText?.uk || adminTitle, en: enMeta.altText?.en || adminTitle },
         caption: { uk: adminTitle, en: adminTitle },
-        ...(crop && { crop })
+        ...buildCoverImageCropPayload(crop)
       }
     };
 

--- a/app/types/common.ts
+++ b/app/types/common.ts
@@ -19,6 +19,11 @@ export interface CropRect {
   height: number;
 }
 
+export type LocalizedCropRect = {
+  uk: CropRect | null;
+  en: CropRect | null;
+};
+
 export interface CropResult {
   rect: CropRect;
 }

--- a/src/interfaces/graphql/resolvers/helpers.ts
+++ b/src/interfaces/graphql/resolvers/helpers.ts
@@ -147,8 +147,11 @@ export const syncImagesCrops = async (
       const locales: Array<'uk' | 'en'> = ['uk', 'en'];
 
       await Promise.all(
-        locales.map((l) =>
-          ImageCropModel.findOneAndUpdate(
+        locales.map(async (l) => {
+          const localeCrop = getCoverImageCropForLocale(image as unknown as Record<string, unknown>, l);
+          if (!localeCrop) return;
+  
+          await ImageCropModel.findOneAndUpdate(
             {
               pageId: contentId,
               cropId,
@@ -156,18 +159,49 @@ export const syncImagesCrops = async (
             },
             {
               $set: {
-                crop: image.crop,
+                crop: localeCrop,
                 pageId: contentId,
                 cropId,
                 locale: l
               }
             },
             { upsert: true, new: true }
-          )
-        )
+          );
+        })
       );
     }
   }
+
+};
+
+function isCropRect(value: unknown): value is NonNullable<LocalizedImage['crop']> {
+  if (!value || typeof value !== 'object') return false;
+
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.x === 'number' &&
+    typeof candidate.y === 'number' &&
+    typeof candidate.width === 'number' &&
+    typeof candidate.height === 'number'
+  );
+}
+
+function getCoverImageCropForLocale(
+  image: Record<string, unknown>,
+  locale: 'uk' | 'en'
+): NonNullable<LocalizedImage['crop']> | null {
+  const localizedCrop = image.localizedCrop;
+  if (localizedCrop && typeof localizedCrop === 'object') {
+    const localized = localizedCrop as Partial<Record<'uk' | 'en', unknown>>;
+    if (isCropRect(localized[locale])) return localized[locale];
+  }
+
+  const crop = image.crop;
+  if (isCropRect(crop)) return crop;
+  if (!crop || typeof crop !== 'object') return null;
+
+  const localizedCropFromField = crop as Partial<Record<'uk' | 'en', unknown>>;
+  return isCropRect(localizedCropFromField[locale]) ? localizedCropFromField[locale] : null;
 };
 
 function normalizeCropId(src: string): string {

--- a/src/interfaces/graphql/resolvers/helpers.ts
+++ b/src/interfaces/graphql/resolvers/helpers.ts
@@ -148,7 +148,7 @@ export const syncImagesCrops = async (
 
       await Promise.all(
         locales.map(async (l) => {
-          const localeCrop = getCoverImageCropForLocale(image as unknown as Record<string, unknown>, l);
+          const localeCrop = getCoverImageCropForLocale(image, l);
           if (!localeCrop) return;
   
           await ImageCropModel.findOneAndUpdate(


### PR DESCRIPTION
## Description

<!-- Briefly describe the purpose of this PR and what was changed -->

## Type of change

- [x] Bug fix

## How to test

Open a publication creation/edit page.

Upload a cover image and set a specific crop in the EN locale.

Switch to the UA locale and verify that the crop frame is reset to default (not copied from EN).

Save the publication to check that both distinct crops persist.

## Video / Screenshots
Was:

https://github.com/user-attachments/assets/daf1c11c-1456-4a4f-8f1c-7e4fb21f91bc

Now:

https://github.com/user-attachments/assets/1c89ad22-fdd6-4d40-8a45-d9602a146b38


## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [x] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
