### PR TITLE
fix(ui): missing add justify text button in CustomFormattingToolbar

### DIFF
--- a/app/shared/components/content-editor/custom-formatting-toolbar/CustomFormattingToolbar.test.tsx
+++ b/app/shared/components/content-editor/custom-formatting-toolbar/CustomFormattingToolbar.test.tsx
@@ -12,6 +12,9 @@ type ToolbarItem = {
 
 jest.mock('@blocknote/react', () => ({
   getFormattingToolbarItems: jest.fn(),
+  TextAlignButton: ({ textAlignment }: { textAlignment: string }) => (
+    <span data-testid={`text-align-${textAlignment}`}>{textAlignment}</span>
+  ),
   FormattingToolbar: ({ children }: { children: (React.ReactElement | ToolbarItem)[] }) => (
     <div data-testid="formatting-toolbar">
       {Array.isArray(children)
@@ -78,5 +81,19 @@ describe('CustomFormattingToolbar', () => {
 
     fireEvent.click(customButton);
     expect(mockOpenMediaModal).toHaveBeenCalledTimes(1);
+  });
+
+  it('should insert TextAlignButton with justify textAlignment after textAlignRightButton', () => {
+    (getFormattingToolbarItems as jest.Mock).mockReturnValue([
+      { key: 'textAlignLeftButton' },
+      { key: 'textAlignCenterButton' },
+      { key: 'textAlignRightButton' }
+    ]);
+
+    render(<CustomFormattingToolbar openMediaModal={mockOpenMediaModal} />);
+
+    expect(screen.getByTestId('default-item-textAlignRightButton')).toBeInTheDocument();
+
+    expect(screen.getByTestId('text-align-justify')).toBeInTheDocument();
   });
 });

--- a/app/shared/components/content-editor/custom-formatting-toolbar/CustomFormattingToolbar.tsx
+++ b/app/shared/components/content-editor/custom-formatting-toolbar/CustomFormattingToolbar.tsx
@@ -1,4 +1,4 @@
-import {  FormattingToolbar, getFormattingToolbarItems } from '@blocknote/react';
+import { FormattingToolbar, getFormattingToolbarItems, TextAlignButton } from '@blocknote/react';
 
 import { MediaModalResult } from '../../media-modal/MediaModal.types';
 import { CustomReplaceButton } from '../custom-replace-button/CustomReplaceButton';
@@ -12,6 +12,11 @@ export const CustomFormattingToolbar = ({ openMediaModal }: Props) => {
 
   if (replaceIndex !== -1) {
     items.splice(replaceIndex, 1, <CustomReplaceButton key="customReplaceButton" openMediaModal={openMediaModal} />);
+  }
+
+  const rightAlignIndex = items.findIndex((item) => item.key === 'textAlignRightButton');
+  if (rightAlignIndex !== -1) {
+    items.splice(rightAlignIndex + 1, 0, <TextAlignButton textAlignment="justify" key="textAlignJustifyButton" />);
   }
 
   return <FormattingToolbar>{items}</FormattingToolbar>;


### PR DESCRIPTION
### Description

This PR resolves an issue where the text justification option was missing from the content editor's custom formatting toolbar. 

### Key Changes

#### 1. UI

- **CustomFormattingToolbar.tsx**:
  - Used `TextAlignButton `component from `@blocknote/react`.
  - Added logic to locate the position of `textAlignRightButton` and insert the justify `TextAlignButton `immediately after it.

#### 2. Tests

  - Added a test case verifying that the justify `TextAlignButton `is correctly injected after `textAlignRightButton`.

Closes #392
US: https://github.com/Liatoshynsky-Foundation/lf-client/issues/396

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Refactoring/tech debt
- [ ] Documentation update
- [ ] Other

## How to test

1. Run the local development server (e.g. `npm run dev`) for lf-admin.
2. Navigate to the publications/events/[]/edit
3. Select a text to show the formatting toolbar.
4. Verify the "Justify" alignment icon is displayed next to the Left, Center, and Right alignment options.
5. Click the "Justify" button and verify that the selected text format updates to `justify`.
6. Run tests to confirm everything passes:
   ```bash
   npm run test -- app/shared/components/content-editor/custom-formatting-toolbar/CustomFormattingToolbar.test.tsx
   ```

## Video / Screenshots

https://github.com/user-attachments/assets/57b34186-7e50-42d8-b32a-b46b0d90591f

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [ ] Linting checks are clean
- [ ] No Sonar issues
- [ ] Branch is up to date with the target branch
- [x] Linked issue/task included
- [ ] Task moved to the review column on the board