### PR TITLE
fix(ui): input loses cursor position

### DIFF
--- a/app/shared/components/custom-formatting-field/CustomFormattingField.test.tsx
+++ b/app/shared/components/custom-formatting-field/CustomFormattingField.test.tsx
@@ -110,7 +110,7 @@ describe('CustomFormattingField', () => {
   });
 
   describe('3. Value Synchronization', () => {
-    it('should call onChange with updated JSON when the editor content changes', () => {
+    it('should call onChange once with updated JSON when the editor content changes', () => {
       const updatedJSON: JSONContent = { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Hello' }] }] };
       mockGetJSON.mockReturnValue(updatedJSON);
 
@@ -119,17 +119,26 @@ describe('CustomFormattingField', () => {
 
       fireEvent.input(editorContent);
 
-      expect(mockGetJSON).toHaveBeenCalledTimes(1);
       expect(mockOnChange).toHaveBeenCalledTimes(1);
       expect(mockOnChange).toHaveBeenCalledWith(updatedJSON);
     });
 
-    it('should call editor.commands.setContent when the external value prop changes', () => {
+    it('should call editor.getJSON twice when the editor content changes', () => {
+      const updatedJSON: JSONContent = { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Hello' }] }] };
+      mockGetJSON.mockReturnValue(updatedJSON);
+
+      render(<CustomFormattingField value={defaultJSON} onChange={mockOnChange} />);
+      const editorContent = screen.getByTestId('editor-content');
+
+      fireEvent.input(editorContent);
+
+      expect(mockGetJSON).toHaveBeenCalledTimes(2);
+    });
+
+    it('should call editor.commands.setContent ONLY when the external value prop changes', () => {
       const { rerender } = render(<CustomFormattingField value={defaultJSON} onChange={mockOnChange} />);
-
-      expect(mockSetContent).toHaveBeenCalledWith(defaultJSON, { emitUpdate: false });
-      mockSetContent.mockClear();
-
+      
+      expect(mockSetContent).not.toHaveBeenCalled();
       const newJSON: JSONContent = { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'New content from parent' }] }] };
       rerender(<CustomFormattingField value={newJSON} onChange={mockOnChange} />);
 

--- a/app/shared/components/custom-formatting-field/CustomFormattingField.tsx
+++ b/app/shared/components/custom-formatting-field/CustomFormattingField.tsx
@@ -53,9 +53,13 @@ export const CustomFormattingField = ({ value, onChange, label = 'Текст', s
   });
 
   useEffect(() => {
-    if (editor && value) {
-      editor.commands.setContent(value, { emitUpdate: false });
-    }
+    if (!editor || !value) return;
+    const currentContent = editor.getJSON();
+    const newContent = value;
+
+    const isNotEqual = JSON.stringify(currentContent) !== JSON.stringify(newContent);
+    
+    if (isNotEqual)  editor.commands.setContent(value, { emitUpdate: false });
   }, [value, editor]);
 
   const isActive = Boolean(isFocused || (editor && !editor.isEmpty));


### PR DESCRIPTION
## Description

In these changes, I have fixed the incorrect behavior of inputs on the /about-us page. 
This bug was caused by the component being constantly updated due to a new value in its state. 

- When a user types smth in a field that uses the editor from the @tip-tap/react library, the useEffect was triggered, and each update fully updated the editor's state, which caused a re-render of the parent component (input) that uses this hook. 
- After the component was updated, the input lost focus, causing all characters after the first to be appended to the end of the input.

I have fixed this by modifying the useEffect in the CustomFormattingField.tsx file, adding the correct checks to avoid unnecessary state updates.

Closes #603 


## Type of change

- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Login into admin 
2. Go to the /about-us page
3. Expand a block to edit
4. Click on an input text field
5. Try to type multiple characters inside existing text and at the end of it
6. Ensure that all characters are in their correct position
7. Save your changes 
8. Ensure that all changes are applied correctly.

**NOTE**: Please, don't forget to remove your changes to avoid incorrect data being on the client page. 

## Video / Screenshots

https://github.com/user-attachments/assets/8d87f461-5982-44d3-b35b-6e1a94cb13a2



## Checklist

- [x] Code compiles and runs correctly
- [X] Tests pass successfully
- [X] Linting checks are clean
- [X] No Sonar issues
- [X] Branch is up to date with the target branch
- [X] Linked issue/task included
- [ ] Task moved to the review column on the board
- [X] All typed characters are inserted at the cursor position, exactly as a native browser input would behave.
- [X] All changes are correctly saved into a database
- [X] All changes are visible both in inputs on an edit page and on the client page.



---
