### PR TITLE
fix: toaster width flexible up to maximum limit

### DIFF
--- a/app/shared/components/toaster/Toaster.styles.ts
+++ b/app/shared/components/toaster/Toaster.styles.ts
@@ -14,7 +14,9 @@ export const slideOut = keyframes`
 
 export const styles = {
   toastContainer: {
-    width: '375px',
+    minWidth: '375px',
+    maxWidth: '500px',
+    width: 'fit-content',
     minHeight: '56px',
     padding: '12px 16px',
     borderRadius: '12px',


### PR DESCRIPTION
## Description

The custom Toaster component had a hardcoded `width: '375px'`, causing text to wrap to a second line prematurely. Replaced with `minWidth: '375px'`, `maxWidth: '500px'`, and `width: 'fit-content'` so the toast expands horizontally for longer messages before wrapping.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Go to admin panel → Новини та події
2. Open any draft article
3. Click "Опублікувати"
4. Observe the toast in the bottom right corner — text should display on a single line

## Video / Screenshots

<img width="537" height="199" alt="image" src="https://github.com/user-attachments/assets/1008d684-5623-478d-b4e6-12a92781c7b8" />

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---

Close #590 