### PR TITLE
fix(navigation): preserve form state on unsaved changes modal dismiss

### DIFF
--- a/app/store/slices/editSlice.ts
+++ b/app/store/slices/editSlice.ts
@@ -21,6 +21,7 @@ const resolveIsTmp = (field: string, value: unknown): boolean | undefined => {
 export const createEditSlice: StateCreator<EditState> = (set, get) => ({
   isChanged: false,
   isInitialized: false,
+  initializedPages: {},
 
   blocks: {},
   originalBlocks: {},
@@ -96,6 +97,10 @@ export const createEditSlice: StateCreator<EditState> = (set, get) => ({
   },
 
   setPageData: <T extends Record<string, BlockData>>(pageId: string, blocks: T, blocksOrder: string[], isInit = false) => {
+    if (isInit && get().initializedPages[pageId]) {
+      return;
+    }
+
     const prevPageBlocks = get().blocks[pageId] || {};
     const nextState: Partial<EditState> = {
       blocks: {
@@ -121,6 +126,10 @@ export const createEditSlice: StateCreator<EditState> = (set, get) => ({
         ...get().originalBlocksOrder,
         [pageId]: [...blocksOrder]
       };
+      nextState.initializedPages = {
+        ...get().initializedPages,
+        [pageId]: true
+      };
     }
     set(nextState as EditState);
   },
@@ -142,6 +151,7 @@ export const createEditSlice: StateCreator<EditState> = (set, get) => ({
   discardChanges: (pageId: string) => {
     const original = get().originalBlocks[pageId] || {};
     const originalOrder = get().originalBlocksOrder[pageId] || [];
+    const { [pageId]: _removed, ...remainingInitialized } = get().initializedPages;
     set({
       blocks: {
         ...get().blocks,
@@ -151,6 +161,7 @@ export const createEditSlice: StateCreator<EditState> = (set, get) => ({
         ...get().blocksOrder,
         [pageId]: [...originalOrder]
       },
+      initializedPages: remainingInitialized,
       isChanged: false
     });
   },

--- a/app/store/types.ts
+++ b/app/store/types.ts
@@ -26,6 +26,7 @@ export interface AdminUserState {
 export interface EditState {
   isChanged: boolean;
   isInitialized: boolean;
+  initializedPages: Record<string, boolean>;
 
   blocks: {
     [pageId: string]: {


### PR DESCRIPTION
## Description
Fixed a bug where dismissing the "Unsaved changes" modal caused the form state to reset — 
the active accordion section collapsed and the newly selected image disappeared from preview.

Root cause: `setPageData` in the edit store was overwriting local state on every re-render 
or re-fetch, even when the page was already initialized with unsaved changes.

Fix: Introduced `initializedPages` map in the edit store slice. `setPageData` now skips 
overwriting local state if the page is already initialized. The flag is cleared on 
`discardChanges` to allow re-initialization after an actual discard.

## How to test
1. Go to "Основні сторінки" → "Про нас"
2. Expand "Вступна секція"
3. Upload and apply a new image
4. Click "Файли" in the sidebar — the unsaved changes modal appears
5. Click "Скасувати зміни" to stay on the page
6. Verify that the accordion remains expanded and the new image is still visible in preview

## Video / Screenshots

https://github.com/user-attachments/assets/26672cac-2517-4b53-a9ea-81d9b914e03a

## Checklist
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board