### PR TITLE
fix: display original filename instead of generated hash

### DIFF
--- a/app/(logged_in)/files/FilesPageContent.tsx
+++ b/app/(logged_in)/files/FilesPageContent.tsx
@@ -214,7 +214,8 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
     const createResult = await createAsset({
       variables: {
         input: {
-          filename: originalName || filename,
+          filename: filename,
+          originalname: originalName,
           url: url,
           mimeType: mimeType,
           sizeBytes: size,
@@ -234,7 +235,7 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
     return (data?.allAssets ?? []).map((asset) => ({
       id: asset.id,
       type: assetCardTypeMap[asset.type],
-      name: asset.filename,
+      name: asset.originalname || asset.filename,
       dateAdded: formatDateAdded(asset.createdAt),
       createdAtRaw: asset.createdAt,
       isStarred: asset.isStarred,

--- a/app/shared/components/media-modal/views/gallery-view/GalleryView.tsx
+++ b/app/shared/components/media-modal/views/gallery-view/GalleryView.tsx
@@ -25,6 +25,7 @@ type Props = Readonly<{
 type GalleryItem = {
   id: string;
   filename: string;
+  originalname?: string;
   url: string;
   isStarred: boolean;
   tags: string[];
@@ -81,6 +82,7 @@ export function GalleryView({ selected: _selected, onPick, filters, onFiltersCha
   type AssetMeta = {
     id: string;
     filename: string;
+    originalname?: string;
     isStarred: boolean;
     tags: string[];
     usageRefs: { pageId?: string | null; blockId?: string | null }[];
@@ -102,6 +104,7 @@ export function GalleryView({ selected: _selected, onPick, filters, onFiltersCha
         return {
           id: asset?.id ?? file.path ?? file.filename,
           filename: asset?.filename ?? file.filename,
+          originalname: asset?.originalname ?? undefined,
           url: file.url,
           isStarred: asset?.isStarred ?? false,
           tags: asset?.tags ?? [],
@@ -176,7 +179,7 @@ export function GalleryView({ selected: _selected, onPick, filters, onFiltersCha
           renderCard={(item) => (
             <GalleryCard
               src={item.url}
-              fileName={item.filename}
+              fileName={item.originalname || item.filename}
               isStarred={item.isStarred}
               usageLocations={getPageNames(item.usageRefs)}
               onClick={() => handleCardClick(item)}

--- a/app/types/graphql/mutations/assets.graphql
+++ b/app/types/graphql/mutations/assets.graphql
@@ -12,6 +12,7 @@ mutation CreateAsset($input: CreateAssetInput!) {
   createAsset(input: $input) {
     id
     filename
+    originalname
     url
     mimeType
     type

--- a/app/types/graphql/queries/assets.graphql
+++ b/app/types/graphql/queries/assets.graphql
@@ -9,6 +9,7 @@ query AllAssets($filters: AssetsFiltersInput) {
       locale
     }
     filename
+    originalname
     mimeType
     sizeBytes
     url

--- a/src/infrastructure/models/asset.model.ts
+++ b/src/infrastructure/models/asset.model.ts
@@ -25,6 +25,7 @@ const assetSchema = new Schema(
     usageRefs: { type: [usageRefSchema], default: [] },
 
     filename: { type: String, required: true, trim: true },
+    originalname: { type: String, required: false, trim: true },
 
     mimeType: { type: String, required: true, trim: true },
     sizeBytes: { type: Number, required: true, min: 0 },

--- a/src/infrastructure/repositories/assetRepository/assetRepository.ts
+++ b/src/infrastructure/repositories/assetRepository/assetRepository.ts
@@ -20,6 +20,7 @@ export type AssetEntity = {
   tags: string[];
   usageRefs: AssetUsageRef[];
   filename: string;
+  originalname?: string;
   mimeType: string;
   sizeBytes: number;
   url: string;
@@ -48,6 +49,7 @@ type DbAsset = {
   tags: string[];
   usageRefs: AssetUsageRef[];
   filename: string;
+  originalname?: string;
   mimeType: string;
   sizeBytes: number;
   url: string;
@@ -78,6 +80,7 @@ const toEntity = (doc: DbAsset): AssetEntity => ({
   tags: doc.tags,
   usageRefs: doc.usageRefs,
   filename: doc.filename,
+  originalname: doc.originalname,
   mimeType: doc.mimeType,
   sizeBytes: doc.sizeBytes,
   url: doc.url,
@@ -133,6 +136,7 @@ export type UpdateAssetData = Partial<Pick<AssetEntity, 'isStarred' | 'filename'
 
 export type CreateAssetData = {
   filename: string;
+  originalname?: string;
   mimeType: string;
   sizeBytes: number;
   url: string;

--- a/src/interfaces/graphql/resolvers/assets/Query.ts
+++ b/src/interfaces/graphql/resolvers/assets/Query.ts
@@ -26,6 +26,7 @@ export interface UpdateAssetArgs {
 export interface CreateAssetArgs {
   input: {
     filename: string;
+    originalname?: string;
     mimeType: string;
     sizeBytes: number;
     url: string;

--- a/src/interfaces/graphql/schemas/assets.graphql
+++ b/src/interfaces/graphql/schemas/assets.graphql
@@ -26,6 +26,7 @@ type Asset {
   tags: [String!]!
   usageRefs: [AssetUsageRef!]!
   filename: String!
+  originalname: String
   mimeType: String!
   sizeBytes: Int!
   url: String!
@@ -60,6 +61,7 @@ input UpdateAssetInput {
 
 input CreateAssetInput {
   filename: String!
+  originalname: String
   mimeType: String!
   sizeBytes: Int!
   url: String!


### PR DESCRIPTION
## Description

Fixes a bug where uploaded files were displayed with system-generated hash names (e.g. 1780674402207-3dd82c.png) instead of their original filenames (e.g. test.png). The originalname was already being preserved in Cloudflare R2 Custom Metadata but was never saved as a distinct field in MongoDB or displayed in the UI.
Added originalname as a distinct field in the MongoDB assets collection. Updated the Gallery Modal and Files management page to display originalname when available, falling back to filename for older assets. Storage behavior (hashed filenames/URLs) remains unchanged.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Run the app 
2. Go to Файли (Files) in the sidebar
3. Upload a new image (e.g. test.png)
4. Verify the file card displays test.png not a hash
5. Go to Основні сторінки → Про нас, expand any section
6. Click Змінити зображення to open the Gallery modal
7. Open the Галерея tab
8. Verify the newly uploaded image shows test.png as its title instead of a hash
9. Verify old files without originalname still display without errors
10. Check MongoDB — new asset document should have both filename (hash) and originalname (original name) as separate fields

## Video / Screenshots

<img width="1891" height="927" alt="image" src="https://github.com/user-attachments/assets/07d84c34-7386-445e-84c3-3df7cd06fe6c" />

<img width="1893" height="919" alt="image" src="https://github.com/user-attachments/assets/8cf4e438-e3a9-47ed-962d-d99110466959" />

<img width="1060" height="342" alt="image" src="https://github.com/user-attachments/assets/4cb4cf11-ad54-45cc-af8c-3b2518a31831" />


## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---

Close #588 