### PR TITLE
fix: adjust CustomFormattingField height for multiline text

### DIFF
--- a/app/shared/components/custom-formatting-field/CustomFormattingField.style.ts
+++ b/app/shared/components/custom-formatting-field/CustomFormattingField.style.ts
@@ -63,7 +63,7 @@ export const styles = {
 
   contentWrapper: {
     position: 'relative',
-    padding: '0 16px',
+    padding: '12px',
     minHeight: '48px',
     display: 'flex',
     alignItems: 'center'


### PR DESCRIPTION
## Description

This PR fixes the alignment and spacing issues in the CustomFormattingField component. Previously, the content wrapper used vertical centering and lacked top/bottom padding, causing multi-line text to touch the borders and preventing the field from expanding correctly.

This style update resolves a bug where fields on various edit or create pages would not adjust their height for multi-line content.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Log in to the admin panel.
2. Navigate to any page with a rich text field, like Group Content edit page or editing the main pages (About the Foundation or Privacy Policy).
3. Find the edit field with rich text.
4. Paste or type multiple lines of text into the formatting field.
5. Verify that the field dynamically adjusts its height to fit the text and maintains proper padding (top and bottom) inside the border.

## Video / Screenshots

Before:
<img width="965" height="277" alt="Знімок екрана 2026-07-15 113029" src="https://github.com/user-attachments/assets/459d04fc-63a3-4578-bc09-399856cfbb2e" />
<img width="957" height="412" alt="Знімок екрана 2026-07-15 113655" src="https://github.com/user-attachments/assets/4efc2463-8c50-4a39-b0ed-a10d07616a7f" />
<img width="977" height="266" alt="Знімок екрана 2026-07-15 113919" src="https://github.com/user-attachments/assets/b91a9e55-80fc-4794-80bb-b96bc1dc15fc" />

After:
<img width="943" height="467" alt="Знімок екрана 2026-07-15 114347" src="https://github.com/user-attachments/assets/608d73ae-6393-44bc-8411-366d8cbea8f0" />
<img width="976" height="287" alt="Знімок екрана 2026-07-15 114536" src="https://github.com/user-attachments/assets/fe0d7d85-5f84-4bd0-bf2c-2439e356d32c" />


## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
