### PR TITLE
fix: return to previous publication category on back navigation

### DIFF
--- a/app/(logged_in)/publications/[type]/[id]/edit/page.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/edit/page.tsx
@@ -37,7 +37,7 @@ export default function EditPublicationsPage() {
   const latestBlocksRef = useRef<SerializedContent | null>(null);
   const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
 
-  const { navigate } = useNavigationGuard();
+  const { navigate, navigateBack } = useNavigationGuard();
 
   useEffect(() => {
     return () => {
@@ -124,7 +124,7 @@ export default function EditPublicationsPage() {
           onAction={handleMenuAction}
           onDeleteConfirm={() => handleMenuAction(MenuActionId.DELETE)}
           onSeoClick={() => navigate(`${PUBLICATIONS_BASE_PATH}/${type}/${id}/seo`)}
-          onBackClick={() => navigate(PUBLICATIONS_BASE_PATH)}
+          onBackClick={navigateBack}
         />
       )}
     </>

--- a/app/(logged_in)/publications/[type]/create/CreatePublicationsView.tsx
+++ b/app/(logged_in)/publications/[type]/create/CreatePublicationsView.tsx
@@ -60,7 +60,7 @@ export default function CreatePublicationsView({
 
   useUnsavedChanges(data.hasUnsavedChanges);
 
-  const { navigate } = useNavigationGuard();
+  const { navigateBack } = useNavigationGuard();
 
   const [anchor, setAnchor] = useState<HTMLButtonElement | null>(null);
   const isOpen = Boolean(anchor);
@@ -151,7 +151,7 @@ export default function CreatePublicationsView({
       {mode !== 'seo' && (
         <DividedHeader
           originUrl={PUBLICATIONS_BASE_PATH}
-          onBackClick={() => navigate(PUBLICATIONS_BASE_PATH)}
+          onBackClick={navigateBack}
           rightActionsComponent={
             publicationType === 'media' ? (
               <HeaderRightActions

--- a/app/constants/navigation.ts
+++ b/app/constants/navigation.ts
@@ -1,0 +1,1 @@
+export const BACK_NAVIGATION = '__NAVIGATION_BACK__';

--- a/app/shared/hooks/use-navigation-guard/useNavigationGuard.test.ts
+++ b/app/shared/hooks/use-navigation-guard/useNavigationGuard.test.ts
@@ -4,6 +4,7 @@ import { usePathname, useRouter } from 'next/navigation';
 import { useNavigationGuard } from './useNavigationGuard';
 import { BACK_NAVIGATION } from '~/constants/navigation';
 import { useStore } from '~/store';
+import type { StoreState } from '~/store/types';
 
 jest.mock('~/store');
 jest.mock('next/navigation');
@@ -18,25 +19,28 @@ describe('useNavigationGuard', () => {
   const setPendingNavigation = jest.fn();
   const setDiscardModalOpen = jest.fn();
 
+  const mockStore = (dirtyPaths: Record<string, boolean> = {}): StoreState =>
+    ({
+      dirtyPaths,
+      setPendingNavigation,
+      setDiscardModalOpen
+    }) as unknown as StoreState;
+
   beforeEach(() => {
     jest.clearAllMocks();
 
     mockedUsePathname.mockReturnValue('/page1');
 
-    mockedUseRouter.mockReturnValue({
+    const mockRouter: Partial<ReturnType<typeof useRouter>> = {
       push,
       back
-    } as any);
+    };
+
+    mockedUseRouter.mockReturnValue(mockRouter as ReturnType<typeof useRouter>);
   });
 
   it('should navigate directly when page is not dirty', () => {
-    mockedUseStore.mockImplementation((selector) =>
-      selector({
-        dirtyPaths: {},
-        setPendingNavigation,
-        setDiscardModalOpen
-      } as any)
-    );
+    mockedUseStore.mockImplementation((selector) => selector(mockStore()));
 
     const { result } = renderHook(() => useNavigationGuard());
 
@@ -49,13 +53,11 @@ describe('useNavigationGuard', () => {
 
   it('should open discard modal when page is dirty', () => {
     mockedUseStore.mockImplementation((selector) =>
-      selector({
-        dirtyPaths: {
+      selector(
+        mockStore({
           '/page1': true
-        },
-        setPendingNavigation,
-        setDiscardModalOpen
-      } as any)
+        })
+      )
     );
 
     const { result } = renderHook(() => useNavigationGuard());
@@ -69,13 +71,11 @@ describe('useNavigationGuard', () => {
 
   it('should not open discard modal when another route is dirty', () => {
     mockedUseStore.mockImplementation((selector) =>
-      selector({
-        dirtyPaths: {
+      selector(
+        mockStore({
           '/page2': true
-        },
-        setPendingNavigation,
-        setDiscardModalOpen
-      } as any)
+        })
+      )
     );
 
     const { result } = renderHook(() => useNavigationGuard());
@@ -88,13 +88,7 @@ describe('useNavigationGuard', () => {
   });
 
   it('should not prevent link click when page is not dirty', () => {
-    mockedUseStore.mockImplementation((selector) =>
-      selector({
-        dirtyPaths: {},
-        setPendingNavigation,
-        setDiscardModalOpen
-      } as any)
-    );
+    mockedUseStore.mockImplementation((selector) => selector(mockStore()));
 
     const preventDefault = jest.fn();
 
@@ -109,13 +103,11 @@ describe('useNavigationGuard', () => {
 
   it('should prevent link click and open discard modal when page is dirty', () => {
     mockedUseStore.mockImplementation((selector) =>
-      selector({
-        dirtyPaths: {
+      selector(
+        mockStore({
           '/page1': true
-        },
-        setPendingNavigation,
-        setDiscardModalOpen
-      } as any)
+        })
+      )
     );
 
     const preventDefault = jest.fn();
@@ -131,13 +123,11 @@ describe('useNavigationGuard', () => {
 
   it('should not intercept link click when another route is dirty', () => {
     mockedUseStore.mockImplementation((selector) =>
-      selector({
-        dirtyPaths: {
+      selector(
+        mockStore({
           '/page2': true
-        },
-        setPendingNavigation,
-        setDiscardModalOpen
-      } as any)
+        })
+      )
     );
 
     const preventDefault = jest.fn();
@@ -152,13 +142,7 @@ describe('useNavigationGuard', () => {
   });
 
   it('should navigate back directly when page is not dirty', () => {
-    mockedUseStore.mockImplementation((selector) =>
-      selector({
-        dirtyPaths: {},
-        setPendingNavigation,
-        setDiscardModalOpen
-      } as any)
-    );
+    mockedUseStore.mockImplementation((selector) => selector(mockStore()));
 
     const { result } = renderHook(() => useNavigationGuard());
 
@@ -171,13 +155,11 @@ describe('useNavigationGuard', () => {
 
   it('should open discard modal when navigating back from dirty page', () => {
     mockedUseStore.mockImplementation((selector) =>
-      selector({
-        dirtyPaths: {
+      selector(
+        mockStore({
           '/page1': true
-        },
-        setPendingNavigation,
-        setDiscardModalOpen
-      } as any)
+        })
+      )
     );
 
     const { result } = renderHook(() => useNavigationGuard());

--- a/app/shared/hooks/use-navigation-guard/useNavigationGuard.test.ts
+++ b/app/shared/hooks/use-navigation-guard/useNavigationGuard.test.ts
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react';
 import { usePathname, useRouter } from 'next/navigation';
 
 import { useNavigationGuard } from './useNavigationGuard';
+import { BACK_NAVIGATION } from '~/constants/navigation';
 import { useStore } from '~/store';
 
 jest.mock('~/store');
@@ -13,6 +14,7 @@ const mockedUseRouter = jest.mocked(useRouter);
 
 describe('useNavigationGuard', () => {
   const push = jest.fn();
+  const back = jest.fn();
   const setPendingNavigation = jest.fn();
   const setDiscardModalOpen = jest.fn();
 
@@ -22,7 +24,8 @@ describe('useNavigationGuard', () => {
     mockedUsePathname.mockReturnValue('/page1');
 
     mockedUseRouter.mockReturnValue({
-      push
+      push,
+      back
     } as any);
   });
 
@@ -146,5 +149,43 @@ describe('useNavigationGuard', () => {
     expect(preventDefault).not.toHaveBeenCalled();
     expect(setPendingNavigation).not.toHaveBeenCalled();
     expect(setDiscardModalOpen).not.toHaveBeenCalled();
+  });
+
+  it('should navigate back directly when page is not dirty', () => {
+    mockedUseStore.mockImplementation((selector) =>
+      selector({
+        dirtyPaths: {},
+        setPendingNavigation,
+        setDiscardModalOpen
+      } as any)
+    );
+
+    const { result } = renderHook(() => useNavigationGuard());
+
+    result.current.navigateBack();
+
+    expect(back).toHaveBeenCalled();
+    expect(setPendingNavigation).not.toHaveBeenCalled();
+    expect(setDiscardModalOpen).not.toHaveBeenCalled();
+  });
+
+  it('should open discard modal when navigating back from dirty page', () => {
+    mockedUseStore.mockImplementation((selector) =>
+      selector({
+        dirtyPaths: {
+          '/page1': true
+        },
+        setPendingNavigation,
+        setDiscardModalOpen
+      } as any)
+    );
+
+    const { result } = renderHook(() => useNavigationGuard());
+
+    result.current.navigateBack();
+
+    expect(back).not.toHaveBeenCalled();
+    expect(setPendingNavigation).toHaveBeenCalledWith(BACK_NAVIGATION);
+    expect(setDiscardModalOpen).toHaveBeenCalledWith(true);
   });
 });

--- a/app/shared/hooks/use-navigation-guard/useNavigationGuard.ts
+++ b/app/shared/hooks/use-navigation-guard/useNavigationGuard.ts
@@ -2,6 +2,7 @@
 
 import { usePathname, useRouter } from 'next/navigation';
 
+import { BACK_NAVIGATION } from '~/constants/navigation';
 import { useStore } from '~/store';
 
 export const useNavigationGuard = () => {
@@ -31,8 +32,19 @@ export const useNavigationGuard = () => {
     }
   };
 
+  const navigateBack = () => {
+    if (dirtyPaths[pathname]) {
+      setPendingNavigation(BACK_NAVIGATION);
+      setDiscardModalOpen(true);
+      return;
+    }
+
+    router.back();
+  };
+
   return {
     navigate,
+    navigateBack,
     interceptLinkClick
   };
 };

--- a/app/shared/providers/discard-modal-provider/DiscardModalProvider.tsx
+++ b/app/shared/providers/discard-modal-provider/DiscardModalProvider.tsx
@@ -2,6 +2,7 @@
 import { useRouter } from 'next/navigation';
 import { ReactNode, useEffect, useState } from 'react';
 
+import { BACK_NAVIGATION } from '~/constants/navigation';
 import DiscardChangesModal from '~/shared/components/design-system/discard-changes-modal/DiscardChangesModal';
 import { useStore } from '~/store';
 
@@ -22,13 +23,19 @@ export default function DiscardModalProvider({ children }: { readonly children: 
     setOpen(false);
   };
   const handleConfirm = () => {
-    if (pendingNavigation) {
-      router.push(pendingNavigation);
-
-      setPendingNavigation(null);
-      setDiscardModalOpen(false);
+    if (!pendingNavigation) {
+      setOpen(false);
+      return;
     }
 
+    if (pendingNavigation === BACK_NAVIGATION) {
+      router.back();
+    } else {
+      router.push(pendingNavigation);
+    }
+
+    setPendingNavigation(null);
+    setDiscardModalOpen(false);
     setOpen(false);
   };
 


### PR DESCRIPTION
## Description

Fixed the back button navigation on publication create/edit pages.

Previously, clicking the back button always redirected users to the Publications root page (/publications), regardless of the category from which the publication was opened.

Now the user is redirected back to the previously opened publication category:

/publications/news for News
/publications/events for Events
/publications/media for Media

The unsaved changes protection logic remains intact and continues to display the confirmation modal when there are pending changes.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Log in to LF Admin.
2. Go to /publications.
3. Open one of the publication categories:

- News (/publications/news)
- Events (/publications/events)
- Media (/publications/media)

4. Open any publication for editing or creating.
5. Click the Back button in the page header.

## Video / Screenshots


https://github.com/user-attachments/assets/4f737896-8990-45e0-a600-8f5a644ed144



## Checklist

- [ ] Code compiles and runs correctly
- [ ] Tests pass successfully
- [ ] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [ ] Linked issue/task included
- [ ] Task moved to the review column on the board

---
