### PR TITLE
feat: input sanitization for publication description text

### DIFF
--- a/app/shared/components/content-editor/BlockNoteEditor.test.tsx
+++ b/app/shared/components/content-editor/BlockNoteEditor.test.tsx
@@ -31,6 +31,7 @@ type CreateOptions = {
 };
 
 const mockUpdateBlock = jest.fn();
+const mockDefaultPasteHandler = jest.fn();
 
 let mockDocumentState: MockBlock[] = [];
 let capturedCreateOptions: CreateOptions | null = null;
@@ -178,27 +179,6 @@ jest.mock('~/shared/components/media-modal/MediaModal', () => ({
   }
 }));
 
-const createMockParsedBlocks = (contentText: string) => (
-  [
-    {
-      id: 'mock-block-id-1',
-      type: 'paragraph',
-      props: {
-        textColor: 'default',
-        backgroundColor: 'default',
-        textAlignment: 'left'
-      },
-      content: [
-        {
-          type: 'text',
-          text: contentText,
-          styles: {}
-        }
-      ],
-      children: []
-    }
-  ]
-);
 
 describe('BlockNoteEditor', () => {
   beforeEach(() => {
@@ -335,11 +315,58 @@ describe('BlockNoteEditor', () => {
       });
 
       expect(screen.queryByTestId('media-modal')).not.toBeInTheDocument();
-      expect(promiseResult).toBeNull();
+      expect(promiseResult).toBe('');;
     });
   });
 
   describe('5. Paste Behaviour', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      if (typeof DataTransfer === 'undefined') {
+        const mockedDataTransfer = class {
+          constructor() {
+            this.data = {};
+            this.files = [];
+            this.items = {
+              add: (file) => this.files.push(file),
+              clear: () => { this.files = []; }
+            };
+          }
+
+          setData(format, value) {
+            this.data[format] = value;
+          }
+
+          getData(format) {
+            return this.data[format] || '';
+          }
+        };
+
+        globalThis.DataTransfer = mockedDataTransfer;
+      }
+    });
+
+    it('calls defaultPasteHandler immediately if clipboardData is missing', () => {
+      render(<BlockNoteEditor />);
+      const event = { clipboardData: null };
+
+      capturedCreateOptions?.pasteHandler({ event, defaultPasteHandler: mockDefaultPasteHandler });
+      expect(mockDefaultPasteHandler).toHaveBeenCalledTimes(1);
+    });
+    it('should return default handler if both html and text are empty', () => {
+      render(<BlockNoteEditor />);
+      const event = {
+        clipboardData: {
+          getData: jest.fn().mockReturnValue('') 
+        }
+      };
+      
+      capturedCreateOptions?.pasteHandler({ event, defaultPasteHandler: mockDefaultPasteHandler });
+
+      expect(mockDefaultPasteHandler).toHaveBeenCalledTimes(1);
+      expect(event.clipboardData.getData).toHaveBeenCalledWith('text/html');
+      expect(event.clipboardData.getData).toHaveBeenCalledWith('text/plain');
+    });
     it('should allow to paste valid plain text', () => {
       render(<BlockNoteEditor />);
       const correctPlainText = 'dfsdfsd';
@@ -352,9 +379,10 @@ describe('BlockNoteEditor', () => {
         }
       };
 
-      const defaultPasteHandler = jest.fn();
-      capturedCreateOptions?.pasteHandler({ event, editor: mockEditor, defaultPasteHandler });
-      expect(mockEditor.insertInlineContent).toHaveBeenCalledWith(correctPlainText);
+      capturedCreateOptions?.pasteHandler({ event, defaultPasteHandler: mockDefaultPasteHandler });
+      expect(event.clipboardData.getData('text/html')).toBe('');;
+      expect(event.clipboardData.getData('text/plain')).toBe('dfsdfsd');
+      expect(mockDefaultPasteHandler).toHaveBeenCalled();
     });
 
     it('should allow to paste valid html', () => {
@@ -369,13 +397,10 @@ describe('BlockNoteEditor', () => {
         }
       };
 
-      const mockParsedBlocks = createMockParsedBlocks('dfsdfsd');
-      mockEditor.tryParseHTMLToBlocks.mockReturnValueOnce(mockParsedBlocks);
-
-      const defaultPasteHandler = jest.fn();
-      capturedCreateOptions?.pasteHandler({ event, editor: mockEditor, defaultPasteHandler });
-      expect(mockEditor.tryParseHTMLToBlocks).toHaveBeenCalledWith(correctHTML);
-      expect(mockEditor.insertInlineContent).toHaveBeenCalledWith(mockParsedBlocks[0].content);
+      capturedCreateOptions?.pasteHandler({ event, defaultPasteHandler: mockDefaultPasteHandler });
+      expect(event.clipboardData.getData('text/html')).toBe(correctHTML);
+      expect(event.clipboardData.getData('text/plain')).toBe('');;
+      expect(mockDefaultPasteHandler).toHaveBeenCalled();
     });
 
 
@@ -392,11 +417,11 @@ describe('BlockNoteEditor', () => {
       };
       const sanitizedText = 'Test';
 
-      const defaultPasteHandler = jest.fn();
-      capturedCreateOptions?.pasteHandler({ event, editor: mockEditor, defaultPasteHandler });
-
+      capturedCreateOptions?.pasteHandler({ event, defaultPasteHandler: mockDefaultPasteHandler });
+      expect(event.clipboardData.getData('text/html')).toBe('');;
+      expect(event.clipboardData.getData('text/plain')).toBe(sanitizedText);
+      expect(mockDefaultPasteHandler).toHaveBeenCalled();
       expect(toast.error).toHaveBeenCalledWith('Використання емодзі та спецсимволів не дозволено');
-      expect(mockEditor.insertInlineContent).toHaveBeenCalledWith(sanitizedText);
     });
 
 
@@ -411,13 +436,11 @@ describe('BlockNoteEditor', () => {
           }
         }
       };
-      const mockParsedBlocks = createMockParsedBlocks('test');
-      mockEditor.tryParseHTMLToBlocks.mockReturnValueOnce(mockParsedBlocks);
-      const defaultPasteHandler = jest.fn();
-      capturedCreateOptions?.pasteHandler({ event, editor: mockEditor, defaultPasteHandler });
 
-      expect(mockEditor.tryParseHTMLToBlocks).toHaveBeenCalledWith('<p>test </p>');
-      expect(mockEditor.insertInlineContent).toHaveBeenCalledWith(mockParsedBlocks[0].content);
+      capturedCreateOptions?.pasteHandler({ event, defaultPasteHandler: mockDefaultPasteHandler });
+      expect(event.clipboardData.getData('text/html')).toBe('<p>test </p>');
+      expect(event.clipboardData.getData('text/plain')).toBe('');
+      expect(toast.error).toHaveBeenCalledWith('Використання емодзі та спецсимволів не дозволено');
     });
   });
 });

--- a/app/shared/components/content-editor/BlockNoteEditor.test.tsx
+++ b/app/shared/components/content-editor/BlockNoteEditor.test.tsx
@@ -315,7 +315,7 @@ describe('BlockNoteEditor', () => {
       });
 
       expect(screen.queryByTestId('media-modal')).not.toBeInTheDocument();
-      expect(promiseResult).toBe('');;
+      expect(promiseResult).toBeNull();
     });
   });
 
@@ -394,7 +394,7 @@ describe('BlockNoteEditor', () => {
       };
 
       capturedCreateOptions?.pasteHandler({ event, defaultPasteHandler: mockDefaultPasteHandler });
-      expect(event.clipboardData.getData('text/html')).toBe('');;
+      expect(event.clipboardData.getData('text/html')).toBe('');
       expect(event.clipboardData.getData('text/plain')).toBe('dfsdfsd');
       expect(mockDefaultPasteHandler).toHaveBeenCalled();
     });
@@ -413,7 +413,7 @@ describe('BlockNoteEditor', () => {
 
       capturedCreateOptions?.pasteHandler({ event, defaultPasteHandler: mockDefaultPasteHandler });
       expect(event.clipboardData.getData('text/html')).toBe(correctHTML);
-      expect(event.clipboardData.getData('text/plain')).toBe('');;
+      expect(event.clipboardData.getData('text/plain')).toBe('');
       expect(mockDefaultPasteHandler).toHaveBeenCalled();
     });
 
@@ -432,7 +432,7 @@ describe('BlockNoteEditor', () => {
       const sanitizedText = 'Test';
 
       capturedCreateOptions?.pasteHandler({ event, defaultPasteHandler: mockDefaultPasteHandler });
-      expect(event.clipboardData.getData('text/html')).toBe('');;
+      expect(event.clipboardData.getData('text/html')).toBe('');
       expect(event.clipboardData.getData('text/plain')).toBe(sanitizedText);
       expect(mockDefaultPasteHandler).toHaveBeenCalled();
       expect(toast.error).toHaveBeenCalledWith('Використання емодзі та спецсимволів не дозволено');

--- a/app/shared/components/content-editor/BlockNoteEditor.test.tsx
+++ b/app/shared/components/content-editor/BlockNoteEditor.test.tsx
@@ -1,5 +1,9 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
+import toast from 'react-hot-toast';
+jest.mock('react-hot-toast', () => ({
+  error: jest.fn()
+}));
 
 import { BlockNoteEditor } from './BlockNoteEditor';
 import { MediaModalResult } from '~/shared/components/media-modal/MediaModal.types';
@@ -23,6 +27,7 @@ type MockBlock = {
 type CreateOptions = {
   uploadFile: (file: File) => Promise<string>;
   onChange?: () => void;
+  pasteHandler: ({ event, editor, defaultPasteHandler }: any) => void;
 };
 
 const mockUpdateBlock = jest.fn();
@@ -30,10 +35,16 @@ const mockUpdateBlock = jest.fn();
 let mockDocumentState: MockBlock[] = [];
 let capturedCreateOptions: CreateOptions | null = null;
 let captureSlashMenuOpenMediaModal: (() => Promise<MediaModalResult | null>) | null = null;
-
+const mockCursorBlock = jest.fn();
 const mockEditor = {
   document: mockDocumentState,
-  updateBlock: mockUpdateBlock
+  updateBlock: mockUpdateBlock,
+  insertBlocks: jest.fn(),
+  insertInlineContent: jest.fn(),
+  tryParseHTMLToBlocks: jest.fn(),
+  getTextCursorPosition: () => ({
+    block: mockCursorBlock
+  })
 };
 
 jest.mock('@blocknote/core', () => ({
@@ -166,6 +177,28 @@ jest.mock('~/shared/components/media-modal/MediaModal', () => ({
     );
   }
 }));
+
+const createMockParsedBlocks = (contentText: string) => (
+  [
+    {
+      id: 'mock-block-id-1',
+      type: 'paragraph',
+      props: {
+        textColor: 'default',
+        backgroundColor: 'default',
+        textAlignment: 'left'
+      },
+      content: [
+        {
+          type: 'text',
+          text: contentText,
+          styles: {}
+        }
+      ],
+      children: []
+    }
+  ]
+);
 
 describe('BlockNoteEditor', () => {
   beforeEach(() => {
@@ -303,6 +336,88 @@ describe('BlockNoteEditor', () => {
 
       expect(screen.queryByTestId('media-modal')).not.toBeInTheDocument();
       expect(promiseResult).toBeNull();
+    });
+  });
+
+  describe('5. Paste Behaviour', () => {
+    it('should allow to paste valid plain text', () => {
+      render(<BlockNoteEditor />);
+      const correctPlainText = 'dfsdfsd';
+      const event = {
+        clipboardData: {
+          getData: (type: 'text/html' | 'text/plain') => {
+            if (type === 'text/plain') return correctPlainText;
+            return null;
+          }
+        }
+      };
+
+      const defaultPasteHandler = jest.fn();
+      capturedCreateOptions?.pasteHandler({ event, mockEditor, defaultPasteHandler });
+      expect(mockEditor.insertInlineContent).toHaveBeenCalledWith(correctPlainText);
+    });
+
+    it('should allow to paste valid html', () => {
+      render(<BlockNoteEditor />);
+      const correctHTML = '<p>dfsdfsd</p>';
+      const event = {
+        clipboardData: {
+          getData: (type: 'text/html' | 'text/plain') => {
+            if (type === 'text/html') return correctHTML;
+            return null;
+          }
+        }
+      };
+
+      const mockParsedBlocks = createMockParsedBlocks('dfsdfsd');
+      mockEditor.tryParseHTMLToBlocks.mockReturnValueOnce(mockParsedBlocks);
+
+      const defaultPasteHandler = jest.fn();
+      capturedCreateOptions?.pasteHandler({ event, mockEditor, defaultPasteHandler });
+      expect(mockEditor.tryParseHTMLToBlocks).toHaveBeenCalledWith(correctHTML);
+      expect(mockEditor.insertBlocks).toHaveBeenCalledWith(mockParsedBlocks, mockCursorBlock, 'after');
+    });
+
+
+    it('should remove emojiis and special symbols like (😀 🎉 ★ ♞ ♣) from pasted text and show error toast', () => {
+      render(<BlockNoteEditor />);
+      const invalidPlainText = 'Test 😀 🎉 ★ ♞ ♣';
+      const event = {
+        clipboardData: {
+          getData: (type: 'text/html' | 'text/plain') => {
+            if (type === 'text/plain') return invalidPlainText;
+            return null;
+          }
+        }
+      };
+      const sanitizedText = 'Test';
+
+      const defaultPasteHandler = jest.fn();
+      capturedCreateOptions?.pasteHandler({ event, mockEditor, defaultPasteHandler });
+
+      expect(toast.error).toHaveBeenCalledWith('Використання емодзі та спецсимволів не дозволено');
+      expect(mockEditor.insertInlineContent).toHaveBeenCalledWith(sanitizedText);
+    });
+
+
+    it('should remove any styles & emojiis or special symblos from pasted HTML and show error toast', () => {
+      render(<BlockNoteEditor />);
+      const formattedHTML = '<p style={} class={}>test 😀 🎉 ★ ♞ ♣</p>';
+      const event = {
+        clipboardData: {
+          getData: (type: 'text/html' | 'text/plain') => {
+            if (type === 'text/html') return formattedHTML;
+            return null;
+          }
+        }
+      };
+      const mockParsedBlocks = createMockParsedBlocks('test');
+      mockEditor.tryParseHTMLToBlocks.mockReturnValueOnce(mockParsedBlocks);
+      const defaultPasteHandler = jest.fn();
+      capturedCreateOptions?.pasteHandler({ event, mockEditor, defaultPasteHandler });
+
+      expect(mockEditor.tryParseHTMLToBlocks).toHaveBeenCalledWith('<p>test </p>');
+      expect(mockEditor.insertBlocks).toHaveBeenCalledWith(mockParsedBlocks, mockCursorBlock, 'after');
     });
   });
 });

--- a/app/shared/components/content-editor/BlockNoteEditor.test.tsx
+++ b/app/shared/components/content-editor/BlockNoteEditor.test.tsx
@@ -320,29 +320,43 @@ describe('BlockNoteEditor', () => {
   });
 
   describe('5. Paste Behaviour', () => {
+    let originalDataTransfer: any;
+
     beforeEach(() => {
       jest.clearAllMocks();
+    });
+
+    beforeAll(() => {
+      originalDataTransfer = globalThis.DataTransfer;
       if (typeof DataTransfer === 'undefined') {
-        const mockedDataTransfer = class {
+        class MockDataTransfer {
+          data: Record<string, string>;
           constructor() {
             this.data = {};
-            this.files = [];
-            this.items = {
-              add: (file) => this.files.push(file),
-              clear: () => { this.files = []; }
-            };
           }
-
-          setData(format, value) {
-            this.data[format] = value;
-          }
-
-          getData(format) {
+          getData(format: string): string {
             return this.data[format] || '';
           }
-        };
 
-        globalThis.DataTransfer = mockedDataTransfer;
+          setData(format: string, data: string): void {
+            this.data[format] = data;
+          }
+        }
+
+        Object.defineProperty(globalThis, 'DataTransfer', {
+          value: MockDataTransfer 
+        });
+      }
+    });
+
+    afterAll(() => {
+      if (originalDataTransfer) {
+        Object.defineProperty(globalThis, 'DataTransfer', {
+          value: originalDataTransfer,
+          configurable: true,
+        });
+      } else {
+        delete (globalThis as any).DataTransfer;
       }
     });
 
@@ -357,10 +371,10 @@ describe('BlockNoteEditor', () => {
       render(<BlockNoteEditor />);
       const event = {
         clipboardData: {
-          getData: jest.fn().mockReturnValue('') 
+          getData: jest.fn().mockReturnValue('')
         }
       };
-      
+
       capturedCreateOptions?.pasteHandler({ event, defaultPasteHandler: mockDefaultPasteHandler });
 
       expect(mockDefaultPasteHandler).toHaveBeenCalledTimes(1);

--- a/app/shared/components/content-editor/BlockNoteEditor.test.tsx
+++ b/app/shared/components/content-editor/BlockNoteEditor.test.tsx
@@ -353,7 +353,7 @@ describe('BlockNoteEditor', () => {
       };
 
       const defaultPasteHandler = jest.fn();
-      capturedCreateOptions?.pasteHandler({ event, mockEditor, defaultPasteHandler });
+      capturedCreateOptions?.pasteHandler({ event, editor: mockEditor, defaultPasteHandler });
       expect(mockEditor.insertInlineContent).toHaveBeenCalledWith(correctPlainText);
     });
 
@@ -373,7 +373,7 @@ describe('BlockNoteEditor', () => {
       mockEditor.tryParseHTMLToBlocks.mockReturnValueOnce(mockParsedBlocks);
 
       const defaultPasteHandler = jest.fn();
-      capturedCreateOptions?.pasteHandler({ event, mockEditor, defaultPasteHandler });
+      capturedCreateOptions?.pasteHandler({ event, editor: mockEditor, defaultPasteHandler });
       expect(mockEditor.tryParseHTMLToBlocks).toHaveBeenCalledWith(correctHTML);
       expect(mockEditor.insertBlocks).toHaveBeenCalledWith(mockParsedBlocks, mockCursorBlock, 'after');
     });
@@ -393,7 +393,7 @@ describe('BlockNoteEditor', () => {
       const sanitizedText = 'Test';
 
       const defaultPasteHandler = jest.fn();
-      capturedCreateOptions?.pasteHandler({ event, mockEditor, defaultPasteHandler });
+      capturedCreateOptions?.pasteHandler({ event, editor: mockEditor, defaultPasteHandler });
 
       expect(toast.error).toHaveBeenCalledWith('Використання емодзі та спецсимволів не дозволено');
       expect(mockEditor.insertInlineContent).toHaveBeenCalledWith(sanitizedText);
@@ -414,7 +414,7 @@ describe('BlockNoteEditor', () => {
       const mockParsedBlocks = createMockParsedBlocks('test');
       mockEditor.tryParseHTMLToBlocks.mockReturnValueOnce(mockParsedBlocks);
       const defaultPasteHandler = jest.fn();
-      capturedCreateOptions?.pasteHandler({ event, mockEditor, defaultPasteHandler });
+      capturedCreateOptions?.pasteHandler({ event, editor: mockEditor, defaultPasteHandler });
 
       expect(mockEditor.tryParseHTMLToBlocks).toHaveBeenCalledWith('<p>test </p>');
       expect(mockEditor.insertBlocks).toHaveBeenCalledWith(mockParsedBlocks, mockCursorBlock, 'after');

--- a/app/shared/components/content-editor/BlockNoteEditor.test.tsx
+++ b/app/shared/components/content-editor/BlockNoteEditor.test.tsx
@@ -375,7 +375,7 @@ describe('BlockNoteEditor', () => {
       const defaultPasteHandler = jest.fn();
       capturedCreateOptions?.pasteHandler({ event, editor: mockEditor, defaultPasteHandler });
       expect(mockEditor.tryParseHTMLToBlocks).toHaveBeenCalledWith(correctHTML);
-      expect(mockEditor.insertBlocks).toHaveBeenCalledWith(mockParsedBlocks, mockCursorBlock, 'after');
+      expect(mockEditor.insertInlineContent).toHaveBeenCalledWith(mockParsedBlocks[0].content);
     });
 
 
@@ -417,7 +417,7 @@ describe('BlockNoteEditor', () => {
       capturedCreateOptions?.pasteHandler({ event, editor: mockEditor, defaultPasteHandler });
 
       expect(mockEditor.tryParseHTMLToBlocks).toHaveBeenCalledWith('<p>test </p>');
-      expect(mockEditor.insertBlocks).toHaveBeenCalledWith(mockParsedBlocks, mockCursorBlock, 'after');
+      expect(mockEditor.insertInlineContent).toHaveBeenCalledWith(mockParsedBlocks[0].content);
     });
   });
 });

--- a/app/shared/components/content-editor/BlockNoteEditor.tsx
+++ b/app/shared/components/content-editor/BlockNoteEditor.tsx
@@ -13,6 +13,7 @@ import { BlockNoteView } from '@blocknote/mantine';
 import { FormattingToolbarController, SuggestionMenuController, useCreateBlockNote } from '@blocknote/react';
 import { Box } from '@mui/material';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import toast from 'react-hot-toast';
 
 import { styles } from './BlockNoteEditor.styles';
 import { CroppedImageBlock } from './cropped-image-block/CroppedImageBlock';
@@ -50,6 +51,44 @@ export const customSchema = BlockNoteSchema.create(
   })
 );
 
+const RESTRICTED_SYMBOLS_REGEX = /[\p{Extended_Pictographic}\p{S}]/gu;
+const getCleanedText = (input: string) => {
+  if (RESTRICTED_SYMBOLS_REGEX.test(input)) {
+    toast.error('Використання емодзі та спецсимволів не дозволено');
+    return input.replace(RESTRICTED_SYMBOLS_REGEX, '');
+  }
+  return input;
+};
+
+
+const proccessHTML = (html: string) => {
+  const parser = new DOMParser();
+
+  const doc = parser.parseFromString(html, 'text/html');
+  doc.querySelectorAll('*').forEach((el) => {
+    el.removeAttribute('style');
+    el.removeAttribute('class');
+  });
+
+  const walker = document.createTreeWalker(
+    doc.body,
+    NodeFilter.SHOW_TEXT,
+    null
+  );
+
+  let node: Node | null = null;
+
+  while ((node = walker.nextNode())) {
+    if (node.nodeValue !== null) {
+      node.nodeValue = getCleanedText(node.nodeValue);
+    }
+  }
+
+  return doc.body.innerHTML;
+};
+
+
+
 export const BlockNoteEditor = (props: BlockNoteEditorProps) => {
   const {
     initialContent,
@@ -83,7 +122,23 @@ export const BlockNoteEditor = (props: BlockNoteEditorProps) => {
       schema: customSchema,
       uploadFile: handleSilentFileUpload,
       initialContent: initialContent || undefined,
-      placeholders: { default: placeholder }
+      placeholders: { default: placeholder },
+      pasteHandler({ event, editor: editorInstance, defaultPasteHandler }) {
+        const clipboardData = event.clipboardData;
+        if (!clipboardData) return defaultPasteHandler();
+
+        const html = clipboardData.getData('text/html');
+        const text = clipboardData.getData('text/plain');
+        if (html) {
+          const cleanedHTML = proccessHTML(html);
+          const blocks = editor.tryParseHTMLToBlocks(cleanedHTML);
+          editor.insertBlocks(blocks, editor.getTextCursorPosition().block, 'after');
+        } else if (text) {
+          const cleanedText = getCleanedText(text);
+          editorInstance.insertInlineContent(cleanedText);
+        }
+        return true;
+      },
     },
     [isMounted]
   );
@@ -123,7 +178,7 @@ export const BlockNoteEditor = (props: BlockNoteEditorProps) => {
 
   const renderFormattingToolbar = useCallback(
     () => (
-      <CustomFormattingToolbar  openMediaModal={openMediaModal} />
+      <CustomFormattingToolbar openMediaModal={openMediaModal} />
     ),
     [openMediaModal]
   );

--- a/app/shared/components/content-editor/BlockNoteEditor.tsx
+++ b/app/shared/components/content-editor/BlockNoteEditor.tsx
@@ -63,7 +63,7 @@ const getCleanedText = (input: string) => {
 };
 
 
-const proccessHTML = (html: string) => {
+const processHTML = (html: string) => {
   const parser = new DOMParser();
 
   const doc = parser.parseFromString(html, 'text/html');
@@ -132,7 +132,7 @@ export const BlockNoteEditor = (props: BlockNoteEditorProps) => {
         const html = clipboardData.getData('text/html');
         const text = clipboardData.getData('text/plain');
         if (html) {
-          const cleanedHTML = proccessHTML(html);
+          const cleanedHTML = processHTML(html);
           const blocks = editor.tryParseHTMLToBlocks(cleanedHTML);
           editor.insertBlocks(blocks, editor.getTextCursorPosition().block, 'after');
         } else if (text) {

--- a/app/shared/components/content-editor/BlockNoteEditor.tsx
+++ b/app/shared/components/content-editor/BlockNoteEditor.tsx
@@ -63,14 +63,14 @@ const defaultFileUploadHandler = async (file: File): Promise<string> => {
 };
 
 export const customSchema = BlockNoteSchema.create(
-  BlockNoteSchema.create({
+  {
     blockSpecs: {
       ...defaultBlockSpecs,
       image: CroppedImageBlock()
     },
     inlineContentSpecs: defaultInlineContentSpecs,
     styleSpecs: defaultStyleSpecs
-  })
+  }
 );
 
 const RESTRICTED_SYMBOLS_REGEX = /[\p{Extended_Pictographic}\p{So}]/gu;
@@ -172,8 +172,13 @@ export const BlockNoteEditor = (props: BlockNoteEditorProps) => {
         const text = clipboardData.getData('text/plain');
         if (html) {
           const cleanedHTML = processHTML(html);
-          const blocks = editor.tryParseHTMLToBlocks(cleanedHTML);
-          editor.insertBlocks(blocks, editor.getTextCursorPosition().block, 'after');
+          const blocks = editorInstance.tryParseHTMLToBlocks(cleanedHTML);
+
+          blocks.forEach((block) => {
+            if (Array.isArray(block.content)) {
+              editorInstance.insertInlineContent(block.content);
+            }
+          });
         } else if (text) {
           const cleanedText = getCleanedText(text).trim();
           editorInstance.insertInlineContent(cleanedText);
@@ -210,13 +215,13 @@ export const BlockNoteEditor = (props: BlockNoteEditorProps) => {
   const handleEditorChange = useCallback(() => {
     if (editor) {
       const charCount = getCharCount(editor);
-      
+
       if (charCount > MAX_CHARS_LIMIT) {
         toast.error(MAX_CHARS_EXCEEDED_MSG);
 
         editor.undo();
-      
-        return; 
+
+        return;
       }
 
       if (onChange) {

--- a/app/shared/components/content-editor/BlockNoteEditor.tsx
+++ b/app/shared/components/content-editor/BlockNoteEditor.tsx
@@ -51,11 +51,13 @@ export const customSchema = BlockNoteSchema.create(
   })
 );
 
-const RESTRICTED_SYMBOLS_REGEX = /[\p{Extended_Pictographic}\p{S}]/gu;
+const RESTRICTED_SYMBOLS_REGEX = /[\p{Extended_Pictographic}\p{So}]/gu;
 const getCleanedText = (input: string) => {
   if (RESTRICTED_SYMBOLS_REGEX.test(input)) {
     toast.error('Використання емодзі та спецсимволів не дозволено');
-    return input.replace(RESTRICTED_SYMBOLS_REGEX, '');
+    return input
+      .replace(RESTRICTED_SYMBOLS_REGEX, '')
+      .replace(/[ \t]{2,}/g, ' ');
   }
   return input;
 };
@@ -134,7 +136,7 @@ export const BlockNoteEditor = (props: BlockNoteEditorProps) => {
           const blocks = editor.tryParseHTMLToBlocks(cleanedHTML);
           editor.insertBlocks(blocks, editor.getTextCursorPosition().block, 'after');
         } else if (text) {
-          const cleanedText = getCleanedText(text);
+          const cleanedText = getCleanedText(text).trim();
           editorInstance.insertInlineContent(cleanedText);
         }
         return true;

--- a/app/shared/components/content-editor/BlockNoteEditor.tsx
+++ b/app/shared/components/content-editor/BlockNoteEditor.tsx
@@ -164,26 +164,42 @@ export const BlockNoteEditor = (props: BlockNoteEditorProps) => {
       uploadFile: handleSilentFileUpload,
       initialContent: initialContent || undefined,
       placeholders: { default: placeholder },
-      pasteHandler({ event, editor: editorInstance, defaultPasteHandler }) {
+      pasteHandler({ event, defaultPasteHandler }) {
         const clipboardData = event.clipboardData;
         if (!clipboardData) return defaultPasteHandler();
 
         const html = clipboardData.getData('text/html');
         const text = clipboardData.getData('text/plain');
-        if (html) {
-          const cleanedHTML = processHTML(html);
-          const blocks = editorInstance.tryParseHTMLToBlocks(cleanedHTML);
 
-          blocks.forEach((block) => {
-            if (Array.isArray(block.content)) {
-              editorInstance.insertInlineContent(block.content);
-            }
-          });
-        } else if (text) {
-          const cleanedText = getCleanedText(text).trim();
-          editorInstance.insertInlineContent(cleanedText);
+        if (!html && !text) {
+          return defaultPasteHandler();
         }
-        return true;
+
+        const cleanedHTML = html ? processHTML(html) : '';
+        const cleanedText = text ? getCleanedText(text).trim() : '';
+
+
+        const dt = new DataTransfer();
+
+        if (cleanedHTML) dt.setData('text/html', cleanedHTML);
+        if (cleanedText) dt.setData('text/plain', cleanedText);
+
+
+        if (clipboardData.files && clipboardData.files.length > 0) {
+          [...clipboardData.files].forEach((file) => {
+            dt.items.add(file);
+          });
+        }
+
+        try {
+          Object.defineProperty(event, 'clipboardData', {
+            value: dt,
+          });
+        } catch (e) {
+          toast.error('Помилка обробки вставленого тексту');
+          console.error('Помилка обробки вставленого тексту:', e);
+        }
+        return defaultPasteHandler();
       },
     },
     [isMounted]


### PR DESCRIPTION
## Description
These changes introduce robust input sanitization for any pasted text in a publication description (and for any component that uses `BlockNoteEditor.tsx`). 

### Key changes

- Implemented `getCleanedText` method that processes plain text by leveraging `RESTRICTED_SYMBOLS_REGEX` to strip away emojis and restricted symbols 
- Added `processHTML` method that processes pasted HTML content. It removes style & class attributes, and it uses **createTreeWalker** for processing all inner text of HTML
- new custom `pasteHandler` processing logic: 

  1. When you paste content, the handler checks if there's anything to paste. If not, it uses BlockNote's default behavior.
  2. For plain text: It removes emojis and special symbols using a regex pattern, collapses extra spaces, and shows an error toast if restricted characters were found.
  3. For HTML: It parses the content, strips all style and class attributes to remove formatting, then walks through all text nodes and removes emojis/special symbols from each one.
  4. Then it creates a fresh clipboard object with only the sanitized plain text and HTML, preserves any files or images, and replaces the original clipboard data in the paste event, leveraging the **DataTransfer API**.
  5. Finally, it passes the cleaned event to BlockNote's default handler, so the editor receives only the sanitized content — no unwanted formatting, no emojis.

Closes #631
US: https://github.com/Liatoshynsky-Foundation/lf-client/issues/396
 
## Type of change

- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Log in to the admin
2. Go to /publications/events/[id]/edit
3. Try to paste a text from Google Docs with some formatting (like bold) & emojis
4. Verify that pasted text doesn't contain any formatting, and emojis are stripped away too.  
5. Verify that you see the error toast with text 'Використання емодзі та спецсимволів не дозволено'

## Video / Screenshots

https://github.com/user-attachments/assets/a09666ab-60e5-4cb1-8019-ec3a254f87f0

https://github.com/user-attachments/assets/2751db47-ee00-4e22-91bd-51f04499b3da



## Checklist

- [X] Code compiles and runs correctly
- [X] Tests pass successfully
- [X] Linting checks are clean
- [X] No Sonar issues
- [X] Branch is up to date with the target branch
- [X] Linked issue/task included
- [X] Task moved to the review column on the board

---
