### PR TITLE
feat(migration): normalize mongodb image references for cloudflare r2

### DIFF
--- a/migrations/1781699582000-migrate-page-image-paths-to-r2.ts
+++ b/migrations/1781699582000-migrate-page-image-paths-to-r2.ts
@@ -1,6 +1,6 @@
-import fs from 'fs';
 import type { Db, ObjectId } from 'mongodb';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 const TARGET_COLLECTION = 'pages';
 const TARGET_SLUGS = ['biography', 'cooperation'];

--- a/migrations/1781699582000-migrate-page-image-paths-to-r2.ts
+++ b/migrations/1781699582000-migrate-page-image-paths-to-r2.ts
@@ -1,0 +1,123 @@
+import fs from 'fs';
+import type { Db, ObjectId } from 'mongodb';
+import path from 'path';
+
+const TARGET_COLLECTION = 'pages';
+const TARGET_SLUGS = ['biography', 'cooperation'];
+
+const MIGRATION_MAP_PATH = path.resolve(
+  process.cwd(),
+  'migrations/data/page-image-paths-to-r2.json'
+);
+
+interface MigrationMapItem {
+  old: string;
+  new: string;
+}
+
+interface MongoDocument {
+  _id: ObjectId;
+  slug?: string;
+  [key: string]: unknown;
+}
+
+function readMigrationMap(): MigrationMapItem[] {
+  return JSON.parse(fs.readFileSync(MIGRATION_MAP_PATH, 'utf8'));
+}
+
+function createReplacementMap(
+  migrationMap: MigrationMapItem[],
+  direction: 'up' | 'down'
+): Map<string, string> {
+  return new Map(
+    migrationMap.map(({ old, new: newValue }) =>
+      direction === 'up' ? [old, newValue] : [newValue, old]
+    )
+  );
+}
+
+function collectUpdates(
+  value: unknown,
+  replacements: Map<string, string>,
+  currentPath = ''
+): Record<string, string> {
+  const updates: Record<string, string> = {};
+
+  if (typeof value === 'string') {
+    const replacement = replacements.get(value);
+
+    if (replacement && replacement !== value) {
+      updates[currentPath] = replacement;
+    }
+
+    return updates;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => {
+      const nextPath = currentPath ? `${currentPath}.${index}` : `${index}`;
+
+      Object.assign(updates, collectUpdates(item, replacements, nextPath));
+    });
+
+    return updates;
+  }
+
+  if (value && typeof value === 'object') {
+    Object.entries(value).forEach(([key, item]) => {
+      if (key === '_id') return;
+
+      const nextPath = currentPath ? `${currentPath}.${key}` : key;
+
+      Object.assign(updates, collectUpdates(item, replacements, nextPath));
+    });
+  }
+
+  return updates;
+}
+
+async function replaceImagePaths(
+  db: Db,
+  direction: 'up' | 'down'
+): Promise<void> {
+  const migrationMap = readMigrationMap();
+  const replacements = createReplacementMap(migrationMap, direction);
+  const collection = db.collection<MongoDocument>(TARGET_COLLECTION);
+
+  const cursor = collection.find({
+    slug: { $in: TARGET_SLUGS }
+  });
+
+  const operations = [];
+
+  for await (const document of cursor) {
+    const $set = collectUpdates(document, replacements);
+
+    if (Object.keys($set).length === 0) {
+      continue;
+    }
+
+    operations.push({
+      updateOne: {
+        filter: { _id: document._id },
+        update: { $set }
+      }
+    });
+  }
+
+  if (operations.length === 0) {
+    return;
+  }
+
+  await collection.bulkWrite(operations, {
+    ordered: false
+  });
+}
+
+export async function up(db: Db): Promise<void> {
+  await replaceImagePaths(db, 'up');
+}
+
+export async function down(db: Db): Promise<void> {
+  await replaceImagePaths(db, 'down');
+}

--- a/migrations/data/page-image-paths-to-r2.json
+++ b/migrations/data/page-image-paths-to-r2.json
@@ -1,0 +1,66 @@
+[
+  {
+    "old": "/images/boris-tsarevich-1914.png",
+    "new": "https://pub-2b50c59c64954ab89b7837f9f4607e12.r2.dev/photos/biography-boris-tsarevich-1914.png"
+  },
+  {
+    "old": "/images/liatoshynsky-1910.png",
+    "new": "https://pub-2b50c59c64954ab89b7837f9f4607e12.r2.dev/photos/biography-liatoshynsky-1910.png"
+  },
+  {
+    "old": "/images/liatoshynsky-1920.png",
+    "new": "https://pub-2b50c59c64954ab89b7837f9f4607e12.r2.dev/photos/biography-liatoshynsky-1920.png"
+  },
+  {
+    "old": "/images/liatoshynsky-1930.png",
+    "new": "https://pub-2b50c59c64954ab89b7837f9f4607e12.r2.dev/photos/biography-liatoshynsky-1930.png"
+  },
+  {
+    "old": "/images/liatoshynsky-1940.png",
+    "new": "https://pub-2b50c59c64954ab89b7837f9f4607e12.r2.dev/photos/biography-liatoshynsky-1940.png"
+  },
+  {
+    "old": "/images/liatoshynsky-1950.png",
+    "new": "https://pub-2b50c59c64954ab89b7837f9f4607e12.r2.dev/photos/biography-liatoshynsky-1950.png"
+  },
+  {
+    "old": "/images/liatoshynsky-application.png",
+    "new": "https://pub-2b50c59c64954ab89b7837f9f4607e12.r2.dev/photos/biography-liatoshynsky-application.png"
+  },
+  {
+    "old": "/images/liatoshynsky-hero-section.png",
+    "new": "https://pub-2b50c59c64954ab89b7837f9f4607e12.r2.dev/photos/biography-liatoshynsky-hero-section.png"
+  },
+  {
+    "old": "/images/liatoshynsky-home-office.png",
+    "new": "https://pub-2b50c59c64954ab89b7837f9f4607e12.r2.dev/photos/biography-liatoshynsky-home-office.png"
+  },
+  {
+    "old": "/images/liatoshynsky-kiev-obs.png",
+    "new": "https://pub-2b50c59c64954ab89b7837f9f4607e12.r2.dev/photos/biography-liatoshynsky-kiev-obs.png"
+  },
+  {
+    "old": "/images/liatoshynsky-praga-1950.png",
+    "new": "https://pub-2b50c59c64954ab89b7837f9f4607e12.r2.dev/photos/biography-liatoshynsky-praga-1950.png"
+  },
+  {
+    "old": "/images/liatoshynsky-with-igor-bels.png",
+    "new": "https://pub-2b50c59c64954ab89b7837f9f4607e12.r2.dev/photos/biography-liatoshynsky-with-igor-bels.png"
+  },
+  {
+    "old": "/images/liatoshynsky-worsel-1967.png",
+    "new": "https://pub-2b50c59c64954ab89b7837f9f4607e12.r2.dev/photos/biography-liatoshynsky-worsel-1967.png"
+  },
+  {
+    "old": "/images/tetiana-gomon.png",
+    "new": "https://pub-2b50c59c64954ab89b7837f9f4607e12.r2.dev/photos/biography-tetiana-gomon.png"
+  },
+  {
+    "old": "/images/partnership-formats-photo-small.png",
+    "new": "https://pub-2b50c59c64954ab89b7837f9f4607e12.r2.dev/photos/cooperation-partnership-formats-photo-small.png"
+  },
+  {
+    "old": "/images/partnership-formats-photo-large.png",
+    "new": "https://pub-2b50c59c64954ab89b7837f9f4607e12.r2.dev/photos/cooperation-partnership-formats-photo-large.png"
+  }
+]


### PR DESCRIPTION
## Description

Added a MongoDB migration to normalize image references for Cloudflare R2.
The migration updates legacy local image paths in the published `pages` collection for:
- `biography`
- `cooperation`
It replaces `/images/...` references with corresponding Cloudflare R2 URLs using a centralized migration map age-image-paths-to-r2.json.

closes #610 

## Type of change

- [x] New feature
- [x] Bug fix
- [ ] Documentation update
- [x] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## Important notes

- This migration changes MongoDB data only when `npm run migrate:up` is executed against a database.
- The migration was tested on a local MongoDB database restored from a backup.
- Local image assets stored in `lf-client/public/images` are intentionally not removed in this task and should be cleaned up in a separate follow-up task after all references have been verified.

## Environment configuration

For local migration testing, MongoDB should point to a local restored database:

```env
MONGO_HOST=localhost
MONGO_PORT=27017
MONGO_DB=lf-dev
MONGO_URL=mongodb://localhost:27017/lf-dev
```

## How to test

### Prepare a local database

1. Create a fresh MongoDB dump from the target database.

```bash
mongodump --uri="your_online_connection_string" --out="./mongo-backup"
```
3. Restore the dump locally:

```bash
mongorestore --uri="mongodb://localhost:27017" ./mongo-backup-test
```

4. Verify that `.env.local` points to the local database.

### Verify initial state

5. Open MongoDB Compass and inspect:

- pages → biography
- pages → cooperation

Expected values before migration:

```text
/images/liatoshynsky-hero-section.png
/images/partnership-formats-photo-small.png
/images/partnership-formats-photo-large.png
```

### Run migration

6. Execute:

```bash
npm run migrate:up
```

7. Refresh MongoDB Compass and verify that image references were replaced with Cloudflare R2 URLs.

### Verify rollback

8. Execute:

```bash
npm run migrate:down -- migrate-page-image-paths-to-r2 --single
```

9. Refresh MongoDB Compass and verify that image references were reverted back to `/images/...`.

### Verify migration again

10. Execute:

```bash
npm run migrate:up
```

11. Refresh MongoDB Compass and verify that Cloudflare R2 URLs were restored.

### Client verification

12. Run the client application.

13. Verify that the following pages render images correctly:

- Biography page
- Cooperation page

14. Confirm that:

- images are loaded from Cloudflare R2 URLs;
- no broken images are displayed;
- content is rendered correctly after migration.

## Migration coverage

The migration updates 16 image references.

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
