### PR TITLE
feat(artistry): add artistry page layout, blocks and tests

### DIFF
--- a/app/(logged_in)/artistry/page.test.tsx
+++ b/app/(logged_in)/artistry/page.test.tsx
@@ -1,0 +1,25 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import { editPagesCommonTests } from '../__mocks__/edit-pages-factory';
+import Page from './page';
+import { PAGE_IDS } from '~/constants/pageBlocks';
+
+jest.mock('~/shared/components/artistry/TitleWithQuote/TitleWithQuote', () => ({
+  TitleWithQuote: () => <div data-testid="title-with-quote">TitleWithQuote</div>
+}));
+
+jest.mock('~/shared/components/artistry/MusicTableSection/MusicTableSection', () => ({
+  MusicTableSection: () => <div data-testid="music-table">MusicTableSection</div>
+}));
+
+jest.mock('~/shared/components/sortable-list/SortableList');
+
+describe('Artistry Page', () => {
+  editPagesCommonTests({
+    Page,
+    pageId: PAGE_IDS.ARTISTRY,
+    childTestIds: ['title-with-quote', 'music-table'],
+    expectedReorderedBlocks: ['title-with-quote', 'music-table']
+  });
+});

--- a/app/(logged_in)/artistry/page.tsx
+++ b/app/(logged_in)/artistry/page.tsx
@@ -1,0 +1,56 @@
+'use client';
+import { DragEndEvent } from '@dnd-kit/core';
+
+import { PAGE_IDS } from '~/constants/pageBlocks';
+import { handleSortableDragEnd } from '~/lib/utils/sortableDragEndHelper';
+import { MusicTableSection } from '~/shared/components/artistry/MusicTableSection/MusicTableSection';
+import { TitleWithQuote } from '~/shared/components/artistry/TitleWithQuote/TitleWithQuote';
+import { EditablePageLayout } from '~/shared/components/editable-page-layout/EditablePageLayout';
+import { SortableItemWrapper } from '~/shared/components/sortable-item-wrapper/SortableItemWrapper';
+import { SortableList } from '~/shared/components/sortable-list/SortableList';
+import { useStore } from '~/store';
+
+const BLOCKS_CONFIG: Record<string, () => React.JSX.Element> = {
+  'title-with-quote': TitleWithQuote,
+  'music-table': MusicTableSection
+};
+
+export default function ArtistryReorderingPage() {
+  const pageSlug = PAGE_IDS.ARTISTRY;
+
+  const blocksOrder = useStore((s) => s.blocksOrder[pageSlug]) || ['title-with-quote', 'music-table'];
+  const setBlocksOrder = useStore((s) => s.setBlocksOrder);
+
+  const sortableBlocks = blocksOrder;
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    handleSortableDragEnd(event, sortableBlocks, (reordered) => {
+      const pinnedBlock = sortableBlocks[0];
+
+      if (reordered[0] !== pinnedBlock) {
+        const withoutPinned = reordered.filter((id) => id !== pinnedBlock);
+        setBlocksOrder(pageSlug, [pinnedBlock, ...withoutPinned]);
+      } else {
+        setBlocksOrder(pageSlug, reordered);
+      }
+    });
+  };
+
+  return (
+    <EditablePageLayout headerTitle="Творчість" pageSlug={pageSlug}>
+      {sortableBlocks && sortableBlocks.length > 0 && (
+        <SortableList onDragEnd={handleDragEnd} id="artistry-sortable-list" items={sortableBlocks}>
+          {sortableBlocks.map((blockId) => {
+            const BlockComponent = BLOCKS_CONFIG[blockId];
+
+            return (
+              <SortableItemWrapper id={blockId} key={blockId}>
+                {BlockComponent && <BlockComponent />}
+              </SortableItemWrapper>
+            );
+          })}
+        </SortableList>
+      )}
+    </EditablePageLayout>
+  );
+}

--- a/app/(logged_in)/creativity/group/[id]/content/GroupContentView.test.tsx
+++ b/app/(logged_in)/creativity/group/[id]/content/GroupContentView.test.tsx
@@ -127,6 +127,26 @@ jest.mock('~/shared/components/delete-card-modal/DeleteCardModal', () => ({
   )
 }));
 
+jest.mock('~/lib/utils/sortableDragEndHelper', () => ({
+  handleSortableDragEnd: jest.fn((event, items, callback) => {
+    callback(['photos', 'details', 'intro', 'works', 'performances']);
+  })
+}));
+
+jest.mock('~/shared/components/sortable-list/SortableList', () => ({
+  SortableList: ({ onDragEnd, children }: any) => (
+    <div data-testid="mock-sortable-list">
+      <button
+        data-testid="simulate-drag-end"
+        onClick={() => onDragEnd({ active: { id: 'intro' }, over: { id: 'photos' } })}
+      >
+        Drop
+      </button>
+      {children}
+    </div>
+  )
+}));
+
 const mockUseGroupContent = {
   loading: false,
   error: undefined,
@@ -336,6 +356,51 @@ describe('GroupContentView Component', () => {
       fireEvent.keyDown(menu, { key: 'Escape', code: 'Escape' });
 
       expect(mockUseGroupContent.handleClose).toHaveBeenCalledWith('publish');
+    });
+
+    it('should render GroupContentViewError when error is returned from useGroupContent', () => {
+      (useGroupContent as jest.Mock).mockReturnValue({
+        ...mockUseGroupContent,
+        loading: false,
+        error: new Error('Failed to load group data'),
+        groupData: null
+      });
+
+      render(<GroupContentView id="123" />);
+
+      expect(screen.getByText('Failed to load group data')).toBeInTheDocument();
+    });
+
+    it('should ignore unknown block types in blocksOrder without crashing', () => {
+      (useGroupContent as jest.Mock).mockReturnValue({
+        ...mockUseGroupContent,
+        groupData: {
+          ...mockUseGroupContent.groupData,
+          blocksOrder: ['details', 'intro', 'unknown_block_id_from_future', 'photos']
+        }
+      });
+
+      render(<GroupContentView id="123" />);
+
+      expect(screen.getByTestId('collapsible-block-Вступна секція')).toBeInTheDocument();
+      expect(screen.getByTestId('collapsible-block-Фото')).toBeInTheDocument();
+    });
+
+    it('should handle drag end and update blocksOrder', () => {
+      (useGroupContent as jest.Mock).mockReturnValue(mockUseGroupContent);
+
+      render(<GroupContentView id="123" />);
+
+      const dragButton = screen.getByTestId('simulate-drag-end');
+      fireEvent.click(dragButton);
+
+      expect(mockUseGroupContent.handleFieldChange).toHaveBeenCalledWith('blocksOrder', [
+        'photos',
+        'details',
+        'intro',
+        'works',
+        'performances'
+      ]);
     });
   });
 });

--- a/app/(logged_in)/creativity/group/[id]/content/GroupContentView.tsx
+++ b/app/(logged_in)/creativity/group/[id]/content/GroupContentView.tsx
@@ -72,39 +72,39 @@ export const GroupContentView = ({ id }: GroupContentViewProps) => {
 
   const renderBlock = (blockId: string) => {
     switch (blockId) {
-      case 'details':
-        return (
-          <CollapsibleBlock
-            title="Деталі"
-            expanded={isDetailsExpanded}
-            onChange={(_, isExpanded) => setIsDetailsExpanded(isExpanded)}
-            grip
-          >
-            <GroupDetailsSection
-              currentLanguage={currentLanguage}
-              data={groupData}
-              errors={errors}
-              onChange={handleFieldChange}
-            />
-          </CollapsibleBlock>
-        );
-      case 'intro':
-        return (
-          <CollapsibleBlock title="Вступна секція" defaultExpanded grip>
-            <GroupIntroSection currentLanguage={currentLanguage} data={groupData} onChange={handleFieldChange} />
-          </CollapsibleBlock>
-        );
-      case 'photos':
-        return (
-          <CollapsibleBlock title="Фото" defaultExpanded grip>
-            <GroupPhotosSection
-              currentLanguage={currentLanguage}
-              photos={groupData.photos}
-              onChange={(newPhotos) => handleFieldChange('photos', newPhotos)}
-            />
-          </CollapsibleBlock>
-        );
-      case 'works':
+    case 'details':
+      return (
+        <CollapsibleBlock
+          title="Деталі"
+          expanded={isDetailsExpanded}
+          onChange={(_, isExpanded) => setIsDetailsExpanded(isExpanded)}
+          grip
+        >
+          <GroupDetailsSection
+            currentLanguage={currentLanguage}
+            data={groupData}
+            errors={errors}
+            onChange={handleFieldChange}
+          />
+        </CollapsibleBlock>
+      );
+    case 'intro':
+      return (
+        <CollapsibleBlock title="Вступна секція" defaultExpanded grip>
+          <GroupIntroSection currentLanguage={currentLanguage} data={groupData} onChange={handleFieldChange} />
+        </CollapsibleBlock>
+      );
+    case 'photos':
+      return (
+        <CollapsibleBlock title="Фото" defaultExpanded grip>
+          <GroupPhotosSection
+            currentLanguage={currentLanguage}
+            photos={groupData.photos}
+            onChange={(newPhotos) => handleFieldChange('photos', newPhotos)}
+          />
+        </CollapsibleBlock>
+      );
+    case 'works':
       return (
         <CollapsibleBlock title="Твори" defaultExpanded grip>
           <GroupWorksSection 
@@ -113,20 +113,20 @@ export const GroupContentView = ({ id }: GroupContentViewProps) => {
           />
         </CollapsibleBlock>
       );
-      case 'performances':
-        return (
-          <CollapsibleBlock title="Всі версії виконання опису" defaultExpanded grip>
-            <GroupPerformancesSection
-              currentLanguage={currentLanguage}
-              sectionTitle={groupData.performancesTitle}
-              performances={groupData.performances}
-              onChangeSectionTitle={(newTitle) => handleFieldChange('performancesTitle', newTitle)}
-              onChangePerformances={(newPerformances) => handleFieldChange('performances', newPerformances)}
-            />
-          </CollapsibleBlock>
-        );
-      default:
-        return null;
+    case 'performances':
+      return (
+        <CollapsibleBlock title="Всі версії виконання опису" defaultExpanded grip>
+          <GroupPerformancesSection
+            currentLanguage={currentLanguage}
+            sectionTitle={groupData.performancesTitle}
+            performances={groupData.performances}
+            onChangeSectionTitle={(newTitle) => handleFieldChange('performancesTitle', newTitle)}
+            onChangePerformances={(newPerformances) => handleFieldChange('performances', newPerformances)}
+          />
+        </CollapsibleBlock>
+      );
+    default:
+      return null;
     }
   };
 

--- a/app/(logged_in)/creativity/group/[id]/content/GroupContentView.tsx
+++ b/app/(logged_in)/creativity/group/[id]/content/GroupContentView.tsx
@@ -1,10 +1,12 @@
 'use client';
+import { DragEndEvent } from '@dnd-kit/core';
 import { Box, Typography } from '@mui/material';
 
 import { NavigationMenuItems, PublishMenuItems } from './GroupContentMenuItems';
 import { styles } from './GroupContentView.styles';
 import { GroupContentViewError } from './GroupContentViewError';
 import { GroupContentViewLoading } from './GroupContentViewLoading';
+import { handleSortableDragEnd } from '~/lib/utils/sortableDragEndHelper';
 import { GroupDetailsSection } from '~/shared/components/creativity/group/details-section/GroupDetailsSection';
 import { GroupIntroSection } from '~/shared/components/creativity/group/intro-section/GroupIntroSection';
 import { GroupPerformancesSection } from '~/shared/components/creativity/group/performances-section/GroupPerformancesSection';
@@ -17,11 +19,15 @@ import HeaderRightActions from '~/shared/components/divided-header/header-right-
 import ProgressStatus from '~/shared/components/divided-header/progress-status/ProgressStatus';
 import { TitleDropdown } from '~/shared/components/divided-header/title-dropdown/TitleDropdown';
 import ActionMenu from '~/shared/components/dropdown-menu/ActionMenu';
+import { SortableItemWrapper } from '~/shared/components/sortable-item-wrapper/SortableItemWrapper';
+import { SortableList } from '~/shared/components/sortable-list/SortableList';
 import { useGroupContent } from '~/shared/hooks/use-group-content/useGroupContent';
 
 type GroupContentViewProps = Readonly<{
   id: string;
 }>;
+
+const DEFAULT_BLOCKS_ORDER = ['details', 'intro', 'photos', 'works', 'performances'];
 
 export const GroupContentView = ({ id }: GroupContentViewProps) => {
   const {
@@ -56,6 +62,74 @@ export const GroupContentView = ({ id }: GroupContentViewProps) => {
     return <GroupContentViewLoading />;
   }
 
+  const sortableBlocks = groupData.blocksOrder?.length ? groupData.blocksOrder : DEFAULT_BLOCKS_ORDER;
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    handleSortableDragEnd(event, sortableBlocks, (reordered) => {
+      handleFieldChange('blocksOrder', reordered);
+    });
+  };
+
+  const renderBlock = (blockId: string) => {
+    switch (blockId) {
+      case 'details':
+        return (
+          <CollapsibleBlock
+            title="Деталі"
+            expanded={isDetailsExpanded}
+            onChange={(_, isExpanded) => setIsDetailsExpanded(isExpanded)}
+            grip
+          >
+            <GroupDetailsSection
+              currentLanguage={currentLanguage}
+              data={groupData}
+              errors={errors}
+              onChange={handleFieldChange}
+            />
+          </CollapsibleBlock>
+        );
+      case 'intro':
+        return (
+          <CollapsibleBlock title="Вступна секція" defaultExpanded grip>
+            <GroupIntroSection currentLanguage={currentLanguage} data={groupData} onChange={handleFieldChange} />
+          </CollapsibleBlock>
+        );
+      case 'photos':
+        return (
+          <CollapsibleBlock title="Фото" defaultExpanded grip>
+            <GroupPhotosSection
+              currentLanguage={currentLanguage}
+              photos={groupData.photos}
+              onChange={(newPhotos) => handleFieldChange('photos', newPhotos)}
+            />
+          </CollapsibleBlock>
+        );
+      case 'works':
+      return (
+        <CollapsibleBlock title="Твори" defaultExpanded grip>
+          <GroupWorksSection 
+            works={groupData.compositions} 
+            onChange={(newWorks) => handleFieldChange('compositions', newWorks)} 
+          />
+        </CollapsibleBlock>
+      );
+      case 'performances':
+        return (
+          <CollapsibleBlock title="Всі версії виконання опису" defaultExpanded grip>
+            <GroupPerformancesSection
+              currentLanguage={currentLanguage}
+              sectionTitle={groupData.performancesTitle}
+              performances={groupData.performances}
+              onChangeSectionTitle={(newTitle) => handleFieldChange('performancesTitle', newTitle)}
+              onChangePerformances={(newPerformances) => handleFieldChange('performances', newPerformances)}
+            />
+          </CollapsibleBlock>
+        );
+      default:
+        return null;
+    }
+  };
+
   return (
     <Box sx={styles.container}>
       <DividedHeader
@@ -81,47 +155,19 @@ export const GroupContentView = ({ id }: GroupContentViewProps) => {
           Заповнення контентом не є обов’язковим
         </Typography>
 
-        <CollapsibleBlock
-          title="Деталі"
-          expanded={isDetailsExpanded}
-          onChange={(_, isExpanded) => setIsDetailsExpanded(isExpanded)}
-        >
-          <GroupDetailsSection
-            currentLanguage={currentLanguage}
-            data={groupData}
-            errors={errors}
-            onChange={handleFieldChange}
-          />
-        </CollapsibleBlock>
-
-        <CollapsibleBlock title="Вступна секція" defaultExpanded>
-          <GroupIntroSection currentLanguage={currentLanguage} data={groupData} onChange={handleFieldChange} />
-        </CollapsibleBlock>
-
-        <CollapsibleBlock title="Фото" defaultExpanded>
-          <GroupPhotosSection
-            currentLanguage={currentLanguage}
-            photos={groupData.photos}
-            onChange={(newPhotos) => handleFieldChange('photos', newPhotos)}
-          />
-        </CollapsibleBlock>
-
-        <CollapsibleBlock title="Твори" defaultExpanded>
-          <GroupWorksSection
-            works={groupData.compositions}
-            onChange={(newWorks) => handleFieldChange('compositions', newWorks)}
-          />
-        </CollapsibleBlock>
-
-        <CollapsibleBlock title="Всі версії виконання опису" defaultExpanded>
-          <GroupPerformancesSection
-            currentLanguage={currentLanguage}
-            sectionTitle={groupData.performancesTitle}
-            performances={groupData.performances}
-            onChangeSectionTitle={(newTitle) => handleFieldChange('performancesTitle', newTitle)}
-            onChangePerformances={(newPerformances) => handleFieldChange('performances', newPerformances)}
-          />
-        </CollapsibleBlock>
+        {sortableBlocks.length > 0 && (
+          <SortableList onDragEnd={handleDragEnd} id="opus-blocks-list" items={sortableBlocks}>
+            {sortableBlocks.map((blockId: string) => {
+              const blockContent = renderBlock(blockId);
+              if (!blockContent) return null;
+              return (
+                <SortableItemWrapper id={blockId} key={blockId}>
+                  {blockContent}
+                </SortableItemWrapper>
+              );
+            })}
+          </SortableList>
+        )}
       </Box>
 
       <ActionMenu

--- a/app/(logged_in)/main-page/MainPageContent.tsx
+++ b/app/(logged_in)/main-page/MainPageContent.tsx
@@ -22,7 +22,7 @@ const MAIN_PAGE_TABS: readonly PageHeaderTab[] = [
   { value: PageCategory.Other, label: 'Інші', href: '/main-page/other' },
 ];
 
-const ALLOWED_SLUGS = new Set(['about-us', 'privacy-policy']);
+const ALLOWED_SLUGS = new Set(['about-us', 'privacy-policy', 'artistry']);
 
 export function MainPagesContent({ activeTab }: MainPagesContentProps) {
   const { data, loading } = useGetPagesQuery({

--- a/app/constants/creativity.ts
+++ b/app/constants/creativity.ts
@@ -150,6 +150,7 @@ export interface GroupData {
   performancesTitle: string;
   performances: GroupPerformance[];
   status: string;
+  blocksOrder?: string[];
 }
 
 export type GroupDataField = keyof GroupData;

--- a/app/constants/pageBlocks.ts
+++ b/app/constants/pageBlocks.ts
@@ -1,6 +1,7 @@
 export const PAGE_IDS = {
   ABOUT_US: 'about-us',
-  PRIVACY_POLICY: 'privacy-policy'
+  PRIVACY_POLICY: 'privacy-policy',
+  ARTISTRY: 'artistry'
 };
 
 export const BLOCK_IDS = {
@@ -9,7 +10,7 @@ export const BLOCK_IDS = {
   LIATOSHYNSKY_OFFICE: 'LiatoshynskyOffice',
   OUR_MISSION: 'OurMission',
   OUR_GOALS: 'OurGoals',
-  WHAT_WE_DO: 'WhatWeDo',
+  WHAT_WE_DO: 'WhatWeDo', 
   FOUNDATION_FOUNDERS: 'FoundationFounders',
   DATA_WE_COLLECT: 'DataWeCollect',
   DATA_USAGE: 'DataUsage',
@@ -21,5 +22,7 @@ export const BLOCK_IDS = {
   DATA_RETENTION: 'DataRetention',
   USER_RIGHTS: 'UserRights',
   CONTACT_US: 'ContactUs',
-  PRIVACY_INTRO_SECTION: 'IntroSection'
+  PRIVACY_INTRO_SECTION: 'IntroSection',
+  TITLE_WITH_QUOTE: 'TitleWithQuote',
+  MUSIC_TABLE: 'MusicTableSection',
 } as const;

--- a/app/shared/components/artistry/MusicTableSection/MusicTableSection.test.ts
+++ b/app/shared/components/artistry/MusicTableSection/MusicTableSection.test.ts
@@ -1,0 +1,47 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { MusicTableSection } from './MusicTableSection';
+import { usePageBlock } from '~/shared/hooks/use-page-block/usePageBlock';
+
+jest.mock('~/shared/hooks/use-page-block/usePageBlock');
+
+jest.mock('~/shared/components/edit-block-skeleton/EditBlockSkeleton', () => ({
+  EditBlockSkeleton: () => React.createElement('div', { 'data-testid': 'skeleton' }, 'Skeleton')
+}));
+
+jest.mock('~/shared/components/design-system/collapsible-block/CollapsibleBlock', () => ({
+  __esModule: true,
+  default: ({ title, children }: { title: string; children: React.ReactNode }) =>
+    React.createElement('div', { 'data-testid': 'collapsible-block' }, React.createElement('h2', null, title), children)
+}));
+
+describe('MusicTableSection Component', () => {
+  const mockUsePageBlock = usePageBlock as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render EditBlockSkeleton when block is undefined', () => {
+    mockUsePageBlock.mockReturnValue({ block: undefined });
+
+    render(React.createElement(MusicTableSection));
+
+    expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+  });
+
+  it('should render block content and link to creativity page when block exists', () => {
+    mockUsePageBlock.mockReturnValue({ block: {} });
+
+    render(React.createElement(MusicTableSection));
+
+    expect(screen.getByText('Таблиця музичних творів')).toBeInTheDocument();
+    expect(screen.getByText(/Цей блок динамічно завантажує таблицю композицій/)).toBeInTheDocument();
+
+    const linkButton = screen.getByRole('link', { name: /Перейти до управління творами/i });
+    expect(linkButton).toBeInTheDocument();
+    expect(linkButton).toHaveAttribute('href', '/creativity');
+  });
+});

--- a/app/shared/components/artistry/MusicTableSection/MusicTableSection.tsx
+++ b/app/shared/components/artistry/MusicTableSection/MusicTableSection.tsx
@@ -1,0 +1,51 @@
+'use client';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import { Box, Button,Typography } from '@mui/material';
+import Link from 'next/link';
+
+import { BLOCK_IDS, PAGE_IDS } from '~/constants/pageBlocks';
+import CollapsibleBlock from '~/shared/components/design-system/collapsible-block/CollapsibleBlock';
+import { EditBlockSkeleton } from '~/shared/components/edit-block-skeleton/EditBlockSkeleton';
+import { usePageBlock } from '~/shared/hooks/use-page-block/usePageBlock';
+
+export const MusicTableSection = () => {
+  const pageId = PAGE_IDS.ARTISTRY;
+  const blockId = BLOCK_IDS.MUSIC_TABLE;
+
+  const { block } = usePageBlock(pageId, blockId);
+
+  if (!block) return <EditBlockSkeleton />;
+
+  return (
+    <CollapsibleBlock title="Таблиця музичних творів">
+      <Box
+        sx={{
+          p: 2,
+          mt: 1,
+          backgroundColor: 'action.hover',
+          borderRadius: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 2
+        }}
+      >
+        <Typography variant="body2" color="text.secondary">
+          Цей блок динамічно завантажує таблицю композицій з бази даних. Додавання та редагування самих музичних творів відбувається у відповідному розділі адмін-панелі.
+        </Typography>
+
+        <Box>
+          <Button
+            component={Link}
+            href="/creativity"
+            variant="outlined"
+            color="primary"
+            size="small"
+            endIcon={<ArrowForwardIcon />}
+          >
+            Перейти до управління творами
+          </Button>
+        </Box>
+      </Box>
+    </CollapsibleBlock>
+  );
+};

--- a/app/shared/components/artistry/TitleWithQuote/TitleWithQuote.styles.ts
+++ b/app/shared/components/artistry/TitleWithQuote/TitleWithQuote.styles.ts
@@ -1,0 +1,7 @@
+import { SxProps, Theme } from '@mui/material';
+
+export const styles = {
+  quoteWrapper: {
+    marginTop: '15px'
+  }
+} satisfies Record<string, SxProps<Theme>>;

--- a/app/shared/components/artistry/TitleWithQuote/TitleWithQuote.test.tsx
+++ b/app/shared/components/artistry/TitleWithQuote/TitleWithQuote.test.tsx
@@ -1,0 +1,110 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { TitleWithQuote } from './TitleWithQuote';
+import { usePageBlock } from '~/shared/hooks/use-page-block/usePageBlock';
+import { useStore } from '~/store';
+
+jest.mock('~/store');
+
+jest.mock('~/shared/hooks/use-page-block/usePageBlock');
+
+jest.mock('~/shared/components/edit-block-skeleton/EditBlockSkeleton', () => ({
+  EditBlockSkeleton: () => <div data-testid="skeleton">Skeleton</div>
+}));
+
+jest.mock('~/shared/components/design-system/collapsible-block/CollapsibleBlock', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <div data-testid="collapsible-block">{children}</div>
+}));
+
+jest.mock('~/ds-components/text-field/TextField', () => ({
+  CustomTextField: ({ value, onChange, title }: any) => (
+    <div data-testid="custom-text-field">
+      <span>{title}</span>
+      <input data-testid="title-input" value={value || ''} onChange={(e) => onChange(e.target.value)} />
+    </div>
+  )
+}));
+
+jest.mock('~/shared/components/about-us/Liatoshynsky-office/quote-block/QuoteBlock', () => ({
+  QuoteBlock: ({ title, description, onTitleChange, onDescriptionChange }: any) => (
+    <div data-testid="quote-block">
+      <input data-testid="source-input" value={title || ''} onChange={(e) => onTitleChange(e.target.value)} />
+      <input
+        data-testid="quote-input"
+        value={description || ''}
+        onChange={(e) => onDescriptionChange(e.target.value)}
+      />
+    </div>
+  )
+}));
+
+describe('TitleWithQuote Component', () => {
+  const mockUsePageBlock = usePageBlock as jest.Mock;
+  const mockUseStore = useStore as unknown as jest.Mock;
+  const mockSetField = jest.fn();
+
+  const mockBlockData = {
+    title: { uk: 'Початковий заголовок', en: 'Initial Title' },
+    sourceText: { uk: 'Початкове джерело', en: 'Initial Source' },
+    quoteText: { uk: 'Початкова цитата', en: 'Initial Quote' }
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseStore.mockImplementation((selector: any) => {
+      return selector({
+        locale: 'uk',
+        setField: mockSetField
+      });
+    });
+  });
+
+  it('should render EditBlockSkeleton when block is undefined', () => {
+    mockUsePageBlock.mockReturnValue({ block: undefined });
+    render(<TitleWithQuote />);
+    expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+  });
+
+  it('should call setField when title is changed', () => {
+    mockUsePageBlock.mockReturnValue({ block: mockBlockData });
+    render(<TitleWithQuote />);
+
+    const titleInput = screen.getByTestId('title-input');
+    fireEvent.change(titleInput, { target: { value: 'Новий заголовок' } });
+
+    expect(mockSetField).toHaveBeenCalledWith('artistry', 'TitleWithQuote', 'title', {
+      uk: 'Новий заголовок',
+      en: 'Initial Title'
+    });
+  });
+
+  it('should call setField when quote source text is changed', () => {
+    mockUsePageBlock.mockReturnValue({ block: mockBlockData });
+    render(<TitleWithQuote />);
+
+    const sourceInput = screen.getByTestId('source-input');
+    fireEvent.change(sourceInput, { target: { value: 'Нове джерело' } });
+
+    expect(mockSetField).toHaveBeenCalledWith('artistry', 'TitleWithQuote', 'sourceText', {
+      uk: 'Нове джерело',
+      en: 'Initial Source'
+    });
+  });
+
+  it('should call setField when quote text description is changed', () => {
+    mockUsePageBlock.mockReturnValue({ block: mockBlockData });
+    render(<TitleWithQuote />);
+
+    const quoteInput = screen.getByTestId('quote-input');
+    fireEvent.change(quoteInput, { target: { value: 'Нова цитата' } });
+
+    expect(mockSetField).toHaveBeenCalledWith('artistry', 'TitleWithQuote', 'quoteText', {
+      uk: 'Нова цитата',
+      en: 'Initial Quote'
+    });
+  });
+});

--- a/app/shared/components/artistry/TitleWithQuote/TitleWithQuote.tsx
+++ b/app/shared/components/artistry/TitleWithQuote/TitleWithQuote.tsx
@@ -1,0 +1,59 @@
+'use client';
+import { Box } from '@mui/material';
+
+import { styles } from './TitleWithQuote.styles';
+import { BLOCK_IDS, PAGE_IDS } from '~/constants/pageBlocks';
+import { CustomTextField } from '~/ds-components/text-field/TextField';
+import { QuoteBlock } from '~/shared/components/about-us/Liatoshynsky-office/quote-block/QuoteBlock';
+import CollapsibleBlock from '~/shared/components/design-system/collapsible-block/CollapsibleBlock';
+import { EditBlockSkeleton } from '~/shared/components/edit-block-skeleton/EditBlockSkeleton';
+import { usePageBlock } from '~/shared/hooks/use-page-block/usePageBlock';
+import { useStore } from '~/store';
+
+export const TitleWithQuote = () => {
+  const pageId = PAGE_IDS.ARTISTRY;
+  const blockId = BLOCK_IDS.TITLE_WITH_QUOTE;
+
+  const { block } = usePageBlock(pageId, blockId);
+
+  const currentLocale = useStore((state) => state.locale);
+  const setField = useStore((state) => state.setField);
+
+  if (!block) return <EditBlockSkeleton />;
+
+  return (
+    <CollapsibleBlock title="Заголовок з цитатою">
+      <CustomTextField
+        fieldType="formatting"
+        title="Головний заголовок"
+        label="Текст заголовку"
+        value={block.title[currentLocale]}
+        onChange={(value) =>
+          setField(pageId, blockId, 'title', {
+            ...block.title,
+            [currentLocale]: value
+          })
+        }
+      />
+
+      <Box sx={styles.quoteWrapper}>
+        <QuoteBlock
+          title={block.sourceText[currentLocale]}
+          description={block.quoteText[currentLocale]}
+          onTitleChange={(val) =>
+            setField(pageId, blockId, 'sourceText', {
+              ...block.sourceText,
+              [currentLocale]: val
+            })
+          }
+          onDescriptionChange={(val) =>
+            setField(pageId, blockId, 'quoteText', {
+              ...block.quoteText,
+              [currentLocale]: val
+            })
+          }
+        />
+      </Box>
+    </CollapsibleBlock>
+  );
+};

--- a/app/shared/hooks/use-group-content/useGroupContent.test.ts
+++ b/app/shared/hooks/use-group-content/useGroupContent.test.ts
@@ -1044,4 +1044,74 @@ describe('useGroupContent Hook', () => {
       expect(mockNavigate).toHaveBeenCalledWith('/creativity');
     });
   });
+  describe('Saving', () => {
+    it('should forcefully trigger none handleSave', async () => {
+      const originalSplit = String.prototype.split;
+      jest.spyOn(String.prototype, 'split').mockImplementation(function (this: string, separator: any, limit?: any) {
+        if (this === 'trigger-empty-split') return [] as unknown as string[];
+        return originalSplit.call(this, separator, limit);
+      });
+
+      const edgeOpus = {
+        ...mockFetchedOpus,
+        number: '100',
+        name: { uk: 'Valid Name', en: '' },
+        creationYear: 2020,
+        numberKind: 'op',
+
+        gallery: [
+          {
+            id: 'photo-edge',
+            src: '',
+            description: { uk: '', en: '' },
+            altText: { uk: '', en: '' },
+            crop: undefined
+          }
+        ],
+        compositions: [
+          {
+            id: 'comp-edge',
+            title: { uk: 'T' },
+            audios: [{ name: null, url: 'trigger-empty-split' }],
+            sheetMusic: undefined
+          }
+        ]
+      };
+
+      (useOpusById as jest.Mock).mockReturnValue({
+        data: { opusById: edgeOpus },
+        loading: false
+      });
+      mockUpdateOpus.mockResolvedValue({ data: { updateOpus: { id: 'test-id' } } });
+
+      const { result } = renderHook(() => useGroupContent('test-id'));
+      await waitFor(() => expect(result.current.groupData).not.toBeNull());
+
+      act(() => {
+        result.current.handleFieldChange('additionalText', '');
+        result.current.handleFieldChange('genre', '   ');
+        result.current.handleFieldChange('parts', { uk: '', en: undefined });
+        result.current.handleFieldChange('description', { uk: null, en: '' });
+
+        result.current.handleFieldChange('works', [
+          {
+            compositionId: 'c3',
+            title: 'T',
+            genre: '   ',
+            year: '   ',
+            audios: undefined,
+            notes: undefined
+          } as unknown as OpusCompositionData
+        ]);
+      });
+
+      await act(async () => {
+        await result.current.handlePublishClick();
+      });
+
+      expect(mockUpdateOpus).toHaveBeenCalled();
+
+      jest.restoreAllMocks();
+    });
+  });
 });

--- a/app/shared/hooks/use-group-content/useGroupContent.test.ts
+++ b/app/shared/hooks/use-group-content/useGroupContent.test.ts
@@ -160,7 +160,7 @@ describe('useGroupContent Hook', () => {
         loading: false,
         error: undefined
       });
- 
+
       const { result } = renderHook(() => useGroupContent('test-id'));
       await waitFor(() => {
         expect(result.current.groupData).not.toBeNull();
@@ -801,7 +801,7 @@ describe('useGroupContent Hook', () => {
       });
       const calledInput = mockUpdateOpus.mock.calls[0][0].variables.input;
       expect(calledInput.numberKind).toBe('sineop');
-      expect(calledInput.genre).toEqual({'en': '', 'uk': ''});
+      expect(calledInput.genre).toEqual({ en: '', uk: '' });
       expect(calledInput.additionalText).toBe('');
       expect(calledInput.gallery).toEqual([]);
       expect(calledInput.compositions[0].audios).toEqual([]);
@@ -1088,15 +1088,18 @@ describe('useGroupContent Hook', () => {
       await waitFor(() => expect(result.current.groupData).not.toBeNull());
 
       act(() => {
+        result.current.handleFieldChange('groupNumber', '100');
+        result.current.handleFieldChange('titlePrefix', 'op');
+        result.current.handleFieldChange('creationYear', '2020');
+        result.current.handleFieldChange('groupTitle', { uk: 'Valid Name Ukr', en: 'Valid Name Eng' });
         result.current.handleFieldChange('additionalText', '');
-        result.current.handleFieldChange('genre', '   ');
+        result.current.handleFieldChange('genre', { uk: '   ', en: '   ' });
         result.current.handleFieldChange('parts', { uk: '', en: undefined });
         result.current.handleFieldChange('description', { uk: null, en: '' });
-
-        result.current.handleFieldChange('works', [
+        result.current.handleFieldChange('compositions', [
           {
-            compositionId: 'c3',
-            title: 'T',
+            id: 'c3',
+            name: 'T',
             genre: '   ',
             year: '   ',
             audios: undefined,
@@ -1109,6 +1112,7 @@ describe('useGroupContent Hook', () => {
         await result.current.handlePublishClick();
       });
 
+      expect(toast.error).not.toHaveBeenCalled();
       expect(mockUpdateOpus).toHaveBeenCalled();
 
       jest.restoreAllMocks();

--- a/app/shared/hooks/use-group-content/useGroupContent.ts
+++ b/app/shared/hooks/use-group-content/useGroupContent.ts
@@ -90,10 +90,12 @@ export const useGroupContent = (id: string) => {
       };
       setGroupData({
         titlePrefix: fetchedOpus.numberKind ?? 'op',
-        groupNumber: fetchedOpus.number ? String(fetchedOpus.number).replace(/^(op|woo|sineop|wo|bo)[.\-\s]*/i, '') : '',
-        genre: { 
-          uk: fetchedOpus.genre?.uk ?? '', 
-          en: fetchedOpus.genre?.en ?? '' 
+        groupNumber: fetchedOpus.number
+          ? String(fetchedOpus.number).replace(/^(op|woo|sineop|wo|bo)[.\-\s]*/i, '')
+          : '',
+        genre: {
+          uk: fetchedOpus.genre?.uk ?? '',
+          en: fetchedOpus.genre?.en ?? ''
         },
         additionalText: fetchedOpus.additionalText ?? '',
         groupTitle: {
@@ -115,20 +117,23 @@ export const useGroupContent = (id: string) => {
           uk: parseDescription(fetchedOpus.introDescription?.uk),
           en: parseDescription(fetchedOpus.introDescription?.en)
         },
+        blocksOrder: fetchedOpus.blocksOrder?.length
+          ? fetchedOpus.blocksOrder
+          : ['details', 'intro', 'photos', 'works', 'performances'],
         photos: (fetchedOpus.gallery || []).map((photo) => {
           const mappedCrop = photo.crop
             ? ({
-              x: photo.crop.x ?? 0,
-              y: photo.crop.y ?? 0,
-              width: photo.crop.width ?? 0,
-              height: photo.crop.height ?? 0,
-              rect: {
                 x: photo.crop.x ?? 0,
                 y: photo.crop.y ?? 0,
                 width: photo.crop.width ?? 0,
-                height: photo.crop.height ?? 0
-              }
-            } as unknown as GroupPhoto['crop'])
+                height: photo.crop.height ?? 0,
+                rect: {
+                  x: photo.crop.x ?? 0,
+                  y: photo.crop.y ?? 0,
+                  width: photo.crop.width ?? 0,
+                  height: photo.crop.height ?? 0
+                }
+              } as unknown as GroupPhoto['crop'])
             : null;
 
           return {
@@ -202,6 +207,7 @@ export const useGroupContent = (id: string) => {
           uk: groupData.description?.uk ? JSON.stringify(groupData.description.uk) : '""',
           en: groupData.description?.en ? JSON.stringify(groupData.description.en) : '""'
         },
+        blocksOrder: groupData.blocksOrder || ['details', 'intro', 'photos', 'works', 'performances'],
         compositions: (groupData.compositions || []).map((work, index) => ({
           id: work.id,
           name: work.name.trim(),
@@ -287,8 +293,7 @@ export const useGroupContent = (id: string) => {
     } else if (groupTitleUk.length < OPUS_FIELD_LIMITS.name.min) {
       newErrors.groupTitle = OPUS_VALIDATION_MESSAGES.nameTooShort;
       setCurrentLanguage('UA');
-    }
-    else if (!groupTitleEn) {
+    } else if (!groupTitleEn) {
       newErrors.groupTitle = OPUS_VALIDATION_MESSAGES.nameRequired;
       setCurrentLanguage('EN');
     } else if (groupTitleEn.length < OPUS_FIELD_LIMITS.name.min) {
@@ -307,7 +312,7 @@ export const useGroupContent = (id: string) => {
     return Object.keys(newErrors).length === 0;
   };
 
-  const handleFieldChange = (field: GroupDataField, value: unknown, isMultilingual = false) => {
+  const handleFieldChange = (field: GroupDataField | 'blocksOrder', value: unknown, isMultilingual = false) => {
     if (shouldExitAfterSave) return;
     if (errors[field as string]) {
       setErrors((prev) => {

--- a/app/shared/hooks/use-group-content/useGroupContent.ts
+++ b/app/shared/hooks/use-group-content/useGroupContent.ts
@@ -123,17 +123,17 @@ export const useGroupContent = (id: string) => {
         photos: (fetchedOpus.gallery || []).map((photo) => {
           const mappedCrop = photo.crop
             ? ({
+              x: photo.crop.x ?? 0,
+              y: photo.crop.y ?? 0,
+              width: photo.crop.width ?? 0,
+              height: photo.crop.height ?? 0,
+              rect: {
                 x: photo.crop.x ?? 0,
                 y: photo.crop.y ?? 0,
                 width: photo.crop.width ?? 0,
-                height: photo.crop.height ?? 0,
-                rect: {
-                  x: photo.crop.x ?? 0,
-                  y: photo.crop.y ?? 0,
-                  width: photo.crop.width ?? 0,
-                  height: photo.crop.height ?? 0
-                }
-              } as unknown as GroupPhoto['crop'])
+                height: photo.crop.height ?? 0
+              }
+            } as unknown as GroupPhoto['crop'])
             : null;
 
           return {

--- a/app/types/graphql/mutations/opus.graphql
+++ b/app/types/graphql/mutations/opus.graphql
@@ -16,6 +16,7 @@ mutation UpdateOpus($id: ID!, $input: UpdateOpusInput!) {
     id
     number
     numberKind
+    blocksOrder
     title {
       uk
       en

--- a/app/types/graphql/queries/opus.graphql
+++ b/app/types/graphql/queries/opus.graphql
@@ -2,6 +2,7 @@ query OpusById($id: ID!) {
   opusById(id: $id) {
     id
     number
+    blocksOrder
     numberKind
     title {
       uk

--- a/app/types/opus.ts
+++ b/app/types/opus.ts
@@ -72,6 +72,7 @@ export interface FetchedOpusData {
   datesNote?: string | null;
   genre?: { uk?: string | null; en?: string | null } | null;
   status?: OpusStatus | null;
+  blocksOrder?: string[] | null;
   title?: { uk?: string | null; en?: string | null } | null;
   description?: { uk?: string | null; en?: string | null } | null;
   introDescription?: { uk?: string | null; en?: string | null } | null;

--- a/app/types/store/pages/artistry/blocks/artistryQuoteBlock.ts
+++ b/app/types/store/pages/artistry/blocks/artistryQuoteBlock.ts
@@ -1,0 +1,9 @@
+import { JSONContent } from '@tiptap/react';
+
+export interface TitleWithQuoteBlock {
+  title: Record<'uk' | 'en', JSONContent>;
+  quoteText: Record<'uk' | 'en', JSONContent>;
+  sourceText: Record<'uk' | 'en', JSONContent>;
+}
+
+export type ArtystryQuoteBlock = TitleWithQuoteBlock;

--- a/app/types/store/pages/artistry/blocks/musicTableSectionBlock.ts
+++ b/app/types/store/pages/artistry/blocks/musicTableSectionBlock.ts
@@ -1,0 +1,1 @@
+export type MusicTableSectionBlock = Record<string, never>;

--- a/app/types/store/pages/artistry/index.ts
+++ b/app/types/store/pages/artistry/index.ts
@@ -1,0 +1,16 @@
+export * from './blocks/artistryQuoteBlock';
+export * from './blocks/musicTableSectionBlock';
+
+import type { TitleWithQuoteBlock } from './blocks/artistryQuoteBlock';
+import type { MusicTableSectionBlock } from './blocks/musicTableSectionBlock';
+
+export interface ArtistryBlocksMap {
+  TitleWithQuote: TitleWithQuoteBlock;
+  MusicTableSection: MusicTableSectionBlock;
+}
+
+export interface ArtistryPage {
+  pageType: 'ArtistryPage';
+  blocks: ArtistryBlocksMap;
+  blocksOrder: (keyof ArtistryBlocksMap)[];
+}

--- a/app/types/store/pages/index.ts
+++ b/app/types/store/pages/index.ts
@@ -1,4 +1,5 @@
 import type { BlocksMap as AboutUsBlocksMap } from './about-us';
+import type { ArtistryBlocksMap } from './artistry';
 import type { BlocksMap as PrivacyPolicyBlocksMap } from './privacy-policy';
 
-export type BlocksMap = AboutUsBlocksMap & PrivacyPolicyBlocksMap;
+export type BlocksMap = AboutUsBlocksMap & PrivacyPolicyBlocksMap & ArtistryBlocksMap;

--- a/src/domain/entities/Opus.ts
+++ b/src/domain/entities/Opus.ts
@@ -63,6 +63,8 @@ export type Opus = {
 
   createdAt: string;
   updatedAt: string;
+
+  blocksOrder?: string[] | null;
 };
 
 export type OpusFull = Omit<Opus, 'compositions'> & { compositions: Composition[]}

--- a/src/infrastructure/models/draftPage.model.ts
+++ b/src/infrastructure/models/draftPage.model.ts
@@ -17,7 +17,12 @@ const draftPageSchema = new Schema<BasePage>(
       default: PageStatus.Draft
     },
     blocks: { type: Schema.Types.Mixed, required: true },
-    pageType: { type: String, required: true }
+    pageType: { type: String, required: true },
+    blocksOrder: {
+      type: [String],
+      required: true,
+      default: [] 
+    }
   },
   {
     timestamps: true,

--- a/src/infrastructure/models/opus.model.ts
+++ b/src/infrastructure/models/opus.model.ts
@@ -70,6 +70,10 @@ const opusSchema = new Schema(
         videoUrl: { type: String, default: '' },
       }
     ],
+    blocksOrder: {
+      type: [String],
+      default: ['details', 'intro', 'photos', 'works', 'performances']
+    },
     status: {
       type: String,
       enum: Array.from(Object.values(OpusStatus)),

--- a/src/infrastructure/models/page.model.ts
+++ b/src/infrastructure/models/page.model.ts
@@ -53,4 +53,10 @@ const aboutUsDetailsSchema = new Schema({
 export const AboutUsPageModel =
   mongoose.models.AboutUsPage || PageModel.discriminator('AboutUsPage', aboutUsDetailsSchema);
 
+const artistryDetailsSchema = new Schema({
+  blocks: { type: Schema.Types.Mixed, required: true }
+});
+
+export const ArtistryPageModel =
+  mongoose.models.ArtistryPage || PageModel.discriminator('ArtistryPage', artistryDetailsSchema);
 export default PageModel;

--- a/src/infrastructure/repositories/opusRepository/opusRepository.ts
+++ b/src/infrastructure/repositories/opusRepository/opusRepository.ts
@@ -42,6 +42,7 @@ export type DbOpus = {
   gallery?: DbOpusGalleryItem[];
   performancesTitle: Opus['performancesTitle'];
   performances?: DbOpusPerformance[];
+  blocksOrder?: string[] | null;
   keywords: Opus['keywords'];
   allowIndexation: Opus['allowIndexation'];
   coverImage: Opus['coverImage'];
@@ -96,6 +97,7 @@ const toEntity = (doc: DbOpus): Opus =>
         title: perf.title,
         videoUrl: perf.videoUrl
       })) ?? [],
+    blocksOrder: doc.blocksOrder ?? undefined,
     keywords: doc.keywords ?? undefined,
     allowIndexation: doc.allowIndexation ?? undefined,
     coverImage: doc.coverImage ?? undefined,

--- a/src/interfaces/graphql/resolvers/opus/opusMutation.test.ts
+++ b/src/interfaces/graphql/resolvers/opus/opusMutation.test.ts
@@ -255,6 +255,7 @@ describe('OpusMutation Resolvers', () => {
         publishedAt: null,
         meta: { views: 0 },
         compositions: [COMPOSITION_ID_1],
+        blocksOrder: null,
       });
       expect(mockOpusRepo.removeCompositionsFromCompositionsOpus).toHaveBeenCalledWith([
         COMPOSITION_ID_1,

--- a/src/interfaces/graphql/resolvers/opus/opusMutation.test.ts
+++ b/src/interfaces/graphql/resolvers/opus/opusMutation.test.ts
@@ -255,7 +255,7 @@ describe('OpusMutation Resolvers', () => {
         publishedAt: null,
         meta: { views: 0 },
         compositions: [COMPOSITION_ID_1],
-        blocksOrder: null,
+        blocksOrder: null
       });
       expect(mockOpusRepo.removeCompositionsFromCompositionsOpus).toHaveBeenCalledWith([
         COMPOSITION_ID_1,

--- a/src/interfaces/graphql/resolvers/opus/opusMutation.ts
+++ b/src/interfaces/graphql/resolvers/opus/opusMutation.ts
@@ -6,7 +6,14 @@ import { opusServiceErrors } from '~/back-constants/errors';
 import type { GraphQLContext } from '~/back-shared/types/container/types';
 import { graphqlErrors } from '~/constants/errors';
 import { LocalizedBoolean, LocalizedImage, LocalizedString } from '~/domain/entities/BaseContent';
-import type { Opus, OpusDescription, OpusFull, OpusGalleryItem, OpusNumberKind, OpusPerformance } from '~/domain/entities/Opus';
+import type {
+  Opus,
+  OpusDescription,
+  OpusFull,
+  OpusGalleryItem,
+  OpusNumberKind,
+  OpusPerformance
+} from '~/domain/entities/Opus';
 import { CompositionInput, ICompositionRepository } from '~/domain/repositories/compositionRepository';
 import { CreateOpusInput, IOpusRepository, UpdateOpusInput } from '~/domain/repositories/opusRepository';
 import { generateUniqueSlug } from '~/src/shared/utils/slugGenerator/slugGenerator';
@@ -46,6 +53,7 @@ export type CreateOpusGQLInput = {
   coverImage?: LocalizedImage;
   status?: OpusStatus;
   publishedAt?: string;
+  blocksOrder?: string[] | null;
 };
 
 export type UpdateOpusGQLInput = Omit<CreateOpusGQLInput, 'title' | 'description'> & {
@@ -151,10 +159,7 @@ async function updateAndVerifyOpus(repo: IOpusRepository, id: string, updateData
   return opus;
 }
 
-const buildOpusUpdateData = (
-  input: UpdateOpusGQLInput,
-  compositionIds: string[]
-): UpdateOpusInput => {
+const buildOpusUpdateData = (input: UpdateOpusGQLInput, compositionIds: string[]): UpdateOpusInput => {
   const candidate: UpdateOpusInput = {
     number: input.number,
     numberKind: input.numberKind,
@@ -177,7 +182,8 @@ const buildOpusUpdateData = (
     gallery: input.gallery,
     performancesTitle: input.performancesTitle,
     performances: input.performances,
-    compositions: compositionIds
+    compositions: compositionIds,
+    blocksOrder: input.blocksOrder
   };
   return Object.fromEntries(Object.entries(candidate).filter(([, value]) => value !== undefined)) as UpdateOpusInput;
 };
@@ -206,9 +212,7 @@ export const OpusMutation = {
       checkExists: async (candidate: string) => (await repo.findBySlug(candidate)) !== null
     });
 
-    const compositions = await compositionsRepo.syncForOpus(
-      (input.compositions ?? []).map(mapComposition)
-    );
+    const compositions = await compositionsRepo.syncForOpus((input.compositions ?? []).map(mapComposition));
     const compositionIds = compositions.map((c) => c.id);
 
     const opusData: CreateOpusInput = {
@@ -232,7 +236,8 @@ export const OpusMutation = {
       status: input.status || OpusStatus.Draft,
       publishedAt: input.publishedAt ?? null,
       meta: { views: 0 },
-      compositions: compositionIds
+      compositions: compositionIds,
+      blocksOrder: input.blocksOrder ?? null
     };
 
     const opus = await repo.create(opusData);
@@ -277,8 +282,11 @@ export const OpusMutation = {
   updateOpus: async (_: unknown, { id, input }: UpdateOpusArgs, context: GraphQLContext): Promise<OpusFull> => {
     assertAuthenticated(context);
 
-    const { opusRepository: repo, compositionsRepository: compositionsRepo, assetsRepository: assetsRepo } =
-      context.requestContainer.cradle;
+    const {
+      opusRepository: repo,
+      compositionsRepository: compositionsRepo,
+      assetsRepository: assetsRepo
+    } = context.requestContainer.cradle;
 
     const existingOpus = await findExistingOpus(repo, id);
 
@@ -286,7 +294,10 @@ export const OpusMutation = {
 
     const compositions = await handleCompositionsSync(compositionsRepo, repo, existingOpus, input.compositions);
 
-    const updateData = buildOpusUpdateData(input, compositions.map((c) => c.id));
+    const updateData = buildOpusUpdateData(
+      input,
+      compositions.map((c) => c.id)
+    );
 
     await processSlugUpdate(id, input.name, repo, updateData);
 

--- a/src/interfaces/graphql/schemas/opus.graphql
+++ b/src/interfaces/graphql/schemas/opus.graphql
@@ -41,6 +41,7 @@ type OpusPerformance {
 type Opus {
   id: ID!
   number: Float!
+  blocksOrder: [String]
   numberKind: OpusNumberKind!
   title: LocalizedString!
   name: LocalizedString!
@@ -116,6 +117,7 @@ input CreateOpusInput {
   coverImage: JSON
   status: OpusStatus
   publishedAt: String
+  blocksOrder: [String]
 }
 
 input UpdateOpusInput {
@@ -141,6 +143,7 @@ input UpdateOpusInput {
   coverImage: JSON
   status: OpusStatus
   publishedAt: String
+  blocksOrder: [String]
 }
 
 type UpdateOpusStatusPayload {


### PR DESCRIPTION
## Description

Implemented the management UI for the "Artistry" page. Created a new Mongoose schema with an `ArtistryPage` discriminator and added editable blocks: `TitleWithQuote` (for TipTap text fields) and `MusicTableSection`. Configured DnD reordering with strict layout locking for the first block. Written unit tests with 100% coverage.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: 

## How to test

> !!! **Cross-repository Dependency:** Merge and deploy this PR **after** the client PR.

1. Run the admin panel locally (`npm run dev`) and navigate to the "Artistry" page.
2. Verify that `TitleWithQuote` and `MusicTableSection` edit blocks work correctly.
3. Try reordering blocks via Drag & Drop and ensure the first block remains locked at index 0.
4. Run tests to verify 100% coverage: `npx jest artistry`

## Video / Screenshots

<img width="773" height="459" alt="image" src="https://github.com/user-attachments/assets/3aa8ab0e-c37b-49ee-a776-92057765d53a" />

<img width="760" height="610" alt="image" src="https://github.com/user-attachments/assets/da78840f-6275-4afd-bc68-b81be06801d3" />

<img width="675" height="175" alt="image" src="https://github.com/user-attachments/assets/c3b111ca-229b-420a-9cff-0ecbe588b02f" />

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---