### PR TITLE
Feature: implement server-side search, filtering, sorting and pagination for the /creativity page

### DIFF
--- a/app/(logged_in)/creativity/WorksPageContent.test.tsx
+++ b/app/(logged_in)/creativity/WorksPageContent.test.tsx
@@ -3,20 +3,14 @@ import React, { act } from 'react';
 
 import { useWorksFiltering } from './useWorksFiltering';
 import { WorksPageContent } from './WorksPageContent';
-import { useAllCompositions } from '~/shared/hooks/use-compositions/useCompositions';
-import { useAllOpusGroups, useAllUngroupedGroups } from '~/shared/hooks/use-opuses/useOpuses';
+import { usePaginatedWorks } from '~/shared/hooks/use-opuses/useOpuses';
 
 jest.mock('./useWorksFiltering', () => ({
   useWorksFiltering: jest.fn()
 }));
 
 jest.mock('~/shared/hooks/use-opuses/useOpuses', () => ({
-  useAllOpusGroups: jest.fn(),
-  useAllUngroupedGroups: jest.fn()
-}));
-
-jest.mock('~/shared/hooks/use-compositions/useCompositions', () => ({
-  useAllCompositions: jest.fn()
+  usePaginatedWorks: jest.fn()
 }));
 
 jest.mock('~/shared/components/dropdown-menu/DropdownMenu', () => ({
@@ -48,13 +42,48 @@ jest.mock('@mui/material/ButtonBase/TouchRipple', () => {
   };
 });
 
+jest.mock('~/shared/components/pagination/Pagination', () => ({
+  Pagination: ({
+    onPageChange,
+    currentPage,
+    totalPages
+  }: {
+    onPageChange: (event: React.ChangeEvent<unknown>, value: number) => void;
+    currentPage: number;
+    totalPages: number;
+  }) => (
+    <div data-testid="mock-pagination">
+      <span data-testid="pagination-current-page">{currentPage}</span>
+      <span data-testid="pagination-total-pages">{totalPages}</span>
+      <button
+        type="button"
+        data-testid="pagination-next-page-button"
+        onClick={(event) => onPageChange(event as unknown as React.ChangeEvent<unknown>, currentPage + 1)}
+      >
+        Next
+      </button>
+    </div>
+  )
+}));
+
+jest.mock('~/shared/components/dropdown-menu/ActionMenu', () => ({
+  __esModule: true,
+  default: ({ anchorEl, onClose }: { anchorEl: HTMLElement | null; onClose: () => void }) =>
+    anchorEl ? (
+      <div data-testid="dropdown-menu">
+        <button type="button" data-testid="dropdown-menu-close-button" onClick={onClose}>
+          Close
+        </button>
+      </div>
+    ) : null
+}));
+
 const mockedUseWorksFiltering = jest.mocked(useWorksFiltering);
-const mockedUseAllOpusGroups = jest.mocked(useAllOpusGroups);
-const mockedUseAllUngroupedGroups = jest.mocked(useAllUngroupedGroups);
-const mockedUseAllCompositions = jest.mocked(useAllCompositions);
+const mockedUsePaginatedWorks = jest.mocked(usePaginatedWorks);
 
 describe('WorksPageContent', () => {
   const defaultFilteringMock = {
+    requestFilters: {},
     sortValue: 'date_desc' as const,
     selectedFilters: {
       status: [],
@@ -73,60 +102,40 @@ describe('WorksPageContent', () => {
     }
   };
 
-  const mockOpusResponse = {
-    data: {
-      allOpuses: [
-        {
-          id: '1',
-          number: 'Op. 1',
-          title: { uk: 'Симфонія 1', en: 'Symphony 1' },
-          genre: 'Симфонія',
-          creationYear: '2020',
-          status: 'published',
-          createdAt: '1700000000',
-          updatedAt: '1700000000',
-          compositions: []
-        },
-        {
-          id: '2',
-          number: 'Op. 2',
-          title: { uk: 'Симфонія 2', en: 'Symphony 2' },
-          genre: 'Симфонія',
-          creationYear: '2021',
-          status: 'published',
-          createdAt: '1600000000',
-          updatedAt: '1600000000',
-          compositions: []
-        }
-      ]
-    },
+  const mockPaginatedResponse = {
+    items: [
+      {
+        id: '1',
+        number: 'Op. 1',
+        name: { uk: 'Симфонія 1', en: 'Symphony 1' },
+        genre: 'Симфонія',
+        creationYear: '2020',
+        status: 'published',
+        createdAt: '1700000000',
+        updatedAt: '1700000000',
+        compositions: []
+      },
+      {
+        id: '2',
+        number: 'Op. 2',
+        name: { uk: 'Симфонія 2', en: 'Symphony 2' },
+        genre: 'Симфонія',
+        creationYear: '2021',
+        status: 'published',
+        createdAt: '1600000000',
+        updatedAt: '1600000000',
+        compositions: []
+      }
+    ],
+    totalPages: 1,
+    totalItems: 2,
     loading: false,
-    error: undefined
-  } as unknown as ReturnType<typeof useAllOpusGroups>;
-
-  const mockCompositionResponse = {
-    data: {
-      allCompositions: [
-        {
-          id: '10',
-          title: { uk: 'Твір 1', en: 'Work 1' },
-          year: 2021,
-          genre: 'Вокал',
-          status: 'draft',
-          createdAt: '1700000000',
-          updatedAt: '1700000000'
-        }
-      ]
-    },
-    loading: false,
-    error: undefined
-  } as unknown as ReturnType<typeof useAllCompositions>;
+    error: null
+  } as unknown as ReturnType<typeof usePaginatedWorks>;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockedUseAllOpusGroups.mockReturnValue(mockOpusResponse);
-    mockedUseAllUngroupedGroups.mockReturnValue(mockOpusResponse);
-    mockedUseAllCompositions.mockReturnValue(mockCompositionResponse);
+    mockedUsePaginatedWorks.mockReturnValue(mockPaginatedResponse);
   });
 
   it('renders correctly with default empty filters and handles search filtering layout', () => {
@@ -165,12 +174,13 @@ describe('WorksPageContent', () => {
       selectedFilters: { status: ['published'], language: ['uk'], genre: [] },
       toolbarProps: { ...defaultFilteringMock.toolbarProps, activeFiltersCount: 1 }
     } as unknown as ReturnType<typeof useWorksFiltering>);
+
     rerender(<WorksPageContent activeTab="all" />);
 
     expect(screen.getByText('Створити')).toBeInTheDocument();
   });
 
-  it('covers specific search match cases for full mock queries inside filtering loop', () => {
+  it('covers rerenders across tabs for different search queries without crashing', () => {
     mockedUseWorksFiltering.mockReturnValue({
       ...defaultFilteringMock,
       toolbarProps: {
@@ -193,7 +203,7 @@ describe('WorksPageContent', () => {
 
       rerender(<WorksPageContent activeTab="all" />);
       rerender(<WorksPageContent activeTab="opus" />);
-      rerender(<WorksPageContent activeTab="ungrouped" />);
+      rerender(<WorksPageContent activeTab="woo" />);
       rerender(<WorksPageContent activeTab="works" />);
     });
 
@@ -206,7 +216,6 @@ describe('WorksPageContent', () => {
     render(<WorksPageContent activeTab="all" />);
 
     const createButton = screen.getByRole('button', { name: /створити/i });
-
     await act(async () => {
       fireEvent.click(createButton);
     });
@@ -224,6 +233,14 @@ describe('WorksPageContent', () => {
       }
     } as unknown as ReturnType<typeof useWorksFiltering>);
 
+    mockedUsePaginatedWorks.mockReturnValue({
+      items: [],
+      totalPages: 0,
+      totalItems: 0,
+      loading: false,
+      error: null
+    } as unknown as ReturnType<typeof usePaginatedWorks>);
+
     render(<WorksPageContent activeTab="all" />);
 
     expect(screen.getByTestId('mock-empty-state')).toBeInTheDocument();
@@ -232,42 +249,33 @@ describe('WorksPageContent', () => {
   it('renders Loading and Error states', () => {
     mockedUseWorksFiltering.mockReturnValue(defaultFilteringMock as unknown as ReturnType<typeof useWorksFiltering>);
 
-    const loadingResponse = { data: undefined, loading: true, error: undefined } as unknown as ReturnType<
-      typeof useAllOpusGroups
-    >;
-    mockedUseAllOpusGroups.mockReturnValue(loadingResponse);
-    mockedUseAllUngroupedGroups.mockReturnValue(loadingResponse);
-    mockedUseAllCompositions.mockReturnValue({
-      data: undefined,
+    const loadingResponse = {
+      items: [],
+      totalPages: 0,
+      totalItems: 0,
       loading: true,
-      error: undefined
-    } as unknown as ReturnType<typeof useAllCompositions>);
+      error: null
+    } as unknown as ReturnType<typeof usePaginatedWorks>;
+
+    mockedUsePaginatedWorks.mockReturnValue(loadingResponse);
 
     const { rerender } = render(<WorksPageContent activeTab="all" />);
     expect(screen.getByTestId('mock-empty-state')).toBeInTheDocument();
 
     const errorResponse = {
-      data: undefined,
+      items: [],
+      totalPages: 0,
+      totalItems: 0,
       loading: false,
       error: new Error('GraphQL Error')
-    } as unknown as ReturnType<typeof useAllOpusGroups>;
-    mockedUseAllOpusGroups.mockReturnValue(errorResponse);
+    } as unknown as ReturnType<typeof usePaginatedWorks>;
+
+    mockedUsePaginatedWorks.mockReturnValue(errorResponse);
     rerender(<WorksPageContent activeTab="all" />);
     expect(screen.getByTestId('mock-empty-state')).toBeInTheDocument();
   });
 
-  it('covers all sorting branches (date_asc, name_asc, name_desc)', () => {
-    mockedUseAllOpusGroups.mockReturnValue({
-      data: {
-        allOpuses: [
-          { id: '1', number: 'Op. 1', title: { uk: 'Б Твір' }, createdAt: '1000', compositions: [] },
-          { id: '2', number: 'Op. 2', title: { uk: 'А Твір' }, createdAt: '2000', compositions: [] }
-        ]
-      },
-      loading: false,
-      error: undefined
-    } as unknown as ReturnType<typeof useAllOpusGroups>);
-
+  it('covers sort value branches passed through to useWorksFiltering (date_asc, name_asc, name_desc)', () => {
     const sorts: ('date_asc' | 'name_asc' | 'name_desc')[] = ['date_asc', 'name_asc', 'name_desc'];
 
     sorts.forEach((sort) => {
@@ -282,48 +290,32 @@ describe('WorksPageContent', () => {
     expect(screen.getAllByTestId('mock-works-table').length).toBeGreaterThan(0);
   });
 
-  it('covers missing status, missing genre, and individual language branches (uk, en)', () => {
-    mockedUseAllOpusGroups.mockReturnValue({
-      data: {
-        allOpuses: [
-          {
-            id: '1',
-            number: 'Op. 1',
-            title: { uk: ' ', en: 'Only English Title' },
-            genre: null,
-            status: null,
-            createdAt: '1700000000',
-            compositions: [{ id: 'c1', title: { uk: '', en: 'Comp En' } }]
-          }
-        ]
-      },
-      loading: false,
-      error: undefined
-    } as unknown as ReturnType<typeof useAllOpusGroups>);
-
-    mockedUseAllCompositions.mockReturnValue({
-      data: {
-        allCompositions: [
-          {
-            id: '10',
-            title: { uk: 'Суто Укр', en: '' },
-            year: null,
-            genre: undefined,
-            status: undefined,
-            createdAt: '1700000000'
-          }
-        ]
-      },
-      loading: false,
-      error: undefined
-    } as unknown as ReturnType<typeof useAllCompositions>);
-
+  it('renders works table when items come back with partial/missing optional fields', () => {
     mockedUseWorksFiltering.mockReturnValue({
       ...defaultFilteringMock,
-      selectedFilters: { status: [], language: ['en', 'uk'] }
+      selectedFilters: { status: [], language: ['en', 'uk'], genre: [] }
     } as unknown as ReturnType<typeof useWorksFiltering>);
 
+    mockedUsePaginatedWorks.mockReturnValue({
+      items: [
+        {
+          id: '1',
+          number: 'Op. 1',
+          name: { uk: ' ', en: 'Only English Title' },
+          genre: null,
+          status: null,
+          createdAt: '1700000000',
+          compositions: [{ id: 'c1', title: { uk: '', en: 'Comp En' } }]
+        }
+      ],
+      totalPages: 1,
+      totalItems: 1,
+      loading: false,
+      error: null
+    } as unknown as ReturnType<typeof usePaginatedWorks>);
+
     render(<WorksPageContent activeTab="all" />);
+
     expect(screen.getByTestId('mock-works-table')).toBeInTheDocument();
   });
 
@@ -335,14 +327,23 @@ describe('WorksPageContent', () => {
         search: { search: '' },
         activeFiltersCount: 0
       },
-      selectedFilters: { status: ['archived'], language: [] }
+      selectedFilters: { status: ['archived'], language: [], genre: [] }
     } as unknown as ReturnType<typeof useWorksFiltering>);
 
+    mockedUsePaginatedWorks.mockReturnValue({
+      items: [],
+      totalPages: 0,
+      totalItems: 0,
+      loading: false,
+      error: null
+    } as unknown as ReturnType<typeof usePaginatedWorks>);
+
     render(<WorksPageContent activeTab="all" />);
+
     expect(screen.getByTestId('mock-empty-state')).toBeInTheDocument();
   });
 
-  it('covers fallback branches for empty search object and missing compositions', () => {
+  it('covers fallback branch for empty/undefined search object', () => {
     mockedUseWorksFiltering.mockReturnValue({
       ...defaultFilteringMock,
       toolbarProps: {
@@ -351,23 +352,24 @@ describe('WorksPageContent', () => {
       }
     } as unknown as ReturnType<typeof useWorksFiltering>);
 
-    mockedUseAllOpusGroups.mockReturnValue({
-      data: {
-        allOpuses: [
-          {
-            id: 'mock-id',
-            number: 'Op. 99',
-            title: { uk: 'Без композицій' },
-            createdAt: '1700000000',
-            compositions: undefined
-          }
-        ]
-      },
+    mockedUsePaginatedWorks.mockReturnValue({
+      items: [
+        {
+          id: 'mock-id',
+          number: 'Op. 99',
+          name: { uk: 'Без композицій' },
+          createdAt: '1700000000',
+          compositions: undefined
+        }
+      ],
+      totalPages: 1,
+      totalItems: 1,
       loading: false,
-      error: undefined
-    } as unknown as ReturnType<typeof useAllOpusGroups>);
+      error: null
+    } as unknown as ReturnType<typeof usePaginatedWorks>);
 
     render(<WorksPageContent activeTab="opus" />);
+
     expect(screen.getByTestId('mock-works-table')).toBeInTheDocument();
   });
 
@@ -375,8 +377,8 @@ describe('WorksPageContent', () => {
     mockedUseWorksFiltering.mockReturnValue(defaultFilteringMock as unknown as ReturnType<typeof useWorksFiltering>);
 
     render(<WorksPageContent activeTab="all" />);
-    const createButton = screen.getByRole('button', { name: /створити/i });
 
+    const createButton = screen.getByRole('button', { name: /створити/i });
     fireEvent.click(createButton);
     expect(screen.getByTestId('dropdown-menu')).toBeInTheDocument();
 
@@ -387,18 +389,57 @@ describe('WorksPageContent', () => {
   it('renders Error state explicitly when loading is complete and error exists', () => {
     mockedUseWorksFiltering.mockReturnValue(defaultFilteringMock as unknown as ReturnType<typeof useWorksFiltering>);
 
-    const errorResponse = {
-      data: undefined,
+    mockedUsePaginatedWorks.mockReturnValue({
+      items: [],
+      totalPages: 0,
+      totalItems: 0,
       loading: false,
       error: new Error('GraphQL Failure')
-    };
-
-    mockedUseAllOpusGroups.mockReturnValue(errorResponse as unknown as ReturnType<typeof useAllOpusGroups>);
-    mockedUseAllUngroupedGroups.mockReturnValue(errorResponse as unknown as ReturnType<typeof useAllOpusGroups>);
-    mockedUseAllCompositions.mockReturnValue(errorResponse as unknown as ReturnType<typeof useAllCompositions>);
+    } as unknown as ReturnType<typeof usePaginatedWorks>);
 
     render(<WorksPageContent activeTab="all" />);
 
     expect(screen.getByTestId('mock-empty-state')).toBeInTheDocument();
+  });
+
+  it('updates the current page when pagination triggers handlePageChange', () => {
+    mockedUseWorksFiltering.mockReturnValue(defaultFilteringMock as unknown as ReturnType<typeof useWorksFiltering>);
+
+    mockedUsePaginatedWorks.mockReturnValue({
+      items: [
+        {
+          id: '1',
+          number: 'Op. 1',
+          name: { uk: 'Симфонія 1' },
+          createdAt: '1700000000',
+          compositions: []
+        }
+      ],
+      totalPages: 3,
+      totalItems: 30,
+      loading: false,
+      error: null
+    } as unknown as ReturnType<typeof usePaginatedWorks>);
+
+    render(<WorksPageContent activeTab="all" />);
+
+    expect(screen.getByTestId('pagination-current-page')).toHaveTextContent('1');
+
+    fireEvent.click(screen.getByTestId('pagination-next-page-button'));
+
+    expect(screen.getByTestId('pagination-current-page')).toHaveTextContent('2');
+  });
+
+  it('closes the create dropdown menu when handleClose is invoked via onClose', () => {
+    mockedUseWorksFiltering.mockReturnValue(defaultFilteringMock as unknown as ReturnType<typeof useWorksFiltering>);
+
+    render(<WorksPageContent activeTab="all" />);
+
+    const createButton = screen.getByRole('button', { name: /створити/i });
+    fireEvent.click(createButton);
+    expect(screen.getByTestId('dropdown-menu')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('dropdown-menu-close-button'));
+    expect(screen.queryByTestId('dropdown-menu')).not.toBeInTheDocument();
   });
 });

--- a/app/(logged_in)/creativity/WorksPageContent.tsx
+++ b/app/(logged_in)/creativity/WorksPageContent.tsx
@@ -20,7 +20,6 @@ import {
   WORKS_LOADING_STATE_TITLE,
   WORKS_PAGE_TITLE,
   WORKS_TABS,
-  WorksLanguageValue,
   type WorksTabValue
 } from '~/constants/creativity';
 import ActionMenu from '~/shared/components/dropdown-menu/ActionMenu';
@@ -29,7 +28,7 @@ import { FilteringToolbar, SortSelect } from '~/shared/components/filtering-tool
 import { PageHeader } from '~/shared/components/page-header/PageHeader';
 import { Pagination } from '~/shared/components/pagination/Pagination';
 import { usePaginatedWorks } from '~/shared/hooks/use-opuses/useOpuses';
-import { BaseContentStatuses } from '~/types/enums/common.enums';
+import { WorksTab } from '~/types/graphql/generated/graphql';
 import { normalizeSearch } from '~/utils/normalizeSearch';
 
 type WorksPageContentProps = Readonly<{
@@ -95,7 +94,7 @@ function WorksCreateAction() {
 export function WorksPageContent({ activeTab }: WorksPageContentProps) {
   const [page, setPage] = useState(1);
 
-  const { sortValue, selectedFilters, toolbarProps, sortProps } = useWorksFiltering();
+  const { requestFilters, sortValue, selectedFilters, toolbarProps, sortProps } = useWorksFiltering();
   const searchValue = normalizeSearch(toolbarProps.search?.search ?? '');
 
   useEffect(() => {
@@ -106,15 +105,10 @@ export function WorksPageContent({ activeTab }: WorksPageContentProps) {
     setPage(value);
   };
 
-  const { items, totalPages, totalItems, loading, error } = usePaginatedWorks({
-    tab: activeTab,
-    search: searchValue,
-    filters: {
-      statuses: selectedFilters.status as BaseContentStatuses[],
-      languages: selectedFilters.language as WorksLanguageValue[]
-    },
-    page,
-    pageSize: ITEMS_PER_PAGE
+  const { items, totalPages, totalItems, loading, error } = usePaginatedWorks(activeTab as WorksTab, {
+    ...requestFilters,
+    limit: ITEMS_PER_PAGE,
+    skip: (page - 1) * ITEMS_PER_PAGE
   });
 
   const hasBaseItems = totalItems > 0;

--- a/app/(logged_in)/creativity/WorksPageContent.tsx
+++ b/app/(logged_in)/creativity/WorksPageContent.tsx
@@ -2,7 +2,7 @@
 
 import { Box, Button } from '@mui/material';
 import { ChevronDown } from 'lucide-react';
-import { ChangeEvent, useRef, useState } from 'react';
+import { ChangeEvent, useEffect, useRef, useState } from 'react';
 
 import { useWorksFiltering } from './useWorksFiltering';
 import { styles } from './WorksPageContent.styles';
@@ -21,122 +21,20 @@ import {
   WORKS_PAGE_TITLE,
   WORKS_TABS,
   WorksLanguageValue,
-  WorksStatusValue,
   type WorksTabValue
 } from '~/constants/creativity';
-import type { FilesSortValue } from '~/constants/sort';
 import ActionMenu from '~/shared/components/dropdown-menu/ActionMenu';
 import { EmptyState } from '~/shared/components/empty-state';
 import { FilteringToolbar, SortSelect } from '~/shared/components/filtering-toolbar';
 import { PageHeader } from '~/shared/components/page-header/PageHeader';
 import { Pagination } from '~/shared/components/pagination/Pagination';
-import { useAllCompositions } from '~/shared/hooks/use-compositions/useCompositions';
-import { useAllOpusGroups, useAllUngroupedGroups } from '~/shared/hooks/use-opuses/useOpuses';
+import { usePaginatedWorks } from '~/shared/hooks/use-opuses/useOpuses';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
-import { AllCompositionsQuery, type AllOpusesQuery } from '~/types/graphql/generated/graphql';
 import { normalizeSearch } from '~/utils/normalizeSearch';
 
 type WorksPageContentProps = Readonly<{
   activeTab: WorksTabValue;
 }>;
-
-type GqlOpus = AllOpusesQuery['allOpuses'][number];
-type GqlComposition = AllCompositionsQuery['allCompositions'][number];
-
-type GroupRowData = Readonly<{
-  id: string;
-  numberLabel: string;
-  title: string;
-  titleData: {
-    uk?: string | null;
-    en?: string | null;
-  };
-  genre: string;
-  startDate: string;
-  endDate?: string;
-  status: WorksStatusValue;
-  createdAt: string;
-  updatedAt: string;
-  publishedAt?: string;
-  numberKind?: string | null;
-  works: ReadonlyArray<{ id: string; title: string }>;
-}>;
-
-type CompositionRowData = Readonly<{
-  id: string;
-  title: string;
-  titleData: {
-    uk?: string | null;
-    en?: string | null;
-  };
-  year: string;
-  genre: string;
-  status: WorksStatusValue;
-  createdAt: string;
-  updatedAt: string;
-  publishedAt?: string;
-}>;
-
-const localizedTitle = (title: { uk: string; en: string }) => title.uk || title.en;
-
-function toGroupRowData(opus: GqlOpus): GroupRowData {
-  const safeStatus = (opus.status as unknown as WorksStatusValue) || BaseContentStatuses.Draft;
-  const safeName = opus.name ?? { uk: '', en: '' };
-
-  return {
-    id: opus.id,
-    numberLabel: opus.number,
-    title: localizedTitle(safeName),
-    titleData: safeName,
-    genre: opus.genre ?? '',
-    startDate: opus.creationYear,
-    endDate: opus.endYear ?? undefined,
-    status: safeStatus,
-    createdAt: opus.createdAt,
-    updatedAt: opus.updatedAt,
-    numberKind: opus.numberKind,
-    works: (opus.compositions ?? []).map((c) => ({
-      id: c.id,
-      title: localizedTitle(c.title)
-    }))
-  };
-}
-
-function toStandaloneRowData(composition: GqlComposition): CompositionRowData {
-  const safeStatus = (composition.status as unknown as WorksStatusValue) || BaseContentStatuses.Draft;
-
-  return {
-    id: composition.id,
-    title: localizedTitle(composition.title),
-    titleData: composition.title,
-    year: composition.year ? String(composition.year) : '',
-    genre: composition.genre ?? '',
-    status: safeStatus,
-    createdAt: composition.createdAt,
-    updatedAt: composition.updatedAt
-  };
-}
-
-function sortGroups<T extends { title: string; createdAt: string }>(
-  groups: readonly T[],
-  sortValue: FilesSortValue
-): T[] {
-  return [...groups].sort((left, right) => {
-    if (sortValue === 'date_desc') {
-      return Number(right.createdAt) - Number(left.createdAt);
-    }
-
-    if (sortValue === 'date_asc') {
-      return Number(left.createdAt) - Number(right.createdAt);
-    }
-
-    if (sortValue === 'name_asc') {
-      return left.title.localeCompare(right.title, 'uk', { sensitivity: 'base' });
-    }
-
-    return right.title.localeCompare(left.title, 'uk', { sensitivity: 'base' });
-  });
-}
 
 function useDropdownState() {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
@@ -194,140 +92,36 @@ function WorksCreateAction() {
   );
 }
 
-type ClientFilteringResult = readonly [GroupRowData[], GroupRowData[], ReturnType<typeof toStandaloneRowData>[]];
-
-const clientFiltering = (
-  opusGroupsData: AllOpusesQuery | undefined,
-  ungroupedGroupsData: AllOpusesQuery | undefined,
-  compositionsData: AllCompositionsQuery | undefined,
-  selectedFilters: Readonly<{
-    status: readonly WorksStatusValue[];
-    language: readonly WorksLanguageValue[];
-  }>,
-  sortValue: FilesSortValue,
-  matchesSearch: (text: string) => boolean
-): ClientFilteringResult => {
-  const getLanguage = (value: { uk?: string | null; en?: string | null }): WorksLanguageValue => {
-    const hasUk = Boolean(value.uk?.trim());
-    const hasEn = Boolean(value.en?.trim());
-
-    if (hasUk && hasEn) {
-      return 'bilingual';
-    }
-
-    if (hasEn) {
-      return 'en';
-    }
-
-    return 'uk';
-  };
-
-  const matchesStatus = (status: WorksStatusValue) =>
-    selectedFilters.status.length === 0 || selectedFilters.status.includes(status);
-
-  const matchesLanguage = (title: { uk?: string | null; en?: string | null }) =>
-    selectedFilters.language.length === 0 || selectedFilters.language.includes(getLanguage(title));
-
-  const matchGroup = (group: { title: string; numberLabel: string; genre: string }) =>
-    matchesSearch(group.title) || matchesSearch(group.numberLabel) || matchesSearch(group.genre);
-
-  const matchComposition = (work: { title: string; genre: string }) =>
-    matchesSearch(work.title) || matchesSearch(work.genre);
-
-  const mappedOpusGroups = sortGroups(
-    (opusGroupsData?.allOpuses ?? [])
-      .map(toGroupRowData)
-      .filter((group) => matchGroup(group) && matchesLanguage(group.titleData) && matchesStatus(group.status)),
-    sortValue
-  );
-
-  const mappedUngroupedGroups = sortGroups(
-    (ungroupedGroupsData?.allOpuses ?? [])
-      .map(toGroupRowData)
-      .filter((group) => matchGroup(group) && matchesLanguage(group.titleData) && matchesStatus(group.status)),
-    sortValue
-  );
-
-  const visibleUngroupedWorks = sortGroups(
-    (compositionsData?.allCompositions ?? [])
-      .map(toStandaloneRowData)
-      .filter((work) => matchComposition(work) && matchesLanguage(work.titleData) && matchesStatus(work.status)),
-    sortValue
-  );
-  return [mappedOpusGroups, mappedUngroupedGroups, visibleUngroupedWorks] as const;
-};
-
 export function WorksPageContent({ activeTab }: WorksPageContentProps) {
   const [page, setPage] = useState(1);
+
   const { sortValue, selectedFilters, toolbarProps, sortProps } = useWorksFiltering();
+  const searchValue = normalizeSearch(toolbarProps.search?.search ?? '');
+
+  useEffect(() => {
+    setPage(1);
+  }, [activeTab, searchValue, selectedFilters.status, selectedFilters.language, sortValue]);
 
   const handlePageChange = (_: ChangeEvent<unknown>, value: number) => {
     setPage(value);
   };
 
-  const searchValue = (toolbarProps.search?.search ?? '').trim().toLowerCase();
-  const normalizedSearch = normalizeSearch(searchValue);
+  const { items, totalPages, totalItems, loading, error } = usePaginatedWorks({
+    tab: activeTab,
+    search: searchValue,
+    filters: {
+      statuses: selectedFilters.status as BaseContentStatuses[],
+      languages: selectedFilters.language as WorksLanguageValue[]
+    },
+    page,
+    pageSize: ITEMS_PER_PAGE
+  });
 
-  const matchesSearch = (text: string) =>
-    !normalizedSearch || normalizeSearch(text.toLowerCase()).includes(normalizedSearch);
-
-  const showOpus = activeTab === 'all' || activeTab === 'opus';
-  const showUngrouped = activeTab === 'all' || activeTab === 'ungrouped';
-  const showCompositions = activeTab === 'all' || activeTab === 'works';
-
-  const {
-    data: opusGroupsData,
-    loading: isOpusGroupsLoading,
-    error: opusGroupsError
-  } = useAllOpusGroups({}, { skip: !showOpus });
-
-  const {
-    data: ungroupedGroupsData,
-    loading: isUngroupedGroupsLoading,
-    error: ungroupedGroupsError
-  } = useAllUngroupedGroups({}, { skip: !showUngrouped });
-
-  const {
-    data: compositionsData,
-    loading: isCompositionsLoading,
-    error: compositionsError
-  } = useAllCompositions({}, { skip: !showCompositions });
-
-  const [mappedOpusGroups, mappedUngroupedGroups, visibleUngroupedWorks] = clientFiltering(
-    opusGroupsData,
-    ungroupedGroupsData,
-    compositionsData,
-    selectedFilters,
-    sortValue,
-    matchesSearch
-  );
-
-  const allItems = [...mappedOpusGroups, ...mappedUngroupedGroups, ...visibleUngroupedWorks];
-  const totalItems = allItems.length;
-  const totalPages = Math.ceil(totalItems / ITEMS_PER_PAGE);
-
-  const paginatedItems = allItems.slice((page - 1) * ITEMS_PER_PAGE, page * ITEMS_PER_PAGE);
-  const paginatedIds = new Set(paginatedItems.map((item) => item.id));
-
-  const paginatedOpusGroups = mappedOpusGroups.filter((group) => paginatedIds.has(group.id));
-  const paginatedUngroupedGroups = mappedUngroupedGroups.filter((group) => paginatedIds.has(group.id));
-  const paginatedUngroupedWorks = visibleUngroupedWorks.filter((work) => paginatedIds.has(work.id));
-
-  const hasOpus = mappedOpusGroups.length > 0;
-  const hasUngrouped = mappedUngroupedGroups.length > 0;
-  const hasCompositions = visibleUngroupedWorks.length > 0;
-
-  const hasBaseItems =
-    (showOpus && hasOpus) || (showUngrouped && hasUngrouped) || (showCompositions && hasCompositions);
+  const hasBaseItems = totalItems > 0;
   const hasActiveCriteria = Boolean(searchValue) || Boolean(toolbarProps.activeFiltersCount);
-  const isLoading =
-    (showOpus && isOpusGroupsLoading) ||
-    (showUngrouped && isUngroupedGroupsLoading) ||
-    (showCompositions && isCompositionsLoading);
-  const activeError = opusGroupsError ?? ungroupedGroupsError ?? compositionsError;
 
-  const shouldShowLoadingState = !hasBaseItems && isLoading;
-  const shouldShowErrorState = !hasBaseItems && Boolean(activeError);
+  const shouldShowLoadingState = !hasBaseItems && loading;
+  const shouldShowErrorState = !hasBaseItems && Boolean(error);
 
   const content = (() => {
     if (shouldShowLoadingState) {
@@ -347,16 +141,7 @@ export function WorksPageContent({ activeTab }: WorksPageContentProps) {
       );
     }
 
-    return (
-      <WorksTable
-        visibleOpusGroups={paginatedOpusGroups}
-        visibleUngroupedGroups={paginatedUngroupedGroups}
-        visibleUngroupedWorks={paginatedUngroupedWorks}
-        showOpus={showOpus}
-        showUngrouped={showUngrouped}
-        showIndividualWorks={showCompositions}
-      />
-    );
+    return <WorksTable items={items} activeTab={activeTab} />;
   })();
 
   return (

--- a/app/(logged_in)/creativity/WorksPageContent.tsx
+++ b/app/(logged_in)/creativity/WorksPageContent.tsx
@@ -2,12 +2,13 @@
 
 import { Box, Button } from '@mui/material';
 import { ChevronDown } from 'lucide-react';
-import { useRef, useState } from 'react';
+import { ChangeEvent, useRef, useState } from 'react';
 
 import { useWorksFiltering } from './useWorksFiltering';
 import { styles } from './WorksPageContent.styles';
 import { WorksTable } from './WorksTable';
 import {
+  ITEMS_PER_PAGE,
   WORKS_CREATE_OPTIONS,
   WORKS_EMPTY_STATE_DESCRIPTION,
   WORKS_EMPTY_STATE_NO_RESULTS_DESCRIPTION,
@@ -28,6 +29,7 @@ import ActionMenu from '~/shared/components/dropdown-menu/ActionMenu';
 import { EmptyState } from '~/shared/components/empty-state';
 import { FilteringToolbar, SortSelect } from '~/shared/components/filtering-toolbar';
 import { PageHeader } from '~/shared/components/page-header/PageHeader';
+import { Pagination } from '~/shared/components/pagination/Pagination';
 import { useAllCompositions } from '~/shared/hooks/use-compositions/useCompositions';
 import { useAllOpusGroups, useAllUngroupedGroups } from '~/shared/hooks/use-opuses/useOpuses';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
@@ -256,7 +258,12 @@ const clientFiltering = (
 };
 
 export function WorksPageContent({ activeTab }: WorksPageContentProps) {
+  const [page, setPage] = useState(1);
   const { sortValue, selectedFilters, toolbarProps, sortProps } = useWorksFiltering();
+
+  const handlePageChange = (_: ChangeEvent<unknown>, value: number) => {
+    setPage(value);
+  };
 
   const searchValue = (toolbarProps.search?.search ?? '').trim().toLowerCase();
   const normalizedSearch = normalizeSearch(searchValue);
@@ -295,6 +302,17 @@ export function WorksPageContent({ activeTab }: WorksPageContentProps) {
     matchesSearch
   );
 
+  const allItems = [...mappedOpusGroups, ...mappedUngroupedGroups, ...visibleUngroupedWorks];
+  const totalItems = allItems.length;
+  const totalPages = Math.ceil(totalItems / ITEMS_PER_PAGE);
+
+  const paginatedItems = allItems.slice((page - 1) * ITEMS_PER_PAGE, page * ITEMS_PER_PAGE);
+  const paginatedIds = new Set(paginatedItems.map((item) => item.id));
+
+  const paginatedOpusGroups = mappedOpusGroups.filter((group) => paginatedIds.has(group.id));
+  const paginatedUngroupedGroups = mappedUngroupedGroups.filter((group) => paginatedIds.has(group.id));
+  const paginatedUngroupedWorks = visibleUngroupedWorks.filter((work) => paginatedIds.has(work.id));
+
   const hasOpus = mappedOpusGroups.length > 0;
   const hasUngrouped = mappedUngroupedGroups.length > 0;
   const hasCompositions = visibleUngroupedWorks.length > 0;
@@ -331,9 +349,9 @@ export function WorksPageContent({ activeTab }: WorksPageContentProps) {
 
     return (
       <WorksTable
-        visibleOpusGroups={mappedOpusGroups}
-        visibleUngroupedGroups={mappedUngroupedGroups}
-        visibleUngroupedWorks={visibleUngroupedWorks}
+        visibleOpusGroups={paginatedOpusGroups}
+        visibleUngroupedGroups={paginatedUngroupedGroups}
+        visibleUngroupedWorks={paginatedUngroupedWorks}
         showOpus={showOpus}
         showUngrouped={showUngrouped}
         showIndividualWorks={showCompositions}
@@ -352,6 +370,8 @@ export function WorksPageContent({ activeTab }: WorksPageContentProps) {
       />
 
       {content}
+
+      {totalPages > 1 && <Pagination totalPages={totalPages} currentPage={page} onPageChange={handlePageChange} />}
     </Box>
   );
 }

--- a/app/(logged_in)/creativity/WorksTable.test.tsx
+++ b/app/(logged_in)/creativity/WorksTable.test.tsx
@@ -128,7 +128,7 @@ describe('WorksTable', () => {
 
     if (groupRow && groupRow.type === 'group') {
       expect(groupRow.groupData).toMatchObject({
-        numberLabel: '1 op',
+        numberLabel: '1',
         title: 'Group title',
         status: BaseContentStatuses.Draft
       });
@@ -189,15 +189,6 @@ describe('WorksTable', () => {
 
     const { data } = mockTableLayout.mock.calls[0][0] as { data: WorksTableRowData[] };
     const row = data[0];
-    expect(row.type === 'group' && row.groupData?.numberLabel).toBe('1 op');
-  });
-
-  it('should format numberLabel with "bo" suffix when numberKind is "bo"', () => {
-    const groupBo: GroupRowData = { ...group, number: '2', numberKind: 'bo' };
-    render(<WorksTable activeTab={WORKS_TABS_NAMES.OPUS} items={{ groups: [groupBo] }} />);
-
-    const { data } = mockTableLayout.mock.calls[0][0] as { data: WorksTableRowData[] };
-    const row = data[0];
-    expect(row.type === 'group' && row.groupData?.numberLabel).toBe('2 bo');
+    expect(row.type === 'group' && row.groupData?.numberLabel).toBe('1');
   });
 });

--- a/app/(logged_in)/creativity/WorksTable.test.tsx
+++ b/app/(logged_in)/creativity/WorksTable.test.tsx
@@ -10,33 +10,35 @@ import {
   OpusWork,
   WorksTable
 } from './WorksTable';
-import { BaseRowData } from '~/shared/components/table-layout/row-variants/Row.types';
+import { WORKS_TABS_NAMES } from '~/constants/creativity';
+import { BaseRowData, ColumnDef } from '~/shared/components/table-layout/row-variants/Row.types';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
 
 const mockTableLayout = jest.fn();
 
 jest.mock('~/shared/components/table-layout/TableLayout', () => ({
-  TableLayout: (props: unknown) => {
+  TableLayout: (props: {
+    data: WorksTableRowData[];
+    columns: ColumnDef<GroupHeaderData, OpusWork, IndividualWork>;
+  }) => {
     mockTableLayout(props);
     return <Box data-testid="table-layout" />;
   }
 }));
 
+type WorksTableRowData = BaseRowData<GroupHeaderData, OpusWork, IndividualWork>;
+
 const group: GroupRowData = {
   id: 'group-1',
-  numberLabel: 'Op.1',
-  title: 'Group title',
+  number: '1',
+  numberKind: 'op',
+  name: 'Group title',
   genre: 'Symphony',
   startDate: '2020',
   endDate: '2022',
   status: BaseContentStatuses.Draft,
   updatedAt: '2024-01-01',
-  works: [
-    {
-      id: 'work-1',
-      title: 'Work 1'
-    }
-  ]
+  works: [{ id: 'work-1', title: 'Work 1' }]
 };
 
 const individualWork: IndividualWork = {
@@ -53,252 +55,149 @@ describe('WorksTable', () => {
     jest.clearAllMocks();
   });
 
-  it('should render opus groups when showOpus is true', () => {
-    render(
-      <WorksTable
-        visibleOpusGroups={[group]}
-        visibleUngroupedGroups={[]}
-        visibleUngroupedWorks={[]}
-        showOpus
-        showUngrouped={false}
-        showIndividualWorks={false}
-      />
-    );
+  it('should render opus groups when activeTab is Opus', () => {
+    render(<WorksTable activeTab={WORKS_TABS_NAMES.OPUS} items={{ groups: [group] }} />);
 
-    const { data } = mockTableLayout.mock.calls[0][0];
-
+    const { data } = mockTableLayout.mock.calls[0][0] as { data: WorksTableRowData[] };
     expect(data).toHaveLength(1);
-    expect(data[0]).toMatchObject({
-      type: 'group',
-      id: 'group-1'
-    });
+    expect(data[0]).toMatchObject({ type: 'group', id: 'group-1' });
   });
 
-  it('should render ungrouped groups when showUngrouped is true', () => {
-    render(
-      <WorksTable
-        visibleOpusGroups={[]}
-        visibleUngroupedGroups={[group]}
-        visibleUngroupedWorks={[]}
-        showOpus={false}
-        showUngrouped
-        showIndividualWorks={false}
-      />
-    );
+  it('should render individual works when activeTab is Works', () => {
+    render(<WorksTable activeTab={WORKS_TABS_NAMES.WORKS} items={{ works: [individualWork] }} />);
 
-    const { data } = mockTableLayout.mock.calls[0][0];
-
+    const { data } = mockTableLayout.mock.calls[0][0] as { data: WorksTableRowData[] };
     expect(data).toHaveLength(1);
-    expect(data[0]).toMatchObject({
-      type: 'group',
-      id: 'group-1'
-    });
+    expect(data[0]).toMatchObject({ type: 'individual', id: 'individual-1' });
   });
 
-  it('should render individual works when showIndividualWorks is true', () => {
+  it('should combine all row types in correct order when activeTab is All', () => {
+    const group2 = { ...group, id: 'group-2' };
     render(
-      <WorksTable
-        visibleOpusGroups={[]}
-        visibleUngroupedGroups={[]}
-        visibleUngroupedWorks={[individualWork]}
-        showOpus={false}
-        showUngrouped={false}
-        showIndividualWorks
-      />
+      <WorksTable activeTab={WORKS_TABS_NAMES.ALL} items={{ groups: [group, group2], works: [individualWork] }} />
     );
 
-    const { data } = mockTableLayout.mock.calls[0][0];
-
-    expect(data).toHaveLength(1);
-    expect(data[0]).toMatchObject({
-      type: 'individual',
-      id: 'individual-1'
-    });
+    const { data } = mockTableLayout.mock.calls[0][0] as { data: WorksTableRowData[] };
+    expect(data.map((row) => row.id)).toEqual(['group-1', 'group-2', 'individual-1']);
   });
 
-  it('should combine all row types in correct order', () => {
-    render(
-      <WorksTable
-        visibleOpusGroups={[group]}
-        visibleUngroupedGroups={[
-          {
-            ...group,
-            id: 'group-2'
-          }
-        ]}
-        visibleUngroupedWorks={[individualWork]}
-        showOpus
-        showUngrouped
-        showIndividualWorks
-      />
-    );
+  it('should execute render functions correctly for columns', () => {
+    render(<WorksTable activeTab={WORKS_TABS_NAMES.ALL} items={{ groups: [group], works: [individualWork] }} />);
 
-    const { data } = mockTableLayout.mock.calls[0][0];
-
-    expect(data).toHaveLength(3);
-    expect(data.map((row: { id: string }) => row.id)).toEqual(['group-1', 'group-2', 'individual-1']);
-  });
-
-  it('should pass columns to TableLayout', () => {
-    render(
-      <WorksTable
-        visibleOpusGroups={[]}
-        visibleUngroupedGroups={[]}
-        visibleUngroupedWorks={[]}
-        showOpus={false}
-        showUngrouped={false}
-        showIndividualWorks={false}
-      />
-    );
-
-    expect(mockTableLayout).toHaveBeenCalledTimes(1);
-
-    const { columns } = mockTableLayout.mock.calls[0][0];
-
-    expect(columns).toHaveLength(6);
-    expect(columns).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ id: 'opus', headerLabel: 'Опуси' }),
-        expect.objectContaining({ id: 'title', headerLabel: 'Назва' }),
-        expect.objectContaining({ id: 'genre', headerLabel: 'Жанр' }),
-        expect.objectContaining({ id: 'years', headerLabel: 'Роки' }),
-        expect.objectContaining({ id: 'status', headerLabel: 'Статус' }),
-        expect.objectContaining({ id: 'actions', headerLabel: '' })
-      ])
-    );
-  });
-
-  it('covers all column rendering functions and logic branches (renderGroup, renderSub, renderPlain) directly', () => {
-    render(
-      <WorksTable
-        visibleOpusGroups={[group]}
-        visibleUngroupedGroups={[]}
-        visibleUngroupedWorks={[individualWork]}
-        showOpus
-        showUngrouped={false}
-        showIndividualWorks
-      />
-    );
-
-    const { data: rowsData } = mockTableLayout.mock.calls[0][0];
-    const groupRow = rowsData.find((r: { type: string }) => r.type === 'group');
-    const individualRow = rowsData.find((r: { type: string }) => r.type === 'individual');
+    const { data: rowsData } = mockTableLayout.mock.calls[0][0] as { data: WorksTableRowData[] };
+    const groupRow = rowsData.find((r) => r.type === 'group');
+    const individualRow = rowsData.find((r) => r.type === 'individual');
 
     originalColumns.forEach((col) => {
-      if (col.renderGroup) col.renderGroup(groupRow.groupData);
-      if (col.renderSub) col.renderSub(groupRow.subRows[0], groupRow.groupData);
-      if (col.renderPlain) col.renderPlain(individualRow.plainData);
+      if (groupRow && col.renderGroup) col.renderGroup(groupRow.groupData as GroupHeaderData);
+      if (groupRow && groupRow.subRows && col.renderSub)
+        col.renderSub(groupRow.subRows[0] as OpusWork, groupRow.groupData as GroupHeaderData);
+      if (individualRow && col.renderPlain) col.renderPlain(individualRow.plainData as IndividualWork);
     });
 
     const yearsColumn = originalColumns.find((c) => c.id === 'years');
-
-    if (yearsColumn?.renderGroup) {
-      expect(
-        yearsColumn.renderGroup({
-          startDate: '2020',
-          endDate: '2020',
-          numberLabel: '',
-          title: '',
-          genre: '',
-          status: BaseContentStatuses.Draft,
-          updatedAt: ''
-        })
-      ).toBe('2020');
-      expect(
-        yearsColumn.renderGroup({
-          startDate: '2020',
-          endDate: undefined,
-          numberLabel: '',
-          title: '',
-          genre: '',
-          status: BaseContentStatuses.Draft,
-          updatedAt: ''
-        })
-      ).toBe('2020');
-      expect(
-        yearsColumn.renderGroup({
-          startDate: '2020',
-          endDate: '2022',
-          numberLabel: '',
-          title: '',
-          genre: '',
-          status: BaseContentStatuses.Draft,
-          updatedAt: ''
-        })
-      ).toBe('2020 - 2022');
-    }
-
-    const groupMenu = groupRow.groupData.menuActions.menuItems;
-    groupMenu.flat().forEach((menuItem: { onClick?: () => void }) => {
-      if (menuItem && typeof menuItem.onClick === 'function') {
-        menuItem.onClick();
-      }
-    });
-
-    const workMenu = individualRow.plainData.menuActions.menuItems;
-    workMenu.flat().forEach((menuItem: { onClick?: () => void }) => {
-      if (menuItem && typeof menuItem.onClick === 'function') {
-        menuItem.onClick();
-      }
-    });
+    expect(yearsColumn?.renderGroup?.(groupRow?.groupData as GroupHeaderData)).toBe('2020 - 2022');
   });
 
-  it('covers group row mapping when group status is Published', () => {
-    const publishedGroup: GroupRowData = {
-      ...group,
-      status: BaseContentStatuses.Published
-    };
+  it('should trigger menu actions successfully', () => {
+    render(<WorksTable activeTab={WORKS_TABS_NAMES.ALL} items={{ groups: [group], works: [individualWork] }} />);
 
-    render(
-      <WorksTable
-        visibleOpusGroups={[publishedGroup]}
-        visibleUngroupedGroups={[]}
-        visibleUngroupedWorks={[]}
-        showOpus
-        showUngrouped={false}
-        showIndividualWorks={false}
-      />
-    );
+    const { data: rowsData } = mockTableLayout.mock.calls[0][0] as { data: WorksTableRowData[] };
 
-    const { data } = mockTableLayout.mock.calls[0][0];
-    expect(data[0].groupData.status).toBe(BaseContentStatuses.Published);
-  });
+    rowsData.forEach((row) => {
+      const actions = row.type === 'group' ? row.groupData?.menuActions : row.plainData?.menuActions;
 
-  it('covers menu item clicks for published and draft states', () => {
-    render(
-      <WorksTable
-        visibleOpusGroups={[{ ...group, status: BaseContentStatuses.Published }]}
-        visibleUngroupedGroups={[]}
-        visibleUngroupedWorks={[{ ...individualWork, status: BaseContentStatuses.Draft }]}
-        showOpus
-        showUngrouped={false}
-        showIndividualWorks
-      />
-    );
-
-    const { data: rowsData } = mockTableLayout.mock.calls[0][0] as {
-      data: readonly BaseRowData<GroupHeaderData, OpusWork, IndividualWork>[];
-    };
-
-    const triggerMenuClicks = (menuGroups: readonly { items: readonly { onClick?: () => void }[] }[]) => {
-      menuGroups.forEach((menuGroup) => {
-        menuGroup.items.forEach((item) => {
-          if (item && typeof item.onClick === 'function') {
+      if (actions?.menuItems) {
+        actions.menuItems.flat().forEach((item) => {
+          if (item && 'onClick' in item && typeof item.onClick === 'function') {
             item.onClick();
           }
         });
-      });
-    };
-
-    rowsData.forEach((row) => {
-      if (row.type === 'group' && row.groupData) {
-        const groupHeader = row.groupData as GroupHeaderData;
-        if (groupHeader.menuActions?.menuItems) {
-          triggerMenuClicks(groupHeader.menuActions.menuItems);
-        }
       }
     });
 
     expect(mockTableLayout).toHaveBeenCalled();
+  });
+
+  it('should correctly map GroupRowData to groupData internal format', () => {
+    render(<WorksTable activeTab={WORKS_TABS_NAMES.OPUS} items={{ groups: [group] }} />);
+
+    const { data } = mockTableLayout.mock.calls[0][0] as { data: WorksTableRowData[] };
+
+    const groupRow = data.find((row) => row.type === 'group');
+
+    if (groupRow && groupRow.type === 'group') {
+      expect(groupRow.groupData).toMatchObject({
+        numberLabel: '1 op',
+        title: 'Group title',
+        status: BaseContentStatuses.Draft
+      });
+    } else {
+      throw new Error('Group row not found');
+    }
+  });
+
+  it('should successfully execute all defined render functions (renderGroup, renderSub, renderPlain)', () => {
+    render(<WorksTable activeTab={WORKS_TABS_NAMES.ALL} items={{ groups: [group], works: [individualWork] }} />);
+
+    const { data: rowsData } = mockTableLayout.mock.calls[0][0] as { data: WorksTableRowData[] };
+    const groupRow = rowsData.find((r) => r.type === 'group')!;
+    const individualRow = rowsData.find((r) => r.type === 'individual')!;
+
+    originalColumns.forEach((col) => {
+      if (col.renderGroup) col.renderGroup(groupRow.groupData as GroupHeaderData);
+      if (col.renderSub && groupRow.subRows) col.renderSub(groupRow.subRows[0], groupRow.groupData as GroupHeaderData);
+      if (col.renderPlain) col.renderPlain(individualRow.plainData as IndividualWork);
+    });
+
+    expect(mockTableLayout).toHaveBeenCalled();
+  });
+
+  it('should format years correctly when endDate is equal to startDate', () => {
+    const yearsCol = originalColumns.find((c) => c.id === 'years');
+    const sameYearData: GroupHeaderData = {
+      ...group,
+      numberLabel: '1',
+      title: '',
+      genre: '',
+      startDate: '2020',
+      endDate: '2020',
+      status: BaseContentStatuses.Draft,
+      updatedAt: ''
+    };
+    expect(yearsCol?.renderGroup?.(sameYearData)).toBe('2020');
+  });
+
+  it('should format years correctly when endDate is different from startDate', () => {
+    const yearsCol = originalColumns.find((c) => c.id === 'years');
+    const diffYearData: GroupHeaderData = {
+      ...group,
+      numberLabel: '1',
+      title: '',
+      genre: '',
+      startDate: '2020',
+      endDate: '2022',
+      status: BaseContentStatuses.Draft,
+      updatedAt: ''
+    };
+    expect(yearsCol?.renderGroup?.(diffYearData)).toBe('2020 - 2022');
+  });
+
+  it('should format numberLabel with "op" suffix when numberKind is "op"', () => {
+    const groupOp: GroupRowData = { ...group, number: '1', numberKind: 'op' };
+    render(<WorksTable activeTab={WORKS_TABS_NAMES.OPUS} items={{ groups: [groupOp] }} />);
+
+    const { data } = mockTableLayout.mock.calls[0][0] as { data: WorksTableRowData[] };
+    const row = data[0];
+    expect(row.type === 'group' && row.groupData?.numberLabel).toBe('1 op');
+  });
+
+  it('should format numberLabel with "bo" suffix when numberKind is "bo"', () => {
+    const groupBo: GroupRowData = { ...group, number: '2', numberKind: 'bo' };
+    render(<WorksTable activeTab={WORKS_TABS_NAMES.OPUS} items={{ groups: [groupBo] }} />);
+
+    const { data } = mockTableLayout.mock.calls[0][0] as { data: WorksTableRowData[] };
+    const row = data[0];
+    expect(row.type === 'group' && row.groupData?.numberLabel).toBe('2 bo');
   });
 });

--- a/app/(logged_in)/creativity/WorksTable.tsx
+++ b/app/(logged_in)/creativity/WorksTable.tsx
@@ -156,7 +156,7 @@ export function WorksTable({ items, activeTab }: WorksTableProps) {
       type: 'group',
       id: group.id,
       groupData: {
-        numberLabel: group.number + (group.numberKind === 'op' ? ' op' : ' bo'),
+        numberLabel: group.number,
         title: group.name,
         genre: group.genre,
         startDate: group.startDate,

--- a/app/(logged_in)/creativity/WorksTable.tsx
+++ b/app/(logged_in)/creativity/WorksTable.tsx
@@ -5,7 +5,16 @@ import React from 'react';
 
 import { styles } from './WorksTable.styles';
 import { GroupMenuItems, WorkMenuItems } from './WorksTableMenuItems';
-import { WORKS_BASE_PATH, WorksStatusValue } from '~/constants/creativity';
+import { GroupMenuItems, WorkMenuItems } from './WorksTableMenusItems';
+import {
+  AllTab,
+  OpusTab,
+  WooTab,
+  WORKS_BASE_PATH,
+  WORKS_TABS_NAMES,
+  WorksStatusValue,
+  WorksTab
+} from '~/constants/creativity';
 import { ActionMenuGroups } from '~/shared/components/dropdown-menu/ActionMenu';
 import { RowActions } from '~/shared/components/table-layout/components/RowActions';
 import { StatusBadge } from '~/shared/components/table-layout/components/StatusBadge';
@@ -20,8 +29,9 @@ type ActionFields = {
 
 export type GroupRowData = Readonly<{
   id: string;
-  numberLabel: string;
-  title: string;
+  number: string;
+  numberKind: 'op' | 'bo';
+  name: string;
   genre: string;
   startDate: string;
   endDate?: string;
@@ -50,8 +60,8 @@ export type OpusWork = Readonly<{
 export type IndividualWork = Readonly<{
   id: string;
   title: string;
-  year: string;
-  genre: string;
+  year: string | number | null | undefined;
+  genre: string | null | undefined;
   status: WorksStatusValue;
   updatedAt: string;
 }> &
@@ -111,23 +121,35 @@ export const columns: readonly ColumnDef<GroupHeaderData, OpusWork, IndividualWo
   }
 ];
 
-type WorksTableProps = Readonly<{
-  visibleOpusGroups: readonly GroupRowData[];
-  visibleUngroupedGroups: readonly GroupRowData[];
-  visibleUngroupedWorks: readonly IndividualWork[];
-  showOpus: boolean;
-  showUngrouped: boolean;
-  showIndividualWorks: boolean;
+type GroupItems = Readonly<{
+  groups: GroupRowData[];
 }>;
 
-export function WorksTable({
-  visibleOpusGroups,
-  visibleUngroupedGroups,
-  visibleUngroupedWorks,
-  showOpus,
-  showUngrouped,
-  showIndividualWorks
-}: WorksTableProps) {
+type WorksItems = Readonly<{
+  works: IndividualWork[];
+}>;
+
+type AllItems = GroupItems & WorksItems;
+
+type WorksTableProps =
+  | {
+      activeTab: AllTab;
+      items: AllItems;
+    }
+  | {
+      activeTab: OpusTab;
+      items: GroupItems;
+    }
+  | {
+      activeTab: WooTab;
+      items: GroupItems;
+    }
+  | {
+      activeTab: WorksTab;
+      items: WorksItems;
+    };
+
+export function WorksTable({ items, activeTab }: WorksTableProps) {
   function groupsRow(group: GroupRowData): BaseRowData<GroupHeaderData, OpusWork, IndividualWork> {
     const isPublished = group.status === BaseContentStatuses.Published;
 
@@ -135,8 +157,8 @@ export function WorksTable({
       type: 'group',
       id: group.id,
       groupData: {
-        numberLabel: group.numberLabel,
-        title: group.title,
+        numberLabel: group.number + (group.numberKind === 'op' ? ' op' : ' bo'),
+        title: group.name,
         genre: group.genre,
         startDate: group.startDate,
         endDate: group.endDate,
@@ -144,7 +166,7 @@ export function WorksTable({
         updatedAt: group.updatedAt,
         editAction: {
           editHref: `${WORKS_BASE_PATH}/group/${group.id}/edit`,
-          editLabel: `Редагувати групу ${group.title}`
+          editLabel: `Редагувати групу ${group.name}`
         },
         menuActions: {
           menuItems: GroupMenuItems({
@@ -153,7 +175,7 @@ export function WorksTable({
             setHideModalOpen: modalMock,
             setPublicationModalOpen: modalMock
           }),
-          menuTriggerLabel: `Дії групи ${group.title}`
+          menuTriggerLabel: `Дії групи ${group.name}`
         }
       },
       subRows: group.works.map((work) => ({
@@ -208,13 +230,20 @@ export function WorksTable({
     });
   };
 
-  if (showOpus) pushGroupRows(visibleOpusGroups);
-  if (showUngrouped) pushGroupRows(visibleUngroupedGroups);
+ swich (activeTab) {
+  case WORKS_TABS_NAMES.ALL:
+    pushGroupRows(items.groups);
+      items.works.forEach((work) => rows.push(individualWorkRow(work)));
+    break;
 
-  if (showIndividualWorks) {
-    visibleUngroupedWorks.forEach((work) => {
-      rows.push(individualWorkRow(work));
-    });
+  case WORKS_TABS_NAMES.OPUS:
+    se WORKS_TABS_NAMES.WOO:
+      pushGroupRows(items.groups);
+    break;
+
+  case WORKS_TABS_NAMES.WORKS:
+      items.works.forEach((work) => rows.push(individualWorkRow(work)));
+      break;
   }
 
   return (

--- a/app/(logged_in)/creativity/WorksTable.tsx
+++ b/app/(logged_in)/creativity/WorksTable.tsx
@@ -5,7 +5,6 @@ import React from 'react';
 
 import { styles } from './WorksTable.styles';
 import { GroupMenuItems, WorkMenuItems } from './WorksTableMenuItems';
-import { GroupMenuItems, WorkMenuItems } from './WorksTableMenusItems';
 import {
   AllTab,
   OpusTab,
@@ -230,20 +229,20 @@ export function WorksTable({ items, activeTab }: WorksTableProps) {
     });
   };
 
- swich (activeTab) {
+  switch (activeTab) {
   case WORKS_TABS_NAMES.ALL:
     pushGroupRows(items.groups);
-      items.works.forEach((work) => rows.push(individualWorkRow(work)));
+    items.works.forEach((work) => rows.push(individualWorkRow(work)));
     break;
 
   case WORKS_TABS_NAMES.OPUS:
-    se WORKS_TABS_NAMES.WOO:
-      pushGroupRows(items.groups);
+  case WORKS_TABS_NAMES.WOO:
+    pushGroupRows(items.groups);
     break;
 
   case WORKS_TABS_NAMES.WORKS:
-      items.works.forEach((work) => rows.push(individualWorkRow(work)));
-      break;
+    items.works.forEach((work) => rows.push(individualWorkRow(work)));
+    break;
   }
 
   return (

--- a/app/(logged_in)/creativity/page.test.tsx
+++ b/app/(logged_in)/creativity/page.test.tsx
@@ -1,5 +1,4 @@
 import '@testing-library/jest-dom';
-import { Box, Button } from '@mui/material';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import React from 'react';
 
@@ -7,19 +6,11 @@ import CreativityPage from './page';
 
 const MOCK_GROUP_LABEL = 'Дії групи Перший струнний квартет';
 const MOCK_WORK_LABEL = 'Дії твору №1 «Після бою»';
-const MOCK_WORK_TEXT = '№1 «Після бою»';
 
 jest.mock('~/shared/hooks/use-opuses/useOpuses', () => ({
+  usePaginatedWorks: jest.fn(),
   useAllOpusGroups: jest.fn(() => ({
-    data: {
-      allOpuses: [
-        {
-          id: '1',
-          name: { uk: 'Перший струнний квартет', en: 'First String Quartet' },
-          type: 'group'
-        }
-      ]
-    },
+    data: { allOpuses: [{ id: '1', name: { uk: 'Перший струнний квартет' }, type: 'group' }] },
     loading: false,
     error: undefined
   })),
@@ -77,6 +68,16 @@ jest.mock('~/shared/components/filtering-toolbar', () => ({
   )
 }));
 
+jest.mock('./useWorksFiltering', () => ({
+  useWorksFiltering: jest.fn(() => ({
+    requestFilters: {},
+    sortValue: 'default',
+    selectedFilters: { status: null, language: null },
+    toolbarProps: { search: { search: '' }, activeFiltersCount: 0 },
+    sortProps: {}
+  }))
+}));
+
 interface TabItem {
   value: string;
   label: string;
@@ -107,7 +108,7 @@ jest.mock('~/shared/components/page-header/PageHeader', () => ({
 }));
 
 jest.mock('./useWorksFiltering', () => ({
-  useWorksFiltering: () => ({
+  useWorksFiltering: jest.fn(() => ({
     sortValue: 'date_desc',
     selectedFilters: { status: [], language: [], genre: [] },
     toolbarProps: {
@@ -127,23 +128,26 @@ jest.mock('./useWorksFiltering', () => ({
       onFieldChange: jest.fn(),
       onValueChange: jest.fn()
     }
-  })
+  }))
 }));
 
-const RenderWithMockData = () => {
-  return (
-    <Box>
-      <CreativityPage />
-      <Box data-testid="mock-db-fallback" style={{ display: 'none' }}>
-        {MOCK_WORK_TEXT}
-        <Button aria-label={MOCK_GROUP_LABEL}>Дії групи</Button>
-        <Button aria-label={MOCK_WORK_LABEL}>Дії твору</Button>
-      </Box>
-    </Box>
-  );
-};
+import { usePaginatedWorks } from '~/shared/hooks/use-opuses/useOpuses';
+import { BaseContentStatuses } from '~/types/enums/common.enums';
+
+const mockUsePaginatedWorks = usePaginatedWorks as jest.Mock;
 
 describe('Creativity page', () => {
+  beforeEach(() => {
+    mockUsePaginatedWorks.mockReset();
+    mockUsePaginatedWorks.mockReturnValue({
+      items: [],
+      totalPages: 0,
+      totalItems: 0,
+      loading: false,
+      error: null
+    });
+  });
+
   it('renders updated tabs and create action links', () => {
     render(<CreativityPage />);
 
@@ -161,13 +165,36 @@ describe('Creativity page', () => {
   });
 
   it('shows different context actions for a group and a work', () => {
-    render(<RenderWithMockData />);
+    mockUsePaginatedWorks.mockReturnValue({
+      items: {
+        groups: [
+          {
+            id: '1',
+            number: '1',
+            numberKind: 'op',
+            name: 'Перший струнний квартет',
+            genre: 'Струнний квартет',
+            startDate: '2020',
+            endDate: undefined,
+            status: BaseContentStatuses.Published,
+            updatedAt: '2024-01-01',
+            works: [{ id: '2', title: '№1 «Після бою»' }]
+          }
+        ],
+        works: []
+      },
+      totalPages: 1,
+      totalItems: 1,
+      loading: false,
+      error: null
+    });
+
+    render(<CreativityPage />);
 
     const groupButton = screen.getAllByRole('button', { name: new RegExp(MOCK_GROUP_LABEL, 'i') })[0];
     fireEvent.click(groupButton);
 
     let dropdownMenu = screen.getByTestId('dropdown-menu');
-
     expect(within(dropdownMenu).getByText('Редагувати групу (SEO)')).toBeInTheDocument();
     expect(within(dropdownMenu).getByText('Редагувати контент')).toBeInTheDocument();
     expect(within(dropdownMenu).getByText('Поширити')).toBeInTheDocument();
@@ -179,15 +206,16 @@ describe('Creativity page', () => {
 
     fireEvent.click(within(dropdownMenu).getByText('Поширити'));
 
+    const accordionToggle = screen.getByRole('button', { name: /^1 op/ });
+    fireEvent.click(accordionToggle);
+
     const workButton = screen.getAllByRole('button', { name: new RegExp(MOCK_WORK_LABEL, 'i') })[0];
     fireEvent.click(workButton);
 
     dropdownMenu = screen.getByTestId('dropdown-menu');
-
     expect(within(dropdownMenu).getByText('Редагувати композицію')).toBeInTheDocument();
     expect(within(dropdownMenu).getByText('Поширити')).toBeInTheDocument();
     expect(within(dropdownMenu).getByText('Видалити')).toBeInTheDocument();
-
     expect(within(dropdownMenu).queryByText('Редагувати контент')).not.toBeInTheDocument();
     expect(within(dropdownMenu).queryByText('Розгрупувати')).not.toBeInTheDocument();
   });

--- a/app/(logged_in)/creativity/page.test.tsx
+++ b/app/(logged_in)/creativity/page.test.tsx
@@ -150,7 +150,7 @@ describe('Creativity page', () => {
     expect(screen.getByText('Творчість')).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Всі' })).toHaveAttribute('aria-selected', 'true');
     expect(screen.getByRole('tab', { name: 'Опуси' })).toHaveAttribute('href', '/creativity/opus');
-    expect(screen.getByRole('tab', { name: 'Безопусні' })).toHaveAttribute('href', '/creativity/ungrouped');
+    expect(screen.getByRole('tab', { name: 'Безопусні' })).toHaveAttribute('href', '/creativity/woo');
     expect(screen.getByRole('tab', { name: 'Твори' })).toHaveAttribute('href', '/creativity/works');
 
     fireEvent.click(screen.getByRole('button', { name: 'Створити' }));

--- a/app/(logged_in)/creativity/page.test.tsx
+++ b/app/(logged_in)/creativity/page.test.tsx
@@ -206,7 +206,7 @@ describe('Creativity page', () => {
 
     fireEvent.click(within(dropdownMenu).getByText('Поширити'));
 
-    const accordionToggle = screen.getByRole('button', { name: /^1 op/ });
+    const accordionToggle = screen.getByRole('button', { name: /^1/ });
     fireEvent.click(accordionToggle);
 
     const workButton = screen.getAllByRole('button', { name: new RegExp(MOCK_WORK_LABEL, 'i') })[0];

--- a/app/(logged_in)/creativity/page.tsx
+++ b/app/(logged_in)/creativity/page.tsx
@@ -10,4 +10,3 @@ export default function CreativityPage() {
     </Box>
   );
 }
-

--- a/app/(logged_in)/creativity/useWorksFiltering.test.ts
+++ b/app/(logged_in)/creativity/useWorksFiltering.test.ts
@@ -54,12 +54,12 @@ describe('useWorksFiltering', () => {
   });
 
   describe('initial state', () => {
-    it('starts with default sort, empty filters, empty search and filters panel open', () => {
+    it('starts with default sort, empty filters, empty search and filters panel closed', () => {
       const { result } = renderHook(() => useWorksFiltering());
 
       expect(result.current.sortValue).toBe('date_desc');
       expect(result.current.selectedFilters).toEqual({ status: [], language: [] });
-      expect(result.current.toolbarProps.isFiltersOpen).toBe(true);
+      expect(result.current.toolbarProps.isFiltersOpen).toBe(false);
       expect(result.current.toolbarProps.activeFiltersCount).toBe(0);
       expect(result.current.toolbarProps.search!.search).toBe('');
       expect(result.current.toolbarProps.search!.placeholder).toBe('Пошук');
@@ -123,18 +123,18 @@ describe('useWorksFiltering', () => {
   });
 
   describe('filters panel toggle', () => {
-    it('toggles isFiltersOpen from true to false and back', () => {
+    it('toggles isFiltersOpen from false to true and back', () => {
       const { result } = renderHook(() => useWorksFiltering());
 
       act(() => {
-        result.current.toolbarProps.onToggleFilters!();
-      });
-      expect(result.current.toolbarProps.isFiltersOpen).toBe(false);
-
-      act(() => {
-        result.current.toolbarProps.onToggleFilters!();
+      result.current.toolbarProps.onToggleFilters!();
       });
       expect(result.current.toolbarProps.isFiltersOpen).toBe(true);
+
+      act(() => {
+      result.current.toolbarProps.onToggleFilters!();
+      });
+      expect(result.current.toolbarProps.isFiltersOpen).toBe(false);
     });
   });
 

--- a/app/(logged_in)/creativity/useWorksFiltering.ts
+++ b/app/(logged_in)/creativity/useWorksFiltering.ts
@@ -97,9 +97,7 @@ export function useWorksFiltering(): Readonly<{
 
   useEffect(() => {
     const saved = localStorage.getItem(SORT_STORAGE_KEY);
-    if (saved && isFilesSortValue(saved)) {
-      setSortValue(saved);
-    }
+    if (saved && isFilesSortValue(saved)) setSortValue(saved);
   }, []);
 
   const activeFiltersCount = statusFilters.length + languageFilters.length;

--- a/app/(logged_in)/creativity/useWorksFiltering.ts
+++ b/app/(logged_in)/creativity/useWorksFiltering.ts
@@ -49,7 +49,7 @@ export function useWorksFiltering(): Readonly<{
   toolbarProps: WorksFilteringToolbarProps;
   sortProps: WorksFilteringSortProps;
 }> {
-  const [isFiltersOpen, setIsFiltersOpen] = useState(true);
+  const [isFiltersOpen, setIsFiltersOpen] = useState(false);
   const [search, setSearch] = useState('');
   const [statusFilters, setStatusFilters] = useState<WorksStatusValue[]>([]);
   const [languageFilters, setLanguageFilters] = useState<WorksLanguageValue[]>([]);

--- a/app/(logged_in)/creativity/useWorksFiltering.ts
+++ b/app/(logged_in)/creativity/useWorksFiltering.ts
@@ -17,6 +17,15 @@ import {
   type SortFieldValue
 } from '~/constants/sort';
 import type { FilteringToolbarProps, SortSelectProps } from '~/shared/components/filtering-toolbar';
+import { BaseContentStatuses } from '~/types/enums/common.enums';
+import {
+  ContentLanguage,
+  OpusStatus,
+  SortOrder,
+  type WorksFiltersInput,
+  WorksSortBy,
+  type WorksSortOptions
+} from '~/types/graphql/generated/graphql';
 
 const SORT_STORAGE_KEY = 'works_sort';
 
@@ -40,7 +49,38 @@ const VALID_SORT_VALUES: ReadonlySet<string> = new Set(['date_desc', 'date_asc',
 
 const isFilesSortValue = (value: string): value is FilesSortValue => VALID_SORT_VALUES.has(value);
 
+const mapWorksStatus = (status: WorksStatusValue): OpusStatus => {
+  if (status === BaseContentStatuses.Published) {
+    return OpusStatus.Published;
+  }
+  return OpusStatus.Draft;
+};
+
+const mapWorksLanguage = (language: WorksLanguageValue): ContentLanguage => {
+  if (language === 'bilingual') {
+    return ContentLanguage.Bilingual;
+  }
+  if (language === 'en') {
+    return ContentLanguage.En;
+  }
+  return ContentLanguage.Uk;
+};
+
+const mapWorksSort = (sortValue: FilesSortValue): WorksSortOptions[] => {
+  if (sortValue === 'name_asc') {
+    return [{ field: WorksSortBy.Number, order: SortOrder.Asc }];
+  }
+  if (sortValue === 'name_desc') {
+    return [{ field: WorksSortBy.Number, order: SortOrder.Desc }];
+  }
+  if (sortValue === 'date_asc') {
+    return [{ field: WorksSortBy.CreatedAt, order: SortOrder.Asc }];
+  }
+  return [{ field: WorksSortBy.CreatedAt, order: SortOrder.Desc }];
+};
+
 export function useWorksFiltering(): Readonly<{
+  requestFilters: Omit<WorksFiltersInput, 'limit' | 'skip'>;
   sortValue: FilesSortValue;
   selectedFilters: Readonly<{
     status: readonly WorksStatusValue[];
@@ -146,7 +186,18 @@ export function useWorksFiltering(): Readonly<{
     [currentSortField, currentSortOption.label, handleSortFieldChange, handleSortValueChange, sortValue]
   );
 
+  const requestFilters = useMemo<Omit<WorksFiltersInput, 'limit' | 'skip'>>(
+    () => ({
+      search: search.trim() || undefined,
+      languages: languageFilters.length ? languageFilters.map(mapWorksLanguage) : undefined,
+      statuses: statusFilters.length ? statusFilters.map(mapWorksStatus) : undefined,
+      sort: mapWorksSort(sortValue)
+    }),
+    [languageFilters, search, statusFilters, sortValue]
+  );
+
   return {
+    requestFilters,
     sortValue,
     selectedFilters: {
       status: statusFilters,

--- a/app/(logged_in)/creativity/useWorksTableActions.test.ts
+++ b/app/(logged_in)/creativity/useWorksTableActions.test.ts
@@ -12,6 +12,7 @@ jest.mock('react-hot-toast', () => ({
 jest.mock('~/types/graphql/generated/graphql', () => ({
   useUpdateOpusMutation: jest.fn(),
   useDeleteOpusMutation: jest.fn(),
+  PaginatedWorksDocument: { kind: 'Document' },
   OpusStatus: {
     Published: 'PUBLISHED',
     Draft: 'DRAFT'
@@ -145,7 +146,8 @@ describe('useWorksTableActions', () => {
 
       expect(mockDeleteOpus).toHaveBeenCalledWith({
         variables: { id: 'group-123' },
-        refetchQueries: ['AllOpuses', 'AllCompositions']
+        refetchQueries: [{ kind: 'Document' }],
+        awaitRefetchQueries: true
       });
       expect(toast.success).toHaveBeenCalledWith('Групу успішно розгруповано');
       expect(result.current.groupToUngroup).toBeNull();

--- a/app/(logged_in)/creativity/useWorksTableActions.ts
+++ b/app/(logged_in)/creativity/useWorksTableActions.ts
@@ -2,7 +2,12 @@ import { useState } from 'react';
 import toast from 'react-hot-toast';
 
 import { WORKS_BASE_PATH } from '~/constants/creativity';
-import { OpusStatus, useDeleteOpusMutation, useUpdateOpusMutation } from '~/types/graphql/generated/graphql';
+import {
+  OpusStatus,
+  PaginatedWorksDocument,
+  useDeleteOpusMutation,
+  useUpdateOpusMutation
+} from '~/types/graphql/generated/graphql';
 
 export function useWorksTableActions() {
   const [updateOpus] = useUpdateOpusMutation();
@@ -39,7 +44,8 @@ export function useWorksTableActions() {
     try {
       await deleteOpus({
         variables: { id: groupToUngroup },
-        refetchQueries: ['AllOpuses', 'AllCompositions']
+        refetchQueries: [PaginatedWorksDocument],
+        awaitRefetchQueries: true
       });
       toast.success('Групу успішно розгруповано');
       setGroupToUngroup(null);

--- a/app/constants/creativity.ts
+++ b/app/constants/creativity.ts
@@ -161,3 +161,5 @@ export type CompositionFileType = keyof typeof COMPOSITION_FILE_TYPES;
 
 export const SHEET_MUSIC_MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024;
 export const SHEET_MUSIC_FILE_SIZE_ERROR = 'Розмір файлу перевищує максимально допустимий ліміт (50 МБ).';
+
+export const ITEMS_PER_PAGE = 8;

--- a/app/constants/creativity.ts
+++ b/app/constants/creativity.ts
@@ -5,7 +5,19 @@ import type { FilterOption } from '~/shared/components/selector/FilterSelect';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
 import { OpusCompositionData } from '~/types/opus';
 
-export type WorksTabValue = 'all' | 'opus' | 'ungrouped' | 'works';
+
+export const WORKS_TABS_NAMES = {
+  ALL: 'all',
+  OPUS: 'opus',
+  WOO: 'woo',
+  WORKS: 'works'
+} as const;
+
+export type WorksTabValue = (typeof WORKS_TABS_NAMES)[keyof typeof WORKS_TABS_NAMES];
+export type AllTab = typeof WORKS_TABS_NAMES.ALL;
+export type OpusTab = typeof WORKS_TABS_NAMES.OPUS;
+export type WooTab = typeof WORKS_TABS_NAMES.WOO;
+export type WorksTab = typeof WORKS_TABS_NAMES.WORKS;
 
 export type WorksStatusValue = (typeof WORKS_STATUSES)[number];
 export type WorksLanguageValue = 'uk' | 'en' | 'bilingual';
@@ -40,10 +52,10 @@ export const WORKS_STATUSES = [
 ] as const;
 
 export const WORKS_TABS: ReadonlyArray<WorksTabConfig> = [
-  { value: 'all', label: 'Всі', href: WORKS_BASE_PATH },
-  { value: 'opus', label: 'Опуси', href: `${WORKS_BASE_PATH}/opus` },
-  { value: 'ungrouped', label: 'Безопусні', href: `${WORKS_BASE_PATH}/ungrouped` },
-  { value: 'works', label: 'Твори', href: `${WORKS_BASE_PATH}/works` }
+  { value: WORKS_TABS_NAMES.ALL, label: 'Всі', href: WORKS_BASE_PATH },
+  { value: WORKS_TABS_NAMES.OPUS, label: 'Опуси', href: `${WORKS_BASE_PATH}/opus` },
+  { value: WORKS_TABS_NAMES.WOO, label: 'Безопусні', href: `${WORKS_BASE_PATH}/woo` },
+  { value: WORKS_TABS_NAMES.WORKS, label: 'Твори', href: `${WORKS_BASE_PATH}/works` }
 ];
 
 export const WORKS_CREATE_OPTIONS: ReadonlyArray<WorksCreateOption> = [

--- a/app/constants/creativity.ts
+++ b/app/constants/creativity.ts
@@ -72,7 +72,7 @@ const WORKS_LANGUAGE_FILTER_OPTIONS: ReadonlyArray<FilterOption> = [
 const WORKS_STATUS_FILTER_OPTIONS: ReadonlyArray<FilterOption> = [
   {
     value: BaseContentStatuses.Draft,
-    label: 'Приховане'
+    label: 'Чернетка (приховано)'
   },
   {
     value: BaseContentStatuses.Published,

--- a/app/shared/hooks/use-compositions/useCompositions.test.ts
+++ b/app/shared/hooks/use-compositions/useCompositions.test.ts
@@ -1,18 +1,11 @@
 import { act, renderHook } from '@testing-library/react';
 
-import { toSuggestionAudio, toSuggestionNote, useAllCompositions, useCompositionsForm } from './useCompositions';
-import { CompositionFiltersInput, useAllCompositionsQuery } from '~/types/graphql/generated/graphql';
+import { toSuggestionAudio, toSuggestionNote, useCompositionsForm } from './useCompositions';
 import { OpusCompositionData, OpusCompositionSuggestion } from '~/types/opus';
 
 jest.mock('~/shared/hooks/use-group-content/useGroupContent', () => ({
   createCompositionId: jest.fn(() => 'mocked-id')
 }));
-
-jest.mock('~/types/graphql/generated/graphql', () => ({
-  useAllCompositionsQuery: jest.fn()
-}));
-
-const mockedUseAllCompositionsQuery = jest.mocked(useAllCompositionsQuery);
 
 describe('useCompositions helpers', () => {
   it('toSuggestionAudio formats audio correctly', () => {
@@ -225,78 +218,5 @@ describe('useCompositions Hook', () => {
 
     expect(mockOnChange).not.toHaveBeenCalled();
     expect(result.current.deleteTargetId).toBeNull();
-  });
-});
-
-describe('useAllCompositions', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockedUseAllCompositionsQuery.mockReturnValue({ data: undefined } as ReturnType<typeof useAllCompositionsQuery>);
-  });
-
-  it('calls query with standalone filter', () => {
-    renderHook(() => useAllCompositions());
-
-    expect(mockedUseAllCompositionsQuery).toHaveBeenCalledWith({
-      variables: {
-        filters: {
-          isStandalone: true
-        }
-      },
-      fetchPolicy: 'network-only',
-      skip: undefined
-    });
-  });
-
-  it('merges provided filters', () => {
-    const filters: CompositionFiltersInput = {
-      search: 'Symphony'
-    };
-
-    renderHook(() => useAllCompositions(filters));
-
-    expect(mockedUseAllCompositionsQuery).toHaveBeenCalledWith({
-      variables: {
-        filters: {
-          ...filters,
-          isStandalone: true
-        }
-      },
-      fetchPolicy: 'network-only',
-      skip: undefined
-    });
-  });
-
-  it('passes skip option', () => {
-    renderHook(() => useAllCompositions(undefined, { skip: true }));
-
-    expect(mockedUseAllCompositionsQuery).toHaveBeenCalledWith({
-      variables: {
-        filters: {
-          isStandalone: true
-        }
-      },
-      fetchPolicy: 'network-only',
-      skip: true
-    });
-  });
-
-  it('overrides isStandalone to true even if false is passed', () => {
-    const filters: CompositionFiltersInput = {
-      isStandalone: false
-    };
-
-    renderHook(() => useAllCompositions(filters));
-
-    expect(mockedUseAllCompositionsQuery).toHaveBeenCalledWith({
-      variables: {
-        filters: {
-          ...filters,
-          isStandalone: true
-        }
-      },
-      fetchPolicy: 'network-only',
-      skip: undefined
-    });
   });
 });

--- a/app/shared/hooks/use-compositions/useCompositions.ts
+++ b/app/shared/hooks/use-compositions/useCompositions.ts
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 
 import { createCompositionId } from '~/shared/hooks/use-group-content/useGroupContent';
-import { CompositionFiltersInput, useAllCompositionsQuery } from '~/types/graphql/generated/graphql';
 import type { OpusCompositionData, OpusCompositionSuggestion, OpusMediaFileData } from '~/types/opus';
 
 const fileNameFromUrl = (url?: string | null): string => {
@@ -25,15 +24,6 @@ export const toSuggestionNote = (sheet: SheetMusicItem): OpusMediaFileData => ({
   fileUrl: sheet.url ?? undefined,
   publishDate: sheet.publishDate ?? ''
 });
-
-type QueryHookOptions = Readonly<{ skip?: boolean }>;
-
-export const useAllCompositions = (filters?: CompositionFiltersInput, options: QueryHookOptions = {}) =>
-  useAllCompositionsQuery({
-    variables: { filters: { ...filters, isStandalone: true } },
-    fetchPolicy: 'network-only',
-    skip: options.skip
-  });
 
 export const useCompositionsForm = (works: OpusCompositionData[], onChange: (works: OpusCompositionData[]) => void) => {
   const [isModalOpen, setIsModalOpen] = useState(false);

--- a/app/shared/hooks/use-opuses/useOpuses.test.tsx
+++ b/app/shared/hooks/use-opuses/useOpuses.test.tsx
@@ -1,37 +1,37 @@
 import { act, renderHook } from '@testing-library/react';
 
 import {
-  useAllOpusGroups,
-  useAllUngroupedGroups,
   useCreateOpus,
   useDeleteOpus,
   useOpusById,
+  usePaginatedWorks,
   useSearchCompositions,
   useUpdateOpus
 } from './useOpuses';
+import { BaseContentStatuses } from '~/types/enums/common.enums';
+import { OpusStatus, WorksTab } from '~/types/graphql/generated/graphql';
 
 const mockCreateMutate = jest.fn();
 const mockUpdateMutate = jest.fn();
 const mockDeleteMutate = jest.fn();
 
 const mockUseOpusByIdQuery = jest.fn();
-const mockUseAllOpusesQuery = jest.fn();
+const mockUsePaginatedWorksQuery = jest.fn();
 const mockUseSearchCompositionsQuery = jest.fn();
 
-jest.mock('~/types/graphql/generated/graphql', () => ({
-  OpusNumberKind: {
-    Op: 'OP',
-    Woo: 'WOO'
-  },
+jest.mock('~/types/graphql/generated/graphql', () => {
+  const actual = jest.requireActual('~/types/graphql/generated/graphql');
 
-  useCreateOpusMutation: () => [mockCreateMutate, {}],
-  useUpdateOpusMutation: () => [mockUpdateMutate, {}],
-  useDeleteOpusMutation: () => [mockDeleteMutate, {}],
-
-  useOpusByIdQuery: (options: unknown) => mockUseOpusByIdQuery(options),
-  useAllOpusesQuery: (options: unknown) => mockUseAllOpusesQuery(options),
-  useSearchCompositionsQuery: (options: unknown) => mockUseSearchCompositionsQuery(options)
-}));
+  return {
+    ...actual,
+    useCreateOpusMutation: () => [mockCreateMutate, {}],
+    useUpdateOpusMutation: () => [mockUpdateMutate, {}],
+    useDeleteOpusMutation: () => [mockDeleteMutate, {}],
+    useOpusByIdQuery: (options: unknown) => mockUseOpusByIdQuery(options),
+    usePaginatedWorksQuery: (options: unknown) => mockUsePaginatedWorksQuery(options),
+    useSearchCompositionsQuery: (options: unknown) => mockUseSearchCompositionsQuery(options)
+  };
+});
 
 describe('useOpuses hooks', () => {
   beforeEach(() => {
@@ -122,82 +122,6 @@ describe('useOpuses hooks', () => {
       })
     );
   });
-
-  it('useAllOpusGroups requests Op groups', () => {
-    mockUseAllOpusesQuery.mockReturnValue({
-      data: undefined,
-      loading: false
-    });
-
-    renderHook(() => useAllOpusGroups({}));
-
-    expect(mockUseAllOpusesQuery).toHaveBeenCalledWith(
-      expect.objectContaining({
-        variables: {
-          filters: {
-            numberKind: 'OP'
-          }
-        },
-        fetchPolicy: 'network-only',
-        skip: undefined
-      })
-    );
-  });
-
-  it('useAllUngroupedGroups requests Woo groups', () => {
-    mockUseAllOpusesQuery.mockReturnValue({
-      data: undefined,
-      loading: false
-    });
-
-    renderHook(() =>
-      useAllUngroupedGroups({
-        statuses: undefined
-      })
-    );
-
-    expect(mockUseAllOpusesQuery).toHaveBeenCalledWith(
-      expect.objectContaining({
-        variables: {
-          filters: {
-            numberKind: 'WOO'
-          }
-        },
-        fetchPolicy: 'network-only',
-        skip: undefined
-      })
-    );
-  });
-
-  it('passes skip option to useAllOpusGroups', () => {
-    mockUseAllOpusesQuery.mockReturnValue({
-      data: undefined,
-      loading: false
-    });
-
-    renderHook(() => useAllOpusGroups(undefined, { skip: true }));
-
-    expect(mockUseAllOpusesQuery).toHaveBeenCalledWith(
-      expect.objectContaining({
-        skip: true
-      })
-    );
-  });
-
-  it('passes skip option to useAllUngroupedGroups', () => {
-    mockUseAllOpusesQuery.mockReturnValue({
-      data: undefined,
-      loading: false
-    });
-
-    renderHook(() => useAllUngroupedGroups(undefined, { skip: true }));
-
-    expect(mockUseAllOpusesQuery).toHaveBeenCalledWith(
-      expect.objectContaining({
-        skip: true
-      })
-    );
-  });
 });
 
 describe('useSearchCompositions', () => {
@@ -233,5 +157,130 @@ describe('useSearchCompositions', () => {
         skip: true
       })
     );
+  });
+});
+
+describe('usePaginatedWorks', () => {
+  it('requests paginated works with provided variables', () => {
+    mockUsePaginatedWorksQuery.mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: undefined
+    });
+
+    renderHook(() =>
+      usePaginatedWorks(WorksTab.Opus, {
+        search: 'test'
+      })
+    );
+
+    expect(mockUsePaginatedWorksQuery).toHaveBeenCalledWith({
+      variables: {
+        tab: WorksTab.Opus,
+        filters: {
+          search: 'test'
+        }
+      },
+      fetchPolicy: 'network-only'
+    });
+  });
+
+  it('maps groups and works', () => {
+    mockUsePaginatedWorksQuery.mockReturnValue({
+      loading: false,
+      error: undefined,
+      data: {
+        paginatedWorks: {
+          total: 2,
+          totalPages: 1,
+          groups: [
+            {
+              id: 'g1',
+              number: 'Op.1',
+              numberKind: 'op',
+              name: { uk: 'Group' },
+              genre: 'Genre',
+              creationYear: '2024',
+              status: OpusStatus.Published,
+              updatedAt: 'today',
+              compositions: [
+                {
+                  id: 'c1',
+                  title: {
+                    uk: 'Work'
+                  }
+                }
+              ]
+            }
+          ],
+          works: [
+            {
+              id: 'w1',
+              title: {
+                uk: 'Standalone'
+              },
+              year: '2023',
+              genre: 'Genre',
+              status: OpusStatus.Draft,
+              updatedAt: 'today'
+            }
+          ]
+        }
+      }
+    });
+
+    const { result } = renderHook(() => usePaginatedWorks());
+
+    expect(result.current.items).toEqual({
+      groups: [
+        {
+          id: 'g1',
+          number: 'Op.1',
+          numberKind: 'op',
+          name: 'Group',
+          genre: 'Genre',
+          startDate: '2024',
+          status: BaseContentStatuses.Published,
+          updatedAt: 'today',
+          works: [
+            {
+              id: 'c1',
+              title: 'Work'
+            }
+          ]
+        }
+      ],
+      works: [
+        {
+          id: 'w1',
+          title: 'Standalone',
+          year: '2023',
+          genre: 'Genre',
+          status: BaseContentStatuses.Draft,
+          updatedAt: 'today'
+        }
+      ]
+    });
+
+    expect(result.current.totalItems).toBe(2);
+    expect(result.current.totalPages).toBe(1);
+  });
+
+  it('returns empty collections when no data', () => {
+    mockUsePaginatedWorksQuery.mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: undefined
+    });
+
+    const { result } = renderHook(() => usePaginatedWorks());
+
+    expect(result.current.items).toEqual({
+      groups: [],
+      works: []
+    });
+
+    expect(result.current.totalItems).toBe(0);
+    expect(result.current.totalPages).toBe(0);
   });
 });

--- a/app/shared/hooks/use-opuses/useOpuses.test.tsx
+++ b/app/shared/hooks/use-opuses/useOpuses.test.tsx
@@ -283,4 +283,44 @@ describe('usePaginatedWorks', () => {
     expect(result.current.totalItems).toBe(0);
     expect(result.current.totalPages).toBe(0);
   });
+
+  it('maps statuses correctly for groups and works', () => {
+    mockUsePaginatedWorksQuery.mockReturnValue({
+      loading: false,
+      data: {
+        paginatedWorks: {
+          total: 2,
+          totalPages: 1,
+          groups: [
+            {
+              id: 'g1',
+              number: 'Op.1',
+              numberKind: 'op',
+              name: { uk: 'Group' },
+              genre: 'Genre',
+              creationYear: '2024',
+              status: OpusStatus.Draft,
+              updatedAt: 'today',
+              compositions: []
+            }
+          ],
+          works: [
+            {
+              id: 'w1',
+              title: { uk: 'Standalone' },
+              year: '2023',
+              genre: 'Genre',
+              status: OpusStatus.Published,
+              updatedAt: 'today'
+            }
+          ]
+        }
+      }
+    });
+
+    const { result } = renderHook(() => usePaginatedWorks());
+
+    expect(result.current.items.groups[0].status).toBe(BaseContentStatuses.Draft);
+    expect(result.current.items.works[0].status).toBe(BaseContentStatuses.Published);
+  });
 });

--- a/app/shared/hooks/use-opuses/useOpuses.tsx
+++ b/app/shared/hooks/use-opuses/useOpuses.tsx
@@ -2,45 +2,117 @@
 
 import { useCallback } from 'react';
 
+import { GroupRowData, IndividualWork } from '~/(logged_in)/creativity/WorksTable';
+import { WorksLanguageValue, WorksTabValue } from '~/constants/creativity';
 import { OpusErrors } from '~/constants/errors';
 import { safeMutate } from '~/lib/utils/safeMutate';
+import { BaseContentStatuses } from '~/types/enums/common.enums';
 import {
+  ContentLanguage,
   type CreateOpusInput,
   type CreateOpusMutation,
   type CreateOpusMutationVariables,
   type DeleteOpusMutationVariables,
-  type OpusFiltersInput,
-  OpusNumberKind,
+  OpusStatus,
   type UpdateOpusMutation,
   type UpdateOpusMutationVariables,
-  useAllOpusesQuery,
   useCreateOpusMutation,
   useDeleteOpusMutation,
   useOpusByIdQuery,
+  usePaginatedWorksQuery,
   useSearchCompositionsQuery,
-  useUpdateOpusMutation
+  useUpdateOpusMutation,
+  WorksTab
 } from '~/types/graphql/generated/graphql';
 
 type QueryHookOptions = Readonly<{
   skip?: boolean;
 }>;
-
 export const useOpusById = (id: string, options: QueryHookOptions = {}) =>
   useOpusByIdQuery({ variables: { id }, fetchPolicy: 'network-only', skip: options.skip || !id });
 
-export const useAllOpusGroups = (filters?: OpusFiltersInput, options: QueryHookOptions = {}) =>
-  useAllOpusesQuery({
-    variables: { filters: { ...filters, numberKind: OpusNumberKind.Op } },
-    fetchPolicy: 'network-only',
-    skip: options.skip
+const TAB_TO_GQL: Record<WorksTabValue, WorksTab> = {
+  all: WorksTab.All,
+  opus: WorksTab.Opus,
+  woo: WorksTab.Woo,
+  works: WorksTab.Works
+};
+
+const LANGUAGE_TO_GQL: Record<WorksLanguageValue, ContentLanguage> = {
+  uk: ContentLanguage.Uk,
+  en: ContentLanguage.En,
+  bilingual: ContentLanguage.Bilingual
+};
+
+const STATUS_TO_GQL: Record<BaseContentStatuses.Draft | BaseContentStatuses.Published, OpusStatus> = {
+  [BaseContentStatuses.Draft]: OpusStatus.Draft,
+  [BaseContentStatuses.Published]: OpusStatus.Published
+};
+
+type UsePaginatedWorksArgs = Readonly<{
+  tab: WorksTabValue;
+  search?: string;
+  filters?: {
+    statuses?: BaseContentStatuses[];
+    languages?: WorksLanguageValue[];
+  };
+  page?: number;
+  pageSize?: number;
+}>;
+
+export function usePaginatedWorks({ tab, search, filters, page, pageSize }: UsePaginatedWorksArgs) {
+  const { data, loading, error } = usePaginatedWorksQuery({
+    variables: {
+      input: {
+        tab: TAB_TO_GQL[tab],
+        search,
+        filters: filters
+          ? {
+            statuses: filters.statuses
+              ?.filter(
+                (status): status is BaseContentStatuses.Draft | BaseContentStatuses.Published =>
+                  status === BaseContentStatuses.Draft || status === BaseContentStatuses.Published
+              )
+              .map((status) => STATUS_TO_GQL[status]),
+            languages: filters.languages?.map((lang) => LANGUAGE_TO_GQL[lang])
+          }
+          : undefined,
+        page,
+        pageSize
+      }
+    },
+    fetchPolicy: 'network-only'
   });
 
-export const useAllUngroupedGroups = (filters?: OpusFiltersInput, options: QueryHookOptions = {}) =>
-  useAllOpusesQuery({
-    variables: { filters: { ...filters, numberKind: OpusNumberKind.Woo } },
-    fetchPolicy: 'network-only',
-    skip: options.skip
-  });
+  const groups: GroupRowData[] = (data?.paginatedWorks.groups ?? []).map((g) => ({
+    id: g.id,
+    number: g.number,
+    numberKind: g.numberKind === 'op' ? 'op' : 'bo',
+    name: g.name.uk,
+    genre: g.genre ?? '',
+    startDate: g.creationYear,
+    status: g.status === OpusStatus.Published ? BaseContentStatuses.Published : BaseContentStatuses.Draft,
+    updatedAt: g.updatedAt,
+    works: g.compositions?.map((c) => ({ id: c.id, title: c.title.uk })) ?? []
+  }));
+
+  const works: IndividualWork[] = (data?.paginatedWorks.works ?? []).map((w) => ({
+    id: w.id,
+    title: w.title.uk,
+    year: w.year,
+    genre: w.genre,
+    status: w.status === OpusStatus.Published ? BaseContentStatuses.Published : BaseContentStatuses.Draft,
+    updatedAt: w.updatedAt
+  }));
+
+  return {
+    items: { groups, works },
+    totalPages: data?.paginatedWorks.totalPages ?? 0,
+    totalItems: data?.paginatedWorks.totalItems ?? 0,
+    loading,
+    error
+  };
+}
 
 export const useSearchCompositions = (search: string, options: QueryHookOptions = {}) =>
   useSearchCompositionsQuery({ variables: { search }, fetchPolicy: 'network-only', skip: options.skip || !search });

--- a/app/shared/hooks/use-opuses/useOpuses.tsx
+++ b/app/shared/hooks/use-opuses/useOpuses.tsx
@@ -3,12 +3,10 @@
 import { useCallback } from 'react';
 
 import { GroupRowData, IndividualWork } from '~/(logged_in)/creativity/WorksTable';
-import { WorksLanguageValue, WorksTabValue } from '~/constants/creativity';
 import { OpusErrors } from '~/constants/errors';
 import { safeMutate } from '~/lib/utils/safeMutate';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
 import {
-  ContentLanguage,
   type CreateOpusInput,
   type CreateOpusMutation,
   type CreateOpusMutationVariables,
@@ -22,6 +20,7 @@ import {
   usePaginatedWorksQuery,
   useSearchCompositionsQuery,
   useUpdateOpusMutation,
+  WorksFiltersInput,
   WorksTab
 } from '~/types/graphql/generated/graphql';
 
@@ -31,55 +30,11 @@ type QueryHookOptions = Readonly<{
 export const useOpusById = (id: string, options: QueryHookOptions = {}) =>
   useOpusByIdQuery({ variables: { id }, fetchPolicy: 'network-only', skip: options.skip || !id });
 
-const TAB_TO_GQL: Record<WorksTabValue, WorksTab> = {
-  all: WorksTab.All,
-  opus: WorksTab.Opus,
-  woo: WorksTab.Woo,
-  works: WorksTab.Works
-};
-
-const LANGUAGE_TO_GQL: Record<WorksLanguageValue, ContentLanguage> = {
-  uk: ContentLanguage.Uk,
-  en: ContentLanguage.En,
-  bilingual: ContentLanguage.Bilingual
-};
-
-const STATUS_TO_GQL: Record<BaseContentStatuses.Draft | BaseContentStatuses.Published, OpusStatus> = {
-  [BaseContentStatuses.Draft]: OpusStatus.Draft,
-  [BaseContentStatuses.Published]: OpusStatus.Published
-};
-
-type UsePaginatedWorksArgs = Readonly<{
-  tab: WorksTabValue;
-  search?: string;
-  filters?: {
-    statuses?: BaseContentStatuses[];
-    languages?: WorksLanguageValue[];
-  };
-  page?: number;
-  pageSize?: number;
-}>;
-
-export function usePaginatedWorks({ tab, search, filters, page, pageSize }: UsePaginatedWorksArgs) {
+export function usePaginatedWorks(tab?: WorksTab | null, filters?: WorksFiltersInput | null) {
   const { data, loading, error } = usePaginatedWorksQuery({
     variables: {
-      input: {
-        tab: TAB_TO_GQL[tab],
-        search,
-        filters: filters
-          ? {
-            statuses: filters.statuses
-              ?.filter(
-                (status): status is BaseContentStatuses.Draft | BaseContentStatuses.Published =>
-                  status === BaseContentStatuses.Draft || status === BaseContentStatuses.Published
-              )
-              .map((status) => STATUS_TO_GQL[status]),
-            languages: filters.languages?.map((lang) => LANGUAGE_TO_GQL[lang])
-          }
-          : undefined,
-        page,
-        pageSize
-      }
+      tab,
+      filters
     },
     fetchPolicy: 'network-only'
   });
@@ -93,7 +48,11 @@ export function usePaginatedWorks({ tab, search, filters, page, pageSize }: UseP
     startDate: g.creationYear,
     status: g.status === OpusStatus.Published ? BaseContentStatuses.Published : BaseContentStatuses.Draft,
     updatedAt: g.updatedAt,
-    works: g.compositions?.map((c) => ({ id: c.id, title: c.title.uk })) ?? []
+    works:
+      g.compositions?.map((c) => ({
+        id: c.id,
+        title: c.title.uk
+      })) ?? []
   }));
 
   const works: IndividualWork[] = (data?.paginatedWorks.works ?? []).map((w) => ({
@@ -108,7 +67,7 @@ export function usePaginatedWorks({ tab, search, filters, page, pageSize }: UseP
   return {
     items: { groups, works },
     totalPages: data?.paginatedWorks.totalPages ?? 0,
-    totalItems: data?.paginatedWorks.totalItems ?? 0,
+    totalItems: data?.paginatedWorks.total ?? 0,
     loading,
     error
   };

--- a/app/types/graphql/queries/opus.graphql
+++ b/app/types/graphql/queries/opus.graphql
@@ -142,6 +142,49 @@ query AllOpuses($filters: OpusFiltersInput) {
   }
 }
 
+query PaginatedWorks($input: WorksInput!) {
+  paginatedWorks(input: $input) {
+    totalItems
+    totalPages
+
+    groups {
+      id
+      number
+      numberKind
+      name {
+        uk
+        en
+      }
+      genre
+      status
+      creationYear
+      endYear
+      updatedAt
+      createdAt
+      compositions {
+        id
+        title {
+          uk
+          en
+        }
+      }
+    }
+
+    works {
+      id
+      title {
+        uk
+        en
+      }
+      genre
+      status
+      year
+      updatedAt
+      createdAt
+    }
+  }
+}
+
 query SearchCompositions($search: String!) {
   searchCompositions(search: $search) {
     id

--- a/app/types/graphql/queries/opus.graphql
+++ b/app/types/graphql/queries/opus.graphql
@@ -113,38 +113,10 @@ query OpusById($id: ID!) {
   }
 }
 
-query AllOpuses($filters: OpusFiltersInput) {
-  allOpuses(filters: $filters) {
-    id
-    number
-    numberKind
-    title {
-      uk
-      en
-    }
-    name {
-      uk
-      en
-    }
-    genre
-    status
-    creationYear
-    endYear
-    updatedAt
-    createdAt
-    compositions {
-      id
-      title {
-        uk
-        en
-      }
-    }
-  }
-}
-
-query PaginatedWorks($input: WorksInput!) {
-  paginatedWorks(input: $input) {
-    totalItems
+query PaginatedWorks($tab: WorksTab, $filters: WorksFiltersInput) {
+  paginatedWorks(tab: $tab, filters: $filters) {
+    total
+    page
     totalPages
 
     groups {

--- a/src/domain/repositories/compositionRepository.ts
+++ b/src/domain/repositories/compositionRepository.ts
@@ -3,7 +3,7 @@ import { FiltersInput, IBaseRepository } from '~/domain/repositories/baseReposit
 
 export type CompositionFilters = FiltersInput & {
   statuses?: string[];
-  opusId?: string | null;
+  isStandalone?: boolean | null;
 };
 
 export type CompositionInput = Omit<Composition, 'id' | 'createdAt' | 'updatedAt'> & { id?: string };

--- a/src/domain/repositories/compositionRepository.ts
+++ b/src/domain/repositories/compositionRepository.ts
@@ -3,7 +3,7 @@ import { FiltersInput, IBaseRepository } from '~/domain/repositories/baseReposit
 
 export type CompositionFilters = FiltersInput & {
   statuses?: string[];
-  isStandalone?: boolean;
+  opusId?: string | null;
 };
 
 export type CompositionInput = Omit<Composition, 'id' | 'createdAt' | 'updatedAt'> & { id?: string };

--- a/src/domain/repositories/opusRepository.ts
+++ b/src/domain/repositories/opusRepository.ts
@@ -10,7 +10,7 @@ export type UpdateOpusInput = Partial<Omit<Opus, 'id' | 'createdAt' | 'updatedAt
 
 export type OpusFilters = FiltersInput & {
   statuses?: OpusStatus[];
-  numberKind: OpusNumberKind;
+  numberKind?: OpusNumberKind;
 };
 
 export interface IOpusRepository extends IBaseRepository<Opus, OpusFilters> {

--- a/src/infrastructure/repositories/compositionRepository/compositionRepository.test.ts
+++ b/src/infrastructure/repositories/compositionRepository/compositionRepository.test.ts
@@ -242,10 +242,8 @@ describe('CompositionRepository', () => {
     expect(updateManyMock).not.toHaveBeenCalled();
   });
 
-  describe('buildQuery configuration (lines 52-54)', () => {
-    it('should set opusId to null in query when opusId filter is provided', async () => {
-      const customOpusId = 'test-opus-id';
-
+  describe('buildQuery configuration', () => {
+    it('should set opusId to null in query when isStandalone is true', async () => {
       const mockQueryBuilder = {
         sort: jest.fn().mockReturnThis(),
         skip: jest.fn().mockReturnThis(),
@@ -254,12 +252,12 @@ describe('CompositionRepository', () => {
       };
       findMock.mockReturnValue(mockQueryBuilder);
 
-      await repository.findAll({ opusId: customOpusId });
+      await repository.findAll({ isStandalone: true });
 
-      expect(findMock).toHaveBeenCalledWith(expect.objectContaining({ opusId: customOpusId }));
+      expect(findMock).toHaveBeenCalledWith(expect.objectContaining({ opusId: null }));
     });
 
-    it('should not modify opusId in query when opusId filter is not provided', async () => {
+    it('should set opusId to { $ne: null } in query when isStandalone is false', async () => {
       const mockQueryBuilder = {
         sort: jest.fn().mockReturnThis(),
         skip: jest.fn().mockReturnThis(),
@@ -268,9 +266,24 @@ describe('CompositionRepository', () => {
       };
       findMock.mockReturnValue(mockQueryBuilder);
 
-      await repository.findAll();
+      await repository.findAll({ isStandalone: false });
 
-      expect(findMock).not.toHaveBeenCalledWith(expect.objectContaining({ opusId: null }));
+      expect(findMock).toHaveBeenCalledWith(expect.objectContaining({ opusId: { $ne: null } }));
+    });
+
+    it('should not include opusId filter when isStandalone is not provided', async () => {
+      const mockQueryBuilder = {
+        sort: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockResolvedValue([createMockDoc()])
+      };
+      findMock.mockReturnValue(mockQueryBuilder);
+
+      await repository.findAll({});
+      const callArgs = findMock.mock.calls[0][0];
+  
+      expect(callArgs).not.toHaveProperty('opusId'); 
     });
   });
 

--- a/src/infrastructure/repositories/compositionRepository/compositionRepository.test.ts
+++ b/src/infrastructure/repositories/compositionRepository/compositionRepository.test.ts
@@ -243,7 +243,9 @@ describe('CompositionRepository', () => {
   });
 
   describe('buildQuery configuration (lines 52-54)', () => {
-    it('should set opusId to null in query when isStandalone filter is true', async () => {
+    it('should set opusId to null in query when opusId filter is provided', async () => {
+      const customOpusId = 'test-opus-id';
+
       const mockQueryBuilder = {
         sort: jest.fn().mockReturnThis(),
         skip: jest.fn().mockReturnThis(),
@@ -252,12 +254,12 @@ describe('CompositionRepository', () => {
       };
       findMock.mockReturnValue(mockQueryBuilder);
 
-      await repository.findAll({ isStandalone: true });
+      await repository.findAll({ opusId: customOpusId });
 
-      expect(findMock).toHaveBeenCalledWith(expect.objectContaining({ opusId: null }));
+      expect(findMock).toHaveBeenCalledWith(expect.objectContaining({ opusId: customOpusId }));
     });
 
-    it('should not modify opusId in query when isStandalone filter is false', async () => {
+    it('should not modify opusId in query when opusId filter is not provided', async () => {
       const mockQueryBuilder = {
         sort: jest.fn().mockReturnThis(),
         skip: jest.fn().mockReturnThis(),
@@ -266,7 +268,7 @@ describe('CompositionRepository', () => {
       };
       findMock.mockReturnValue(mockQueryBuilder);
 
-      await repository.findAll({ isStandalone: false });
+      await repository.findAll();
 
       expect(findMock).not.toHaveBeenCalledWith(expect.objectContaining({ opusId: null }));
     });

--- a/src/infrastructure/repositories/compositionRepository/compositionRepository.ts
+++ b/src/infrastructure/repositories/compositionRepository/compositionRepository.ts
@@ -1,10 +1,11 @@
 import mongoose, { Model } from 'mongoose';
 
 import { createBaseRepository } from '../baseRepository/baseRepository';
-import { buildBaseQuery, getBaseSort } from '../helpers';
+import { buildBaseQuery, combineConditions, fieldCondition, getBaseSort } from '../helpers';
 import { Composition } from '~/domain/entities/Composition';
 import { CompositionFilters, CompositionInput, ICompositionRepository } from '~/domain/repositories/compositionRepository';
 import dbConnect from '~/infrastructure/db/connect';
+import { OpusStatus } from '~/types/graphql/generated/graphql';
 
 export type DbComposition = {
   _id: { toString(): string };
@@ -49,9 +50,13 @@ export const CompositionRepository = ({ CompositionModel }: CompositionRepoDeps)
     model: CompositionModel,
     toEntity,
     buildQuery: (filters) => {
-      const query = buildBaseQuery(filters);
-      if (filters?.opusId) query.opusId = filters.opusId;
-      return query;
+      const query = buildBaseQuery({ ...filters, statuses: undefined }, ['genre', 'title.uk', 'title.en']) ?? {};
+
+      return combineConditions<DbComposition>([
+        query,
+        fieldCondition<DbComposition>('status', filters?.statuses as unknown as string[], OpusStatus.Draft as string),
+        filters?.opusId ? { opusId: filters.opusId } : null
+      ]);
     },
     getDefaultSort: getBaseSort
   });

--- a/src/infrastructure/repositories/compositionRepository/compositionRepository.ts
+++ b/src/infrastructure/repositories/compositionRepository/compositionRepository.ts
@@ -55,7 +55,8 @@ export const CompositionRepository = ({ CompositionModel }: CompositionRepoDeps)
       return combineConditions<DbComposition>([
         query,
         fieldCondition<DbComposition>('status', filters?.statuses as unknown as string[], OpusStatus.Draft as string),
-        filters?.opusId ? { opusId: filters.opusId } : null
+        filters?.isStandalone === true ? { opusId: null } : null,
+        filters?.isStandalone === false ? { opusId: { $ne: null } } : null
       ]);
     },
     getDefaultSort: getBaseSort

--- a/src/infrastructure/repositories/compositionRepository/compositionRepository.ts
+++ b/src/infrastructure/repositories/compositionRepository/compositionRepository.ts
@@ -50,7 +50,7 @@ export const CompositionRepository = ({ CompositionModel }: CompositionRepoDeps)
     toEntity,
     buildQuery: (filters) => {
       const query = buildBaseQuery(filters);
-      if (filters?.isStandalone) query.opusId = null;
+      if (filters?.opusId) query.opusId = filters.opusId;
       return query;
     },
     getDefaultSort: getBaseSort

--- a/src/infrastructure/repositories/helpers.test.ts
+++ b/src/infrastructure/repositories/helpers.test.ts
@@ -1,4 +1,4 @@
-import { buildBaseQuery, createToEntity, getBaseSort } from './helpers';
+import { buildBaseQuery, combineConditions, createToEntity, fieldCondition, getBaseSort } from './helpers';
 import { BaseEntity } from '~/domain/repositories/baseRepository';
 import { SortByDate, SortOrder } from '~/types/enums/common.enums';
 
@@ -130,5 +130,116 @@ describe('Repository Helpers', () => {
       const result = getBaseSort(filters);
       expect(result).toEqual({ createdAt: -1 });
     });
+  });
+});
+
+describe('getLanguageCondition and language filtering', () => {
+  it('should build query for "uk" language', () => {
+    const result = buildBaseQuery({ languages: ['uk'] });
+    expect(result).toEqual({
+      $or: [{
+        $and: [{ 'title.uk': { $nin: ['', null] } }, { 'title.en': { $in: ['', null] } }]
+      }]
+    });
+  });
+
+  it('should build query for "en" language', () => {
+    const result = buildBaseQuery({ languages: ['en'] });
+    expect(result).toEqual({
+      $or: [{
+        $and: [{ 'title.en': { $nin: ['', null] } }, { 'title.uk': { $in: ['', null] } }]
+      }]
+    });
+  });
+
+  it('should build query for "bilingual" language', () => {
+    const result = buildBaseQuery({ languages: ['bilingual'] });
+    expect(result).toEqual({
+      $or: [{
+        $and: [{ 'title.uk': { $nin: ['', null] } }, { 'title.en': { $nin: ['', null] } }]
+      }]
+    });
+  });
+
+  it('should ignore unknown languages (returning null) and empty language arrays', () => {
+    const result = buildBaseQuery({ languages: [] });
+    expect(result).toEqual({});
+  });
+
+  it('should combine multiple valid languages with $or', () => {
+    const result = buildBaseQuery({ languages: ['uk', 'en'] });
+    expect(result).toEqual({
+      $or: [
+        { $and: [{ 'title.uk': { $nin: ['', null] } }, { 'title.en': { $in: ['', null] } }] },
+        { $and: [{ 'title.en': { $nin: ['', null] } }, { 'title.uk': { $in: ['', null] } }] }
+      ]
+    });
+  });
+});
+
+describe('fieldCondition', () => {
+  it('should return null for undefined, null, or empty array values', () => {
+    expect(fieldCondition('status', undefined)).toBeNull();
+    expect(fieldCondition('status', null)).toBeNull();
+    expect(fieldCondition('status', [])).toBeNull();
+  });
+
+  it('should return simple field match for single value', () => {
+    expect(fieldCondition('status', 'draft')).toEqual({ status: 'draft' });
+  });
+
+  it('should return $in operator for array of values', () => {
+    expect(fieldCondition('status', ['draft', 'published'])).toEqual({ 
+      status: { $in: ['draft', 'published'] } 
+    });
+  });
+
+  it('should handle fallbackValue correctly', () => {
+    const field = 'category';
+    const fallback = 'uncategorized';
+      
+    const result = fieldCondition(field, ['news', fallback], fallback);
+    expect(result).toEqual({
+      $or: [
+        { $or: [{ [field]: fallback }, { [field]: { $exists: false } }, { [field]: null }] },
+        { [field]: { $in: ['news'] } }
+      ]
+    });
+  });
+
+  it('should return only fallback query if no other values provided', () => {
+    const field = 'category';
+    const fallback = 'uncategorized';
+      
+    const result = fieldCondition(field, [fallback], fallback);
+    expect(result).toEqual({
+      $or: [{ [field]: fallback }, { [field]: { $exists: false } }, { [field]: null }]
+    });
+  });
+});
+
+describe('combineConditions', () => {
+  it('should return empty object if all conditions are null/undefined or empty', () => {
+    expect(combineConditions([null, undefined])).toEqual({});
+    expect(combineConditions([{}])).toEqual({});
+  });
+
+  it('should return the single non-empty condition as is', () => {
+    const cond = { status: 'published' };
+    expect(combineConditions([null, cond])).toEqual(cond);
+  });
+
+  it('should combine multiple conditions with $and', () => {
+    const cond1 = { status: 'published' };
+    const cond2 = { slug: 'test' };
+      
+    expect(combineConditions([cond1, cond2])).toEqual({
+      $and: [cond1, cond2]
+    });
+  });
+
+  it('should filter out empty objects before combining', () => {
+    const cond1 = { status: 'published' };
+    expect(combineConditions([cond1, {}])).toEqual(cond1);
   });
 });

--- a/src/infrastructure/repositories/helpers.ts
+++ b/src/infrastructure/repositories/helpers.ts
@@ -103,3 +103,43 @@ export const getBaseSort = (filters?: FiltersInput): Record<string, 1 | -1> => {
 
   return { createdAt: -1 };
 };
+export const fieldCondition = <TDb>(
+  field: string,
+  value: string | string[] | undefined | null,
+  fallbackValue?: string
+): FilterQuery<TDb> | null => {
+  const isEmpty = value === undefined || value === null || (Array.isArray(value) && value.length === 0);
+  if (isEmpty) {
+    return null;
+  }
+
+  const values = Array.isArray(value) ? value : [value];
+  const includesFallback = fallbackValue !== undefined && values.includes(fallbackValue);
+
+  if (!includesFallback) {
+    return { [field]: Array.isArray(value) ? { $in: values } : value } as FilterQuery<TDb>;
+  }
+
+  const fallbackCondition = {
+    $or: [{ [field]: fallbackValue }, { [field]: { $exists: false } }, { [field]: null }]
+  };
+
+  const otherValues = values.filter((v) => v !== fallbackValue);
+  if (otherValues.length === 0) {
+    return fallbackCondition as FilterQuery<TDb>;
+  }
+
+  return { $or: [fallbackCondition, { [field]: { $in: otherValues } }] } as FilterQuery<TDb>;
+};
+
+export const combineConditions = <TDb>(
+  conditions: (FilterQuery<TDb> | null | undefined)[]
+): FilterQuery<TDb> => {
+  const nonEmpty = conditions.filter(
+    (c): c is FilterQuery<TDb> => Boolean(c && Object.keys(c).length > 0)
+  );
+
+  if (nonEmpty.length === 0) return {} as FilterQuery<TDb>;
+  if (nonEmpty.length === 1) return nonEmpty[0];
+  return { $and: nonEmpty } as FilterQuery<TDb>;
+};

--- a/src/infrastructure/repositories/helpers.ts
+++ b/src/infrastructure/repositories/helpers.ts
@@ -4,6 +4,11 @@ import { BaseEntity, FiltersInput } from '~/domain/repositories/baseRepository';
 
 const NON_EMPTY_STRING_QUERY = { $nin: ['', null] } as const;
 const EMPTY_STRING_QUERY = { $in: ['', null] } as const;
+const DEFAULT_SEARCH_FIELDS = [
+  'adminTitle',
+  'title.uk',
+  'title.en'
+] as const;
 
 const escapeRegex = (value: string): string => value.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 
@@ -43,7 +48,10 @@ export const createToEntity = <
     ...extraFields
   }) as TEntity;
 
-export const buildBaseQuery = <TDb>(filters?: FiltersInput & { statuses?: string[] }): FilterQuery<TDb> => {
+export const buildBaseQuery = <TDb>(
+  filters?: FiltersInput & { statuses?: string[] },
+  searchFields: readonly string[] = DEFAULT_SEARCH_FIELDS
+): FilterQuery<TDb> => {
   const conditions: FilterQuery<TDb>[] = [];
 
   if (filters?.statuses?.length) {
@@ -54,11 +62,13 @@ export const buildBaseQuery = <TDb>(filters?: FiltersInput & { statuses?: string
     conditions.push({ slug: filters.slug } as FilterQuery<TDb>);
   }
 
-  if (filters?.search?.trim()) {
-    const searchRegex = new RegExp(escapeRegex(filters.search.trim()), 'i');
+  if (filters?.search?.trim() && searchFields.length) {
+    const regex = new RegExp(escapeRegex(filters.search.trim()), 'i');
 
     conditions.push({
-      $or: [{ adminTitle: searchRegex }, { 'title.uk': searchRegex }, { 'title.en': searchRegex }]
+      $or: searchFields.map((field) => ({
+        [field]: regex
+      }))
     } as FilterQuery<TDb>);
   }
 

--- a/src/infrastructure/repositories/opusRepository/opusRepository.test.ts
+++ b/src/infrastructure/repositories/opusRepository/opusRepository.test.ts
@@ -261,6 +261,34 @@ describe('OpusRepository', () => {
       });
       expect(result?.performances?.[1]?.id).toBe('');
     });
+
+    it('normalizes crop coordinates, falling back to 0 for invalid/missing values', async (): Promise<void> => {
+      const doc = createMockOpusDoc({
+        gallery: [
+          {
+            _id: { toString: () => 'gal-crop' },
+            src: 'crop.jpg',
+            crop: {
+              x: '5' as unknown as number,
+              y: 0,
+              width: undefined as unknown as number,
+              height: 'not-a-number' as unknown as number
+            }
+          }
+        ]
+      });
+      findOneMock.mockReturnValue({ lean: jest.fn().mockResolvedValue(doc) });
+
+      const result = await repository.findByNumber('op.1');
+
+      expect(result?.gallery?.[0]?.crop).toEqual({
+        x: 5,
+        y: 0,
+        width: 0,
+        height: 0
+      });
+    });
+
   });
 
   describe('findAll', () => {
@@ -340,6 +368,55 @@ describe('OpusRepository', () => {
       expect(findMock).toHaveBeenCalledWith({
         numberKind: OpusNumberKind.Woo
       });
+    });
+
+    it('falls back numberKind to "op" when nullish', async (): Promise<void> => {
+      const doc = createMockOpusDoc({ numberKind: undefined });
+      findOneMock.mockReturnValue({ lean: jest.fn().mockResolvedValue(doc) });
+
+      const result = await repository.findByNumber('op.1');
+
+      expect(result?.numberKind).toBe('op');
+    });
+
+    it('converts a string name into a bilingual object', async (): Promise<void> => {
+      const doc = createMockOpusDoc({
+        name: 'Просто рядкова назва' as unknown as DbOpus['name']
+      });
+      findOneMock.mockReturnValue({ lean: jest.fn().mockResolvedValue(doc) });
+
+      const result = await repository.findByNumber('op.1');
+
+      expect(result?.name).toEqual({
+        uk: 'Просто рядкова назва',
+        en: 'Просто рядкова назва'
+      });
+    });
+
+    it('sets introDescription and parts to undefined when nullish', async (): Promise<void> => {
+      const doc = createMockOpusDoc({
+        introDescription: null,
+        parts: undefined
+      });
+      findOneMock.mockReturnValue({ lean: jest.fn().mockResolvedValue(doc) });
+
+      const result = await repository.findByNumber('op.1');
+
+      expect(result?.introDescription).toBeUndefined();
+      expect(result?.parts).toBeUndefined();
+    });
+
+    it('keeps provided introDescription and parts values', async (): Promise<void> => {
+      const doc = createMockOpusDoc({
+        introDescription: { uk: 'Вступ', en: 'Intro' },
+        parts: { uk: 'Частини', en: 'Parts' }
+      });
+      findOneMock.mockReturnValue({ lean: jest.fn().mockResolvedValue(doc) });
+
+      const result = await repository.findByNumber('op.1');
+
+      expect(result?.introDescription).toEqual({ uk: 'Вступ', en: 'Intro' });
+      expect(result?.parts).toEqual({ uk: 'Частини', en: 'Parts' });
     });
   });
 });

--- a/src/infrastructure/repositories/opusRepository/opusRepository.ts
+++ b/src/infrastructure/repositories/opusRepository/opusRepository.ts
@@ -6,8 +6,8 @@ import { LocalizedString } from '~/domain/entities/BaseContent';
 import { Opus } from '~/domain/entities/Opus';
 import { CreateOpusInput, IOpusRepository, OpusFilters } from '~/domain/repositories/opusRepository';
 import dbConnect from '~/infrastructure/db/connect';
-import { buildBaseQuery, createToEntity, getBaseSort } from '~/infrastructure/repositories/helpers';
-import { OpusNumberKind } from '~/types/graphql/generated/graphql';
+import { buildBaseQuery, combineConditions, createToEntity, fieldCondition, getBaseSort } from '~/infrastructure/repositories/helpers';
+import { OpusNumberKind, OpusStatus } from '~/types/graphql/generated/graphql';
 
 export type DbOpusGalleryItem = {
   _id?: { toString(): string };
@@ -110,39 +110,15 @@ export const OpusRepository = ({ OpusModel }: OpusRepoDeps): IOpusRepository => 
     model: OpusModel,
     toEntity,
     buildQuery: (filters) => {
-      
-      const query = buildBaseQuery(filters, [
-        'genre',
-        'name.uk',
-        'name.en',
-      ]) ?? {};
+      const query = buildBaseQuery({ ...filters, statuses: undefined }, ['genre', 'name.uk', 'name.en']) ?? {};
 
-      if (filters?.numberKind) {
-        const numberKindCondition =
-      filters.numberKind === OpusNumberKind.Op
-        ? {
-          $or: [
-            { numberKind: OpusNumberKind.Op },
-            { numberKind: { $exists: false } },
-            { numberKind: null }
-          ]
-        }
-        : {
-          numberKind: filters.numberKind
-        };
-
-        if (Object.keys(query).length === 0) {
-          return numberKindCondition;
-        }
-
-        return {
-          $and: [query, numberKindCondition]
-        };
-      }
-
-      return query;
+      return combineConditions<DbOpus>([
+        query,
+        fieldCondition<DbOpus>('status', filters?.statuses as unknown as string[], OpusStatus.Draft as string),
+        fieldCondition<DbOpus>('numberKind', filters?.numberKind as unknown as string, OpusNumberKind.Op as string)
+      ]);
     },
-    getDefaultSort: getBaseSort 
+    getDefaultSort: getBaseSort
   });
 
   const findByNumber = async (number: string): Promise<Opus | null> => {

--- a/src/infrastructure/repositories/opusRepository/opusRepository.ts
+++ b/src/infrastructure/repositories/opusRepository/opusRepository.ts
@@ -110,21 +110,39 @@ export const OpusRepository = ({ OpusModel }: OpusRepoDeps): IOpusRepository => 
     model: OpusModel,
     toEntity,
     buildQuery: (filters) => {
-      const query = buildBaseQuery(filters) ?? {};
+      
+      const query = buildBaseQuery(filters, [
+        'genre',
+        'name.uk',
+        'name.en',
+      ]) ?? {};
+
       if (filters?.numberKind) {
-        if (filters.numberKind === OpusNumberKind.Op) {
-          query.$or = [
+        const numberKindCondition =
+      filters.numberKind === OpusNumberKind.Op
+        ? {
+          $or: [
             { numberKind: OpusNumberKind.Op },
             { numberKind: { $exists: false } },
             { numberKind: null }
-          ];
-        } else {
-          query.numberKind = filters.numberKind;
+          ]
         }
+        : {
+          numberKind: filters.numberKind
+        };
+
+        if (Object.keys(query).length === 0) {
+          return numberKindCondition;
+        }
+
+        return {
+          $and: [query, numberKindCondition]
+        };
       }
+
       return query;
     },
-    getDefaultSort: getBaseSort
+    getDefaultSort: getBaseSort 
   });
 
   const findByNumber = async (number: string): Promise<Opus | null> => {

--- a/src/interfaces/graphql/opusSchema.smoke.test.ts
+++ b/src/interfaces/graphql/opusSchema.smoke.test.ts
@@ -19,7 +19,8 @@ describe('GraphQL schema (opus SDL wiring)', () => {
     expect(mutationFields.deleteOpus).toBeDefined();
 
     const queryFields = schema.getQueryType()?.getFields() ?? {};
-    expect(queryFields.allOpuses).toBeDefined();
     expect(queryFields.opusById).toBeDefined();
+    expect(queryFields.searchCompositions).toBeDefined();
+    expect(queryFields.paginatedWorks).toBeDefined();
   });
 });

--- a/src/interfaces/graphql/resolvers/compositions/compositionsQuery.test.ts
+++ b/src/interfaces/graphql/resolvers/compositions/compositionsQuery.test.ts
@@ -32,29 +32,28 @@ describe('CompositionsQuery Resolvers', () => {
   it('allCompositions should call repo.findAll with mapped filters and explicit opusId', async () => {
     (mockCompositionsRepo.findAll as jest.Mock).mockResolvedValue([mockCompositionEntity]);
 
-    const opusId = 'opus-123';
     const result = await CompositionsQuery.allCompositions(
       {}, 
-      { filters: { opusId: opusId } }, 
+      { filters: { isStandalone: true } }, 
       adminContext
     );
 
     expect(mockCompositionsRepo.findAll).toHaveBeenCalledWith(
       expect.objectContaining({
-        opusId: opusId,
+        isStandalone: true,
       })
     );
     expect(result).toEqual([mockCompositionEntity]);
   });
 
-  it('allCompositions should call repo.findAll with undefined opusId if filter is omitted', async () => {
+  it('allCompositions should call repo.findAll with undefined isStandalone if filter is omitted', async () => {
     (mockCompositionsRepo.findAll as jest.Mock).mockResolvedValue([mockCompositionEntity]);
 
     await CompositionsQuery.allCompositions({}, { filters: {} }, adminContext);
 
     expect(mockCompositionsRepo.findAll).toHaveBeenCalledWith(
       expect.objectContaining({
-        opusId: undefined
+        isStandalone: null
       })
     );
   });

--- a/src/interfaces/graphql/resolvers/compositions/compositionsQuery.test.ts
+++ b/src/interfaces/graphql/resolvers/compositions/compositionsQuery.test.ts
@@ -29,31 +29,32 @@ describe('CompositionsQuery Resolvers', () => {
     jest.clearAllMocks();
   });
 
-  it('allCompositions should call repo.findAll with mapped filters and explicit isStandalone', async () => {
+  it('allCompositions should call repo.findAll with mapped filters and explicit opusId', async () => {
     (mockCompositionsRepo.findAll as jest.Mock).mockResolvedValue([mockCompositionEntity]);
 
+    const opusId = 'opus-123';
     const result = await CompositionsQuery.allCompositions(
       {}, 
-      { filters: { isStandalone: true } }, 
+      { filters: { opusId: opusId } }, 
       adminContext
     );
 
     expect(mockCompositionsRepo.findAll).toHaveBeenCalledWith(
       expect.objectContaining({
-        isStandalone: true
+        opusId: opusId,
       })
     );
     expect(result).toEqual([mockCompositionEntity]);
   });
 
-  it('allCompositions should call repo.findAll with undefined isStandalone if filter is omitted', async () => {
+  it('allCompositions should call repo.findAll with undefined opusId if filter is omitted', async () => {
     (mockCompositionsRepo.findAll as jest.Mock).mockResolvedValue([mockCompositionEntity]);
 
     await CompositionsQuery.allCompositions({}, { filters: {} }, adminContext);
 
     expect(mockCompositionsRepo.findAll).toHaveBeenCalledWith(
       expect.objectContaining({
-        isStandalone: undefined
+        opusId: undefined
       })
     );
   });

--- a/src/interfaces/graphql/resolvers/compositions/compositionsQuery.ts
+++ b/src/interfaces/graphql/resolvers/compositions/compositionsQuery.ts
@@ -5,7 +5,7 @@ import { CompositionFilters } from '~/src/domain/repositories/compositionReposit
 
 interface FilterArgs {
   filters?: NonNullable<Parameters<typeof mapFilters>[0]> & {
-    isStandalone?: boolean | null;
+    opusId?: string | null;
   };
 }
 
@@ -15,7 +15,7 @@ export const CompositionsQuery = {
   allCompositions: endpointHandler<FilterArgs, Composition[]>(async ({ args: { filters }, repo }) => {
     const mappedFilters: CompositionFilters = {
       ...mapFilters<CompositionFilters>(filters),
-      isStandalone: filters?.isStandalone ?? undefined
+      opusId: filters?.opusId ?? undefined
     };
 
     const compositions = await repo.findAll(mappedFilters);

--- a/src/interfaces/graphql/resolvers/compositions/compositionsQuery.ts
+++ b/src/interfaces/graphql/resolvers/compositions/compositionsQuery.ts
@@ -5,7 +5,7 @@ import { CompositionFilters } from '~/src/domain/repositories/compositionReposit
 
 interface FilterArgs {
   filters?: NonNullable<Parameters<typeof mapFilters>[0]> & {
-    opusId?: string | null;
+    isStandalone?: boolean | null;
   };
 }
 
@@ -15,7 +15,7 @@ export const CompositionsQuery = {
   allCompositions: endpointHandler<FilterArgs, Composition[]>(async ({ args: { filters }, repo }) => {
     const mappedFilters: CompositionFilters = {
       ...mapFilters<CompositionFilters>(filters),
-      opusId: filters?.opusId ?? undefined
+      isStandalone: filters?.isStandalone ?? null,
     };
 
     const compositions = await repo.findAll(mappedFilters);

--- a/src/interfaces/graphql/resolvers/opus/opusQuery.test.ts
+++ b/src/interfaces/graphql/resolvers/opus/opusQuery.test.ts
@@ -1,32 +1,42 @@
 import { OpusQuery } from './opusQuery';
+import { handleGroup } from './tab-handlers/handleGroup';
+import { handleMixed } from './tab-handlers/handleMixed';
+import { handleWorksTab } from './tab-handlers/handleWork';
 import type { GraphQLContext } from '~/back-shared/types/container/types';
 import { Opus } from '~/domain/entities/Opus';
 import type { ICompositionRepository } from '~/domain/repositories/compositionRepository';
 import type { IOpusRepository } from '~/domain/repositories/opusRepository';
-import { OpusStatus } from '~/types/enums/common.enums';
-import { OpusNumberKind } from '~/types/graphql/generated/graphql';
+import { WorksTab } from '~/types/graphql/generated/graphql';
 
 interface MockCompositionRepository extends ICompositionRepository {
   findByOpusIds: jest.Mock;
 }
 
+const mockRepo: jest.Mocked<Partial<IOpusRepository>> = {
+  findById: jest.fn(),
+  findByNumber: jest.fn(),
+  findAll: jest.fn(),
+  findPaginated: jest.fn(),
+  count: jest.fn()
+};
+
+const mockCompositionsRepo: jest.Mocked<Partial<MockCompositionRepository>> = {
+  findByOpusId: jest.fn(),
+  findByOpusIds: jest.fn(),
+  syncForOpus: jest.fn(),
+  deleteByOpusId: jest.fn(),
+  searchByTitle: jest.fn()
+};
+
+jest.mock('./tab-handlers/handleGroup');
+jest.mock('./tab-handlers/handleMixed');
+jest.mock('./tab-handlers/handleWork');
+
+const mockedHandleGroup = handleGroup as jest.MockedFunction<typeof handleGroup>;
+const mockedHandleMixed = handleMixed as jest.MockedFunction<typeof handleMixed>;
+const mockedHandleWorksTab = handleWorksTab as jest.MockedFunction<typeof handleWorksTab>;
+
 describe('OpusQuery Resolvers', () => {
-  const mockRepo: jest.Mocked<Partial<IOpusRepository>> = {
-    findById: jest.fn(),
-    findByNumber: jest.fn(),
-    findAll: jest.fn(),
-    findPaginated: jest.fn(),
-    count: jest.fn()
-  };
-
-  const mockCompositionsRepo: jest.Mocked<Partial<MockCompositionRepository>> = {
-    findByOpusId: jest.fn(),
-    findByOpusIds: jest.fn(),
-    syncForOpus: jest.fn(),
-    deleteByOpusId: jest.fn(),
-    searchByTitle: jest.fn()
-  };
-
   const buildContext = (isAdmin: boolean): GraphQLContext =>
     ({
       admin: isAdmin,
@@ -45,8 +55,34 @@ describe('OpusQuery Resolvers', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+
     (mockCompositionsRepo.findByOpusId as jest.Mock).mockResolvedValue([]);
     (mockCompositionsRepo.findByOpusIds as jest.Mock).mockResolvedValue([]);
+    (mockCompositionsRepo.searchByTitle as jest.Mock).mockResolvedValue([]);
+
+    mockedHandleGroup.mockResolvedValue({
+      groups: [],
+      works: [],
+      total: 0,
+      page: 1,
+      totalPages: 1
+    });
+
+    mockedHandleMixed.mockResolvedValue({
+      groups: [],
+      works: [],
+      total: 0,
+      page: 1,
+      totalPages: 1
+    });
+
+    mockedHandleWorksTab.mockResolvedValue({
+      groups: [],
+      works: [],
+      total: 0,
+      page: 1,
+      totalPages: 1
+    });
   });
 
   it('opusById should reject unauthenticated requests', async () => {
@@ -63,6 +99,16 @@ describe('OpusQuery Resolvers', () => {
     expect(mockRepo.findById).toHaveBeenCalledWith('1');
     expect(mockCompositionsRepo.findByOpusId).toHaveBeenCalledWith('1');
     expect(result).toEqual({ ...mockEntity, compositions: [] });
+  });
+
+  it('opusById should return null when opus is not found', async () => {
+    (mockRepo.findById as jest.Mock).mockResolvedValue(null);
+
+    const result = await OpusQuery.opusById({}, { id: '1' }, adminContext);
+
+    expect(mockRepo.findById).toHaveBeenCalledWith('1');
+    expect(mockCompositionsRepo.findByOpusId).not.toHaveBeenCalled();
+    expect(result).toBeNull();
   });
 
   it('opusByNumber should call repo.findByNumber', async () => {
@@ -83,44 +129,116 @@ describe('OpusQuery Resolvers', () => {
     expect(result).toEqual([]);
   });
 
-  it('allOpuses should call repo.findAll with mapped filters and numberKind', async () => {
-    (mockRepo.findAll as jest.Mock).mockResolvedValue([mockEntity]);
-    const mockComposition = { id: '100', opusId: '1', title: { uk: 'Твір' } };
-    (mockCompositionsRepo.findByOpusIds as jest.Mock).mockResolvedValue([mockComposition]);
-
-    const result = await OpusQuery.allOpuses({}, { filters: { statuses: [OpusStatus.Draft] } }, adminContext);
-
-    expect(mockRepo.findAll).toHaveBeenCalledWith(
-      expect.objectContaining({
-        statuses: [OpusStatus.Draft],
-        numberKind: OpusNumberKind.Op
-      })
+  it('should call handleGroup for Opus tab', async () => {
+    await OpusQuery.paginatedWorks(
+      {},
+      {
+        tab: WorksTab.Opus,
+        filters: {
+          limit: 10,
+          skip: 20
+        }
+      },
+      adminContext
     );
-    expect(mockCompositionsRepo.findByOpusIds).toHaveBeenCalledWith(['1']);
-    expect(result).toHaveLength(1);
-    expect(result[0].compositions).toEqual([mockComposition]);
+
+    expect(mockedHandleGroup).toHaveBeenCalledWith(
+      WorksTab.Opus,
+      mockRepo,
+      {
+        limit: 10,
+        skip: 20
+      },
+      3,
+      mockCompositionsRepo,
+      10
+    );
   });
 
-  it('allOpuses should return empty array if no opuses found', async () => {
-    (mockRepo.findAll as jest.Mock).mockResolvedValue([]);
+  it('should call handleGroup for Woo tab', async () => {
+    await OpusQuery.paginatedWorks(
+      {},
+      {
+        tab: WorksTab.Woo,
+        filters: {
+          limit: 5,
+          skip: 5
+        }
+      },
+      adminContext
+    );
 
-    const result = await OpusQuery.allOpuses({}, { filters: {} }, adminContext);
-
-    expect(result).toEqual([]);
-    expect(mockCompositionsRepo.findByOpusIds).not.toHaveBeenCalled();
+    expect(mockedHandleGroup).toHaveBeenCalledWith(
+      WorksTab.Woo,
+      mockRepo,
+      {
+        limit: 5,
+        skip: 5
+      },
+      2,
+      mockCompositionsRepo,
+      5
+    );
   });
 
-  it('paginatedOpuses should call repo.findPaginated', async () => {
-    (mockRepo.findPaginated as jest.Mock).mockResolvedValue({
-      items: [mockEntity],
-      total: 1,
-      page: 1,
-      totalPages: 1
-    });
+  it('should call handleWorksTab', async () => {
+    await OpusQuery.paginatedWorks(
+      {},
+      {
+        tab: WorksTab.Works,
+        filters: {
+          limit: 25,
+          skip: 50
+        }
+      },
+      adminContext
+    );
 
-    const result = await OpusQuery.paginatedOpuses({}, { page: 1, limit: 10 }, adminContext);
+    expect(mockedHandleWorksTab).toHaveBeenCalledWith(
+      mockCompositionsRepo,
+      {
+        limit: 25,
+        skip: 50
+      },
+      3,
+      25
+    );
+  });
 
-    expect(mockRepo.findPaginated).toHaveBeenCalledWith(1, 10, undefined);
-    expect(result.total).toBe(1);
+  it('should call handleMixed when tab is undefined', async () => {
+    await OpusQuery.paginatedWorks({}, {}, adminContext);
+
+    expect(mockedHandleMixed).toHaveBeenCalledWith(
+      mockRepo,
+      mockCompositionsRepo,
+      undefined,
+      1,
+      10
+    );
+  });
+
+  it('should call handleMixed for All tab', async () => {
+    await OpusQuery.paginatedWorks(
+      {},
+      {
+        tab: WorksTab.All,
+        filters: {
+          limit: 15,
+          skip: 15
+        }
+      },
+      adminContext
+    );
+
+    expect(mockedHandleMixed).toHaveBeenCalledWith(
+      mockRepo,
+      mockCompositionsRepo,
+      {
+        limit: 15,
+        skip: 15
+      },
+      2,
+      15
+    );
   });
 });

--- a/src/interfaces/graphql/resolvers/opus/opusQuery.ts
+++ b/src/interfaces/graphql/resolvers/opus/opusQuery.ts
@@ -1,13 +1,14 @@
 import { GraphQLError } from 'graphql';
 
 import { endpointRepositoryHandler, mapFilters } from '../helpers';
+import { handleGroup } from './tab-handlers/handleGroup';
+import { handleMixed } from './tab-handlers/handleMixed';
+import { handleWorksTab } from './tab-handlers/handleWork';
 import type { GraphQLContext } from '~/back-shared/types/container/types';
 import { graphqlErrors } from '~/constants/errors';
 import { Composition } from '~/domain/entities/Composition';
 import { Opus } from '~/domain/entities/Opus';
-import { OpusFilters } from '~/domain/repositories/opusRepository';
-import { CompositionFilters } from '~/src/domain/repositories/compositionRepository';
-import { OpusNumberKind, WorksFiltersInput, WorksTab } from '~/types/graphql/generated/graphql';
+import { WorksTab } from '~/types/graphql/generated/graphql';
 
 interface IdArgs {
   id: string;
@@ -18,24 +19,18 @@ interface NumberArgs {
 interface SearchArgs {
   search: string;
 }
-interface FilterArgs {
-  filters?: NonNullable<Parameters<typeof mapFilters>[0]> & {
-    numberKind?: OpusNumberKind;
-  };
-}
 
-interface PaginatedWorksInput {
+export type WorksFilter = NonNullable<Parameters<typeof mapFilters>[0]>;
+export interface PaginatedWorksArgs {
   tab?: WorksTab;
-  search?: string;
-  filters?: WorksFiltersInput;
-  page?: number;
-  pageSize?: number;
+  filters?: WorksFilter;
 }
 
-interface PaginatedWorksResult {
+export interface PaginatedWorksResult {
   groups: Opus[];
   works: Composition[];
-  totalItems: number;
+  total: number;
+  page: number;
   totalPages: number;
 }
 
@@ -48,49 +43,6 @@ const assertAuthenticated = (context: GraphQLContext): void => {
 };
 
 const endpointHandler = endpointRepositoryHandler('opusRepository');
-
-const mappedGroups = async (repo: any, compositionsRepo: any, page: number, pageSize: number, filters: any) => {
-  const total = await repo.count(filters);
-
-  let groups: Opus[] = await repo.findAll({
-    ...filters,
-    skip: (page - 1) * pageSize,
-    limit: pageSize
-  });
-
-  const opusIds = groups.map((o) => o.id);
-  const allCompositions: Composition[] = await compositionsRepo.findByOpusIds(opusIds);
-
-  const compositionsByOpusId = new Map<string, typeof allCompositions>();
-  
-  for (const comp of allCompositions) {
-    if (comp.opusId) {
-      const idStr = String(comp.opusId);
-      if (!compositionsByOpusId.has(idStr)) {
-        compositionsByOpusId.set(idStr, []);
-      }
-      compositionsByOpusId.get(idStr)!.push(comp);
-    }
-  }
-
-  groups = groups.map((group) => ({
-    ...group,
-    compositions: compositionsByOpusId.get(String(group.id)) ?? []
-  }));
-      
-  return { groups, total};
-};
-
-const mappedCompositions = async (repo: any, page: number, pageSize: number, filters: any) => {
-  const total = await repo.count(filters);
-  const works = await repo.findAll({
-    ...filters,
-    skip: (page - 1) * pageSize,
-    limit: pageSize
-  });
-
-  return { works, total };
-};
 
 export const OpusQuery = {
   opusById: async (_: unknown, { id }: IdArgs, context: GraphQLContext): Promise<Opus | null> => {
@@ -121,157 +73,18 @@ export const OpusQuery = {
     return context.requestContainer.cradle.compositionsRepository.searchByTitle(search);
   },
 
-  allOpuses: endpointHandler<FilterArgs, Opus[]>(async ({ args: { filters }, repo, requestContainer }) => {
-    const mappedFilters: OpusFilters = {
-      ...mapFilters<OpusFilters>(filters),
-      numberKind: filters?.numberKind ?? OpusNumberKind.Op
-    };
-    
-    const opuses = await repo.findAll(mappedFilters);
-    if (!opuses || opuses.length === 0) return [];
-
-    const opusIds = opuses.map((o) => o.id);
+  paginatedWorks: endpointHandler<PaginatedWorksArgs, PaginatedWorksResult>(async ({ args, repo, requestContainer }) => {
+    const { tab, filters } = args;
     const compositionsRepo = requestContainer.cradle.compositionsRepository;
-    const allCompositions = await compositionsRepo.findByOpusIds(opusIds);
-
-    const compositionsByOpusId = new Map<string, typeof allCompositions>();
-  
-    for (const comp of allCompositions) {
-      if (comp.opusId) {
-        const idStr = String(comp.opusId);
-        if (!compositionsByOpusId.has(idStr)) {
-          compositionsByOpusId.set(idStr, []);
-        }
-      compositionsByOpusId.get(idStr)!.push(comp);
-      }
-    }
-
-    return opuses.map((opus) => ({
-      ...opus,
-      compositions: compositionsByOpusId.get(String(opus.id)) ?? []
-    }));
-  }),
-
-  paginatedWorks: endpointHandler< { input: PaginatedWorksInput }, PaginatedWorksResult 
-  >(async ({ args: { input }, repo, requestContainer }) => {
-    console.log('paginatedWorks', input);
-    console.log('paginatedWorks', input.filters);
-
-    const compositionsRepo = requestContainer.cradle.compositionsRepository;
-    const { tab = WorksTab.All, page = 1, pageSize = 10 } = input;
-
-    const totalPages = (totalItems: number, pageSize: number) => Math.ceil(totalItems / pageSize);
+    const pageSize = filters?.limit ?? 10;
+    const skip = filters?.skip ?? 0;
+    const page = Math.floor(skip / pageSize) + 1;
 
     if (tab === WorksTab.Opus || tab === WorksTab.Woo) {
-      const numberKind =
-      tab === WorksTab.Opus
-        ? OpusNumberKind.Op
-        : OpusNumberKind.Woo;
-
-      const mappedFilters: OpusFilters = {
-        ...mapFilters<OpusFilters>(input.filters),
-        numberKind
-      };
-      const groupsResult = await mappedGroups(repo, compositionsRepo, page, pageSize, mappedFilters);
-
-      return {
-        groups: groupsResult.groups,
-        works: [],
-        totalItems: groupsResult.total,
-        totalPages: totalPages(groupsResult.total, pageSize),
-      };
+      return handleGroup(tab, repo, filters, page, compositionsRepo, pageSize);
     } else if (tab === WorksTab.Works) {
-      const mappedFilters: CompositionFilters = {
-        ...mapFilters<CompositionFilters>(input.filters),
-        opusId: null
-      };
-      const worksResult = await mappedCompositions(compositionsRepo, page, pageSize, mappedFilters);
-      
-      return {
-        groups: [],
-        works: worksResult.works,
-        totalItems: worksResult.total,
-        totalPages: totalPages(worksResult.total, pageSize),
-      };
-    } 
-
-    const mappedOpusFilters: OpusFilters = {
-      ...mapFilters<OpusFilters>(input.filters),
-    };
-
-    const mappedCompositionFilters: CompositionFilters = {
-      ...mapFilters<CompositionFilters>(input.filters),
-      opusId: null
-    };
-
-    const totalGroups = await repo.count(mappedOpusFilters);
-    const totalWorks = await compositionsRepo.count(mappedCompositionFilters);
-
-    const totalItems = totalGroups + totalWorks;
-    const offset = (page - 1) * pageSize;
-
-    if (offset + pageSize <= totalGroups) {
-      const groupsResult = await mappedGroups(
-        repo,
-        compositionsRepo,
-        page,
-        pageSize,
-        mappedOpusFilters
-      );
-
-      return {
-        groups: groupsResult.groups,
-        works: [],
-        totalItems,
-        totalPages: totalPages(totalItems, pageSize),
-      };
+      return handleWorksTab(compositionsRepo, filters, page, pageSize);
     }
-
-    if (offset < totalGroups) {
-      const groupsLimit = totalGroups - offset;
-      const worksLimit = pageSize - groupsLimit;
-
-      const groups = await mappedGroups(
-        repo,
-        compositionsRepo,
-        page,
-        groupsLimit,
-        mappedOpusFilters
-      );
-
-      const works = await mappedCompositions(
-        compositionsRepo,
-        1,
-        worksLimit,
-        mappedCompositionFilters
-      );
-
-      return {
-        groups: groups.groups,
-        works: works.works,
-        totalItems,
-        totalPages: totalPages(totalItems, pageSize),
-      };
-    }
-
-    const worksOffset = offset - totalGroups;
-    const worksPage = Math.floor(worksOffset / pageSize) + 1;
-
-    const works = await mappedCompositions(
-      compositionsRepo,
-      worksPage,
-      pageSize,
-      mappedCompositionFilters
-    );
-
-    console.log('totalItems', totalItems);
-    console.log('totalPages', totalPages(totalItems, pageSize));
-
-    return {
-      groups: [],
-      works: works.works,
-      totalItems,
-      totalPages: totalPages(totalItems, pageSize),
-    };
+    return handleMixed(repo, compositionsRepo, filters, page, pageSize);
   }),
 };

--- a/src/interfaces/graphql/resolvers/opus/opusQuery.ts
+++ b/src/interfaces/graphql/resolvers/opus/opusQuery.ts
@@ -6,7 +6,8 @@ import { graphqlErrors } from '~/constants/errors';
 import { Composition } from '~/domain/entities/Composition';
 import { Opus } from '~/domain/entities/Opus';
 import { OpusFilters } from '~/domain/repositories/opusRepository';
-import { OpusNumberKind } from '~/types/graphql/generated/graphql';
+import { CompositionFilters } from '~/src/domain/repositories/compositionRepository';
+import { OpusNumberKind, WorksFiltersInput, WorksTab } from '~/types/graphql/generated/graphql';
 
 interface IdArgs {
   id: string;
@@ -22,10 +23,20 @@ interface FilterArgs {
     numberKind?: OpusNumberKind;
   };
 }
-interface PaginatedArgs {
-  page: number;
-  limit: number;
-  filters?: NonNullable<FilterArgs['filters']>;
+
+interface PaginatedWorksInput {
+  tab?: WorksTab;
+  search?: string;
+  filters?: WorksFiltersInput;
+  page?: number;
+  pageSize?: number;
+}
+
+interface PaginatedWorksResult {
+  groups: Opus[];
+  works: Composition[];
+  totalItems: number;
+  totalPages: number;
 }
 
 const assertAuthenticated = (context: GraphQLContext): void => {
@@ -37,6 +48,49 @@ const assertAuthenticated = (context: GraphQLContext): void => {
 };
 
 const endpointHandler = endpointRepositoryHandler('opusRepository');
+
+const mappedGroups = async (repo: any, compositionsRepo: any, page: number, pageSize: number, filters: any) => {
+  const total = await repo.count(filters);
+
+  let groups: Opus[] = await repo.findAll({
+    ...filters,
+    skip: (page - 1) * pageSize,
+    limit: pageSize
+  });
+
+  const opusIds = groups.map((o) => o.id);
+  const allCompositions: Composition[] = await compositionsRepo.findByOpusIds(opusIds);
+
+  const compositionsByOpusId = new Map<string, typeof allCompositions>();
+  
+  for (const comp of allCompositions) {
+    if (comp.opusId) {
+      const idStr = String(comp.opusId);
+      if (!compositionsByOpusId.has(idStr)) {
+        compositionsByOpusId.set(idStr, []);
+      }
+      compositionsByOpusId.get(idStr)!.push(comp);
+    }
+  }
+
+  groups = groups.map((group) => ({
+    ...group,
+    compositions: compositionsByOpusId.get(String(group.id)) ?? []
+  }));
+      
+  return { groups, total};
+};
+
+const mappedCompositions = async (repo: any, page: number, pageSize: number, filters: any) => {
+  const total = await repo.count(filters);
+  const works = await repo.findAll({
+    ...filters,
+    skip: (page - 1) * pageSize,
+    limit: pageSize
+  });
+
+  return { works, total };
+};
 
 export const OpusQuery = {
   opusById: async (_: unknown, { id }: IdArgs, context: GraphQLContext): Promise<Opus | null> => {
@@ -98,10 +152,126 @@ export const OpusQuery = {
     }));
   }),
 
-  paginatedOpuses: endpointHandler<
-    PaginatedArgs,
-    { items: Opus[]; total: number; page: number; totalPages: number }
-  >(async ({ args: { page, limit, filters }, repo }) =>
-    repo.findPaginated(page, limit, mapFilters<OpusFilters>(filters))
-  ),
+  paginatedWorks: endpointHandler< { input: PaginatedWorksInput }, PaginatedWorksResult 
+  >(async ({ args: { input }, repo, requestContainer }) => {
+    console.log('paginatedWorks', input);
+    console.log('paginatedWorks', input.filters);
+
+    const compositionsRepo = requestContainer.cradle.compositionsRepository;
+    const { tab = WorksTab.All, page = 1, pageSize = 10 } = input;
+
+    const totalPages = (totalItems: number, pageSize: number) => Math.ceil(totalItems / pageSize);
+
+    if (tab === WorksTab.Opus || tab === WorksTab.Woo) {
+      const numberKind =
+      tab === WorksTab.Opus
+        ? OpusNumberKind.Op
+        : OpusNumberKind.Woo;
+
+      const mappedFilters: OpusFilters = {
+        ...mapFilters<OpusFilters>(input.filters),
+        numberKind
+      };
+      const groupsResult = await mappedGroups(repo, compositionsRepo, page, pageSize, mappedFilters);
+
+      return {
+        groups: groupsResult.groups,
+        works: [],
+        totalItems: groupsResult.total,
+        totalPages: totalPages(groupsResult.total, pageSize),
+      };
+    } else if (tab === WorksTab.Works) {
+      const mappedFilters: CompositionFilters = {
+        ...mapFilters<CompositionFilters>(input.filters),
+        opusId: null
+      };
+      const worksResult = await mappedCompositions(compositionsRepo, page, pageSize, mappedFilters);
+      
+      return {
+        groups: [],
+        works: worksResult.works,
+        totalItems: worksResult.total,
+        totalPages: totalPages(worksResult.total, pageSize),
+      };
+    } 
+
+    const mappedOpusFilters: OpusFilters = {
+      ...mapFilters<OpusFilters>(input.filters),
+    };
+
+    const mappedCompositionFilters: CompositionFilters = {
+      ...mapFilters<CompositionFilters>(input.filters),
+      opusId: null
+    };
+
+    const totalGroups = await repo.count(mappedOpusFilters);
+    const totalWorks = await compositionsRepo.count(mappedCompositionFilters);
+
+    const totalItems = totalGroups + totalWorks;
+    const offset = (page - 1) * pageSize;
+
+    if (offset + pageSize <= totalGroups) {
+      const groupsResult = await mappedGroups(
+        repo,
+        compositionsRepo,
+        page,
+        pageSize,
+        mappedOpusFilters
+      );
+
+      return {
+        groups: groupsResult.groups,
+        works: [],
+        totalItems,
+        totalPages: totalPages(totalItems, pageSize),
+      };
+    }
+
+    if (offset < totalGroups) {
+      const groupsLimit = totalGroups - offset;
+      const worksLimit = pageSize - groupsLimit;
+
+      const groups = await mappedGroups(
+        repo,
+        compositionsRepo,
+        page,
+        groupsLimit,
+        mappedOpusFilters
+      );
+
+      const works = await mappedCompositions(
+        compositionsRepo,
+        1,
+        worksLimit,
+        mappedCompositionFilters
+      );
+
+      return {
+        groups: groups.groups,
+        works: works.works,
+        totalItems,
+        totalPages: totalPages(totalItems, pageSize),
+      };
+    }
+
+    const worksOffset = offset - totalGroups;
+    const worksPage = Math.floor(worksOffset / pageSize) + 1;
+
+    const works = await mappedCompositions(
+      compositionsRepo,
+      worksPage,
+      pageSize,
+      mappedCompositionFilters
+    );
+
+    console.log('totalItems', totalItems);
+    console.log('totalPages', totalPages(totalItems, pageSize));
+
+    return {
+      groups: [],
+      works: works.works,
+      totalItems,
+      totalPages: totalPages(totalItems, pageSize),
+    };
+  }),
 };

--- a/src/interfaces/graphql/resolvers/opus/tab-handlers/handleGroup.test.ts
+++ b/src/interfaces/graphql/resolvers/opus/tab-handlers/handleGroup.test.ts
@@ -1,0 +1,218 @@
+import { handleGroup } from './handleGroup';
+import { Opus } from '~/domain/entities/Opus';
+import type { ICompositionRepository } from '~/domain/repositories/compositionRepository';
+import type { IOpusRepository } from '~/domain/repositories/opusRepository';
+import { Composition, OpusNumberKind, WorksTab } from '~/types/graphql/generated/graphql';
+
+interface MockCompositionRepository extends ICompositionRepository {
+  findByOpusIds: jest.Mock;
+}
+
+const mockRepo: jest.Mocked<Partial<IOpusRepository>> = {
+  findById: jest.fn(),
+  findByNumber: jest.fn(),
+  findAll: jest.fn(),
+  findPaginated: jest.fn(),
+  count: jest.fn()
+};
+
+const mockCompositionsRepo: jest.Mocked<Partial<MockCompositionRepository>> = {
+  findByOpusId: jest.fn(),
+  findByOpusIds: jest.fn(),
+  syncForOpus: jest.fn(),
+  deleteByOpusId: jest.fn(),
+  searchByTitle: jest.fn()
+};
+
+describe('handleGroup', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return opus groups with compositions', async () => {
+    const groups = [
+      { id: '1', number: 'op.1' },
+      { id: '2', number: 'op.2' },
+    ] as Opus[];
+
+    const compositions = [
+      { id: 'c1', opusId: '1' },
+      { id: 'c2', opusId: '1' },
+      { id: 'c3', opusId: '2' },
+    ] as Composition[];
+
+    (mockRepo.count as jest.Mock).mockResolvedValue(2);
+    (mockRepo.findAll as jest.Mock).mockResolvedValue(groups);
+    (mockCompositionsRepo.findByOpusIds as jest.Mock).mockResolvedValue(compositions);
+
+    const result = await handleGroup(
+      WorksTab.Opus,
+      mockRepo as IOpusRepository,
+      undefined,
+      1,
+      mockCompositionsRepo as unknown as ICompositionRepository,
+      10
+    );
+
+    expect(mockRepo.count).toHaveBeenCalledWith({
+      numberKind: OpusNumberKind.Op,
+    });
+
+    expect(mockRepo.findAll).toHaveBeenCalledWith({
+      numberKind: OpusNumberKind.Op,
+    });
+
+    expect(mockCompositionsRepo.findByOpusIds).toHaveBeenCalledWith(['1', '2']);
+
+    expect(result).toEqual({
+      groups: [
+        {
+          id: '1',
+          number: 'op.1',
+          compositions: [
+            { id: 'c1', opusId: '1' },
+            { id: 'c2', opusId: '1' },
+          ],
+        },
+        {
+          id: '2',
+          number: 'op.2',
+          compositions: [{ id: 'c3', opusId: '2' }],
+        },
+      ],
+      works: [],
+      total: 2,
+      page: 1,
+      totalPages: 1,
+    });
+  });
+
+  it('should use Woo number kind', async () => {
+    (mockRepo.count as jest.Mock).mockResolvedValue(0);
+    (mockRepo.findAll as jest.Mock).mockResolvedValue([]);
+    (mockCompositionsRepo.findByOpusIds as jest.Mock).mockResolvedValue([]);
+
+    await handleGroup(
+      WorksTab.Woo,
+      mockRepo as IOpusRepository,
+      undefined,
+      1,
+      mockCompositionsRepo as unknown as ICompositionRepository,
+      10
+    );
+
+    expect(mockRepo.count).toHaveBeenCalledWith({
+      numberKind: OpusNumberKind.Woo,
+    });
+  });
+
+  it('should return empty groups', async () => {
+    (mockRepo.count as jest.Mock).mockResolvedValue(0);
+    (mockRepo.findAll as jest.Mock).mockResolvedValue([]);
+    (mockCompositionsRepo.findByOpusIds as jest.Mock).mockResolvedValue([]);
+
+    const result = await handleGroup(
+      WorksTab.Opus,
+      mockRepo as IOpusRepository,
+      undefined,
+      1,
+      mockCompositionsRepo as unknown as ICompositionRepository,
+      10
+    );
+
+    expect(result).toEqual({
+      groups: [],
+      works: [],
+      total: 0,
+      page: 1,
+      totalPages: 0,
+    });
+  });
+
+  it('should calculate totalPages', async () => {
+    (mockRepo.count as jest.Mock).mockResolvedValue(21);
+    (mockRepo.findAll as jest.Mock).mockResolvedValue([]);
+    (mockCompositionsRepo.findByOpusIds as jest.Mock).mockResolvedValue([]);
+
+    const result = await handleGroup(
+      WorksTab.Opus,
+      mockRepo as IOpusRepository,
+      undefined,
+      3,
+      mockCompositionsRepo as unknown as ICompositionRepository,
+      10
+    );
+
+    expect(result.page).toBe(3);
+    expect(result.totalPages).toBe(3);
+  });
+
+  it('should pass filters to repositories', async () => {
+    (mockRepo.count as jest.Mock).mockResolvedValue(0);
+    (mockRepo.findAll as jest.Mock).mockResolvedValue([]);
+    (mockCompositionsRepo.findByOpusIds as jest.Mock).mockResolvedValue([]);
+
+    const filters = {
+      search: 'test',
+      statuses: ['draft'],
+    };
+
+    await handleGroup(
+      WorksTab.Opus,
+      mockRepo as IOpusRepository,
+      filters,
+      1,
+      mockCompositionsRepo as unknown as ICompositionRepository,
+      10
+    );
+
+    expect(mockRepo.count).toHaveBeenCalledWith({
+      search: 'test',
+      statuses: ['draft'],
+      numberKind: OpusNumberKind.Op,
+    });
+
+    expect(mockRepo.findAll).toHaveBeenCalledWith({
+      search: 'test',
+      statuses: ['draft'],
+      numberKind: OpusNumberKind.Op,
+    });
+  });
+
+  it('should assign empty compositions array when group has no compositions', async () => {
+    const groups = [
+      { id: '1', number: 'op.1' },
+      { id: '2', number: 'op.2' },
+    ] as Opus[];
+
+    const compositions = [
+      { id: 'c1', opusId: '1' },
+    ] as Composition[];
+
+    (mockRepo.count as jest.Mock).mockResolvedValue(2);
+    (mockRepo.findAll as jest.Mock).mockResolvedValue(groups);
+    (mockCompositionsRepo.findByOpusIds as jest.Mock).mockResolvedValue(compositions);
+
+    const result = await handleGroup(
+      WorksTab.Opus,
+    mockRepo as IOpusRepository,
+    undefined,
+    1,
+    mockCompositionsRepo as unknown as ICompositionRepository,
+    10
+    );
+
+    expect(result.groups).toEqual([
+      {
+        id: '1',
+        number: 'op.1',
+        compositions: [{ id: 'c1', opusId: '1' }],
+      },
+      {
+        id: '2',
+        number: 'op.2',
+        compositions: [],
+      },
+    ]);
+  });
+});

--- a/src/interfaces/graphql/resolvers/opus/tab-handlers/handleGroup.ts
+++ b/src/interfaces/graphql/resolvers/opus/tab-handlers/handleGroup.ts
@@ -1,0 +1,31 @@
+import { mapFilters } from '../../helpers';
+import { PaginatedWorksResult, WorksFilter } from '../opusQuery';
+import { mappedGroups, numberKindByTab, totalPages } from './tabHandlersHelpers';
+import { ICompositionRepository } from '~/src/domain/repositories/compositionRepository';
+import { IOpusRepository, OpusFilters } from '~/src/domain/repositories/opusRepository';
+import { WorksTab } from '~/types/graphql/generated/graphql';
+
+export async function handleGroup(
+  tab: WorksTab.Opus | WorksTab.Woo,
+  repo: IOpusRepository,
+  filters: WorksFilter | undefined,
+  page: number,
+  compositionsRepo: ICompositionRepository,
+  pageSize: number,
+): Promise<PaginatedWorksResult> {
+  const numberKind = numberKindByTab[tab];
+  
+  const mappedFilters: OpusFilters = {
+    ...mapFilters<OpusFilters>(filters),
+    numberKind
+  };
+  const groupsResult = await mappedGroups(repo, compositionsRepo, mappedFilters);
+  
+  return {
+    groups: groupsResult.groups,
+    works: [],
+    total: groupsResult.total,
+    page,
+    totalPages: totalPages(groupsResult.total, pageSize),
+  };
+}

--- a/src/interfaces/graphql/resolvers/opus/tab-handlers/handleMixed.test.ts
+++ b/src/interfaces/graphql/resolvers/opus/tab-handlers/handleMixed.test.ts
@@ -1,0 +1,173 @@
+import { mapFilters } from '../../helpers';
+import { handleMixed } from './handleMixed';
+import { mappedCompositions, mappedGroups } from './tabHandlersHelpers';
+import type { ICompositionRepository } from '~/src/domain/repositories/compositionRepository';
+import type { IOpusRepository } from '~/src/domain/repositories/opusRepository';
+
+jest.mock('../../helpers', () => ({
+  mapFilters: jest.fn(),
+}));
+
+jest.mock('./tabHandlersHelpers', () => ({
+  mappedGroups: jest.fn(),
+  mappedCompositions: jest.fn(),
+  totalPages: jest.fn((total: number, pageSize: number) => Math.ceil(total / pageSize)),
+}));
+
+describe('handleMixed', () => {
+  const repo = {
+    count: jest.fn(),
+  } as unknown as jest.Mocked<Partial<IOpusRepository>>;
+
+  const compositionsRepo = {
+    count: jest.fn(),
+  } as unknown as jest.Mocked<Partial<ICompositionRepository>>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (mapFilters as jest.Mock).mockImplementation((f) => f);
+
+    (mappedGroups as jest.Mock).mockResolvedValue({
+      groups: [{ id: 'g1' }],
+      total: 5,
+    });
+
+    (mappedCompositions as jest.Mock).mockResolvedValue({
+      works: [{ id: 'w1' }],
+      total: 8,
+    });
+  });
+
+  it('should return only groups when page contains only opuses', async () => {
+    (repo.count as jest.Mock).mockResolvedValue(10);
+    (compositionsRepo.count as jest.Mock).mockResolvedValue(5);
+
+    const result = await handleMixed(
+      repo as IOpusRepository,
+      compositionsRepo as ICompositionRepository,
+      undefined,
+      1,
+      5
+    );
+
+    expect(mappedGroups).toHaveBeenCalledWith(
+      repo,
+      compositionsRepo,
+      {}
+    );
+
+    expect(mappedCompositions).not.toHaveBeenCalled();
+
+    expect(result).toEqual({
+      groups: [{ id: 'g1' }],
+      works: [],
+      total: 15,
+      page: 1,
+      totalPages: 3,
+    });
+  });
+
+  it('should return mixed groups and works', async () => {
+    (repo.count as jest.Mock).mockResolvedValue(8);
+    (compositionsRepo.count as jest.Mock).mockResolvedValue(12);
+
+    const result = await handleMixed(
+      repo as IOpusRepository,
+      compositionsRepo as ICompositionRepository,
+      undefined,
+      2,
+      5
+    );
+
+    expect(mappedGroups).toHaveBeenCalledWith(
+      repo,
+      compositionsRepo,
+      {
+        limit: 3,
+      }
+    );
+
+    expect(mappedCompositions).toHaveBeenCalledWith(
+      compositionsRepo,
+      {
+        opusId: null,
+        limit: 2,
+        skip: 0,
+      }
+    );
+
+    expect(result).toEqual({
+      groups: [{ id: 'g1' }],
+      works: [{ id: 'w1' }],
+      total: 20,
+      page: 2,
+      totalPages: 4,
+    });
+  });
+
+  it('should return only compositions when all groups are skipped', async () => {
+    (repo.count as jest.Mock).mockResolvedValue(5);
+    (compositionsRepo.count as jest.Mock).mockResolvedValue(12);
+
+    const result = await handleMixed(
+      repo as IOpusRepository,
+      compositionsRepo as ICompositionRepository,
+      undefined,
+      3,
+      5
+    );
+
+    expect(mappedGroups).not.toHaveBeenCalled();
+
+    expect(mappedCompositions).toHaveBeenCalledWith(
+      compositionsRepo,
+      {
+        opusId: null,
+        skip: 5,
+        limit: 5,
+      }
+    );
+
+    expect(result).toEqual({
+      groups: [],
+      works: [{ id: 'w1' }],
+      total: 17,
+      page: 3,
+      totalPages: 4,
+    });
+  });
+
+  it('should pass mapped filters to repositories', async () => {
+    (mapFilters as jest.Mock).mockReturnValue({
+      search: 'test',
+      statuses: ['draft'],
+    });
+
+    (repo.count as jest.Mock).mockResolvedValue(1);
+    (compositionsRepo.count as jest.Mock).mockResolvedValue(1);
+
+    await handleMixed(
+      repo as IOpusRepository,
+      compositionsRepo as ICompositionRepository,
+      { search: 'test', statuses: ['draft'] },
+      1,
+      10
+    );
+
+    expect(repo.count).toHaveBeenCalledWith(
+      expect.objectContaining({
+        search: 'test',
+        statuses: ['draft'],
+      })
+    );
+
+    expect(compositionsRepo.count).toHaveBeenCalledWith(
+      expect.objectContaining({
+        search: 'test',
+        statuses: ['draft'],
+        opusId: null,
+      })
+    );
+  });
+});

--- a/src/interfaces/graphql/resolvers/opus/tab-handlers/handleMixed.test.ts
+++ b/src/interfaces/graphql/resolvers/opus/tab-handlers/handleMixed.test.ts
@@ -2,7 +2,8 @@ import { mapFilters } from '../../helpers';
 import { handleMixed } from './handleMixed';
 import { mappedCompositions, mappedGroups } from './tabHandlersHelpers';
 import type { ICompositionRepository } from '~/src/domain/repositories/compositionRepository';
-import type { IOpusRepository } from '~/src/domain/repositories/opusRepository';
+import type { IOpusRepository, OpusFilters } from '~/src/domain/repositories/opusRepository';
+import { OpusNumberKind } from '~/types/graphql/generated/graphql';
 
 jest.mock('../../helpers', () => ({
   mapFilters: jest.fn(),
@@ -18,21 +19,17 @@ describe('handleMixed', () => {
   const repo = {
     count: jest.fn(),
   } as unknown as jest.Mocked<Partial<IOpusRepository>>;
-
   const compositionsRepo = {
     count: jest.fn(),
   } as unknown as jest.Mocked<Partial<ICompositionRepository>>;
 
   beforeEach(() => {
     jest.clearAllMocks();
-
     (mapFilters as jest.Mock).mockImplementation((f) => f);
-
     (mappedGroups as jest.Mock).mockResolvedValue({
       groups: [{ id: 'g1' }],
       total: 5,
     });
-
     (mappedCompositions as jest.Mock).mockResolvedValue({
       works: [{ id: 'w1' }],
       total: 8,
@@ -40,7 +37,9 @@ describe('handleMixed', () => {
   });
 
   it('should return only groups when page contains only opuses', async () => {
-    (repo.count as jest.Mock).mockResolvedValue(10);
+    (repo.count as jest.Mock).mockImplementation((filters: OpusFilters) =>
+      Promise.resolve(filters.numberKind === OpusNumberKind.Op ? 10 : 0)
+    );
     (compositionsRepo.count as jest.Mock).mockResolvedValue(5);
 
     const result = await handleMixed(
@@ -51,12 +50,16 @@ describe('handleMixed', () => {
       5
     );
 
+    expect(repo.count).toHaveBeenCalledTimes(2);
+    expect(repo.count).toHaveBeenCalledWith({ numberKind: OpusNumberKind.Op });
+    expect(repo.count).toHaveBeenCalledWith({ numberKind: OpusNumberKind.Woo });
+
+    expect(mappedGroups).toHaveBeenCalledTimes(1);
     expect(mappedGroups).toHaveBeenCalledWith(
       repo,
       compositionsRepo,
-      {}
+      { numberKind: OpusNumberKind.Op, skip: 0, limit: 5 }
     );
-
     expect(mappedCompositions).not.toHaveBeenCalled();
 
     expect(result).toEqual({
@@ -69,7 +72,9 @@ describe('handleMixed', () => {
   });
 
   it('should return mixed groups and works', async () => {
-    (repo.count as jest.Mock).mockResolvedValue(8);
+    (repo.count as jest.Mock).mockImplementation((filters: OpusFilters) =>
+      Promise.resolve(filters.numberKind === OpusNumberKind.Op ? 8 : 0)
+    );
     (compositionsRepo.count as jest.Mock).mockResolvedValue(12);
 
     const result = await handleMixed(
@@ -80,21 +85,15 @@ describe('handleMixed', () => {
       5
     );
 
+    expect(mappedGroups).toHaveBeenCalledTimes(1);
     expect(mappedGroups).toHaveBeenCalledWith(
       repo,
       compositionsRepo,
-      {
-        limit: 3,
-      }
+      { numberKind: OpusNumberKind.Op, skip: 5, limit: 3 }
     );
-
     expect(mappedCompositions).toHaveBeenCalledWith(
       compositionsRepo,
-      {
-        opusId: null,
-        limit: 2,
-        skip: 0,
-      }
+      { opusId: null, skip: 0, limit: 2 }
     );
 
     expect(result).toEqual({
@@ -107,7 +106,9 @@ describe('handleMixed', () => {
   });
 
   it('should return only compositions when all groups are skipped', async () => {
-    (repo.count as jest.Mock).mockResolvedValue(5);
+    (repo.count as jest.Mock).mockImplementation((filters: OpusFilters) =>
+      Promise.resolve(filters.numberKind === OpusNumberKind.Op ? 5 : 0)
+    );
     (compositionsRepo.count as jest.Mock).mockResolvedValue(12);
 
     const result = await handleMixed(
@@ -119,14 +120,9 @@ describe('handleMixed', () => {
     );
 
     expect(mappedGroups).not.toHaveBeenCalled();
-
     expect(mappedCompositions).toHaveBeenCalledWith(
       compositionsRepo,
-      {
-        opusId: null,
-        skip: 5,
-        limit: 5,
-      }
+      { opusId: null, skip: 5, limit: 5 }
     );
 
     expect(result).toEqual({
@@ -138,12 +134,41 @@ describe('handleMixed', () => {
     });
   });
 
+  it('should include both op and woo groups when page spans both kinds', async () => {
+    (repo.count as jest.Mock).mockImplementation((filters: OpusFilters) =>
+      Promise.resolve(filters.numberKind === OpusNumberKind.Op ? 3 : 6)
+    );
+    (compositionsRepo.count as jest.Mock).mockResolvedValue(0);
+
+    await handleMixed(
+      repo as IOpusRepository,
+      compositionsRepo as ICompositionRepository,
+      undefined,
+      1,
+      5
+    );
+
+    expect(mappedGroups).toHaveBeenCalledTimes(2);
+    expect(mappedGroups).toHaveBeenNthCalledWith(
+      1,
+      repo,
+      compositionsRepo,
+      { numberKind: OpusNumberKind.Op, skip: 0, limit: 3 }
+    );
+    expect(mappedGroups).toHaveBeenNthCalledWith(
+      2,
+      repo,
+      compositionsRepo,
+      { numberKind: OpusNumberKind.Woo, skip: 0, limit: 2 }
+    );
+    expect(mappedCompositions).not.toHaveBeenCalled();
+  });
+
   it('should pass mapped filters to repositories', async () => {
     (mapFilters as jest.Mock).mockReturnValue({
       search: 'test',
       statuses: ['draft'],
     });
-
     (repo.count as jest.Mock).mockResolvedValue(1);
     (compositionsRepo.count as jest.Mock).mockResolvedValue(1);
 
@@ -159,9 +184,16 @@ describe('handleMixed', () => {
       expect.objectContaining({
         search: 'test',
         statuses: ['draft'],
+        numberKind: OpusNumberKind.Op,
       })
     );
-
+    expect(repo.count).toHaveBeenCalledWith(
+      expect.objectContaining({
+        search: 'test',
+        statuses: ['draft'],
+        numberKind: OpusNumberKind.Woo,
+      })
+    );
     expect(compositionsRepo.count).toHaveBeenCalledWith(
       expect.objectContaining({
         search: 'test',

--- a/src/interfaces/graphql/resolvers/opus/tab-handlers/handleMixed.test.ts
+++ b/src/interfaces/graphql/resolvers/opus/tab-handlers/handleMixed.test.ts
@@ -93,7 +93,7 @@ describe('handleMixed', () => {
     );
     expect(mappedCompositions).toHaveBeenCalledWith(
       compositionsRepo,
-      { opusId: null, skip: 0, limit: 2 }
+      { isStandalone: true, skip: 0, limit: 2 }
     );
 
     expect(result).toEqual({
@@ -122,7 +122,7 @@ describe('handleMixed', () => {
     expect(mappedGroups).not.toHaveBeenCalled();
     expect(mappedCompositions).toHaveBeenCalledWith(
       compositionsRepo,
-      { opusId: null, skip: 5, limit: 5 }
+      { isStandalone: true, skip: 5, limit: 5 }
     );
 
     expect(result).toEqual({
@@ -198,7 +198,7 @@ describe('handleMixed', () => {
       expect.objectContaining({
         search: 'test',
         statuses: ['draft'],
-        opusId: null,
+        isStandalone: true,
       })
     );
   });

--- a/src/interfaces/graphql/resolvers/opus/tab-handlers/handleMixed.ts
+++ b/src/interfaces/graphql/resolvers/opus/tab-handlers/handleMixed.ts
@@ -1,0 +1,111 @@
+import { mapFilters } from '../../helpers';
+import { PaginatedWorksResult, WorksFilter } from '../opusQuery';
+import { mappedCompositions, mappedGroups, totalPages } from './tabHandlersHelpers';
+import { CompositionFilters, ICompositionRepository } from '~/src/domain/repositories/compositionRepository';
+import { IOpusRepository, OpusFilters } from '~/src/domain/repositories/opusRepository';
+
+interface PaginationParams {
+  page: number;
+  pageSize: number;
+  totalItems: number;
+}
+
+const getOnlyOpus = async (
+  repo: IOpusRepository,
+  compositionsRepo: ICompositionRepository,
+  mappedOpusFilters: OpusFilters,
+  params: PaginationParams
+) => {
+  const groupsResult = await mappedGroups(repo, compositionsRepo, mappedOpusFilters);
+
+  return {
+    groups: groupsResult.groups,
+    works: [],
+    total: params.totalItems,
+    page: params.page,
+    totalPages: totalPages(params.totalItems, params.pageSize),
+  };
+};
+
+const getMixed = async (
+  repo: IOpusRepository,
+  compositionsRepo: ICompositionRepository,
+  mappedOpusFilters: OpusFilters,
+  mappedCompositionFilters: CompositionFilters,
+  totalGroups: number,
+  offset: number,
+  params: PaginationParams
+) => {
+  const groupsLimit = Math.max(0, totalGroups - offset);
+  const worksLimit = params.pageSize - groupsLimit;
+
+  mappedOpusFilters.limit = groupsLimit;
+  
+  mappedCompositionFilters.limit = worksLimit;
+  mappedCompositionFilters.skip = 0;
+
+  const groups = await mappedGroups(repo, compositionsRepo, mappedOpusFilters);
+  const works = await mappedCompositions(compositionsRepo, mappedCompositionFilters);
+
+  return {
+    groups: groups.groups,
+    works: works.works,
+    total: params.totalItems,
+    page: params.page,
+    totalPages: totalPages(params.totalItems, params.pageSize),
+  };
+};
+
+const getLeftCompositions = async (
+  compositionsRepo: ICompositionRepository,
+  mappedCompositionFilters: CompositionFilters,
+  totalGroups: number,
+  offset: number,
+  params: PaginationParams
+) => {
+  const worksOffset = Math.max(0, offset - totalGroups);
+
+  mappedCompositionFilters.skip = worksOffset;
+  mappedCompositionFilters.limit = params.pageSize;
+
+  const works = await mappedCompositions(compositionsRepo, mappedCompositionFilters);
+
+  return {
+    groups: [],
+    works: works.works,
+    total: params.totalItems,
+    page: params.page,
+    totalPages: totalPages(params.totalItems, params.pageSize),
+  };
+};
+
+export async function handleMixed(
+  repo: IOpusRepository,
+  compositionsRepo: ICompositionRepository,
+  filters: WorksFilter | undefined,
+  page: number,
+  pageSize: number,
+): Promise<PaginatedWorksResult> {
+  const mappedOpusFilters: OpusFilters = { ...mapFilters<OpusFilters>(filters) };
+  const mappedCompositionFilters: CompositionFilters = { 
+    ...mapFilters<CompositionFilters>(filters), 
+    opusId: null 
+  };
+    
+  const totalGroups = await repo.count(mappedOpusFilters);
+  const totalWorks = await compositionsRepo.count(mappedCompositionFilters);
+
+  const totalItems = totalGroups + totalWorks;
+  const offset = (page - 1) * pageSize;
+  const pagination = { page, pageSize, totalItems };
+
+  if (offset + pageSize <= totalGroups) {
+    return await getOnlyOpus(repo, compositionsRepo, mappedOpusFilters, pagination);
+  }
+
+  if (offset < totalGroups) {
+    return await getMixed(repo, compositionsRepo, mappedOpusFilters, mappedCompositionFilters, totalGroups, offset, pagination);
+  }
+
+  return await getLeftCompositions(compositionsRepo, mappedCompositionFilters, totalGroups, offset, pagination);
+}

--- a/src/interfaces/graphql/resolvers/opus/tab-handlers/handleMixed.ts
+++ b/src/interfaces/graphql/resolvers/opus/tab-handlers/handleMixed.ts
@@ -3,109 +3,89 @@ import { PaginatedWorksResult, WorksFilter } from '../opusQuery';
 import { mappedCompositions, mappedGroups, totalPages } from './tabHandlersHelpers';
 import { CompositionFilters, ICompositionRepository } from '~/src/domain/repositories/compositionRepository';
 import { IOpusRepository, OpusFilters } from '~/src/domain/repositories/opusRepository';
-
-interface PaginationParams {
-  page: number;
-  pageSize: number;
-  totalItems: number;
-}
-
-const getOnlyOpus = async (
-  repo: IOpusRepository,
-  compositionsRepo: ICompositionRepository,
-  mappedOpusFilters: OpusFilters,
-  params: PaginationParams
-) => {
-  const groupsResult = await mappedGroups(repo, compositionsRepo, mappedOpusFilters);
-
-  return {
-    groups: groupsResult.groups,
-    works: [],
-    total: params.totalItems,
-    page: params.page,
-    totalPages: totalPages(params.totalItems, params.pageSize),
-  };
-};
-
-const getMixed = async (
-  repo: IOpusRepository,
-  compositionsRepo: ICompositionRepository,
-  mappedOpusFilters: OpusFilters,
-  mappedCompositionFilters: CompositionFilters,
-  totalGroups: number,
-  offset: number,
-  params: PaginationParams
-) => {
-  const groupsLimit = Math.max(0, totalGroups - offset);
-  const worksLimit = params.pageSize - groupsLimit;
-
-  mappedOpusFilters.limit = groupsLimit;
-  
-  mappedCompositionFilters.limit = worksLimit;
-  mappedCompositionFilters.skip = 0;
-
-  const groups = await mappedGroups(repo, compositionsRepo, mappedOpusFilters);
-  const works = await mappedCompositions(compositionsRepo, mappedCompositionFilters);
-
-  return {
-    groups: groups.groups,
-    works: works.works,
-    total: params.totalItems,
-    page: params.page,
-    totalPages: totalPages(params.totalItems, params.pageSize),
-  };
-};
-
-const getLeftCompositions = async (
-  compositionsRepo: ICompositionRepository,
-  mappedCompositionFilters: CompositionFilters,
-  totalGroups: number,
-  offset: number,
-  params: PaginationParams
-) => {
-  const worksOffset = Math.max(0, offset - totalGroups);
-
-  mappedCompositionFilters.skip = worksOffset;
-  mappedCompositionFilters.limit = params.pageSize;
-
-  const works = await mappedCompositions(compositionsRepo, mappedCompositionFilters);
-
-  return {
-    groups: [],
-    works: works.works,
-    total: params.totalItems,
-    page: params.page,
-    totalPages: totalPages(params.totalItems, params.pageSize),
-  };
-};
+import { OpusNumberKind } from '~/types/graphql/generated/graphql';
 
 export async function handleMixed(
   repo: IOpusRepository,
   compositionsRepo: ICompositionRepository,
   filters: WorksFilter | undefined,
   page: number,
-  pageSize: number,
+  pageSize: number
 ): Promise<PaginatedWorksResult> {
-  const mappedOpusFilters: OpusFilters = { ...mapFilters<OpusFilters>(filters) };
-  const mappedCompositionFilters: CompositionFilters = { 
-    ...mapFilters<CompositionFilters>(filters), 
-    opusId: null 
+  const opFilters: OpusFilters = {
+    ...mapFilters<OpusFilters>(filters),
+    numberKind: OpusNumberKind.Op
   };
-    
-  const totalGroups = await repo.count(mappedOpusFilters);
-  const totalWorks = await compositionsRepo.count(mappedCompositionFilters);
 
+  const wooFilters: OpusFilters = {
+    ...mapFilters<OpusFilters>(filters),
+    numberKind: OpusNumberKind.Woo
+  };
+
+  const compositionFilters: CompositionFilters = {
+    ...mapFilters<CompositionFilters>(filters),
+    opusId: null
+  };
+
+  const totalOp = await repo.count(opFilters);
+  const totalWoo = await repo.count(wooFilters);
+  const totalWorks = await compositionsRepo.count(compositionFilters);
+
+  const totalGroups = totalOp + totalWoo;
   const totalItems = totalGroups + totalWorks;
+
   const offset = (page - 1) * pageSize;
-  const pagination = { page, pageSize, totalItems };
 
-  if (offset + pageSize <= totalGroups) {
-    return await getOnlyOpus(repo, compositionsRepo, mappedOpusFilters, pagination);
+  const groups = [];
+  const works = [];
+
+  let remaining = pageSize;
+
+  if (offset < totalOp && remaining > 0) {
+    const take = Math.min(remaining, totalOp - offset);
+
+    const result = await mappedGroups(repo, compositionsRepo, {
+      ...opFilters,
+      skip: offset,
+      limit: take
+    });
+
+    groups.push(...result.groups);
+    remaining -= take;
   }
 
-  if (offset < totalGroups) {
-    return await getMixed(repo, compositionsRepo, mappedOpusFilters, mappedCompositionFilters, totalGroups, offset, pagination);
+  const wooOffset = Math.max(0, offset - totalOp);
+
+  if (remaining > 0 && wooOffset < totalWoo) {
+    const take = Math.min(remaining, totalWoo - wooOffset);
+
+    const result = await mappedGroups(repo, compositionsRepo, {
+      ...wooFilters,
+      skip: wooOffset,
+      limit: take
+    });
+
+    groups.push(...result.groups);
+    remaining -= take;
   }
 
-  return await getLeftCompositions(compositionsRepo, mappedCompositionFilters, totalGroups, offset, pagination);
+  const worksOffset = Math.max(0, offset - totalGroups);
+
+  if (remaining > 0) {
+    const result = await mappedCompositions(compositionsRepo, {
+      ...compositionFilters,
+      skip: worksOffset,
+      limit: remaining
+    });
+
+    works.push(...result.works);
+  }
+
+  return {
+    groups,
+    works,
+    total: totalItems,
+    page,
+    totalPages: totalPages(totalItems, pageSize)
+  };
 }

--- a/src/interfaces/graphql/resolvers/opus/tab-handlers/handleMixed.ts
+++ b/src/interfaces/graphql/resolvers/opus/tab-handlers/handleMixed.ts
@@ -24,7 +24,7 @@ export async function handleMixed(
 
   const compositionFilters: CompositionFilters = {
     ...mapFilters<CompositionFilters>(filters),
-    opusId: null
+    isStandalone: true
   };
 
   const totalOp = await repo.count(opFilters);

--- a/src/interfaces/graphql/resolvers/opus/tab-handlers/handleWork.test.ts
+++ b/src/interfaces/graphql/resolvers/opus/tab-handlers/handleWork.test.ts
@@ -1,0 +1,89 @@
+import { mapFilters } from '../../helpers';
+import { WorksFilter } from '../opusQuery';
+import { handleWorksTab } from './handleWork';
+import { Composition } from '~/src/domain/entities/Composition';
+import type { ICompositionRepository } from '~/src/domain/repositories/compositionRepository';
+
+jest.mock('../../helpers', () => ({
+  mapFilters: jest.fn(),
+}));
+
+
+describe('handleWorksTab', () => {
+  const compositionsRepo = {
+    count: jest.fn(),
+    findAll: jest.fn(),
+  } as unknown as jest.Mocked<ICompositionRepository>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should map filters and return paginated works', async () => {
+    (mapFilters as jest.Mock).mockReturnValue({
+      search: 'test',
+    });
+    const work = {
+      id: '1',
+	  title: { en: 'Test Work' },
+	  createdAt: new Date().toISOString(),
+	  updatedAt: new Date().toISOString(),
+    } as Composition;
+
+    compositionsRepo.findAll.mockResolvedValue([work]);
+    compositionsRepo.count.mockResolvedValue(15);
+
+    const result = await handleWorksTab(
+      compositionsRepo,
+      { search: 'test' } as WorksFilter, 2, 10 
+    );
+
+    expect(compositionsRepo.count).toHaveBeenCalledWith({
+      search: 'test',
+      opusId: null,
+    });
+
+    expect(compositionsRepo.findAll).toHaveBeenCalledWith({
+      search: 'test',
+      opusId: null,
+    });
+
+    expect(result).toEqual({
+      groups: [],
+      works: [work],
+      total: 15,
+      page: 2,
+      totalPages: 2,
+    });
+  });
+
+  it('should work without filters', async () => {
+    (mapFilters as jest.Mock).mockReturnValue(undefined);
+
+    compositionsRepo.count.mockResolvedValue(0);
+    compositionsRepo.findAll.mockResolvedValue([]);
+
+    const result = await handleWorksTab(
+      compositionsRepo,
+      undefined,
+      1,
+      10
+    );
+
+    expect(compositionsRepo.count).toHaveBeenCalledWith({
+      opusId: null,
+    });
+
+    expect(compositionsRepo.findAll).toHaveBeenCalledWith({
+      opusId: null,
+    });
+
+    expect(result).toEqual({
+      groups: [],
+      works: [],
+      total: 0,
+      page: 1,
+      totalPages: 0,
+    });
+  });
+});

--- a/src/interfaces/graphql/resolvers/opus/tab-handlers/handleWork.test.ts
+++ b/src/interfaces/graphql/resolvers/opus/tab-handlers/handleWork.test.ts
@@ -8,8 +8,7 @@ jest.mock('../../helpers', () => ({
   mapFilters: jest.fn(),
 }));
 
-
-describe('handleWorksTab', () => {
+describe('handleWorks', () => {
   const compositionsRepo = {
     count: jest.fn(),
     findAll: jest.fn(),
@@ -40,12 +39,12 @@ describe('handleWorksTab', () => {
 
     expect(compositionsRepo.count).toHaveBeenCalledWith({
       search: 'test',
-      opusId: null,
+      isStandalone: true,
     });
 
     expect(compositionsRepo.findAll).toHaveBeenCalledWith({
       search: 'test',
-      opusId: null,
+      isStandalone: true,
     });
 
     expect(result).toEqual({
@@ -71,11 +70,11 @@ describe('handleWorksTab', () => {
     );
 
     expect(compositionsRepo.count).toHaveBeenCalledWith({
-      opusId: null,
+      isStandalone: true,
     });
 
     expect(compositionsRepo.findAll).toHaveBeenCalledWith({
-      opusId: null,
+      isStandalone: true,
     });
 
     expect(result).toEqual({

--- a/src/interfaces/graphql/resolvers/opus/tab-handlers/handleWork.ts
+++ b/src/interfaces/graphql/resolvers/opus/tab-handlers/handleWork.ts
@@ -10,9 +10,9 @@ export async function handleWorksTab(
   page: number,
   pageSize: number,
 ): Promise<PaginatedWorksResult> {
-  const mappedFilters: QueryFilters<CompositionFilters> & { opusId?: string | null } = {
+  const mappedFilters: QueryFilters<CompositionFilters> = {
     ...mapFilters(filters),
-    opusId: null
+    isStandalone: true
   };
   const worksResult = await mappedCompositions(compositionsRepo, mappedFilters);
   

--- a/src/interfaces/graphql/resolvers/opus/tab-handlers/handleWork.ts
+++ b/src/interfaces/graphql/resolvers/opus/tab-handlers/handleWork.ts
@@ -1,0 +1,26 @@
+import { mapFilters } from '../../helpers';
+import { PaginatedWorksResult, WorksFilter } from '../opusQuery';
+import { mappedCompositions, totalPages } from './tabHandlersHelpers';
+import { QueryFilters } from '~/src/domain/repositories/baseRepository';
+import { CompositionFilters, ICompositionRepository } from '~/src/domain/repositories/compositionRepository';
+
+export async function handleWorksTab(
+  compositionsRepo: ICompositionRepository,
+  filters: WorksFilter | undefined,
+  page: number,
+  pageSize: number,
+): Promise<PaginatedWorksResult> {
+  const mappedFilters: QueryFilters<CompositionFilters> & { opusId?: string | null } = {
+    ...mapFilters(filters),
+    opusId: null
+  };
+  const worksResult = await mappedCompositions(compositionsRepo, mappedFilters);
+  
+  return {
+    groups: [],
+    works: worksResult.works,
+    total: worksResult.total,
+    page,
+    totalPages: totalPages(worksResult.total, pageSize),
+  };
+}

--- a/src/interfaces/graphql/resolvers/opus/tab-handlers/tabHandlersHelpers.ts
+++ b/src/interfaces/graphql/resolvers/opus/tab-handlers/tabHandlersHelpers.ts
@@ -1,15 +1,16 @@
 import { Composition } from '~/src/domain/entities/Composition';
 import { Opus } from '~/src/domain/entities/Opus';
-import { QueryFilters } from '~/src/domain/repositories/baseRepository';
 import { CompositionFilters, ICompositionRepository } from '~/src/domain/repositories/compositionRepository';
 import { IOpusRepository, OpusFilters } from '~/src/domain/repositories/opusRepository';
 import { OpusNumberKind, WorksTab } from '~/types/graphql/generated/graphql';
 
-export const mappedGroups = async (repo: IOpusRepository, compositionsRepo: ICompositionRepository, filters: QueryFilters<OpusFilters>) => {
-  const total = await repo.count(filters);
+export const mappedGroups = async (
+  repo: IOpusRepository,
+  compositionsRepo: ICompositionRepository,
+  filters: OpusFilters
+) => {  const total = await repo.count(filters);
 
-  let groups: Opus[] = await repo.findAll(filters
-  );
+  let groups: Opus[] = await repo.findAll(filters);
 
   const opusIds = groups.map((o) => o.id);
   const allCompositions: Composition[] = await compositionsRepo.findByOpusIds(opusIds);
@@ -34,7 +35,10 @@ export const mappedGroups = async (repo: IOpusRepository, compositionsRepo: ICom
   return { groups, total};
 };
 
-export const mappedCompositions = async (repo: ICompositionRepository, filters: QueryFilters<CompositionFilters> & { opusId?: string | null }) => {
+export const mappedCompositions = async (
+  repo: ICompositionRepository,
+  filters: CompositionFilters & { opusId?: string | null }
+) => {
   const total = await repo.count(filters);
   const works = await repo.findAll(filters);
 

--- a/src/interfaces/graphql/resolvers/opus/tab-handlers/tabHandlersHelpers.ts
+++ b/src/interfaces/graphql/resolvers/opus/tab-handlers/tabHandlersHelpers.ts
@@ -1,0 +1,49 @@
+import { Composition } from '~/src/domain/entities/Composition';
+import { Opus } from '~/src/domain/entities/Opus';
+import { QueryFilters } from '~/src/domain/repositories/baseRepository';
+import { CompositionFilters, ICompositionRepository } from '~/src/domain/repositories/compositionRepository';
+import { IOpusRepository, OpusFilters } from '~/src/domain/repositories/opusRepository';
+import { OpusNumberKind, WorksTab } from '~/types/graphql/generated/graphql';
+
+export const mappedGroups = async (repo: IOpusRepository, compositionsRepo: ICompositionRepository, filters: QueryFilters<OpusFilters>) => {
+  const total = await repo.count(filters);
+
+  let groups: Opus[] = await repo.findAll(filters
+  );
+
+  const opusIds = groups.map((o) => o.id);
+  const allCompositions: Composition[] = await compositionsRepo.findByOpusIds(opusIds);
+
+  const compositionsByOpusId = new Map<string, typeof allCompositions>();
+  
+  for (const comp of allCompositions) {
+    if (comp.opusId) {
+	  const idStr = String(comp.opusId);
+	  if (!compositionsByOpusId.has(idStr)) {
+        compositionsByOpusId.set(idStr, []);
+	  }
+	  compositionsByOpusId.get(idStr)!.push(comp);
+    }
+  }
+
+  groups = groups.map((group) => ({
+    ...group,
+    compositions: compositionsByOpusId.get(String(group.id)) ?? []
+  }));
+	  
+  return { groups, total};
+};
+
+export const mappedCompositions = async (repo: ICompositionRepository, filters: QueryFilters<CompositionFilters> & { opusId?: string | null }) => {
+  const total = await repo.count(filters);
+  const works = await repo.findAll(filters);
+
+  return { works, total };
+};
+
+export const numberKindByTab: Partial<Record<WorksTab, OpusNumberKind>> = {
+  [WorksTab.Opus]: OpusNumberKind.Op,
+  [WorksTab.Woo]: OpusNumberKind.Woo,
+};
+
+export const totalPages = (totalItems: number, pageSize: number) => Math.ceil(totalItems / pageSize);

--- a/src/interfaces/graphql/schemas/opus.graphql
+++ b/src/interfaces/graphql/schemas/opus.graphql
@@ -22,13 +22,46 @@ type OpusPerformance {
   videoUrl: String
 }
 
+input WorksFiltersInput {
+  statuses: [OpusStatus]
+  languages: [ContentLanguage]
+}
+
+enum WorksSortBy {
+  number
+  releaseYear
+  createdAt
+  updatedAt
+  publishedAt
+}
+
+input WorksSortOptions {
+  field: WorksSortBy!
+  order: SortOrder!
+}
+
+enum WorksTab {
+  all
+  opus
+  woo
+  works
+}
+
+input WorksInput {
+  tab: WorksTab
+  search: String
+  filters: WorksFiltersInput
+  page: Int
+  pageSize: Int
+}
+
 type Opus {
   id: ID!
   number: String!
-  numberKind: OpusNumberKind
+  numberKind: OpusNumberKind!
   title: LocalizedString!
   releaseYear: Int
-  name: LocalizedString
+  name: LocalizedString!
   additionalText: String
   creationYear: String!
   endYear: String
@@ -136,11 +169,22 @@ input UpdateOpusInput {
   publishedAt: String
 }
 
+type PaginatedWorks {
+  groups: [Opus!]!
+  works: [Composition!]!
+
+  totalItems: Int!
+  totalPages: Int!
+}
+
 extend type Query {
   opusById(id: ID!): Opus
   opusByNumber(number: String!): Opus
   searchCompositions(search: String!): [Composition!]!
+
   allOpuses(filters: OpusFiltersInput): [Opus!]!
+  paginatedWorks(input: WorksInput!): PaginatedWorks!
+
   paginatedOpuses(page: Int!, limit: Int!, filters: OpusFiltersInput): PaginatedOpuses!
   opusesCount(status: OpusStatus): Int!
 }

--- a/src/interfaces/graphql/schemas/opus.graphql
+++ b/src/interfaces/graphql/schemas/opus.graphql
@@ -8,6 +8,20 @@ enum OpusNumberKind {
   woo
 }
 
+enum WorksTab {
+  all
+  opus
+  woo
+  works
+}
+
+enum WorksSortBy {
+  number
+  createdAt
+  updatedAt
+  publishedAt
+}
+
 type OpusGalleryItem {
   id: ID!
   src: String!
@@ -20,39 +34,6 @@ type OpusPerformance {
   id: ID!
   title: LocalizedString
   videoUrl: String
-}
-
-input WorksFiltersInput {
-  statuses: [OpusStatus]
-  languages: [ContentLanguage]
-}
-
-enum WorksSortBy {
-  number
-  releaseYear
-  createdAt
-  updatedAt
-  publishedAt
-}
-
-input WorksSortOptions {
-  field: WorksSortBy!
-  order: SortOrder!
-}
-
-enum WorksTab {
-  all
-  opus
-  woo
-  works
-}
-
-input WorksInput {
-  tab: WorksTab
-  search: String
-  filters: WorksFiltersInput
-  page: Int
-  pageSize: Int
 }
 
 type Opus {
@@ -88,35 +69,27 @@ type Opus {
   meta: ContentMeta
 }
 
-type PaginatedOpuses {
-  items: [Opus!]!
+type PaginatedWorks {
+  groups: [Opus!]!
+  works: [Composition!]!
+
   total: Int!
   page: Int!
   totalPages: Int!
 }
 
-enum OpusSortBy {
-  number
-  releaseYear
-  createdAt
-  updatedAt
-  publishedAt
-}
-
-input OpusSortOptions {
-  field: OpusSortBy!
+input WorksSortOptions {
+  field: WorksSortBy!
   order: SortOrder!
 }
 
-input OpusFiltersInput {
-  statuses: [OpusStatus!]
+input WorksFiltersInput {
+  statuses: [OpusStatus]
+  languages: [ContentLanguage]
+  search: String
   limit: Int
   skip: Int
-  slug: String
-  search: String
-  languages: [ContentLanguage!]
-  sort: [OpusSortOptions!]
-  numberKind: OpusNumberKind
+  sort: [WorksSortOptions!]
 }
 
 input CreateOpusInput {
@@ -169,23 +142,11 @@ input UpdateOpusInput {
   publishedAt: String
 }
 
-type PaginatedWorks {
-  groups: [Opus!]!
-  works: [Composition!]!
-
-  totalItems: Int!
-  totalPages: Int!
-}
-
 extend type Query {
   opusById(id: ID!): Opus
   opusByNumber(number: String!): Opus
   searchCompositions(search: String!): [Composition!]!
-
-  allOpuses(filters: OpusFiltersInput): [Opus!]!
-  paginatedWorks(input: WorksInput!): PaginatedWorks!
-
-  paginatedOpuses(page: Int!, limit: Int!, filters: OpusFiltersInput): PaginatedOpuses!
+  paginatedWorks(tab: WorksTab, filters: WorksFiltersInput): PaginatedWorks!
   opusesCount(status: OpusStatus): Int!
 }
 


### PR DESCRIPTION
## Description

Implement server-side filtering, search, sorting, and pagination for the `/creativity` page.

Previously, the frontend fetched all opuses, opus groups, and compositions in separate requests, merged the data on the client, and then applied filtering, searching, and sorting locally. This approach did not scale well and required unnecessary data processing in the browser.

The page now requests only the data required for the current tab, active filters, search query, sort order, and requested page from the backend.

## What was changed

- Moved filtering, search, sorting, and pagination logic from the frontend to the backend.
- Replaced multiple client-side requests with a single `usePaginatedWorks` query.
- Added backend pagination support while keeping the existing frontend `Pagination` component.
- Implemented tab-specific data retrieval:
  - `Всі` (all) tab – returns both opus groups and standalone compositions.
  - `Опуси` (op) tab – returns only `op` groups (`numberKind = op`).
  - `Безопусні` (woo) tab – returns only `woo` groups (`numberKind = woo`).
  - `Твори`(work) tab – returns only standalone compositions (without `opus_id`).
- Added dedicated tab handlers to encapsulate backend logic for each tab.
- Implemented mixed pagination logic for the `All` tab:
  - pages display opus groups first;
  - than it shows `bo` (woo) groups;
  - once opus groups are exhausted, standalone compositions are appended;
  - applied the same mixed-pagination approach for transitions between `Opuses → Without Opus` and `Without Opus → Works` without duplicating or skipping records.
- Added repository helpers to normalize legacy data by assigning default draft statuses to records that previously had no status in the database (both `Opus` and `Composition` repositories).
- Extended `buildBaseQuery` to support custom searchable fields instead of relying on a fixed set of fields.
- Updated and fixed unit tests to reflect the new server-side behavior.

> **Note:** Sorting by title will work correctly after the `number` field is migrated from a `string` to a `number`, as intended.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Open the `/creativity` page.
2. Verify that each tab displays the correct data:
   - `All` – opus groups first, followed by without-opus groups, then standalone compositions.
   - `Opuses` – only `op` groups.
   - `Without Opus` – only `woo` groups.
   - `Works` – only standalone compositions.
3. Verify that pagination displays the correct number of pages and loads the expected data.
4. Verify that changing pages triggers a new API request.
5. Verify that status and language filters trigger backend requests and return the expected results.
6. Verify that searching filters records by title and work number.
7. Verify that sorting works correctly for all supported fields.

## Video / Screenshots

### How it used to work

<img width="1499" height="1275" alt="image" src="https://github.com/user-attachments/assets/44140128-552f-4d8f-b761-60af3a8f0008" />


### How it works now
***Всі tab***
<img width="1664" height="1073" alt="image" src="https://github.com/user-attachments/assets/8221903e-3208-439b-9ca2-4f01f2f517a3" />

***Всі tab***: correct order of `op`, `bo` and `works`
<img width="1666" height="1075" alt="image" src="https://github.com/user-attachments/assets/ed0a1d6b-6fcc-412a-8f9c-5a070d212c57" />

***Всі tab***: all drafts with edge cases 
<img width="1649" height="1082" alt="image" src="https://github.com/user-attachments/assets/7e0ed011-e76b-44df-90e8-a944b7b6fca0" />

***Опуси tab***
<img width="1657" height="1017" alt="image" src="https://github.com/user-attachments/assets/8b80ee83-ca5b-47c9-88c2-0bdfaa98d241" />

***Безопусні tab***
<img width="1442" height="787" alt="image" src="https://github.com/user-attachments/assets/2ef014ae-5ee0-4b3c-b647-1b78d6af4207" />

***Твори tab***
<img width="1448" height="1015" alt="image" src="https://github.com/user-attachments/assets/026e21ad-f474-4ba7-83f0-d90acb310c02" />


### Tests

<img width="753" height="44" alt="image" src="https://github.com/user-attachments/assets/7475da88-a91d-41bb-8394-49b2252ae45a" />
<img width="749" height="109" alt="image" src="https://github.com/user-attachments/assets/92169a28-e675-462f-b8e2-629608e4c41b" />
<img width="703" height="170" alt="image" src="https://github.com/user-attachments/assets/4e97d1d1-e035-4c6e-be93-6f67af3c9580" />
<img width="803" height="26" alt="image" src="https://github.com/user-attachments/assets/8257b3bc-b1ce-45f8-81a9-b4704750273c" />
<img width="713" height="27" alt="image" src="https://github.com/user-attachments/assets/eed9487f-b428-41b2-b6b0-ec6617d74a04" />
<img width="738" height="41" alt="image" src="https://github.com/user-attachments/assets/1560f654-c9db-4bfe-9694-1fbc54d4c8fd" />
<img width="731" height="43" alt="image" src="https://github.com/user-attachments/assets/708701a7-21a2-46a0-8dbe-6775ccffa707" />
<img width="784" height="45" alt="image" src="https://github.com/user-attachments/assets/fbc8962d-d2d9-424b-af8d-c2317650b1b7" />
<img width="788" height="52" alt="image" src="https://github.com/user-attachments/assets/b4ae5f24-a333-4452-8bb6-219c7ef517e4" />

## Checklist

- [ ] Code compiles and runs correctly
- [ ] Tests pass successfully
- [ ] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [ ] Linked issue/task included
- [ ] Task moved to the review column on the board

---
Closes #686