### PR TITLE
bugfix: Recalculate crop selection proportionally during container resize  

### DIFF
--- a/app/shared/components/media-modal/views/crop-view/CropView.test.tsx
+++ b/app/shared/components/media-modal/views/crop-view/CropView.test.tsx
@@ -1,21 +1,35 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 
 import { SelectedMedia } from '../../MediaModal.types';
 import { CropView } from './CropView';
 
+let resizeCallback: ResizeObserverCallback | null = null;
+
 beforeAll(() => {
   globalThis.URL.createObjectURL = jest.fn(() => 'blob:test-url');
   globalThis.URL.revokeObjectURL = jest.fn();
+
+  globalThis.ResizeObserver = class ResizeObserver {
+    constructor(callback: ResizeObserverCallback) {
+      resizeCallback = callback;
+    }
+    observe = jest.fn();
+    unobserve = jest.fn();
+    disconnect = jest.fn(() => {
+      resizeCallback = null;
+    });
+  };
 });
 
 afterEach(() => {
   jest.clearAllMocks();
+  resizeCallback = null;
 });
 
 jest.mock('react-image-crop', () => ({
   __esModule: true,
-  default: ({ children, onChange, onComplete }: any) => (
-    <div data-testid="mock-react-crop">
+  default: ({ children, onChange, onComplete, crop }: any) => (
+    <div data-testid="mock-react-crop" data-current-crop={JSON.stringify(crop)}>
       {children}
       <button
         data-testid="trigger-change"
@@ -150,5 +164,62 @@ describe('CropView', () => {
       <CropView selected={defaultSelected} crop={null} resetSeq={5} onBaseline={jest.fn()} onChange={jest.fn()} />
     );
     expect(screen.getByTestId('CropView')).toHaveAttribute('data-reset-seq', '5');
+  });
+
+  it('should scale down the internal crop state proportionally when container shrinks', () => {
+    render(
+      <CropView selected={defaultSelected} crop={null} resetSeq={0} onBaseline={jest.fn()} onChange={jest.fn()} />
+    );
+
+    const imgInitialSozes = { width: 400, height: 300, naturalWidth: 800, naturalHeight: 600 };
+    const cropPosition = { x: 0, y: 0 };
+    const newContainerSize = { width: 200, height: 150 };
+    const img = screen.getByAltText('');
+    const container = screen.getByTestId('mock-react-crop').parentElement;
+
+    Object.defineProperty(img, 'width', { value: imgInitialSozes.width, configurable: true });
+    Object.defineProperty(img, 'height', { value: imgInitialSozes.height, configurable: true });
+    Object.defineProperty(img, 'naturalWidth', { value: imgInitialSozes.naturalWidth, configurable: true });
+    Object.defineProperty(img, 'naturalHeight', { value: imgInitialSozes.naturalHeight, configurable: true });
+
+    Object.defineProperty(container, 'clientWidth', { value: imgInitialSozes.width, configurable: true });
+    Object.defineProperty(container, 'clientHeight', { value: imgInitialSozes.height, configurable: true });
+
+    act(() => {
+      fireEvent.load(img);
+    });
+
+    const mockReactCropBefore = screen.getByTestId('mock-react-crop');
+    const cropBefore = JSON.parse(mockReactCropBefore.dataset.currentCrop || '{}');
+    expect(cropBefore).toEqual({
+      unit: 'px',
+      x: cropPosition.x,
+      y: cropPosition.y,
+      width: imgInitialSozes.width,
+      height: imgInitialSozes.height
+    });
+
+    Object.defineProperty(container, 'clientWidth', { value: newContainerSize.width, configurable: true });
+    Object.defineProperty(container, 'clientHeight', { value: newContainerSize.height, configurable: true });
+
+    Object.defineProperty(img, 'width', { value: newContainerSize.width, configurable: true });
+    Object.defineProperty(img, 'height', { value: newContainerSize.height, configurable: true });
+
+    if (resizeCallback) {
+      act(() => {
+        resizeCallback!([], {} as ResizeObserver);
+      });
+    }
+
+    const mockReactCropAfter = screen.getByTestId('mock-react-crop');
+    const cropAfter = JSON.parse(mockReactCropAfter.dataset.currentCrop || '{}');
+
+    expect(cropAfter).toEqual({
+      unit: 'px',
+      x: cropPosition.x,
+      y: cropPosition.y,
+      width: newContainerSize.width,
+      height: newContainerSize.height
+    });
   });
 });

--- a/app/shared/components/media-modal/views/crop-view/CropView.tsx
+++ b/app/shared/components/media-modal/views/crop-view/CropView.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import 'react-image-crop/dist/ReactCrop.css';
 import { Box, Typography } from '@mui/material';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -93,17 +95,30 @@ export function CropView({
   const imgRef = useRef<HTMLImageElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const latestRef = useRef({ crop, stateCrop, imgDimensions });
-  latestRef.current = { crop, stateCrop, imgDimensions };
+  const latestRef = useRef<{ crop: PixelCrop | undefined; stateCrop: typeof stateCrop; imgDimensions: Size | null }>({
+    crop: undefined,
+    stateCrop,
+    imgDimensions: null
+  });
+  latestRef.current.stateCrop = stateCrop;
+
+  const setCropState = useCallback((next: PixelCrop | undefined) => {
+    latestRef.current.crop = next;
+    setCrop(next);
+  }, []);
+
+  const setDimensionsState = useCallback((next: Size | null) => {
+    latestRef.current.imgDimensions = next;
+    setImgDimensions(next);
+  }, []);
 
   const forCropAngle = imgDimensions ? Math.min(imgDimensions.width, imgDimensions.height) * 0.1 : 40;
 
   useEffect(() => {
     setImgError(false);
-    setImgDimensions(null);
-    latestRef.current.imgDimensions = null;
-    setCrop(undefined);
-  }, [selected.id]);
+    setDimensionsState(null);
+    setCropState(undefined);
+  }, [selected.id, setDimensionsState, setCropState]);
 
   useEffect(() => {
     if (!uploadFile) {
@@ -131,13 +146,15 @@ export function CropView({
 
   const applyCrop = useCallback(
     (rect: Rect, img: HTMLImageElement, overrideSize?: Size) => {
+      if (!img.naturalWidth || !img.naturalHeight) return;
+
       const displayWidth = overrideSize?.width ?? img.width;
       const displayHeight = overrideSize?.height ?? img.height;
 
       const scaleX = displayWidth / img.naturalWidth;
       const scaleY = displayHeight / img.naturalHeight;
 
-      setCrop({
+      setCropState({
         unit: 'px',
         x: rect.x * scaleX,
         y: rect.y * scaleY,
@@ -147,7 +164,7 @@ export function CropView({
 
       onBaseline({ rect });
     },
-    [onBaseline]
+    [onBaseline, setCropState]
   );
 
   useEffect(() => {
@@ -165,8 +182,7 @@ export function CropView({
         { width: container.clientWidth, height: container.clientHeight }
       );
 
-      setImgDimensions(newDimensions);
-      latestRef.current.imgDimensions = newDimensions;
+      setDimensionsState(newDimensions);
 
       const { width: domMinWidth, height: domMinHeight } = calculateMinDomDimensions(
         img,
@@ -179,7 +195,7 @@ export function CropView({
         const resizeScaleX = newDimensions.width / oldDimensions.width;
         const resizeScaleY = newDimensions.height / oldDimensions.height;
 
-        setCrop({
+        setCropState({
           unit: 'px',
           x: currentCrop.x * resizeScaleX,
           y: currentCrop.y * resizeScaleY,
@@ -195,7 +211,7 @@ export function CropView({
 
     resizeObserver.observe(container);
     return () => resizeObserver.disconnect();
-  }, [applyCrop, aspectRatio]);
+  }, [applyCrop, aspectRatio, setDimensionsState, setCropState]);
 
   useEffect(() => {
     if (resetSeq > 0 && imgRef.current) {
@@ -208,8 +224,7 @@ export function CropView({
   const onImageLoad = (e: React.SyntheticEvent<HTMLImageElement>) => {
     const img = e.currentTarget;
     const dimensions = { width: img.width, height: img.height };
-    setImgDimensions(dimensions);
-    latestRef.current.imgDimensions = dimensions;
+    setDimensionsState(dimensions);
 
     const { width: domMinWidth, height: domMinHeight } = calculateMinDomDimensions(img, img.height, aspectRatio);
     setMinDOMDimensions({ width: domMinWidth, height: domMinHeight });
@@ -224,7 +239,7 @@ export function CropView({
   };
 
   const handleCropChange = (pixelCrop: PixelCrop) => {
-    setCrop(pixelCrop);
+    setCropState(pixelCrop);
   };
 
   const handleComplete = (c: PixelCrop) => {

--- a/app/shared/components/media-modal/views/crop-view/CropView.tsx
+++ b/app/shared/components/media-modal/views/crop-view/CropView.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import 'react-image-crop/dist/ReactCrop.css';
 import { Box, Typography } from '@mui/material';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -13,7 +11,17 @@ const canRevokeObjectUrl = () => typeof URL !== 'undefined' && typeof URL.revoke
 
 const MIN_NATURAL_HEIGHT = 800;
 
-function calculateInitialRect(naturalWidth: number, naturalHeight: number, aspectRatio?: number) {
+interface Size {
+  width: number;
+  height: number;
+}
+
+interface Rect extends Size {
+  x: number;
+  y: number;
+}
+
+function calculateInitialRect(naturalWidth: number, naturalHeight: number, aspectRatio?: number): Rect {
   let rectWidth = naturalWidth;
   let rectHeight = naturalHeight;
   let x = 0;
@@ -36,6 +44,36 @@ function calculateInitialRect(naturalWidth: number, naturalHeight: number, aspec
   return { x, y, width: rectWidth, height: rectHeight };
 }
 
+function calculateContainSize(imgNatural: Size, container: Size): Size {
+  if (imgNatural.width <= container.width && imgNatural.height <= container.height) {
+    return { width: imgNatural.width, height: imgNatural.height };
+  }
+
+  const imgRatio = imgNatural.width / imgNatural.height;
+  const containerRatio = container.width / container.height;
+
+  return imgRatio > containerRatio
+    ? { width: container.width, height: container.width / imgRatio }
+    : { width: container.height * imgRatio, height: container.height };
+}
+
+function calculateMinDomDimensions(
+  img: HTMLImageElement,
+  displayHeight: number,
+  aspectRatio?: number
+): { width?: number; height: number } {
+  const maxPossibleNaturalHeight = aspectRatio
+    ? Math.min(img.naturalHeight, img.naturalWidth / aspectRatio)
+    : img.naturalHeight;
+
+  const actualMinNaturalHeight = Math.min(MIN_NATURAL_HEIGHT, maxPossibleNaturalHeight);
+  const scaleY = displayHeight / img.naturalHeight;
+  const domMinHeight = actualMinNaturalHeight * scaleY;
+  const domMinWidth = aspectRatio ? domMinHeight * aspectRatio : undefined;
+
+  return { width: domMinWidth, height: domMinHeight };
+}
+
 export function CropView({
   selected,
   crop: stateCrop,
@@ -49,17 +87,22 @@ export function CropView({
   const [imgError, setImgError] = useState(false);
 
   const [crop, setCrop] = useState<PixelCrop>();
-  const [imgDimensions, setImgDimensions] = useState<{ width: number; height: number } | null>(null);
-
+  const [imgDimensions, setImgDimensions] = useState<Size | null>(null);
   const [minDOMDimensions, setMinDOMDimensions] = useState<{ width?: number; height?: number }>({});
 
   const imgRef = useRef<HTMLImageElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const latestRef = useRef({ crop, stateCrop, imgDimensions });
+  latestRef.current = { crop, stateCrop, imgDimensions };
 
   const forCropAngle = imgDimensions ? Math.min(imgDimensions.width, imgDimensions.height) * 0.1 : 40;
 
   useEffect(() => {
     setImgError(false);
     setImgDimensions(null);
+    latestRef.current.imgDimensions = null;
+    setCrop(undefined);
   }, [selected.id]);
 
   useEffect(() => {
@@ -86,19 +129,13 @@ export function CropView({
     return selected.src;
   }, [selected, uploadObjectUrl]);
 
-  const didInitForSelectedRef = useRef<string | null>(null);
-
-  useEffect(() => {
-    if (didInitForSelectedRef.current !== selected.id) {
-      setCrop(undefined);
-      didInitForSelectedRef.current = selected.id;
-    }
-  }, [selected.id]);
-
   const applyCrop = useCallback(
-    (rect: { x: number; y: number; width: number; height: number }, img: HTMLImageElement) => {
-      const scaleX = img.width / img.naturalWidth;
-      const scaleY = img.height / img.naturalHeight;
+    (rect: Rect, img: HTMLImageElement, overrideSize?: Size) => {
+      const displayWidth = overrideSize?.width ?? img.width;
+      const displayHeight = overrideSize?.height ?? img.height;
+
+      const scaleX = displayWidth / img.naturalWidth;
+      const scaleY = displayHeight / img.naturalHeight;
 
       setCrop({
         unit: 'px',
@@ -114,6 +151,53 @@ export function CropView({
   );
 
   useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const resizeObserver = new ResizeObserver(() => {
+      const img = imgRef.current;
+      if (!img || img.naturalWidth === 0 || img.naturalHeight === 0) return;
+
+      const { crop: currentCrop, stateCrop: latestStateCrop, imgDimensions: oldDimensions } = latestRef.current;
+
+      const newDimensions = calculateContainSize(
+        { width: img.naturalWidth, height: img.naturalHeight },
+        { width: container.clientWidth, height: container.clientHeight }
+      );
+
+      setImgDimensions(newDimensions);
+      latestRef.current.imgDimensions = newDimensions;
+
+      const { width: domMinWidth, height: domMinHeight } = calculateMinDomDimensions(
+        img,
+        newDimensions.height,
+        aspectRatio
+      );
+      setMinDOMDimensions({ width: domMinWidth, height: domMinHeight });
+
+      if (currentCrop && oldDimensions && oldDimensions.width > 0 && oldDimensions.height > 0) {
+        const resizeScaleX = newDimensions.width / oldDimensions.width;
+        const resizeScaleY = newDimensions.height / oldDimensions.height;
+
+        setCrop({
+          unit: 'px',
+          x: currentCrop.x * resizeScaleX,
+          y: currentCrop.y * resizeScaleY,
+          width: currentCrop.width * resizeScaleX,
+          height: currentCrop.height * resizeScaleY
+        });
+      } else {
+        const activeRect =
+          latestStateCrop?.rect ?? calculateInitialRect(img.naturalWidth, img.naturalHeight, aspectRatio);
+        applyCrop(activeRect, img, newDimensions);
+      }
+    });
+
+    resizeObserver.observe(container);
+    return () => resizeObserver.disconnect();
+  }, [applyCrop, aspectRatio]);
+
+  useEffect(() => {
     if (resetSeq > 0 && imgRef.current) {
       const img = imgRef.current;
       const initialRect = calculateInitialRect(img.naturalWidth, img.naturalHeight, aspectRatio);
@@ -123,19 +207,11 @@ export function CropView({
 
   const onImageLoad = (e: React.SyntheticEvent<HTMLImageElement>) => {
     const img = e.currentTarget;
-    setImgDimensions({ width: img.width, height: img.height });
+    const dimensions = { width: img.width, height: img.height };
+    setImgDimensions(dimensions);
+    latestRef.current.imgDimensions = dimensions;
 
-    let maxPossibleNaturalHeight = img.naturalHeight;
-    if (aspectRatio) {
-      maxPossibleNaturalHeight = Math.min(img.naturalHeight, img.naturalWidth / aspectRatio);
-    }
-
-    const actualMinNaturalHeight = Math.min(MIN_NATURAL_HEIGHT, maxPossibleNaturalHeight);
-
-    const scaleY = img.height / img.naturalHeight;
-    const domMinHeight = actualMinNaturalHeight * scaleY;
-    const domMinWidth = aspectRatio ? domMinHeight * aspectRatio : undefined;
-
+    const { width: domMinWidth, height: domMinHeight } = calculateMinDomDimensions(img, img.height, aspectRatio);
     setMinDOMDimensions({ width: domMinWidth, height: domMinHeight });
 
     if (stateCrop?.rect) {
@@ -181,7 +257,7 @@ export function CropView({
     }
 
     return (
-      <Box sx={styles.imageContainer}>
+      <Box ref={containerRef} sx={styles.imageContainer}>
         <ReactCrop
           crop={crop}
           onChange={handleCropChange}
@@ -199,9 +275,7 @@ export function CropView({
             src={previewSrc}
             alt=""
             onLoad={onImageLoad}
-            onError={() => {
-              setImgError(true);
-            }}
+            onError={() => setImgError(true)}
             style={styles.cropComponentImage}
           />
         </ReactCrop>


### PR DESCRIPTION
## Description

Implements dynamic responsive scaling for the image crop selection overlay to prevent layout misalignment during browser window resizes.

Previously, the crop selection maintained static pixel dimensions while the underlying image adjusted fluidly, leading to incorrect sizing and broken boundaries. Implemented structural canvas mutation tracking via a `ResizeObserver` on the media wrapper. When triggered, the component automatically recalculates scales and positions proportionally based on the layout modifications, satisfying all responsive bounding criteria without throwing boundary exceptions. 

**What was changed:**
- Added `ResizeObserver` lifecycle management inside `CropView` to track structural mutations and responsive layout modifications of the wrapper container. 
- Implemented a mutable `latestRef` container to persist references to `crop`, `stateCrop`, and `imgDimensions` across re-renders without breaking observer microtasks.
- Added the `calculateContainSize` function to calculate the actual responsive DOM layout boundaries of the image relative to its container via a CSS `contain` logic simulation.
- Defined a new `setCropState` callback wrapped in `useCallback` to centrally synchronize both the local component state and the mutable tracking reference for the pixel crop coordinates.
- Defined a new `setDimensionsState` callback wrapped in `useCallback` to safely track responsive visual mutations of the rendered media element.
- Implemented proportional scaling math (`resizeScaleX` / `resizeScaleY`) inside the `ResizeObserver` layout effect to dynamically scale and update `x`, `y`, `width`, and `height` coordinates of the active crop context on the fly.
- Unified the calculation logic for layout restrictions inside the `calculateMinDomDimensions` function and bounded the state using `setMinDOMDimensions` to maintain responsive scaling constraints.
- Added the test to verify that the internal crop state scales down proportionally and handles layout recalculation.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Log in to the application environment. 
2. Navigate to the `/publications/news/create` page. 
3. Click on "Змінити зображення". 
4. Switch to the "Галерея" tab and choose any image.
5. Drag and move the crop selection overlay.
6. Resize the desktop window manually or toggle device emulation in developer tools.
7. Verify that the crop overlay bounding geometry automatically scales down proportionally and locks onto the selected layout features without tearing out of boundaries.


## Video / Screenshots
Result:

https://github.com/user-attachments/assets/be0e6382-035e-4be5-bb1e-609b461034ae

## Checklist

- [ ] Code compiles and runs correctly
- [ ] Tests pass successfully
- [ ] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [ ] Linked issue/task included
- [ ] Task moved to the review column on the board

---

Closes #641