### PR TITLE
feat(UI): strict aspect ratio constraints

### DIFF
--- a/app/constants/publications.ts
+++ b/app/constants/publications.ts
@@ -266,3 +266,12 @@ export const ADMIN_TITLE_LABELS: Record<PublicationsItemType, string> = {
   news: 'Назва новини в адмінці',
   media: 'Назва публікації в адмінці'
 };
+
+export const CROP_RATIOS = {
+  HERO_BANNER: 816 / 300,
+  FUNDATION_PROFILE_SMALL: 336 / 400,
+  FUNDATION_PROFILE_BIG: 816 / 498,
+  TEAM_AVATAR: 200 / 180,
+  SOCIAL_MEDIA_PREVIEW: 295 / 225
+} as const;
+

--- a/app/shared/components/about-us/Intro-section/IntroSection.tsx
+++ b/app/shared/components/about-us/Intro-section/IntroSection.tsx
@@ -6,6 +6,7 @@ import { EditBlockSkeleton } from '../../edit-block-skeleton/EditBlockSkeleton';
 import { QuoteBlock } from '../Liatoshynsky-office/quote-block/QuoteBlock';
 import { styles } from './IntroSection.styles';
 import { BLOCK_IDS, PAGE_IDS } from '~/constants/pageBlocks';
+import { CROP_RATIOS } from '~/constants/publications';
 import { ImagePreviewBlock } from '~/ds-components/photo-block/PhotoBlock';
 import { CustomTextField } from '~/ds-components/text-field/TextField';
 import type { MediaModalResult } from '~/shared/components/media-modal/MediaModal.types';
@@ -45,6 +46,7 @@ export const IntroSection = () => {
           imageUrl={getImageUrl(block.image)}
           fileName={block.image.src || ''}
           initialCrop={block.image.crop}
+          aspectRatio={CROP_RATIOS.HERO_BANNER}
           onChangeImage={(url: string, crop?: MediaModalResult['crop']) => {
             setField(pageId, blockId, 'image', {
               ...block.image,

--- a/app/shared/components/about-us/Liatoshynsky-foundation/foundation-block/FoundationBlock.tsx
+++ b/app/shared/components/about-us/Liatoshynsky-foundation/foundation-block/FoundationBlock.tsx
@@ -5,6 +5,7 @@ import { JSONContent } from '@tiptap/react';
 import React from 'react';
 
 import {MediaModalResult} from '~/components/media-modal/MediaModal.types';
+import { CROP_RATIOS } from '~/constants/publications';
 import { CustomTextField } from '~/ds-components/text-field/TextField';
 import { ImagePreviewBlock } from '~/shared/components/design-system/photo-block/PhotoBlock';
 
@@ -56,6 +57,7 @@ export const FoundationBlock = ({
         initialCrop={initialCrop}
         onChangeImage={onImageChange}
         title="Основне зображення"
+        aspectRatio={CROP_RATIOS.FUNDATION_PROFILE_SMALL}
       />
     </Box>
   );

--- a/app/shared/components/about-us/our-mission/OurMission.tsx
+++ b/app/shared/components/about-us/our-mission/OurMission.tsx
@@ -9,6 +9,7 @@ import { EditBlockSkeleton } from '../../edit-block-skeleton/EditBlockSkeleton';
 import { styles } from './OurMission.styles';
 import ConfigurableList from '~/components/configurable-list/ConfigurableList';
 import { BLOCK_IDS, PAGE_IDS } from '~/constants/pageBlocks';
+import { CROP_RATIOS } from '~/constants/publications';
 import CollapsibleBlock from '~/ds-components/collapsible-block/CollapsibleBlock';
 import { ImagePreviewBlock } from '~/ds-components/photo-block/PhotoBlock';
 import { CustomTextField } from '~/ds-components/text-field/TextField';
@@ -34,17 +35,19 @@ type MissionImageBlockProps = {
   image: MissionImage;
   locale: 'uk' | 'en';
   title: string;
+  aspectRatio?: number;
   onChangeCaption: (value: JSONContent) => void;
   onChangeImage: (url: string, crop?: CropResult | null) => void;
 };
 
-const MissionImageBlock = ({ image, locale, title, onChangeCaption, onChangeImage }: MissionImageBlockProps) => (
+const MissionImageBlock = ({ image, locale, title, aspectRatio, onChangeCaption, onChangeImage }: MissionImageBlockProps) => (
   <Box sx={styles.imageBlockWrapper}>
     <ImagePreviewBlock
       imageUrl={getImageUrl(image)}
       title={title}
       fileName={image.src || ''}
       initialCrop={image.crop}
+      aspectRatio = {aspectRatio}
       onChangeImage={onChangeImage}
     />
     <CustomTextField
@@ -162,6 +165,7 @@ const OurMission = () => {
           image={block.smallImage}
           locale={currentLocale}
           title="Перше зображення секції"
+          aspectRatio={CROP_RATIOS.FUNDATION_PROFILE_SMALL}
           onChangeCaption={(value) => handleCaptionChange('smallImage', value)}
           onChangeImage={(url, crop) => handleImageChange('smallImage', url, crop)}
         />
@@ -172,6 +176,7 @@ const OurMission = () => {
           image={block.bigImage}
           locale={currentLocale}
           title="Друге зображення секції"
+          aspectRatio={CROP_RATIOS.FUNDATION_PROFILE_BIG}
           onChangeCaption={(value) => handleCaptionChange('bigImage', value)}
           onChangeImage={(url, crop) => handleImageChange('bigImage', url, crop)}
         />

--- a/app/shared/components/contributor-card/ContributorCard.tsx
+++ b/app/shared/components/contributor-card/ContributorCard.tsx
@@ -3,6 +3,7 @@ import { Stack } from '@mui/material';
 import { JSONContent } from '@tiptap/react';
 import React from 'react';
 
+import { CROP_RATIOS } from '~/constants/publications';
 import { CustomTextField } from '~/ds-components/text-field/TextField';
 import { proseToText } from '~/lib/utils/prose';
 import { ImagePreviewBlock } from '~/shared/components/design-system/photo-block/PhotoBlock';
@@ -48,6 +49,7 @@ export const ContributorCard = ({
         imageUrl={contributor.photo.generatedSrc || contributor.photo.src || '/images/oval-contributor-card.png'}
         fileName={proseToText(contributor.photo.alt[currentLocale] as ProseDoc)}
         initialCrop={(contributor.photo as unknown as { crop: CropResult }).crop}
+        aspectRatio={CROP_RATIOS.TEAM_AVATAR}
         onChangeImage={handleChangeImage}
         direction="column"
         buttonSpacing="8px"

--- a/app/shared/components/design-system/photo-block/PhotoBlock.tsx
+++ b/app/shared/components/design-system/photo-block/PhotoBlock.tsx
@@ -30,6 +30,7 @@ interface ImagePreviewBlockProps extends StackProps {
   showAlternativeText?: boolean;
   disabled?: boolean;
   locale?: 'uk' | 'en';
+  aspectRatio?: number;
 }
 
 export const ImagePreviewBlock = ({
@@ -47,7 +48,8 @@ export const ImagePreviewBlock = ({
   altText,
   onChangeAltText,
   disabled = false,
-  locale = 'uk'
+  locale = 'uk',
+  aspectRatio
 }: ImagePreviewBlockProps) => {
   const [previewImage, setPreviewImage] = useState<string>(imageUrl);
 
@@ -210,6 +212,7 @@ export const ImagePreviewBlock = ({
         onClose={closeMediaModal}
         onApply={handleApplyMediaModal}
         directory="photos"
+        aspectRatio={aspectRatio}
       />
     </Box>
   );

--- a/app/shared/components/forms/seo-metadata-form/SeoMetadataForm.tsx
+++ b/app/shared/components/forms/seo-metadata-form/SeoMetadataForm.tsx
@@ -8,6 +8,7 @@ import { useEffect, useState } from 'react';
 
 import { SeoBaseFields } from './seo-base-fields/SeoBaseFields';
 import { styles } from './SeoMetadataForm.styles';
+import { CROP_RATIOS } from '~/constants/publications';
 import { ImagePreviewBlock as PhotoBlock } from '~/shared/components/design-system/photo-block/PhotoBlock';
 import TooltipCustom from '~/shared/components/design-system/tooltip/Tooltip';
 import { CropRect, CropResult } from '~/types/common';
@@ -150,6 +151,7 @@ export default function SeoMetadataForm({
         imageUrl={ogImagePreview || ''}
         fileName={displayFileName}
         onChangeImage={handleImageChange}
+        aspectRatio={CROP_RATIOS.SOCIAL_MEDIA_PREVIEW}
         disabled={isUploading}
         buttonSpacing="8px"
         stackSpacing="0"

--- a/app/shared/components/media-modal/MediaModal.renderers.ts
+++ b/app/shared/components/media-modal/MediaModal.renderers.ts
@@ -29,6 +29,7 @@ export type CropRendererProps = {
   onBaseline: (crop: CropResult | null) => void;
   resetSeq: number;
   onChange: (crop: CropResult | null) => void;
+  aspectRatio?: number;
 };
 
 export type MediaModalRenderers = {

--- a/app/shared/components/media-modal/flow/MediaModalFlow.tsx
+++ b/app/shared/components/media-modal/flow/MediaModalFlow.tsx
@@ -25,6 +25,7 @@ export type MediaModalFlowProps = {
   renderers: MediaModalRenderers;
   directory?: string;
   hideTabs?: boolean;
+  aspectRatio?: number;
 };
 
 const isNonImageUploadSelection = (selected: SelectedMedia | null): boolean => {
@@ -42,7 +43,8 @@ export function MediaModalFlow({
   initial,
   renderers,
   directory,
-  hideTabs
+  hideTabs,
+  aspectRatio
 }: Readonly<MediaModalFlowProps>) {
   const [state, dispatch] = useReducer(reducer, initial, buildInitialState);
 
@@ -231,7 +233,8 @@ export function MediaModalFlow({
         crop: state.crop,
         onBaseline: handleCropBaseline,
         resetSeq: state.resetSeq,
-        onChange: handleCropChange
+        onChange: handleCropChange,
+        aspectRatio
       });
     }
 

--- a/app/shared/components/media-modal/views/crop-view/CropView.tsx
+++ b/app/shared/components/media-modal/views/crop-view/CropView.tsx
@@ -11,7 +11,30 @@ import { cropViewContainer, styles } from './CropView.styles';
 const canCreateObjectUrl = () => typeof URL !== 'undefined' && typeof URL.createObjectURL === 'function';
 const canRevokeObjectUrl = () => typeof URL !== 'undefined' && typeof URL.revokeObjectURL === 'function';
 
-const MIN_NATURAL_HEIGHT = 100; // Should be 800, but mosst of the images are much smaller e.g. 336 × 400 or even 816 x 498, what should i do with them?
+const MIN_NATURAL_HEIGHT = 800;
+
+function calculateInitialRect(naturalWidth: number, naturalHeight: number, aspectRatio?: number) {
+  let rectWidth = naturalWidth;
+  let rectHeight = naturalHeight;
+  let x = 0;
+  let y = 0;
+
+  if (aspectRatio) {
+    const imgAspect = naturalWidth / naturalHeight;
+
+    if (imgAspect > aspectRatio) {
+      rectHeight = naturalHeight;
+      rectWidth = rectHeight * aspectRatio;
+      x = (naturalWidth - rectWidth) / 2;
+    } else {
+      rectWidth = naturalWidth;
+      rectHeight = rectWidth / aspectRatio;
+      y = (naturalHeight - rectHeight) / 2;
+    }
+  }
+
+  return { x, y, width: rectWidth, height: rectHeight };
+}
 
 export function CropView({
   selected,
@@ -93,26 +116,8 @@ export function CropView({
   useEffect(() => {
     if (resetSeq > 0 && imgRef.current) {
       const img = imgRef.current;
-      let rectWidth = img.naturalWidth;
-      let rectHeight = img.naturalHeight;
-      let x = 0;
-      let y = 0;
-
-      if (aspectRatio) {
-        const imgAspect = img.naturalWidth / img.naturalHeight;
-
-        if (imgAspect > aspectRatio) {
-          rectHeight = img.naturalHeight;
-          rectWidth = rectHeight * aspectRatio;
-          x = (img.naturalWidth - rectWidth) / 2;
-        } else {
-          rectWidth = img.naturalWidth;
-          rectHeight = rectWidth / aspectRatio;
-          y = (img.naturalHeight - rectHeight) / 2;
-        }
-      }
-
-      applyCrop({ x, y, width: rectWidth, height: rectHeight }, img);
+      const initialRect = calculateInitialRect(img.naturalWidth, img.naturalHeight, aspectRatio);
+      applyCrop(initialRect, img);
     }
   }, [resetSeq, applyCrop, aspectRatio]);
 
@@ -132,33 +137,14 @@ export function CropView({
     const domMinWidth = aspectRatio ? domMinHeight * aspectRatio : undefined;
 
     setMinDOMDimensions({ width: domMinWidth, height: domMinHeight });
-    setMinDOMDimensions({ width: domMinWidth, height: domMinHeight });
 
     if (stateCrop?.rect) {
       applyCrop(stateCrop.rect, img);
       return;
     }
 
-    let rectWidth = img.naturalWidth;
-    let rectHeight = img.naturalHeight;
-    let x = 0;
-    let y = 0;
-
-    if (aspectRatio) {
-      const imgAspect = img.naturalWidth / img.naturalHeight;
-
-      if (imgAspect > aspectRatio) {
-        rectHeight = img.naturalHeight;
-        rectWidth = rectHeight * aspectRatio;
-        x = (img.naturalWidth - rectWidth) / 2;
-      } else {
-        rectWidth = img.naturalWidth;
-        rectHeight = rectWidth / aspectRatio;
-        y = (img.naturalHeight - rectHeight) / 2;
-      }
-    }
-
-    applyCrop({ x, y, width: rectWidth, height: rectHeight }, img);
+    const initialRect = calculateInitialRect(img.naturalWidth, img.naturalHeight, aspectRatio);
+    applyCrop(initialRect, img);
   };
 
   const handleCropChange = (pixelCrop: PixelCrop) => {

--- a/app/shared/components/media-modal/views/crop-view/CropView.tsx
+++ b/app/shared/components/media-modal/views/crop-view/CropView.tsx
@@ -11,18 +11,24 @@ import { cropViewContainer, styles } from './CropView.styles';
 const canCreateObjectUrl = () => typeof URL !== 'undefined' && typeof URL.createObjectURL === 'function';
 const canRevokeObjectUrl = () => typeof URL !== 'undefined' && typeof URL.revokeObjectURL === 'function';
 
-const INITIAL_CROP_COORDINATES = {
-  x: 0,
-  y: 0
-};
+const MIN_NATURAL_HEIGHT = 100; // Should be 800, but mosst of the images are much smaller e.g. 336 × 400 or even 816 x 498, what should i do with them?
 
-export function CropView({ selected, crop: stateCrop, resetSeq, onBaseline, onChange }: Readonly<CropRendererProps>) {
+export function CropView({
+  selected,
+  crop: stateCrop,
+  resetSeq,
+  onBaseline,
+  onChange,
+  aspectRatio
+}: Readonly<CropRendererProps>) {
   const uploadFile = selected.kind === 'upload' ? selected.file : null;
   const [uploadObjectUrl, setUploadObjectUrl] = useState('');
   const [imgError, setImgError] = useState(false);
 
   const [crop, setCrop] = useState<PixelCrop>();
   const [imgDimensions, setImgDimensions] = useState<{ width: number; height: number } | null>(null);
+
+  const [minDOMDimensions, setMinDOMDimensions] = useState<{ width?: number; height?: number }>({});
 
   const imgRef = useRef<HTMLImageElement>(null);
 
@@ -87,21 +93,72 @@ export function CropView({ selected, crop: stateCrop, resetSeq, onBaseline, onCh
   useEffect(() => {
     if (resetSeq > 0 && imgRef.current) {
       const img = imgRef.current;
-      applyCrop({ ...INITIAL_CROP_COORDINATES, width: img.naturalWidth, height: img.naturalHeight }, img);
+      let rectWidth = img.naturalWidth;
+      let rectHeight = img.naturalHeight;
+      let x = 0;
+      let y = 0;
+
+      if (aspectRatio) {
+        const imgAspect = img.naturalWidth / img.naturalHeight;
+
+        if (imgAspect > aspectRatio) {
+          rectHeight = img.naturalHeight;
+          rectWidth = rectHeight * aspectRatio;
+          x = (img.naturalWidth - rectWidth) / 2;
+        } else {
+          rectWidth = img.naturalWidth;
+          rectHeight = rectWidth / aspectRatio;
+          y = (img.naturalHeight - rectHeight) / 2;
+        }
+      }
+
+      applyCrop({ x, y, width: rectWidth, height: rectHeight }, img);
     }
-  }, [resetSeq, applyCrop]);
+  }, [resetSeq, applyCrop, aspectRatio]);
 
   const onImageLoad = (e: React.SyntheticEvent<HTMLImageElement>) => {
     const img = e.currentTarget;
     setImgDimensions({ width: img.width, height: img.height });
 
-    const activeRect = stateCrop?.rect ?? {
-      ...INITIAL_CROP_COORDINATES,
-      width: img.naturalWidth,
-      height: img.naturalHeight
-    };
+    let maxPossibleNaturalHeight = img.naturalHeight;
+    if (aspectRatio) {
+      maxPossibleNaturalHeight = Math.min(img.naturalHeight, img.naturalWidth / aspectRatio);
+    }
 
-    applyCrop(activeRect, e.currentTarget);
+    const actualMinNaturalHeight = Math.min(MIN_NATURAL_HEIGHT, maxPossibleNaturalHeight);
+
+    const scaleY = img.height / img.naturalHeight;
+    const domMinHeight = actualMinNaturalHeight * scaleY;
+    const domMinWidth = aspectRatio ? domMinHeight * aspectRatio : undefined;
+
+    setMinDOMDimensions({ width: domMinWidth, height: domMinHeight });
+    setMinDOMDimensions({ width: domMinWidth, height: domMinHeight });
+
+    if (stateCrop?.rect) {
+      applyCrop(stateCrop.rect, img);
+      return;
+    }
+
+    let rectWidth = img.naturalWidth;
+    let rectHeight = img.naturalHeight;
+    let x = 0;
+    let y = 0;
+
+    if (aspectRatio) {
+      const imgAspect = img.naturalWidth / img.naturalHeight;
+
+      if (imgAspect > aspectRatio) {
+        rectHeight = img.naturalHeight;
+        rectWidth = rectHeight * aspectRatio;
+        x = (img.naturalWidth - rectWidth) / 2;
+      } else {
+        rectWidth = img.naturalWidth;
+        rectHeight = rectWidth / aspectRatio;
+        y = (img.naturalHeight - rectHeight) / 2;
+      }
+    }
+
+    applyCrop({ x, y, width: rectWidth, height: rectHeight }, img);
   };
 
   const handleCropChange = (pixelCrop: PixelCrop) => {
@@ -145,6 +202,9 @@ export function CropView({ selected, crop: stateCrop, resetSeq, onBaseline, onCh
           onComplete={handleComplete}
           keepSelection
           ruleOfThirds
+          aspect={aspectRatio}
+          minHeight={minDOMDimensions.height}
+          minWidth={minDOMDimensions.width}
           style={styles.cropComponent}
         >
           {/* eslint-disable-next-line @next/next/no-img-element */}


### PR DESCRIPTION
## Description

This PR implements strict aspect ratio constraints for the admin panel image cropper, completing the requirements for US-Admin-IMG-10

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Open any admin page that utilizes the ImagePreviewBlock with an enforced ratio (e.g., Hero block).
2. Click the "Редагувати" button to open the CropView component inside the modal.
3. Verify that the selection handle movements are strictly locked to the predefined aspect ratio (e.g., 816/300).
4. Attempt to shrink the crop area to its minimum; verify it blocks at equivalent of 100px natural height.
5. Resize/reposition the crop frame, then click the "Undo" button at the top header. Verify the frame immediately maximizes and auto-centers itself.

## Video / Screenshots


https://github.com/user-attachments/assets/4f10a787-9402-458c-9d44-622ee86d7367



## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
