### PR TITLE
fix(files): prevent file details panel from deforming cards size 

### DIFF
--- a/app/(logged_in)/files/FilesPageContent.styles.ts
+++ b/app/(logged_in)/files/FilesPageContent.styles.ts
@@ -3,7 +3,13 @@ import { SxProps, Theme } from '@mui/material';
 import { SIDEBAR_WIDTH } from '~/shared/components/file-info-sidebar/FileInfoSidebar.styles';
 import { mainHexPalette as colors } from '~/shared/theme/colors';
 
-export const styles = {
+type FilesPageContentStyles = {
+  pageHeaderButton: SxProps<Theme>;
+  contentLayout: SxProps<Theme>;
+  filesArea: SxProps<Theme>;
+};
+
+export const styles: FilesPageContentStyles = {
   pageHeaderButton: {
     borderRadius: '20px',
     px: '24px',
@@ -19,8 +25,17 @@ export const styles = {
       bgcolor: colors.yellow[600],
       boxShadow: 'none'
     }
+  },
+
+  contentLayout: {
+    width: '100%',
+    minWidth: 0
+  },
+
+  filesArea: {
+    minWidth: 0
   }
-} satisfies Record<string, SxProps<Theme>>;
+};
 
 export const getFilePageContentWrapper = (hasSidebarFile: boolean): SxProps<Theme> => ({
   width: '100%',
@@ -30,6 +45,6 @@ export const getFilePageContentWrapper = (hasSidebarFile: boolean): SxProps<Them
   display: 'flex',
   flexDirection: 'column',
   gap: '20px',
-  pr: { xs: 0, md: hasSidebarFile ? `${SIDEBAR_WIDTH}px` : 0 },
+  pr: { xs: 0, lg: hasSidebarFile ? `${SIDEBAR_WIDTH + 24}px` : 0 },
   transition: 'padding-right 0.2s ease'
 });

--- a/app/(logged_in)/files/FilesPageContent.tsx
+++ b/app/(logged_in)/files/FilesPageContent.tsx
@@ -2,7 +2,7 @@
 
 import { Box, Button } from '@mui/material';
 import { Upload } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import toast from 'react-hot-toast';
 
 import { getFilePageContentWrapper, styles } from './FilesPageContent.styles';
@@ -166,7 +166,7 @@ const usageToLink = (pageId?: string | null) => {
 export function FilesPageContent({ activeTab }: FilesPageContentProps) {
   const [view, setView] = useState<FilesCardsLayoutView>('grid');
   const [selectedFileId, setSelectedFileId] = useState<string | null>(null);
-  const [hasInitializedSelection, setHasInitializedSelection] = useState(false);
+  const fileCardRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
   const [deleteModalState, setDeleteModalState] = useState<{ open: boolean; fileId: string | null }>({
     open: false,
@@ -181,6 +181,14 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
   const { data, loading, error, refetch } = useAllAssets();
   const [createAsset] = useCreateAssetMutation();
   const [deleteAsset, { loading: isDeleting }] = useDeleteAssetMutation();
+
+  const handleItemRef = useCallback((itemId: string, node: HTMLDivElement | null) => {
+    fileCardRefs.current[itemId] = node;
+  }, []);
+
+  const handleItemClick = useCallback((item: FilesCardsLayoutItem) => {
+    setSelectedFileId(item.id);
+  }, []);
 
   const handleOpenUploadFlow = () => {
     setUploadModalInitial({ tab: 'UPLOAD' });
@@ -285,8 +293,9 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
       toast.success('Файл успішно видалено');
       setDeleteModalState({ open: false, fileId: null });
       if (selectedFileId === id) setSelectedFileId(null);
-    } catch (error: any) {
-      toast.error(error.message || 'Не вдалося видалити файл. Спробуйте пізніше.');
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Не вдалося видалити файл. Спробуйте пізніше.';
+      toast.error(message);
     }
   };
 
@@ -310,20 +319,49 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
   useEffect(() => {
     if (!filteredFiles.length) {
       setSelectedFileId(null);
-      setHasInitializedSelection(false);
-      return;
-    }
-
-    if (!hasInitializedSelection) {
-      setSelectedFileId(filteredFiles[0].id);
-      setHasInitializedSelection(true);
       return;
     }
 
     if (selectedFileId && !filteredFiles.some((file) => file.id === selectedFileId)) {
-      setSelectedFileId(filteredFiles[0].id);
+      setSelectedFileId(null);
     }
-  }, [filteredFiles, hasInitializedSelection, selectedFileId]);
+  }, [filteredFiles, selectedFileId]);
+
+  useEffect(() => {
+    if (!selectedFileId) {
+      return;
+    }
+
+    const animationFrameId = window.requestAnimationFrame(() => {
+      fileCardRefs.current[selectedFileId]?.scrollIntoView({
+        block: 'nearest',
+        inline: 'nearest',
+        behavior: 'smooth'
+      });
+    });
+
+    return () => {
+      window.cancelAnimationFrame(animationFrameId);
+    };
+  }, [selectedFileId]);
+
+  useEffect(() => {
+    if (!selectedFileId) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setSelectedFileId(null);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [selectedFileId]);
 
   const selectedFile = useMemo(
     () => filteredFiles.find((file) => file.id === selectedFileId) ?? null,
@@ -372,36 +410,43 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
         bottomTrailingContent={<SortSelect {...sortProps} minWidth={208} dataTestId="files-sort-select" />}
       />
 
-      {loading && <EmptyState title={FILES_LOADING_STATE_TITLE} description={FILES_LOADING_STATE_DESCRIPTION} />}
+      <Box sx={styles.contentLayout}>
+        <Box sx={styles.filesArea}>
+          {loading && <EmptyState title={FILES_LOADING_STATE_TITLE} description={FILES_LOADING_STATE_DESCRIPTION} />}
 
-      {!loading && error && <EmptyState title={FILES_ERROR_STATE_TITLE} description={FILES_ERROR_STATE_DESCRIPTION} />}
+          {!loading && error && <EmptyState title={FILES_ERROR_STATE_TITLE} description={FILES_ERROR_STATE_DESCRIPTION} />}
 
-      {!loading && !error && filteredFiles.length > 0 && (
-        <FilesCardsLayout
-          view={view}
-          items={filteredFiles}
-          onItemClick={(item) => setSelectedFileId(item.id)}
-          onItemAction={handleItemAction}
-        />
-      )}
+          {!loading && !error && filteredFiles.length > 0 && (
+            <FilesCardsLayout
+              view={view}
+              items={filteredFiles}
+              selectedItemId={selectedFileId}
+              gridColumns={sidebarFile ? { xlCols: 3 } : undefined}
+              setItemRef={handleItemRef}
+              onItemClick={handleItemClick}
+              onItemAction={handleItemAction}
+            />
+          )}
 
-      {hasNoFiles && isFavoritesTab && !hasActiveCriteria && (
-        <EmptyState
-          title={FILES_FAVORITES_EMPTY_STATE_TITLE}
-          description={FILES_FAVORITES_EMPTY_STATE_DESCRIPTION}
-          icon={<FavouriteStarIcon />}
-          action={{ label: FILES_FAVORITES_EMPTY_STATE_BUTTON, href: '/files' }}
-        />
-      )}
+          {hasNoFiles && isFavoritesTab && !hasActiveCriteria && (
+            <EmptyState
+              title={FILES_FAVORITES_EMPTY_STATE_TITLE}
+              description={FILES_FAVORITES_EMPTY_STATE_DESCRIPTION}
+              icon={<FavouriteStarIcon />}
+              action={{ label: FILES_FAVORITES_EMPTY_STATE_BUTTON, href: '/files' }}
+            />
+          )}
 
-      {hasNoFiles && hasActiveCriteria && (
-        <EmptyState title={FILES_EMPTY_STATE_NO_RESULTS_TITLE} description={FILES_EMPTY_STATE_NO_RESULTS_DESCRIPTION} />
-      )}
+          {hasNoFiles && hasActiveCriteria && (
+            <EmptyState title={FILES_EMPTY_STATE_NO_RESULTS_TITLE} description={FILES_EMPTY_STATE_NO_RESULTS_DESCRIPTION} />
+          )}
 
-      {hasNoFiles && !isFavoritesTab && !hasActiveCriteria && (
-        <EmptyState title={FILES_EMPTY_STATE_TITLE} description={FILES_EMPTY_STATE_DESCRIPTION} />
-      )}
+          {hasNoFiles && !isFavoritesTab && !hasActiveCriteria && (
+            <EmptyState title={FILES_EMPTY_STATE_TITLE} description={FILES_EMPTY_STATE_DESCRIPTION} />
+          )}
+        </Box>
 
+      </Box>
       {sidebarFile && (
         <FileInfoSidebar
           file={sidebarFile}

--- a/app/(logged_in)/files/FilesPageContent.tsx
+++ b/app/(logged_in)/files/FilesPageContent.tsx
@@ -332,7 +332,7 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
       return;
     }
 
-    const animationFrameId = window.requestAnimationFrame(() => {
+    const animationFrameId = globalThis.requestAnimationFrame(() => {
       fileCardRefs.current[selectedFileId]?.scrollIntoView({
         block: 'nearest',
         inline: 'nearest',
@@ -341,7 +341,7 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
     });
 
     return () => {
-      window.cancelAnimationFrame(animationFrameId);
+      globalThis.cancelAnimationFrame(animationFrameId);
     };
   }, [selectedFileId]);
 
@@ -356,10 +356,10 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
       }
     };
 
-    window.addEventListener('keydown', handleKeyDown);
+    globalThis.addEventListener('keydown', handleKeyDown);
 
     return () => {
-      window.removeEventListener('keydown', handleKeyDown);
+      globalThis.removeEventListener('keydown', handleKeyDown);
     };
   }, [selectedFileId]);
 

--- a/app/(logged_in)/files/FilesPageContent.tsx
+++ b/app/(logged_in)/files/FilesPageContent.tsx
@@ -186,9 +186,9 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
     fileCardRefs.current[itemId] = node;
   }, []);
 
-  const handleItemClick = useCallback((item: FilesCardsLayoutItem) => {
+  const handleItemClick = (item: FilesCardsLayoutItem) => {
     setSelectedFileId(item.id);
-  }, []);
+  };
 
   const handleOpenUploadFlow = () => {
     setUploadModalInitial({ tab: 'UPLOAD' });
@@ -332,17 +332,11 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
       return;
     }
 
-    const animationFrameId = globalThis.requestAnimationFrame(() => {
-      fileCardRefs.current[selectedFileId]?.scrollIntoView({
-        block: 'nearest',
-        inline: 'nearest',
-        behavior: 'smooth'
-      });
+    fileCardRefs.current[selectedFileId]?.scrollIntoView({
+      block: 'nearest',
+      inline: 'nearest',
+      behavior: 'smooth'
     });
-
-    return () => {
-      globalThis.cancelAnimationFrame(animationFrameId);
-    };
   }, [selectedFileId]);
 
   useEffect(() => {

--- a/app/shared/components/card-layout/CardLayout.styles.ts
+++ b/app/shared/components/card-layout/CardLayout.styles.ts
@@ -3,7 +3,7 @@ import { alpha, SxProps, Theme } from '@mui/material';
 import { mainHexPalette as colors } from '~/shared/theme/colors';
 
 const styles = {
-  card: (interactive: boolean): SxProps<Theme> => ({
+  card: (interactive: boolean, isSelected = false): SxProps<Theme> => ({
     display: 'flex',
     flexDirection: 'column',
     minHeight: '266px',
@@ -12,13 +12,15 @@ const styles = {
     borderRadius: '16px',
     overflow: 'hidden',
     border: '1px solid',
-    borderColor: 'blue.200',
+    borderColor: isSelected ? 'blue.700' : 'blue.200',
+    backgroundColor: isSelected ? 'adminBlue.100' : 'white',
     boxShadow: 0,
     cursor: interactive ? 'pointer' : 'default',
-    transition: interactive ? 'box-shadow 0.2s, opacity 0.2s' : 'none',
+    transition: interactive ? 'background-color 0.2s, border-color 0.2s, box-shadow 0.2s, opacity 0.2s' : 'none',
     '&:hover': interactive
       ? {
         opacity: 0.95,
+        backgroundColor: 'adminBlue.100',
         boxShadow: `0 2px 8px ${alpha(colors.black, 0.1)}`
       }
       : {}

--- a/app/shared/components/card-layout/CardLayout.test.tsx
+++ b/app/shared/components/card-layout/CardLayout.test.tsx
@@ -51,7 +51,7 @@ const defaultItems = [
   { text: { name: 'Delete' }, href: '/delete' }
 ];
 
-const renderCardLayout = (overrides = {}) =>
+const renderCardLayout = (overrides: Partial<React.ComponentProps<typeof CardLayout>> = {}) =>
   render(
     <CardLayout
       coverImage={<div data-testid="cover" />}
@@ -234,13 +234,19 @@ describe('CardLayout', () => {
     it('passes interactive=true to styles.card', async () => {
       const styles = (await import('./CardLayout.styles')).default;
       renderCardLayout({ interactive: true });
-      expect(styles.card).toHaveBeenCalledWith(true);
+      expect(styles.card).toHaveBeenCalledWith(true, false);
     });
 
     it('passes interactive=false (default) to styles.card', async () => {
       const styles = (await import('./CardLayout.styles')).default;
       renderCardLayout();
-      expect(styles.card).toHaveBeenCalledWith(false);
+      expect(styles.card).toHaveBeenCalledWith(false, false);
+    });
+
+    it('passes isSelected=true to styles.card', async () => {
+      const styles = (await import('./CardLayout.styles')).default;
+      renderCardLayout({ isSelected: true });
+      expect(styles.card).toHaveBeenCalledWith(false, true);
     });
   });
 });

--- a/app/shared/components/card-layout/CardLayout.tsx
+++ b/app/shared/components/card-layout/CardLayout.tsx
@@ -21,6 +21,7 @@ interface CardLayoutProps {
   contentBottom?: React.ReactNode;
   spaceBetweenContent?: number;
   interactive?: boolean;
+  isSelected?: boolean;
 }
 
 const CardLayout = ({
@@ -31,6 +32,7 @@ const CardLayout = ({
   contentBottom,
   contentUpper,
   interactive = false,
+  isSelected = false,
   spaceBetweenContent = 200
 }: CardLayoutProps) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -68,7 +70,7 @@ const CardLayout = ({
   }, [anchorEl]);
 
   return (
-    <Card sx={styles.card(interactive)}>
+    <Card sx={styles.card(interactive, isSelected)}>
       <Box sx={styles.imageContainer}>{coverImage}</Box>
 
       <CardContent sx={styles.cardContent}>

--- a/app/shared/components/file-card/FileCard.tsx
+++ b/app/shared/components/file-card/FileCard.tsx
@@ -39,11 +39,12 @@ export interface FileCardData {
 export interface FileCardProps {
   fileType: FileType;
   fileData: FileCardData;
+  isSelected?: boolean;
   onClick?: () => void;
   onAction?: (action: 'rename' | 'delete' | 'download', fileId: string) => void;
 }
 
-const FileCard = ({ fileType, fileData, onClick, onAction }: FileCardProps) => {
+const FileCard = ({ fileType, fileData, isSelected = false, onClick, onAction }: FileCardProps) => {
   const [isTooltipOpen, setIsTooltipOpen] = useState(false);
 
   const { id, name, dateAdded, isStarred = false, usageLinks, imageSrc } = fileData;
@@ -151,6 +152,7 @@ const FileCard = ({ fileType, fileData, onClick, onAction }: FileCardProps) => {
         info={infoNode}
         spaceBetweenContent={400}
         interactive={true}
+        isSelected={isSelected}
         items={itemsNode}
       />
     </Box>

--- a/app/shared/components/file-info-sidebar/FileInfoSidebar.styles.ts
+++ b/app/shared/components/file-info-sidebar/FileInfoSidebar.styles.ts
@@ -4,16 +4,17 @@ import type { SxProps, Theme } from '@mui/material/styles';
 import { mainHexPalette as colors } from '~/shared/theme/colors';
 
 export const SIDEBAR_WIDTH = 320;
+export type FileInfoSidebarVariant = 'fixed' | 'inline';
 
 export const styles = {
-  root: {
+  root: (variant: FileInfoSidebarVariant = 'fixed'): SxProps<Theme> => ({
     width: `${SIDEBAR_WIDTH}px`,
-    height: '100dvh',
+    height: variant === 'inline' ? 'calc(100dvh - 48px)' : '100dvh',
     bgcolor: colors.blue[100],
 
-    position: 'fixed',
-    top: 0,
-    right: 0,
+    position: variant === 'inline' ? 'sticky' : 'fixed',
+    top: variant === 'inline' ? '24px' : 0,
+    right: variant === 'inline' ? 'auto' : 0,
 
     display: 'flex',
     flexDirection: 'column',
@@ -25,7 +26,7 @@ export const styles = {
 
     overflowY: 'auto',
     scrollbarWidth: 'none'
-  },
+  }),
   header: {
     position: 'sticky',
     top: 0,

--- a/app/shared/components/file-info-sidebar/FileInfoSidebar.tsx
+++ b/app/shared/components/file-info-sidebar/FileInfoSidebar.tsx
@@ -5,7 +5,7 @@ import toast from 'react-hot-toast';
 
 import DeleteFileModal from '../delete-file-modal/DeleteFileModal';
 import TooltipCustom from '../design-system/tooltip/Tooltip';
-import { styles } from './FileInfoSidebar.styles';
+import { type FileInfoSidebarVariant, styles } from './FileInfoSidebar.styles';
 import { ImagePreviewModal } from './image-preview-modal/ImagePreviewModal';
 import { useAutosavedDescription } from './useAutosavedDescription';
 import { downloadFile } from '~/lib/utils/downloadFile';
@@ -56,6 +56,7 @@ export type FileSidebarAction =
 
 export type FileInfoSidebarProps = {
   file?: FileDetailsSidebarFile | null;
+  variant?: FileInfoSidebarVariant;
 
   onClose: () => void;
 
@@ -88,7 +89,13 @@ const RowText = ({ children }: { children: React.ReactNode }) => (
   <Typography variant='textMd' sx={styles.rowText}>{children}</Typography>
 );
 
-export function FileInfoSidebar({ file, onClose, onDescriptionSave, onRequestAction }: Readonly<FileInfoSidebarProps>) {
+export function FileInfoSidebar({
+  file,
+  variant = 'fixed',
+  onClose,
+  onDescriptionSave,
+  onRequestAction
+}: Readonly<FileInfoSidebarProps>) {
   const theme = useTheme();
   const fileId = file?.id;
   const filename = file?.filename ?? '—';
@@ -158,7 +165,7 @@ export function FileInfoSidebar({ file, onClose, onDescriptionSave, onRequestAct
     try {
       await deleteAsset({
         variables: { id },
-        update: (cache: ApolloCache<any>) => {
+        update: (cache: ApolloCache<unknown>) => {
           cache.evict({ id: cache.identify({ __typename: 'Asset', id }) });
           cache.gc();
         }
@@ -183,7 +190,7 @@ export function FileInfoSidebar({ file, onClose, onDescriptionSave, onRequestAct
     : null;
 
   return (
-    <Box sx={styles.root}>
+    <Box sx={styles.root(variant)}>
       <Box sx={styles.header}>
         <Box sx={styles.headerIcon}>
           <TypeIcon />

--- a/app/shared/components/files-cards-layout/FilesCardsLayout.styles.ts
+++ b/app/shared/components/files-cards-layout/FilesCardsLayout.styles.ts
@@ -10,5 +10,8 @@ export const styles: Record<string, SxProps<Theme>> = {
   listItem: {
     width: '100%',
     minWidth: 0
+  },
+  gridItem: {
+    minWidth: 0
   }
 };

--- a/app/shared/components/files-cards-layout/FilesCardsLayout.tsx
+++ b/app/shared/components/files-cards-layout/FilesCardsLayout.tsx
@@ -20,6 +20,14 @@ export type FilesCardsLayoutItem = {
 type FilesCardsLayoutProps = Readonly<{
   view: FilesCardsLayoutView;
   items: FilesCardsLayoutItem[];
+  selectedItemId?: string | null;
+  gridColumns?: {
+    xsCols?: number;
+    smCols?: number;
+    mdCols?: number;
+    xlCols?: number;
+  };
+  setItemRef?: (itemId: string, node: HTMLDivElement | null) => void;
   onItemClick?: (item: FilesCardsLayoutItem) => void;
   onItemAction?: (action: 'rename' | 'delete' | 'download', item: FilesCardsLayoutItem) => void;
 }>;
@@ -34,13 +42,27 @@ const minimizedTypeMap: Record<FileType, 'img' | 'audio' | 'pdf' | 'doc' | 'xls'
   archive: 'archive'
 };
 
-export function FilesCardsLayout({ view, items, onItemClick, onItemAction }: FilesCardsLayoutProps) {
+export function FilesCardsLayout({
+  view,
+  items,
+  selectedItemId,
+  gridColumns,
+  setItemRef,
+  onItemClick,
+  onItemAction
+}: FilesCardsLayoutProps) {
   if (view === 'list') {
     return (
       <Box sx={styles.root} data-testid="FilesCardsLayout-list">
         <Box sx={styles.list}>
           {items.map((item) => (
-            <Box key={item.id} sx={styles.listItem}>
+            <Box
+              key={item.id}
+              ref={(node: HTMLDivElement | null) => {
+                setItemRef?.(item.id, node);
+              }}
+              sx={styles.listItem}
+            >
               <MinimizedFileCard
                 id={item.id}
                 fileType={minimizedTypeMap[item.type]}
@@ -48,6 +70,7 @@ export function FilesCardsLayout({ view, items, onItemClick, onItemAction }: Fil
                 linked={!!item.usageLinks && item.usageLinks > 0}
                 name={item.name}
                 date={item.dateAdded}
+                isSelected={item.id === selectedItemId}
                 onClick={() => onItemClick?.(item)}
                 onAction={(action) => onItemAction?.(action, item)}
               />
@@ -59,22 +82,30 @@ export function FilesCardsLayout({ view, items, onItemClick, onItemAction }: Fil
   }
 
   return (
-    <CardsGrid dataTestId="FilesCardsLayout-grid">
+    <CardsGrid columns={gridColumns} dataTestId="FilesCardsLayout-grid">
       {items.map((item) => (
-        <FileCard
+        <Box
           key={item.id}
-          fileType={item.type}
-          fileData={{
-            id: item.id,
-            name: item.name,
-            dateAdded: item.dateAdded,
-            isStarred: item.isStarred,
-            usageLinks: item.usageLinks,
-            imageSrc: item.imageSrc
+          ref={(node: HTMLDivElement | null) => {
+            setItemRef?.(item.id, node);
           }}
-          onClick={() => onItemClick?.(item)}
-          onAction={(action) => onItemAction?.(action, item)}
-        />
+          sx={styles.gridItem}
+        >
+          <FileCard
+            fileType={item.type}
+            fileData={{
+              id: item.id,
+              name: item.name,
+              dateAdded: item.dateAdded,
+              isStarred: item.isStarred,
+              usageLinks: item.usageLinks,
+              imageSrc: item.imageSrc
+            }}
+            isSelected={item.id === selectedItemId}
+            onClick={() => onItemClick?.(item)}
+            onAction={(action) => onItemAction?.(action, item)}
+          />
+        </Box>
       ))}
     </CardsGrid>
   );

--- a/app/shared/components/minimized-file-card/MinimizedFileCard.styles.ts
+++ b/app/shared/components/minimized-file-card/MinimizedFileCard.styles.ts
@@ -3,14 +3,14 @@ import { alpha } from '@mui/material';
 import { mainHexPalette as colors } from '~/shared/theme/colors';
 
 export const styles = {
-  container: {
+  container: (isSelected = false) => ({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between',
     p: '11px 16px',
     borderRadius: '16px',
-    borderColor: 'blue.300',
-    backgroundColor: 'white',
+    borderColor: isSelected ? 'blue.700' : 'blue.300',
+    backgroundColor: isSelected ? 'adminBlue.100' : 'white',
     cursor: 'pointer',
     transition: 'background-color 0.2s, border-color 0.2s',
     '&:hover': {
@@ -20,7 +20,7 @@ export const styles = {
       backgroundColor: 'adminBlue.100',
       borderColor: 'blue.700'
     }
-  },
+  }),
 
   content: {
     gap: '8px'

--- a/app/shared/components/minimized-file-card/MinimizedFileCard.tsx
+++ b/app/shared/components/minimized-file-card/MinimizedFileCard.tsx
@@ -32,6 +32,7 @@ interface MinimizedFileCardProps {
   linked?: boolean;
   name: string;
   date: string;
+  isSelected?: boolean;
   onClick?: () => void;
   onAction?: (action: 'rename' | 'delete' | 'download', fileId: string) => void;
   onMenuClick?: (e: MouseEvent<HTMLButtonElement>) => void;
@@ -44,6 +45,7 @@ const MinimizedFileCard = ({
   linked = false,
   name,
   date,
+  isSelected = false,
   onClick,
   onAction,
   onMenuClick
@@ -96,7 +98,7 @@ const MinimizedFileCard = ({
   const isMenuOpen = Boolean(anchorEl);
 
   return (
-    <Paper variant="outlined" sx={styles.container} onClick={onClick}>
+    <Paper variant="outlined" sx={styles.container(isSelected)} onClick={onClick}>
       <Stack direction="row" sx={styles.content} alignItems="center" flexGrow={1}>
         <Image
           src={`/icons/${FILE_TYPES[fileType]}.svg`}


### PR DESCRIPTION
## Description

Fixed the behavior of the file details panel on the Files page to match the approved design.

Closes #653 
Changes:

* The file details panel now opens without affecting the page layout.
* Prevented file cards from resizing when the details panel is opened.
* Updated the selected file state to match the approved design.
* Ensured that only one file can be selected at a time.
* Added support for closing the details panel using the Esc key and the Close (X) button.
* Preserved the scroll position so the selected file remains visible after opening the details panel.
* Applied consistent behavior across all Files tabs: All, Images, Docs, Audio, and Favorites.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. Open the Files page.
2. Verify that no file is selected by default.
3. Select any file.
4. Verify that opening the details panel does not resize the file cards.
5. Select another file while the details panel is open and verify that the selection updates correctly.
6. Press Esc and verify that the details panel closes.
7. Open the details panel again and close it using the Close (X) button.
8. Select a file from the middle of the list and verify that it remains visible after the details panel is opened.
9. Repeat the verification in the All, Images, Docs, Audio, and Favorites tabs.

## Video / Screenshots

https://github.com/user-attachments/assets/7cf233e0-2ffb-46f5-b0d1-4fe1da55e3e2

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
