### PR TITLE
fix: add missing fields to UpdateOpus

### DIFF
--- a/app/types/graphql/mutations/opus.graphql
+++ b/app/types/graphql/mutations/opus.graphql
@@ -20,6 +20,16 @@ mutation UpdateOpus($id: ID!, $input: UpdateOpusInput!) {
       uk
       en
     }
+    name {
+      uk
+      en
+    }
+    additionalText
+    creationYear
+    endYear
+    datesNote
+    genre
+    status
     compositions {
       id
       order


### PR DESCRIPTION
## Description

This PR fixes a UI cache synchronization issue on the Group Content edit page where fields would visually revert to their previous values immediately after publishing.

Previously, the UpdateOpus GraphQL mutation response did not include several fields (such as Name, Creation Year, Genre, and Additional Text). Because these fields were missing from the response, the local cache could not update with the newly saved data, causing the useGroupContent hook to re-render the old values.

By adding the missing fields (name, additionalText, creationYear, endYear, datesNote, genre, and status) to the mutation response in opus.graphql, the local cache now properly syncs with the database, and the UI correctly displays the updated data after saving.

Closes #697 

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Log in to the admin panel.
2. Navigate to the Group Content edit page (/creativity/group/{id}/content).
3. Make changes to any of the affected fields: Назва групи (Name), Рік створення (Creation Year), Рік закінчення (End Year), Уточнення (Dates Note), Жанр (Genre), or Примітка (Additional Text).
4. Click the "Опублікувати" (Publish) button.
5. Verify that the success notification appears and the edited fields retain your newly entered values instead of reverting to the old ones.

## Video / Screenshots

Before:

https://github.com/user-attachments/assets/99c7d2bb-9d9d-444b-9fe0-59bf5d30ce46

After:

https://github.com/user-attachments/assets/60514157-a225-453c-abec-0e97e87307fe


## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board
