### PR TITLE
fix: enable page preview from the admin panel via proxy

### DIFF
--- a/app/api/preview-proxy/route.test.ts
+++ b/app/api/preview-proxy/route.test.ts
@@ -1,0 +1,95 @@
+import 'whatwg-fetch';
+import type { NextRequest } from 'next/server';
+
+import { GET } from './route';
+
+const verifyAccessTokenMock = jest.fn();
+
+jest.mock('next/server', () => ({
+  __esModule: true,
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) => new Response(JSON.stringify(body), init)
+  }
+}));
+
+jest.mock('~/src/application/use-cases/tokenService/createToken.service', () => ({
+  __esModule: true,
+  createTokenService: () => ({
+    verifyAccessToken: verifyAccessTokenMock
+  })
+}));
+
+const buildRequest = (cookies: Record<string, string> = {}): NextRequest =>
+  ({
+    cookies: {
+      get: (name: string) => (name in cookies ? { name, value: cookies[name] } : undefined)
+    }
+  }) as unknown as NextRequest;
+
+describe('GET /api/preview-proxy', () => {
+  const originalPreviewSecret = process.env.PREVIEW_SECRET;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.PREVIEW_SECRET = 'test-preview-secret';
+  });
+
+  afterAll(() => {
+    process.env.PREVIEW_SECRET = originalPreviewSecret;
+  });
+
+  it('returns 401 when access token cookie is missing', async () => {
+    const response = await GET(buildRequest());
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ message: 'Unauthorized' });
+  });
+
+  it('returns 401 when access token is invalid', async () => {
+    verifyAccessTokenMock.mockImplementation(() => {
+      throw new Error('Invalid token');
+    });
+
+    const response = await GET(buildRequest({ accessToken: 'bad-token' }));
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ message: 'Unauthorized' });
+  });
+
+  it('returns 403 when user is not admin or superadmin', async () => {
+    verifyAccessTokenMock.mockReturnValue({ id: '1', type: 'user' });
+
+    const response = await GET(buildRequest({ accessToken: 'valid-token' }));
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ message: 'Forbidden' });
+  });
+
+  it('returns 500 when PREVIEW_SECRET is not configured', async () => {
+    verifyAccessTokenMock.mockReturnValue({ id: '1', type: 'admin' });
+    delete process.env.PREVIEW_SECRET;
+
+    const response = await GET(buildRequest({ accessToken: 'valid-token' }));
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ message: 'Preview secret is not configured' });
+  });
+
+  it('returns preview secret for authorized admin', async () => {
+    verifyAccessTokenMock.mockReturnValue({ id: '1', type: 'admin' });
+
+    const response = await GET(buildRequest({ accessToken: 'valid-token' }));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ previewSecret: 'test-preview-secret' });
+  });
+
+  it('returns preview secret for authorized superadmin', async () => {
+    verifyAccessTokenMock.mockReturnValue({ id: '1', type: 'superadmin' });
+
+    const response = await GET(buildRequest({ accessToken: 'valid-token' }));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ previewSecret: 'test-preview-secret' });
+  });
+});

--- a/app/api/preview-proxy/route.ts
+++ b/app/api/preview-proxy/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { createTokenService } from '~/src/application/use-cases/tokenService/createToken.service';
+import { ACCESS_TOKEN_COOKIE_NAME } from '~/src/constants';
+
+export async function GET(request: NextRequest) {
+  const accessToken = request.cookies.get(ACCESS_TOKEN_COOKIE_NAME)?.value;
+
+  if (!accessToken) {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+  }
+
+  let user;
+  try {
+    user = createTokenService().verifyAccessToken(accessToken);
+  } catch {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (user.type !== 'admin' && user.type !== 'superadmin') {
+    return NextResponse.json({ message: 'Forbidden' }, { status: 403 });
+  }
+
+  const previewSecret = process.env.PREVIEW_SECRET;
+  if (!previewSecret) {
+    return NextResponse.json({ message: 'Preview secret is not configured' }, { status: 500 });
+  }
+
+  return NextResponse.json({ previewSecret });
+}

--- a/app/lib/utils/fetchPreview.test.ts
+++ b/app/lib/utils/fetchPreview.test.ts
@@ -9,10 +9,11 @@ interface PreviewProps {
 describe('fetchPreview', () => {
   const mockFetch = jest.fn();
   const mockWindowOpen = jest.fn();
-  const mockConsoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
   const props: PreviewProps = { slug: 'about', lang: 'uk', draftId: 123 };
   const configResponse = { clientAppUrl: 'http://localhost:3000' };
-  const expectedUrl = 'http://localhost:3000/api/preview?lang=uk&slug=about&draftId=123';
+  const proxyResponse = { previewSecret: 'test-preview-secret' };
+  const expectedUrl =
+    'http://localhost:3000/api/preview?lang=uk&slug=about&draftId=123&previewSecret=test-preview-secret';
 
   beforeEach(() => {
     globalThis.fetch = mockFetch;
@@ -23,49 +24,48 @@ describe('fetchPreview', () => {
     jest.clearAllMocks();
   });
 
-  it('should call fetch twice and open a new window when all requests are successful', async () => {
+  it('should fetch config and proxy, then open preview URL with secret', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => configResponse
     });
     mockFetch.mockResolvedValueOnce({
-      ok: true
+      ok: true,
+      json: async () => proxyResponse
     });
 
     await fetchPreview(props);
 
     expect(mockFetch).toHaveBeenCalledTimes(2);
     expect(mockFetch).toHaveBeenCalledWith('/api/config');
-    expect(mockFetch).toHaveBeenCalledWith(expectedUrl, {
+    expect(mockFetch).toHaveBeenCalledWith('/api/preview-proxy', {
       method: 'GET',
       credentials: 'include'
     });
     expect(window.open).toHaveBeenCalledWith(expectedUrl, '_blank');
-    expect(mockConsoleWarn).not.toHaveBeenCalled();
   });
 
-  it('should still open a new window even if the second fetch fails', async () => {
+  it('should throw and not open a window if proxy request fails', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => configResponse
     });
-    const corsError = new Error('Failed to fetch');
-    mockFetch.mockRejectedValueOnce(corsError);
+    mockFetch.mockResolvedValueOnce({
+      ok: false
+    });
 
-    await fetchPreview(props);
-
+    await expect(fetchPreview(props)).rejects.toThrow('Failed to obtain preview credentials');
     expect(mockFetch).toHaveBeenCalledTimes(2);
-    expect(mockConsoleWarn).toHaveBeenCalledWith('Temporary preview fetch failed');
-    expect(window.open).toHaveBeenCalledWith(expectedUrl, '_blank');
+    expect(window.open).not.toHaveBeenCalled();
   });
 
   it('should throw an error and not open a window if fetching the config fails', async () => {
     const configError = new Error('API is down');
     mockFetch.mockRejectedValueOnce(configError);
+
     await expect(fetchPreview(props)).rejects.toThrow('API is down');
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(mockFetch).toHaveBeenCalledWith('/api/config');
     expect(window.open).not.toHaveBeenCalled();
-    expect(mockConsoleWarn).not.toHaveBeenCalled();
   });
 });

--- a/app/lib/utils/fetchPreview.ts
+++ b/app/lib/utils/fetchPreview.ts
@@ -8,20 +8,33 @@ type ConfigResponse = {
   clientAppUrl: string;
 };
 
+type PreviewProxyResponse = {
+  previewSecret: string;
+};
+
 export const fetchPreview = async ({ slug, lang, draftId }: PreviewProps) => {
   const response = await fetch('/api/config');
   const data: ConfigResponse = await response.json();
-  const previewApiUrl = `${data.clientAppUrl}/api/preview?lang=${lang}&slug=${slug}&draftId=${draftId}`;
 
-  try {
-    await fetch(previewApiUrl, {
-      method: 'GET',
-      credentials: 'include'
-    });
-  } catch {
-    //eslint-disable-next-line no-console
-    console.warn('Temporary preview fetch failed');
+  const proxyResponse = await fetch('/api/preview-proxy', {
+    method: 'GET',
+    credentials: 'include'
+  });
+
+  if (!proxyResponse.ok) {
+    throw new Error('Failed to obtain preview credentials');
   }
+
+  const { previewSecret } = (await proxyResponse.json()) as PreviewProxyResponse;
+
+  const params = new URLSearchParams({
+    lang,
+    slug,
+    draftId: String(draftId),
+    previewSecret
+  });
+
+  const previewApiUrl = `${data.clientAppUrl}/api/preview?${params}`;
 
   window.open(previewApiUrl, '_blank');
 };

--- a/src/shared/types/env.d.ts
+++ b/src/shared/types/env.d.ts
@@ -10,5 +10,6 @@ namespace NodeJS {
     JWT_ACCESS_TOKEN_SECRET: string;
     JWT_REFRESH_TOKEN_SECRET: string;
     CLIENT_BASE_URL: string;
+    PREVIEW_SECRET?: string;
   }
 }


### PR DESCRIPTION
## Description

Preview from the admin panel failed when admin and client run on different domains. The browser could not send accessToken (httpOnly cookie on the admin domain) to the client /api/preview endpoint, resulting in Missing access token in cookies.

Changes:
- Added GET /api/preview-proxy - verifies authenticated admin/superadmin via cookie and returns PREVIEW_SECRET
- Updated fetchPreview to call the proxy first, then open the client preview URL with previewSecret query param
- Added unit tests for proxy route and fetchPreview

Related [PR](https://github.com/Liatoshynsky-Foundation/lf-client/pull/1472) - must be merged and deployed together.

Closes [#494](https://github.com/Liatoshynsky-Foundation/lf-admin/issues/494)

Env (stage/prod): add PREVIEW_SECRET (same value as lf-client). Ensure CLIENT_BASE_URL points to the client URL without trailing slash.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

Locally:
1. Add to lf-admin/.env.local and lf-client/.env.local same value of PREVIEW_SECRET + for admin CLIENT_BASE_URL=http://localhost:3000
2. Run client on :3000, admin on :3001
3. Log in to admin -> open a page editor (e.g. about-us) -> change content -> click Preview
4. In Network: GET /api/preview-proxy is 200; new tab opens client preview without errors
5. Preview tab shows draft; incognito on /uk/about-us shows published content but not recent changes


## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
