### PR TITLE
fix: fix buttons styles for image actions on /about-us

### DIFF
--- a/app/shared/components/design-system/photo-block/PhotoBlock.styles.ts
+++ b/app/shared/components/design-system/photo-block/PhotoBlock.styles.ts
@@ -1,3 +1,4 @@
+
 export const PREVIEW_W = 196;
 export const PREVIEW_H = 120;
 
@@ -61,26 +62,16 @@ export const styles = {
     fontStyle: 'italic'
   },
 
+  imageActionButton: {
+    gap: '8px'
+  },
+
   editButton: {
     width: '127px',
-
-    '& .MuiButton-startIcon svg': {
-      marginRight: '-8px',
-      width: '16px',
-      height: '24px',
-      marginTop: '6px'
-    }
   },
 
   changeButton: {
     width: '190px',
-
-    '& .MuiButton-startIcon svg': {
-      marginRight: '-8px',
-      width: '16px',
-      height: '24px',
-      marginTop: '6px'
-    }
   },
 
   fileNameText: {

--- a/app/shared/components/design-system/photo-block/PhotoBlock.tsx
+++ b/app/shared/components/design-system/photo-block/PhotoBlock.tsx
@@ -185,7 +185,7 @@ export const ImagePreviewBlock = ({
               color="primary"
               size="small"
               onClick={openEditCrop}
-              sx={styles.editButton}
+              sx={[styles.imageActionButton, styles.editButton]}
               disabled={disabled || !previewImage}
             >
               Редагувати
@@ -197,7 +197,7 @@ export const ImagePreviewBlock = ({
               color="primary"
               size="small"
               onClick={openChangeImage}
-              sx={styles.changeButton}
+              sx={[styles.imageActionButton, styles.changeButton]}
               disabled={disabled}
             >
               Змінити зображення


### PR DESCRIPTION
## Description

This small PR fixes incorrect styles for icons in image actions buttons for `PhotoBlock.tsx` that is used on /about-us & /privacy-policy pages

Closes https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/494

## Type of change

- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. Open /about-us on admin 
2. Open a block with an image 
3. Verify that both the edit and change an image buttons have the correct gap before the text

## Video / Screenshots

before 
<img width="1280" height="684" alt="image" src="https://github.com/user-attachments/assets/099a597f-e1d8-4e20-a1b2-863d9580bcc8" />


after 
<img width="583" height="297" alt="image" src="https://github.com/user-attachments/assets/9d323724-1f57-4eb2-9c92-9e8fe37f2fb3" />


## Checklist

- [X] Code compiles and runs correctly
- [X] Tests pass successfully
- [X] Linting checks are clean
- [X] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [X] Branch is up to date with the target branch
- [X] Linked issue/task included
- [ ] Task moved to the review column on the board

---
