### PR TITLE
fix: remove duplicate CreateAssetInput and fix gallery cache staleness

### DIFF
--- a/app/(logged_in)/files/FilesPageContent.tsx
+++ b/app/(logged_in)/files/FilesPageContent.tsx
@@ -220,7 +220,8 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
           sizeBytes: size,
           type: assetType
         }
-      }
+      },
+      refetchQueries: ['AllAssets']
     });
 
     if (!createResult.data?.createAsset) {

--- a/app/shared/components/media-modal/views/gallery-view/GalleryView.test.tsx
+++ b/app/shared/components/media-modal/views/gallery-view/GalleryView.test.tsx
@@ -251,4 +251,50 @@ describe('GalleryView', () => {
     expect(screen.getByText('piano-studio.jpg')).toBeInTheDocument();
     expect(screen.queryByText('composer-portrait.jpg')).not.toBeInTheDocument();
   });
+
+  it('should display originalname instead of filename when available', () => {
+    (useAllAssetsQuery as jest.Mock).mockReturnValue({
+      data: {
+        allAssets: [
+          {
+            id: 'asset-1',
+            url: 'https://example.com/piano-studio.jpg',
+            filename: '1234567890-hash.jpg',
+            originalname: 'piano-studio.jpg',
+            isStarred: false,
+            tags: [],
+            usageRefs: []
+          }
+        ]
+      },
+      loading: false
+    });
+
+    renderGalleryView();
+
+    expect(screen.getByText('piano-studio.jpg')).toBeInTheDocument();
+    expect(screen.queryByText('1234567890-hash.jpg')).not.toBeInTheDocument();
+  });
+
+  it('should fall back to filename when originalname is missing', () => {
+    (useAllAssetsQuery as jest.Mock).mockReturnValue({
+      data: {
+        allAssets: [
+          {
+            id: 'asset-1',
+            url: 'https://example.com/piano-studio.jpg',
+            filename: 'piano-studio.jpg',
+            isStarred: false,
+            tags: [],
+            usageRefs: []
+          }
+        ]
+      },
+      loading: false
+    });
+
+    renderGalleryView();
+
+    expect(screen.getByText('piano-studio.jpg')).toBeInTheDocument();
+  });
 });

--- a/app/shared/components/media-modal/views/gallery-view/GalleryView.tsx
+++ b/app/shared/components/media-modal/views/gallery-view/GalleryView.tsx
@@ -74,7 +74,8 @@ export function GalleryView({ selected: _selected, onPick, filters, onFiltersCha
   const { files: r2Files, isLoading: r2Loading } = useGalleryFiles();
 
   const { data: assetsData, loading: assetsLoading } = useAllAssetsQuery({
-    variables: { filters: { type: AssetType.Image } }
+    variables: { filters: { type: AssetType.Image } },
+    fetchPolicy: 'cache-and-network'
   });
 
   const debouncedSearchValue = useDebounce(filters.search, 200);

--- a/src/interfaces/graphql/schemas/assets.graphql
+++ b/src/interfaces/graphql/schemas/assets.graphql
@@ -74,16 +74,3 @@ extend type Mutation {
   createAsset(input: CreateAssetInput!): Asset!
   deleteAsset(id: ID!): Boolean!
 }
-
-input CreateAssetInput {
-  filename: String!
-  mimeType: String!
-  sizeBytes: Int!
-  url: String!
-  type: String! # 'image', 'audio', 'document', 'archive', etc.
-  description: String
-}
-
-extend type Mutation {
-  createAsset(input: CreateAssetInput!): Asset!
-}


### PR DESCRIPTION
## Description

Bug reproducible — root cause identified and fixed. A leftover duplicate `CreateAssetInput` definition in `assets.graphql` was 
silently overriding the schema, causing `originalname` to be dropped on new uploads. Also fixed a related Apollo cache staleness issue in the Gallery view.

Related task: #588 

---