### PR TITLE
fix: nothing to save error on about-us / privacy-policy pages

### DIFF
--- a/app/shared/components/editable-page-layout/EditablePageLayout.test.tsx
+++ b/app/shared/components/editable-page-layout/EditablePageLayout.test.tsx
@@ -11,13 +11,18 @@ const mockSetLocale = jest.fn();
 const mockDiscardChanges = jest.fn();
 const mockSetPageData = jest.fn();
 
+const defaultStoreState = {
+  setLocale: mockSetLocale,
+  discardChanges: mockDiscardChanges,
+  setPageData: mockSetPageData,
+  isChanged: false,
+};
+
+let mockStoreState = { ...defaultStoreState };
+
 jest.mock('~/store', () => ({
   useStore: jest.fn((selector) =>
-    selector({
-      setLocale: mockSetLocale,
-      discardChanges: mockDiscardChanges,
-      setPageData: mockSetPageData,
-    })
+    selector(mockStoreState)
   ),
 }));
 
@@ -61,6 +66,8 @@ describe('EditablePageLayout', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    mockStoreState = { ...defaultStoreState };
 
     (useGetPageQuery as jest.Mock).mockReturnValue({
       data: null,
@@ -173,7 +180,19 @@ describe('EditablePageLayout', () => {
       expect(screen.getByTestId('saving-flag')).toHaveTextContent('false');
     });
 
-    it('should trigger preview, save, cancel and language change callbacks when header controls are clicked', () => {
+    it('should pass isActionsDisabled as true on initial render (when isChanged is false)', () => {
+      runSimulation();
+      expect(screen.getByTestId('actions-disabled-flag')).toHaveTextContent('true');
+    });
+
+    it('should pass isActionsDisabled as false when isChanged is true', () => {
+      mockStoreState.isChanged = true;
+      runSimulation();
+      expect(screen.getByTestId('actions-disabled-flag')).toHaveTextContent('false');
+    });
+
+    it('should trigger preview, save, cancel and language change callbacks when header controls are clicked and isChanged is true', () => {
+      mockStoreState.isChanged = true;
       runSimulation();
 
       fireEvent.click(screen.getByTestId('preview-btn'));

--- a/app/shared/components/editable-page-layout/EditablePageLayout.tsx
+++ b/app/shared/components/editable-page-layout/EditablePageLayout.tsx
@@ -24,6 +24,7 @@ export const EditablePageLayout = ({
   const [isMounted, setIsMounted] = useState(false);
 
   const setLocale = useStore((s) => s.setLocale);
+  const isChanged = useStore((s) => s.isChanged);
   const discardChanges = useStore((s) => s.discardChanges);
 
   const { data, loading: queryLoading } = useGetPageQuery({
@@ -56,6 +57,7 @@ export const EditablePageLayout = ({
         title={headerTitle}
         onPreview={preview}
         onSave={save}
+        isActionsDisabled={!isChanged}
         onCancel={() => discardChanges(pageSlug)}
         isSaving={editorLoading || saveLoading}
         onLanguageChange={(lang: 'uk' | 'en') => setLocale(lang)}

--- a/app/shared/components/header/Header.styles.ts
+++ b/app/shared/components/header/Header.styles.ts
@@ -9,5 +9,12 @@ export const styles = {
     alignItems: 'center',
     flexWrap: 'wrap',
     gap: 2
+  },
+  
+  actionButton: {
+    '&.Mui-disabled': {
+      cursor: 'not-allowed',
+      pointerEvents: 'auto'
+    }
   }
 };

--- a/app/shared/components/header/Header.test.tsx
+++ b/app/shared/components/header/Header.test.tsx
@@ -7,13 +7,13 @@ type HeaderProps = {
   onPreview: () => void;
   onSave: () => void;
   isSaving: boolean;
-  onLanguageChange: (lang: 'ua' | 'en') => void;
+  onLanguageChange: (lang: 'uk' | 'en') => void;
   children?: React.ReactNode;
 };
 
 jest.mock('../language-switcher/LanguageSwitcher', () => ({
   __esModule: true,
-  default: ({ languageSwitcher }: { languageSwitcher: (lang: 'ua' | 'en') => void }) => (
+  default: ({ languageSwitcher }: { languageSwitcher: (lang: 'uk' | 'en') => void }) => (
     <button data-testid="language-switcher" onClick={() => languageSwitcher('en')}>
       Switch Language
     </button>
@@ -37,7 +37,8 @@ describe('Header', () => {
     onSave: jest.fn(),
     onCancel: jest.fn(),
     isSaving: false,
-    onLanguageChange: jest.fn()
+    onLanguageChange: jest.fn(),
+    isActionsDisabled: true,
   };
 
   beforeEach(() => {

--- a/app/shared/components/header/Header.test.tsx
+++ b/app/shared/components/header/Header.test.tsx
@@ -45,41 +45,98 @@ describe('Header', () => {
     jest.clearAllMocks();
   });
 
-  it('should render title and description', () => {
-    render(<Header {...defaultProps} />);
-    expect(screen.getByText('Про нас')).toBeInTheDocument();
-    expect(screen.getByText('Редагуйте та змінюйте вміст сторінки “Про нас”.')).toBeInTheDocument();
+  describe('UI', () => {
+    it('should render title, description & "Скасувати зміни" and "Зберегти" buttons ', () => {
+      render(<Header {...defaultProps} />);
+      expect(screen.getByText('Про нас')).toBeInTheDocument();
+      expect(screen.getByText('Редагуйте та змінюйте вміст сторінки “Про нас”.')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Скасувати зміни/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Зберегти/i })).toBeInTheDocument();
+    });
+  });
+  describe('actions logic', () => {
+
+    it.each([
+      {
+        verb: 'call',
+        buttonName: 'Попередній перегляд',
+        propsAction: 'onPreview' as const,
+        props: { isActionsDisabled: false },
+        expectedCall: true,
+        condition: ''
+      },
+      {
+        verb: 'NOT call',
+        buttonName: 'Зберегти',
+        propsAction: 'onSave' as const,
+        props: { isActionsDisabled: true },
+        expectedCall: false,
+        condition: 'if isActionsDisabled is true'
+      },
+      {
+        verb: 'NOT call',
+        buttonName: 'Скасувати зміни',
+        propsAction: 'onCancel' as const,
+        props: { isActionsDisabled: true },
+        expectedCall: false,
+        condition: 'if isActionsDisabled is true'
+      },
+      {
+        verb: 'call',
+        buttonName: 'Зберегти',
+        propsAction: 'onSave' as const,
+        props: { isActionsDisabled: false },
+        expectedCall: true,
+        condition: 'if isActionsDisabled is false'
+      },
+      {
+        verb: 'call',
+        buttonName: 'Скасувати зміни',
+        propsAction: 'onCancel' as const,
+        props: { isActionsDisabled: false },
+        expectedCall: true,
+        condition: 'if isActionsDisabled is false'
+      },
+    ])(
+      'should $verb $propsAction when "$buttonName" button is clicked $condition',
+      ({ buttonName, propsAction, props, expectedCall }) => {
+        const mergedProps = { ...defaultProps, ...props };
+        render(<Header {...mergedProps} />);
+
+        const button = screen.getByRole('button', { name: new RegExp(buttonName, 'i') });
+        fireEvent.click(button);
+
+        if (expectedCall) {
+          expect(mergedProps[propsAction]).toHaveBeenCalledTimes(1);
+        } else {
+          expect(mergedProps[propsAction]).not.toHaveBeenCalled();
+        }
+      }
+    );
+
+    it('should call onLanguageChange when LanguageSwitcher is used', () => {
+      render(<Header {...defaultProps} />);
+      const switcher = screen.getByTestId('language-switcher');
+      fireEvent.click(switcher);
+      expect(defaultProps.onLanguageChange).toHaveBeenCalledWith('en');
+    });
   });
 
-  it('should call onPreview when "Попередній перегляд" button is clicked', () => {
-    render(<Header {...defaultProps} />);
-    const previewButton = screen.getByRole('button', { name: /Попередній перегляд/i });
-    fireEvent.click(previewButton);
-    expect(defaultProps.onPreview).toHaveBeenCalledTimes(1);
-  });
+  describe('UI states', () => {
+    it('should disable "Зберегти" button when isSaving is true', () => {
+      render(<Header {...defaultProps} isSaving={true} />);
+      const saveButton = screen.getByRole('button', { name: /Зберегти/i });
+      expect(saveButton).toBeDisabled();
+    });
 
-  it('should call onSave when "Зберегти" button is clicked', () => {
-    render(<Header {...defaultProps} />);
-    const saveButton = screen.getByRole('button', { name: /Зберегти/i });
-    fireEvent.click(saveButton);
-    expect(defaultProps.onSave).toHaveBeenCalledTimes(1);
-  });
+    it('should disable "Скасувати зміни" and "Зберегти" buttons when isActionsDisabled is true', () => {
+      render(<Header {...defaultProps} isActionsDisabled={true} />);
 
-  it('should disable "Зберегти" button when isSaving is true', () => {
-    render(<Header {...defaultProps} isSaving={true} />);
-    const saveButton = screen.getByRole('button', { name: /Зберегти/i });
-    expect(saveButton).toBeDisabled();
-  });
+      const cancelButton = screen.getByRole('button', { name: /Скасувати зміни/i });
+      const saveButton = screen.getByRole('button', { name: /Зберегти/i });
 
-  it('should render "Скасувати зміни" button', () => {
-    render(<Header {...defaultProps} />);
-    expect(screen.getByRole('button', { name: /Скасувати зміни/i })).toBeInTheDocument();
-  });
-
-  it('should call onLanguageChange when LanguageSwitcher is used', () => {
-    render(<Header {...defaultProps} />);
-    const switcher = screen.getByTestId('language-switcher');
-    fireEvent.click(switcher);
-    expect(defaultProps.onLanguageChange).toHaveBeenCalledWith('en');
+      expect(cancelButton).toBeDisabled();
+      expect(saveButton).toBeDisabled();
+    });
   });
 });

--- a/app/shared/components/header/Header.tsx
+++ b/app/shared/components/header/Header.tsx
@@ -14,9 +14,10 @@ type HeaderProps = {
   onCancel: () => void;
   isSaving: boolean;
   onLanguageChange: (lang: 'uk' | 'en') => void;
+  isActionsDisabled?: boolean;
 };
 
-export const Header = ({ title, onPreview, onSave, onCancel, isSaving, onLanguageChange }: HeaderProps) => {
+export const Header = ({ title, onPreview, onSave, onCancel, isSaving, onLanguageChange, isActionsDisabled }: HeaderProps) => {
   return (
     <Box sx={styles.container}>
       <Box>
@@ -44,10 +45,10 @@ export const Header = ({ title, onPreview, onSave, onCancel, isSaving, onLanguag
         </Stack>
 
         <Stack direction="row" spacing={2}>
-          <Button variant="outlined" color="primary" onClick={onCancel}>
+          <Button variant="outlined" color="primary" sx={styles.actionButton} onClick={onCancel} disabled={isActionsDisabled}>
             Скасувати зміни
           </Button>
-          <Button variant="filled" color="primary" onClick={onSave} disabled={isSaving}>
+          <Button variant="filled" color="primary" sx={styles.actionButton} onClick={onSave} disabled={isSaving || isActionsDisabled}>
             Зберегти
           </Button>
         </Stack>

--- a/app/shared/components/header/__mocks__/Header.tsx
+++ b/app/shared/components/header/__mocks__/Header.tsx
@@ -29,7 +29,7 @@ export const Header = ({
       cancel
     </button>
     <span data-testid="saving-flag">{String(isSaving)}</span>
-    <span data-testid="actions-disabled-flag">{isActionsDisabled}</span>
+    <span data-testid="actions-disabled-flag">{String(isActionsDisabled)}</span>
     <button data-testid="lang-en" onClick={() => onLanguageChange('en')}>
       set-en
     </button>

--- a/app/shared/components/header/__mocks__/Header.tsx
+++ b/app/shared/components/header/__mocks__/Header.tsx
@@ -6,7 +6,8 @@ export const Header = ({
   onSave,
   onCancel,
   isSaving,
-  onLanguageChange
+  onLanguageChange,
+  isActionsDisabled
 }: {
   title: string;
   onPreview: () => void;
@@ -14,6 +15,7 @@ export const Header = ({
   onCancel: () => void;
   isSaving: boolean;
   onLanguageChange: (lang: 'uk' | 'en') => void;
+  isActionsDisabled?: boolean;
 }) => (
   <div data-testid="header">
     <span data-testid="title">{title}</span>
@@ -27,6 +29,7 @@ export const Header = ({
       cancel
     </button>
     <span data-testid="saving-flag">{String(isSaving)}</span>
+    <span data-testid="actions-disabled-flag">{isActionsDisabled}</span>
     <button data-testid="lang-en" onClick={() => onLanguageChange('en')}>
       set-en
     </button>

--- a/app/shared/hooks/use-save-page/UseSavePage.test.tsx
+++ b/app/shared/hooks/use-save-page/UseSavePage.test.tsx
@@ -89,17 +89,6 @@ it('throws when no page blocks found', async () => {
   await expect(result.current.save()).rejects.toThrow('No page blocks found');
 });
 
-it('throws when nothing changed', async () => {
-  storeState = {
-    ...storeState,
-    originalBlocks: { test: { A: { title: 't' } } },
-    originalBlocksOrder: { test: ['A'] }
-  };
-
-  const { result } = renderHook(() => useSavePageBlocks('test'));
-  await expect(result.current.save()).rejects.toThrow('Nothing to save');
-});
-
 it('throws when publish returns no published page', async () => {
   publishMutate.mockResolvedValueOnce({ data: { publishPage: null } });
   const { result } = renderHook(() => useSavePageBlocks('test'));

--- a/app/shared/hooks/use-save-page/UseSavePage.tsx
+++ b/app/shared/hooks/use-save-page/UseSavePage.tsx
@@ -1,5 +1,4 @@
 'use client';
-import isEqual from 'fast-deep-equal';
 
 import { safeMutate } from '~/lib/utils/safeMutate';
 import { useStore } from '~/store';
@@ -12,9 +11,6 @@ import {
   useUpsertPageDraftMutation
 } from '~/types/graphql/generated/graphql';
 
-const hasChanged = (current: unknown, baseline: unknown): boolean =>
-  baseline === undefined || (current !== baseline && !isEqual(current, baseline));
-
 export const useSavePageBlocks = (slug: string) => {
   const markSaved = useStore((s) => s.saveAsDraft);
 
@@ -25,14 +21,10 @@ export const useSavePageBlocks = (slug: string) => {
     const state = useStore.getState();
 
     const current = state.blocks[slug];
-    const baseline = state.originalBlocks?.[slug];
 
     const currentBlocksOrder = state.blocksOrder[slug];
-    const baselineBlocksOrder = state.originalBlocksOrder[slug];
 
     if (current == null) throw new Error('No page blocks found');
-    if (!hasChanged(current, baseline) && !hasChanged(currentBlocksOrder, baselineBlocksOrder)) throw new Error('Nothing to save');
-
     await safeMutate<UpsertPageDraftMutation, UpsertPageDraftMutationVariables>(
       upsertDraft,
       { input: { slug, blocks: current, blocksOrder: currentBlocksOrder } },

--- a/app/store/slices/editSlice.test.ts
+++ b/app/store/slices/editSlice.test.ts
@@ -117,6 +117,20 @@ describe('editSlice', () => {
   });
 
   describe('setPageData', () => {
+    it('should early return from if the page is already initialized & we pass isInit=true', () => {
+      const state = store.getState();
+      state.initializedPages = {
+        [PAGE_ID]: true
+      };
+      const blocks = state.blocks;
+      const blocksPayload = { [BLOCK_ID as string]: { text: 'A' } } as unknown as SetPageDataPayload;
+
+      store.getState().setPageData(PAGE_ID, blocksPayload, [BLOCK_ID as string], true);
+
+
+      const stateAfter = store.getState();
+      expect(stateAfter.blocks).toStrictEqual(blocks);
+    });
     it('should set blocks and order, and mark as changed if not init', () => {
       const blocksPayload = { [BLOCK_ID as string]: { text: 'A' } } as unknown as SetPageDataPayload;
 

--- a/app/store/slices/editSlice.test.ts
+++ b/app/store/slices/editSlice.test.ts
@@ -149,18 +149,36 @@ describe('editSlice', () => {
     expect(store.getState().isChanged).toBe(true);
   });
 
-  it('should save as draft (reset isChanged)', () => {
+  it.each([
+    {
+      method: 'saveAsDraft' as const,
+      desc: 'save as draft (reset isChanged, originalBlocks & originalBlocksOrder are updated)'
+    },
+    {
+      method: 'publishPage' as const,
+      desc: 'publish page (reset isChanged, blocks & blocksOrder are updated)'
+    },
+  ])('should $desc', ({ method }) => {
     store.getState().setField(PAGE_ID, BLOCK_ID, 'title' as FieldKey, 'New' as FieldValue);
     expect(store.getState().isChanged).toBe(true);
 
-    store.getState().saveAsDraft(PAGE_ID);
+    store.getState()[method](PAGE_ID);
     expect(store.getState().isChanged).toBe(false);
-  });
 
-  it('should publish page (reset isChanged)', () => {
-    store.getState().setField(PAGE_ID, BLOCK_ID, 'title' as FieldKey, 'New' as FieldValue);
-    store.getState().publishPage(PAGE_ID);
-    expect(store.getState().isChanged).toBe(false);
+    const currentBlocks = store.getState().blocks;
+    const currentBlocksOrder = store.getState().blocksOrder;
+    const newBlocks = store.getState().blocks[PAGE_ID];
+    const newBlocksOrder = store.getState().blocksOrder[PAGE_ID];
+
+
+    expect(store.getState().originalBlocks).toStrictEqual({
+      ...currentBlocks,
+      [PAGE_ID]: newBlocks
+    });
+    expect(store.getState().originalBlocksOrder).toStrictEqual({
+      ...currentBlocksOrder,
+      [PAGE_ID]: newBlocksOrder
+    });
   });
 
   it('should discard changes and restore from original', () => {

--- a/app/store/slices/editSlice.ts
+++ b/app/store/slices/editSlice.ts
@@ -145,7 +145,20 @@ export const createEditSlice: StateCreator<EditState> = (set, get) => ({
   },
 
   saveAsDraft: (_pageId: string) => {
-    set({ isChanged: false });
+    const newBlocks = get().blocks[_pageId];
+    const newBlocksOrder = get().blocksOrder[_pageId];
+
+    set({
+      isChanged: false,
+      originalBlocks: {
+        ...get().blocks,
+        [_pageId]: newBlocks
+      },
+      originalBlocksOrder: {
+        ...get().blocksOrder,
+        [_pageId]: newBlocksOrder
+      }
+    });
   },
 
   discardChanges: (pageId: string) => {
@@ -167,7 +180,20 @@ export const createEditSlice: StateCreator<EditState> = (set, get) => ({
   },
 
   publishPage: (_pageId: string) => {
-    set({ isChanged: false });
+    const newBlocks = get().blocks[_pageId];
+    const newBlocksOrder = get().blocksOrder[_pageId];
+
+    set({
+      isChanged: false,
+      originalBlocks: {
+        ...get().blocks,
+        [_pageId]: newBlocks
+      },
+      originalBlocksOrder: {
+        ...get().blocksOrder,
+        [_pageId]: newBlocksOrder
+      }
+    });
   },
 
   setLocale: (locale: 'uk' | 'en') => set({ locale })


### PR DESCRIPTION
## Description
Closes #660 

This PR fixes a weird bug causing a saving error on the about-us & privacy-policy pages. Previously, after a user edited content on a page and saved it by clicking the "Зберегти" button, if he clicked the "Скасувати зміни" button and then tried to save the page, he received the 'nothing to save' error. 

After these changes, we get a new behavior with better UX.
Currently, if a user changes something and then clicks the save button, his changes become the new 'old' in the global state. So, in further cancel changes, the user will undo to the state of the last saved changes. 

### Key changes: 

- `editSlice.ts`: updated logic for publishing and saving as a draft page, now it updates originalBlocks & originalBlocksOrder fields.
- `Header`: added `cursor: not-allowed` style for action buttons to prevent cases that can cause bugs. Also, I have added a new prop called `isActionsDisabled `to properly disable both the cancel and save actions when no changes have been made. 
-` UseSavePage.tsx`: remove logic for 'nothing to save' error
- `tests`: updated & refactored tests for `Header`, `EditableLayoutPage`, `useSavePage `& `editSlice `

## Type of change

- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [X] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. Log in to the admin panel
2. Open a /about-us or /privacy-policy page 
3. Change the order of blocks/list items or edit the text content within blocks. 
4. Save your changes by clicking on the save button in the header
5. Verify that both cancel & save buttons are having cursor not allowed style on hover, and they are not clickable
6. Repeat step 3 
7. Don't save the page, click on the cancel button, and verify that your changes are reverted to the state after step 4. 

## Video / Screenshots


https://github.com/user-attachments/assets/015f9147-f607-4687-8897-a29b642d719d



## Checklist

- [X] Code compiles and runs correctly
- [X] Tests pass successfully
- [X] Linting checks are clean
- [X] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [X] Branch is up to date with the target branch
- [X] Linked issue/task included
- [X] Task moved to the review column on the board

---
