### PR TITLE
fix(ui): convert news title to uppercase on input change

### DIFF
--- a/app/(logged_in)/publications/[type]/create/CreatePublicationsView.test.tsx
+++ b/app/(logged_in)/publications/[type]/create/CreatePublicationsView.test.tsx
@@ -119,20 +119,21 @@ describe('CreatePublicationsView Component', () => {
   });
 
   describe('User Interactions', () => {
-    it('should call setAdminTitle when the admin title input changes', () => {
+    it('should call setAdminTitle & convert a text to uppercase when the admin title input changes', () => {
       const mockSetAdminTitle = jest.fn();
       const mockData = createMockData({
         publicationType: 'news',
         setAdminTitle: mockSetAdminTitle
       });
+      const title = 'New Test Title';
 
       render(<CreatePublicationsView data={mockData} />);
 
       const input = screen.getByLabelText('Назва новини в адмінці');
-      fireEvent.change(input, { target: { value: 'New Test Title' } });
+      fireEvent.change(input, { target: { value: title } });
 
       expect(mockSetAdminTitle).toHaveBeenCalledTimes(1);
-      expect(mockSetAdminTitle).toHaveBeenCalledWith('New Test Title');
+      expect(mockSetAdminTitle).toHaveBeenCalledWith(title.toUpperCase());
     });
 
     it('should display an error message on the admin title field if adminTitleError is present', () => {

--- a/app/(logged_in)/publications/[type]/create/CreatePublicationsView.tsx
+++ b/app/(logged_in)/publications/[type]/create/CreatePublicationsView.tsx
@@ -186,7 +186,7 @@ export default function CreatePublicationsView({
           <TextField
             label={ADMIN_TITLE_LABELS[publicationType]}
             value={adminTitle}
-            onChange={(e) => setAdminTitle(e.target.value)}
+            onChange={(e) => setAdminTitle(e.target.value.toUpperCase())}
             error={Boolean(adminTitleError)}
             helperText={adminTitleError}
             sx={styles.textField}


### PR DESCRIPTION
## Description
This PR fixes a bug in which news titles were not following the required uppercase format. 
 
Closes [471](https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/471#issuecomment-4892268149)

## Type of change

- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. Open the admin panel
2. Go to the /publications
3. Go to the publications/[type]/create
4. Verify that all lowercase text is transformed in the "назва в адмінці" field
5. Click on edit to proceed
6. Verify that the title in the header is uppercase.

## Video / Screenshots

https://github.com/user-attachments/assets/4d07a076-f20b-4154-beab-cfb5bbc73649


## Checklist

- [X] Code compiles and runs correctly
- [X] Tests pass successfully
- [X] Linting checks are clean
- [X] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [X] Branch is up to date with the target branch
- [X] Linked issue/task included
- [ ] Task moved to the review column on the board

---
