### PR TITLE
feat(ui): simplify filtering toolbar for publications 

### DIFF
--- a/app/(logged_in)/publications/page.test.tsx
+++ b/app/(logged_in)/publications/page.test.tsx
@@ -389,7 +389,6 @@ describe('Publications page', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Фільтри' }));
 
     expect(screen.getByTestId('filter-status')).toHaveTextContent('Статус');
-    expect(screen.getByTestId('filter-language')).toHaveTextContent('Мова');
     expect(screen.getByTestId('sort-select')).toHaveTextContent('Нові спочатку');
   });
 

--- a/app/constants/publications.ts
+++ b/app/constants/publications.ts
@@ -106,16 +106,10 @@ export const PUBLICATIONS_CREATE_OPTIONS: ReadonlyArray<PublicationsCreateOption
 );
 
 const PUBLICATIONS_STATUS_FILTER_OPTIONS: ReadonlyArray<FilterOption> = [
-  { value: BaseContentStatuses.Draft, label: 'Чернетка' },
+  { value: BaseContentStatuses.Draft, label: 'Чернетка (прихована)' },
   { value: BaseContentStatuses.Published, label: 'Опублікована' },
-  { value: BaseContentStatuses.Editing, label: 'Опублікована з чернеткою' }
 ];
 
-const PUBLICATIONS_LANGUAGE_FILTER_OPTIONS: ReadonlyArray<FilterOption> = [
-  { value: 'uk', label: 'Українська' },
-  { value: 'en', label: 'Англійська' },
-  { value: 'bilingual', label: 'Двомовна' }
-];
 
 export const PUBLICATIONS_FILTERS: ReadonlyArray<PublicationsFilterConfig> = [
   {
@@ -124,12 +118,6 @@ export const PUBLICATIONS_FILTERS: ReadonlyArray<PublicationsFilterConfig> = [
     options: PUBLICATIONS_STATUS_FILTER_OPTIONS,
     menuMinWidth: 170
   },
-  {
-    id: 'language',
-    label: 'Мова',
-    options: PUBLICATIONS_LANGUAGE_FILTER_OPTIONS,
-    menuMinWidth: 205
-  }
 ];
 
 export type PublicationLanguageOption = Readonly<{

--- a/app/shared/hooks/use-publications/usePublicationsFiltering.test.ts
+++ b/app/shared/hooks/use-publications/usePublicationsFiltering.test.ts
@@ -19,24 +19,20 @@ describe('usePublicationsFiltering', () => {
     act(() => {
       result.current.toolbarProps.search?.setSearch(' фестиваль ');
       result.current.toolbarProps.filters?.[0]?.onChange(['editing']);
-      result.current.toolbarProps.filters?.[1]?.onChange(['bilingual']);
     });
 
     expect(result.current.requestFilters.news).toEqual({
       search: 'фестиваль',
-      languages: ['bilingual'],
       statuses: ['editing'],
       sort: [{ field: NewsSortBy.CreatedAt, order: 'desc' }]
     });
     expect(result.current.requestFilters.media).toEqual({
       search: 'фестиваль',
-      languages: ['bilingual'],
       statuses: ['editing'],
       sort: [{ field: MediaMentionsSortBy.CreatedAt, order: 'desc' }]
     });
     expect(result.current.requestFilters.events).toEqual({
       search: 'фестиваль',
-      languages: ['bilingual'],
       statuses: ['editing'],
       sort: [{ field: EventSortBy.CreatedAt, order: 'desc' }]
     });

--- a/app/shared/hooks/use-publications/usePublicationsFiltering.ts
+++ b/app/shared/hooks/use-publications/usePublicationsFiltering.ts
@@ -2,7 +2,6 @@ import { useCallback, useMemo, useState } from 'react';
 
 import {
   PUBLICATIONS_FILTERS,
-  type PublicationsLanguageValue,
   type PublicationsStatusValue
 } from '~/constants/publications';
 import {
@@ -15,7 +14,6 @@ import {
 import type { FilteringToolbarProps, SortSelectProps } from '~/shared/components/filtering-toolbar';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
 import {
-  ContentLanguage,
   EventFiltersInput,
   EventSortBy,
   EventStatus,
@@ -64,17 +62,6 @@ const mapPublicationStatus = <TStatus extends string>(
   return statusEnum[PUBLICATION_STATUS_TO_ENUM_KEY[status]];
 };
 
-const mapPublicationLanguageToApiLanguage = (language: PublicationsLanguageValue): ContentLanguage => {
-  if (language === 'bilingual') {
-    return ContentLanguage.Bilingual;
-  }
-
-  if (language === 'en') {
-    return ContentLanguage.En;
-  }
-
-  return ContentLanguage.Uk;
-};
 
 type BaseContentSortEnum<TField extends string> = Readonly<{
   AdminTitle: TField;
@@ -130,10 +117,9 @@ export function usePublicationsFiltering(): Readonly<{
   const [isFiltersOpen, setIsFiltersOpen] = useState(false);
   const [search, setSearch] = useState('');
   const [statusFilters, setStatusFilters] = useState<PublicationsStatusValue[]>([]);
-  const [languageFilters, setLanguageFilters] = useState<PublicationsLanguageValue[]>([]);
   const [sortValue, setSortValue] = useState<FilesSortValue>(getInitialSortValue);
 
-  const activeFiltersCount = statusFilters.length + languageFilters.length;
+  const activeFiltersCount = statusFilters.length;
   const currentSortOption = SORT_OPTIONS.find((option) => option.value === sortValue) ?? SORT_OPTIONS[0];
   const currentSortField: SortFieldValue = sortValue.startsWith('date') ? 'date' : 'name';
   const normalizedSearch = search.trim();
@@ -141,24 +127,21 @@ export function usePublicationsFiltering(): Readonly<{
     () => ({
       news: {
         search: normalizedSearch || undefined,
-        languages: languageFilters.length ? languageFilters.map(mapPublicationLanguageToApiLanguage) : undefined,
         statuses: statusFilters.length ? statusFilters.map((status) => mapPublicationStatus(status, NewsStatus)) : undefined,
         sort: getBaseContentSortOptions(sortValue, NewsSortBy) as NonNullable<NewsFiltersInput['sort']>
       },
       events: {
         search: normalizedSearch || undefined,
-        languages: languageFilters.length ? languageFilters.map(mapPublicationLanguageToApiLanguage) : undefined,
         statuses: statusFilters.length ? statusFilters.map((status) => mapPublicationStatus(status, EventStatus)) : undefined,
         sort: getBaseContentSortOptions(sortValue, EventSortBy) as NonNullable<EventFiltersInput['sort']>
       },
       media: {
         search: normalizedSearch || undefined,
-        languages: languageFilters.length ? languageFilters.map(mapPublicationLanguageToApiLanguage) : undefined,
         statuses: statusFilters.length ? statusFilters.map((status) => mapPublicationStatus(status, MediaStatus)) : undefined,
         sort: getBaseContentSortOptions(sortValue, MediaMentionsSortBy) as NonNullable<MediaMentionsFiltersInput['sort']>
       }
     }),
-    [languageFilters, normalizedSearch, sortValue, statusFilters]
+    [normalizedSearch, sortValue, statusFilters]
   );
 
   const toggleFilters = useCallback(() => {
@@ -167,7 +150,6 @@ export function usePublicationsFiltering(): Readonly<{
 
   const clearFilters = useCallback(() => {
     setStatusFilters([]);
-    setLanguageFilters([]);
   }, []);
 
   const handleSortFieldChange = useCallback((field: SortFieldValue) => {
@@ -198,15 +180,13 @@ export function usePublicationsFiltering(): Readonly<{
         id: filter.id,
         label: filter.label,
         options: filter.options,
-        value: filter.id === 'status' ? statusFilters : languageFilters,
+        value: statusFilters,
         hideClearAction: true,
         menuMinWidth: filter.menuMinWidth,
         onChange:
-          filter.id === 'status'
-            ? (value: string[]) => setStatusFilters(value as PublicationsStatusValue[])
-            : (value: string[]) => setLanguageFilters(value as PublicationsLanguageValue[])
+          (value: string[]) => setStatusFilters(value as PublicationsStatusValue[])
       })),
-    [languageFilters, statusFilters]
+    [statusFilters]
   );
 
   const toolbarProps = useMemo<PublicationsFilteringToolbarProps>(


### PR DESCRIPTION
### Description

This PR simplifies the publications filtering toolbar by removing all unused language filter options and streamlining the status selection.
Closes #699 
### Key Changes

- **app/constants/publications.ts**: removed `PUBLICATIONS_LANGUAGE_FILTER_OPTIONS` and its corresponding filter entry in `PUBLICATIONS_FILTERS`. Streamlined `PUBLICATIONS_STATUS_FILTER_OPTIONS` by removing the redundant `Editing` status filter and updating the Draft option label to `'Чернетка (прихована)'`.

- **app/shared/hooks/use-publications/usePublicationsFiltering.ts**: removed the `languageFilters` state, the `mapPublicationLanguageToApiLanguage` mapping function, and GraphQL request variables for language.

- **app/shared/hooks/use-publications/usePublicationsFiltering.test.ts**: removed language filtering actions and query filter expectations from hook unit tests.
- **app/(logged_in)/publications/page.test.tsx**: removed test assertions expecting the presence of the language filter elements in the toolbar UI.


## Type of change

- [X] New feature
- [ ] Bug fix
- [X] Refactoring/tech debt
- [ ] Documentation update
- [ ] Other ( )

## How to test

1. Open the publications page `/publications`.
2. Click on the "Filters" toggle button in the control panel.
3. Verify that only the **Status** selector and text search field are rendered, and that the **Language** filter dropdown is removed. Status only contains "Чернетка (приховано)" & "Опубліковано"
4. Run tests using `npm run test`

## Video / Screenshots

After: 
<img width="1280" height="270" alt="image" src="https://github.com/user-attachments/assets/d8ebc1b2-66f3-48ee-8b74-7d7480f5483d" />
<img width="1280" height="554" alt="image" src="https://github.com/user-attachments/assets/744b463b-ad90-4b9c-831b-53a1a3ca7355" />
<img width="1280" height="647" alt="image" src="https://github.com/user-attachments/assets/87349bb2-5461-4f51-b5e0-b0b547574985" />


## Checklist

- [X] Code compiles and runs correctly
- [X] Tests pass successfully
- [X] Linting checks are clean
- [ ] No Sonar issues
- [X] Branch is up to date with the target branch
- [ ] Linked issue/task included
- [ ] Task moved to the review column on the board