### PR TITLE
feature: Implement dynamic overflow tracking in TitleWithTooltip and integrate into FileCard

### DIFF
--- a/app/shared/components/card-layout/TitleWithTooltip.style.ts
+++ b/app/shared/components/card-layout/TitleWithTooltip.style.ts
@@ -10,6 +10,7 @@ const styles = {
     WebkitLineClamp: lineClamp,
     WebkitBoxOrient: 'vertical',
     overflow: 'hidden',
+    wordBreak: 'break-word'
   }),
 };
 

--- a/app/shared/components/card-layout/TitleWithTooltip.test.tsx
+++ b/app/shared/components/card-layout/TitleWithTooltip.test.tsx
@@ -2,6 +2,12 @@ import { render, screen, waitFor } from '@testing-library/react';
 
 import TitleWithTooltip from './TitleWithTooltip';
 
+globalThis.ResizeObserver = jest.fn().mockImplementation((callback) => ({
+  observe: jest.fn(() => callback()),
+  unobserve: jest.fn(),
+  disconnect: jest.fn()
+}));
+
 jest.mock('~/ds-components/tooltip/Tooltip', () => {
   return function MockTooltip({ title, children }: any) {
     return (

--- a/app/shared/components/card-layout/TitleWithTooltip.tsx
+++ b/app/shared/components/card-layout/TitleWithTooltip.tsx
@@ -29,7 +29,7 @@ const TitleWithTooltip = ({ text, lineClamp, fontWeight }: TitleWithTooltipProps
     checkOverflow();
 
     return () => resizeObserver.disconnect();
-  }, []);
+  }, [text]);
 
   return (
     <TooltipCustom title={isTitleTruncated ? text : ''}>

--- a/app/shared/components/card-layout/TitleWithTooltip.tsx
+++ b/app/shared/components/card-layout/TitleWithTooltip.tsx
@@ -19,8 +19,17 @@ const TitleWithTooltip = ({ text, lineClamp, fontWeight }: TitleWithTooltipProps
     const element = titleRef.current;
     if (!element) return;
 
-    setIsTitleTruncated(element.scrollHeight > element.clientHeight);
-  }, [text]);
+    const checkOverflow = () => {
+      const hasOverflow = element.scrollHeight > element.clientHeight;
+      setIsTitleTruncated((prev) => (prev === hasOverflow ? prev : hasOverflow));
+    };
+
+    const resizeObserver = new ResizeObserver(checkOverflow);
+    resizeObserver.observe(element);
+    checkOverflow();
+
+    return () => resizeObserver.disconnect();
+  }, []);
 
   return (
     <TooltipCustom title={isTitleTruncated ? text : ''}>

--- a/app/shared/components/content-card/ContentCard.test.tsx
+++ b/app/shared/components/content-card/ContentCard.test.tsx
@@ -92,6 +92,12 @@ jest.mock('../delete-card-modal/DeleteCardModal', () => ({
     ) : null
 }));
 
+globalThis.ResizeObserver = jest.fn().mockImplementation((callback) => ({
+  observe: jest.fn(() => callback()),
+  unobserve: jest.fn(),
+  disconnect: jest.fn()
+}));
+
 describe('ContentCard', () => {
   const defaultProps = {
     id: '1',

--- a/app/shared/components/file-card/FileCard.styles.ts
+++ b/app/shared/components/file-card/FileCard.styles.ts
@@ -9,14 +9,6 @@ export const styles: Record<string, SxProps<Theme>> = {
     backgroundColor: 'adminBlue.100'
   },
 
-  fileTitle: {
-    color: 'text.primary',
-    display: '-webkit-box',
-    WebkitLineClamp: 1,
-    WebkitBoxOrient: 'vertical',
-    wordBreak: 'break-all',
-  },
-
   fileDate: {
     fontSize: '16px',
     fontStyle: 'italic',

--- a/app/shared/components/file-card/FileCard.test.tsx
+++ b/app/shared/components/file-card/FileCard.test.tsx
@@ -7,6 +7,12 @@ jest.mock('~/types/graphql/generated/graphql', () => ({
   useUpdateAssetMutation: () => [jest.fn(), { loading: false }]
 }));
 
+globalThis.ResizeObserver = jest.fn().mockImplementation((callback) => ({
+  observe: jest.fn(() => callback()),
+  unobserve: jest.fn(),
+  disconnect: jest.fn()
+}));
+
 describe('FileCard', () => {
   const mockOnClick = jest.fn();
 

--- a/app/shared/components/file-card/FileCard.tsx
+++ b/app/shared/components/file-card/FileCard.tsx
@@ -6,6 +6,7 @@ import { MouseEvent, useState } from 'react';
 import toast from 'react-hot-toast';
 
 import CardLayout from '../card-layout/CardLayout';
+import TitleWithTooltip from '../card-layout/TitleWithTooltip';
 import { styles } from './FileCard.styles';
 import FileCardMenuItems from './FileCardMenuItems';
 import TooltipCustom from '~/ds-components/tooltip/Tooltip';
@@ -94,9 +95,8 @@ const FileCard = ({ fileType, fileData, onClick, onAction }: FileCardProps) => {
         alt={`${fileType} icon`}
         style={{ width: ICON_SIZE, height: ICON_SIZE, flexShrink: 0 }}
       />
-      <Typography variant="subtitle1" sx={styles.fileTitle}>
-        {name}
-      </Typography>
+
+      <TitleWithTooltip text={name} fontWeight={500} lineClamp={1} />
     </Stack>
   );
 

--- a/app/shared/components/page-card/PageCard.test.tsx
+++ b/app/shared/components/page-card/PageCard.test.tsx
@@ -16,6 +16,12 @@ jest.mock('~/shared/components/card-layout/CardMenu', () => {
   };
 });
 
+globalThis.ResizeObserver = jest.fn().mockImplementation((callback) => ({
+  observe: jest.fn(() => callback()),
+  unobserve: jest.fn(),
+  disconnect: jest.fn()
+}));
+
 describe('PageCard Component', () => {
   const mockProps = {
     coverImage: {


### PR DESCRIPTION
## Description

Implemented text truncation tooltips for the `FileCard` component on the `/files` page. 

Additionally, the underlying tooltip was updated to dynamically adapt when layout containers deform. This ensures that the tooltip will not continue showing once the file details panel is closed and the full title text is revealed..

**What was changed:**
* Integrated the existing `TitleWithTooltip` component into `FileCard` to match the behavior seen in `PageCard` and `ContentCard`. 
* Added a debounced `ResizeObserver` layout-check mechanism within `TitleWithTooltip` to accurately track text overflow conditions when the file details panel or workspace shifts size. * Updated `TitleWithTooltip` typography configurations to use `word-break: 'break-word'`, keeping long strings inside `FileCard` safely bounded. 
* Updated and fixed breaking unit tests. 

## Type of change

- [x] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Log in to the application environment. 
2. Navigate to the `/files` page. 
3. Verify that long file titles are cleanly truncated. 
4. Open and close the file details sidebar panel to verify the tooltip accurately displays. 

## Video / Screenshots

***Tooltip before:***

https://github.com/user-attachments/assets/5e42bcf1-41d0-403c-851c-7fba7bdd93e1

***Results:***

https://github.com/user-attachments/assets/7b5bc6a2-edb4-4e72-bedb-bbfd15c470c7

https://github.com/user-attachments/assets/9f1917d2-f64b-4bbf-98db-81b2cbad8a73

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---

Closes #612 