### PR TITLE
fix(auth): verify reset token via use-case instead of self-fetch to /api/graphql

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -4,13 +4,10 @@ import svgr from 'vite-plugin-svgr';
 
 const config: StorybookConfig = {
   stories: ['../app/**/*.stories.@(ts|tsx)'],
-  addons: [
-    '@storybook/addon-essentials',
-    '@storybook/addon-interactions',
-  ],
+  addons: ['@storybook/addon-essentials', '@storybook/addon-interactions'],
   framework: {
     name: '@storybook/react-vite',
-    options: {},
+    options: {}
   },
   staticDirs: ['../public'],
   viteFinal: async (config) => {
@@ -21,7 +18,7 @@ const config: StorybookConfig = {
     config.esbuild = {
       ...(typeof config.esbuild === 'object' ? config.esbuild : {}),
       jsx: 'automatic',
-      jsxImportSource: 'react',
+      jsxImportSource: 'react'
     };
 
     config.optimizeDeps = config.optimizeDeps || {};
@@ -35,6 +32,7 @@ const config: StorybookConfig = {
     config.resolve = config.resolve || {};
     config.resolve.alias = {
       ...config.resolve.alias,
+      '~/container/index': path.resolve(__dirname, './mocks/container.ts'),
       '~/src': path.resolve(__dirname, '../src'),
       '~/ds-components': path.resolve(__dirname, '../app/shared/components/design-system'),
       '~/components': path.resolve(__dirname, '../app/shared/components'),
@@ -48,7 +46,7 @@ const config: StorybookConfig = {
       'next/image': path.resolve(__dirname, './mocks/next-image.tsx'),
       'next/link': path.resolve(__dirname, './mocks/next-link.tsx'),
       'next/navigation': path.resolve(__dirname, './mocks/next-navigation.ts'),
-      '~': path.resolve(__dirname, '../app'),
+      '~': path.resolve(__dirname, '../app')
     };
 
     config.plugins = config.plugins || [];
@@ -58,7 +56,9 @@ const config: StorybookConfig = {
     config.build.chunkSizeWarningLimit = 1000;
     config.build.rollupOptions = config.build.rollupOptions || {};
     config.build.rollupOptions.onwarn = (warning, warn) => {
-      const isSourcemapReportingWarning = typeof warning.message === 'string' && warning.message.includes('Error when using sourcemap for reporting an error');
+      const isSourcemapReportingWarning =
+        typeof warning.message === 'string' &&
+        warning.message.includes('Error when using sourcemap for reporting an error');
       const isModuleDirectiveWarning =
         warning.code === 'MODULE_LEVEL_DIRECTIVE' &&
         typeof warning.id === 'string' &&
@@ -67,7 +67,8 @@ const config: StorybookConfig = {
           warning.id.includes('/node_modules/lucide-react/') ||
           warning.id.includes('/app/'));
 
-      const isStorybookEvalWarning = warning.code === 'EVAL' && typeof warning.id === 'string' && warning.id.includes('/node_modules/@storybook/');
+      const isStorybookEvalWarning =
+        warning.code === 'EVAL' && typeof warning.id === 'string' && warning.id.includes('/node_modules/@storybook/');
 
       if (isSourcemapReportingWarning || isModuleDirectiveWarning || isStorybookEvalWarning) {
         return;
@@ -84,11 +85,11 @@ const config: StorybookConfig = {
     return config;
   },
   typescript: {
-    reactDocgen: 'react-docgen-typescript',
+    reactDocgen: 'react-docgen-typescript'
   },
   docs: {
-    autodocs: 'tag',
-  },
+    autodocs: 'tag'
+  }
 };
 
 export default config;

--- a/.storybook/mocks/container.ts
+++ b/.storybook/mocks/container.ts
@@ -1,0 +1,14 @@
+import { fn } from '@storybook/test';
+
+export const mockExecute = fn();
+
+export function resetContainerMock() {
+  mockExecute.mockReset();
+  mockExecute.mockResolvedValue(true);
+}
+
+export function createRootContainer() {
+  return {
+    resolve: () => ({ execute: mockExecute })
+  };
+}

--- a/app/reset-password/page.stories.tsx
+++ b/app/reset-password/page.stories.tsx
@@ -1,14 +1,18 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { expect, userEvent, within } from '@storybook/test';
+import { expect, fn, userEvent, within } from '@storybook/test';
 import { graphql, HttpResponse } from 'msw';
 
 import { getRouter } from '../../.storybook/mocks/next-navigation';
 import { withMswHandlers } from '../../.storybook/msw';
 import ResetPasswordPage from './page';
 
-const verifyTokenHandler = graphql.query('VerifyResetToken', () =>
-  HttpResponse.json({ data: { verifyResetToken: true } })
-);
+const mockExecute = fn();
+
+jest.mock('~/container/index', () => ({
+  createRootContainer: jest.fn(() => ({
+    resolve: jest.fn(() => ({ execute: mockExecute }))
+  }))
+}));
 
 const meta = {
   title: 'Pages/ResetPasswordPage',
@@ -18,8 +22,11 @@ const meta = {
   },
   parameters: {
     layout: 'fullscreen',
-    nextNavigation: { pathname: '/reset-password' },
-    ...withMswHandlers(verifyTokenHandler)
+    nextNavigation: { pathname: '/reset-password' }
+  },
+  beforeEach: () => {
+    mockExecute.mockReset();
+    mockExecute.mockResolvedValue(true);
   }
 } satisfies Meta<typeof ResetPasswordPage>;
 
@@ -29,7 +36,7 @@ type Story = StoryObj<typeof meta>;
 async function fillResetForm(canvasElement: HTMLElement, pass1: string, pass2: string) {
   const canvas = within(canvasElement);
   await userEvent.type(await canvas.findByLabelText(/^Новий пароль/i), pass1);
-  await userEvent.type(await canvas.findByLabelText(/Повторіть пароль/i), pass2); // було: /Підтвердження паролю/i
+  await userEvent.type(await canvas.findByLabelText(/Повторіть пароль/i), pass2);
   await userEvent.click(await canvas.findByRole('button', { name: /Змінити пароль/i }));
   return canvas;
 }
@@ -39,7 +46,6 @@ export const Default: Story = {};
 export const SuccessfulReset: Story = {
   parameters: {
     ...withMswHandlers(
-      verifyTokenHandler,
       graphql.mutation('ResetPassword', () =>
         HttpResponse.json({
           data: {
@@ -60,9 +66,6 @@ export const SuccessfulReset: Story = {
 };
 
 export const PasswordMismatch: Story = {
-  parameters: {
-    ...withMswHandlers(verifyTokenHandler)
-  },
   async play({ canvasElement }) {
     await fillResetForm(canvasElement, 'Pass123456!', 'WrongPass!');
     await expect(await within(canvasElement).findByText(/Паролі не збігаються/i)).toBeInTheDocument();

--- a/app/reset-password/page.stories.tsx
+++ b/app/reset-password/page.stories.tsx
@@ -1,18 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { expect, fn, userEvent, within } from '@storybook/test';
+import { expect, userEvent, within } from '@storybook/test';
 import { graphql, HttpResponse } from 'msw';
 
+import { resetContainerMock } from '../../.storybook/mocks/container';
 import { getRouter } from '../../.storybook/mocks/next-navigation';
 import { withMswHandlers } from '../../.storybook/msw';
 import ResetPasswordPage from './page';
-
-const mockExecute = fn();
-
-jest.mock('~/container/index', () => ({
-  createRootContainer: jest.fn(() => ({
-    resolve: jest.fn(() => ({ execute: mockExecute }))
-  }))
-}));
 
 const meta = {
   title: 'Pages/ResetPasswordPage',
@@ -25,8 +18,7 @@ const meta = {
     nextNavigation: { pathname: '/reset-password' }
   },
   beforeEach: () => {
-    mockExecute.mockReset();
-    mockExecute.mockResolvedValue(true);
+    resetContainerMock();
   }
 } satisfies Meta<typeof ResetPasswordPage>;
 

--- a/app/reset-password/page.test.tsx
+++ b/app/reset-password/page.test.tsx
@@ -23,7 +23,7 @@ jest.mock('~/shared/components/auth-card/AuthCardLayout', () => ({
 
 const mockExecute = jest.fn();
 
-jest.mock('~/container/index', () => ({
+jest.mock('../../src/container', () => ({
   createRootContainer: jest.fn(() => ({
     resolve: jest.fn(() => ({ execute: mockExecute }))
   }))

--- a/app/reset-password/page.test.tsx
+++ b/app/reset-password/page.test.tsx
@@ -21,15 +21,17 @@ jest.mock('~/shared/components/auth-card/AuthCardLayout', () => ({
   }
 }));
 
-const mockFetch = (verifyResult: boolean) => {
-  globalThis.fetch = jest.fn().mockResolvedValue({
-    json: () => Promise.resolve({ data: { verifyResetToken: verifyResult } })
-  });
-};
+const mockExecute = jest.fn();
+
+jest.mock('~/container/index', () => ({
+  createRootContainer: jest.fn(() => ({
+    resolve: jest.fn(() => ({ execute: mockExecute }))
+  }))
+}));
 
 describe('ResetPasswordPage (Server Component)', () => {
   afterEach(() => {
-    jest.restoreAllMocks();
+    jest.clearAllMocks();
   });
 
   it('renders error if no token is provided', async () => {
@@ -41,7 +43,7 @@ describe('ResetPasswordPage (Server Component)', () => {
   });
 
   it('renders the form when token is valid', async () => {
-    mockFetch(true);
+    mockExecute.mockResolvedValue(true);
     const UI = await ResetPasswordPage({ searchParams: Promise.resolve({ token: 'valid-token-123' }) });
     render(UI);
 
@@ -49,7 +51,7 @@ describe('ResetPasswordPage (Server Component)', () => {
   });
 
   it('renders error if token is expired or already used', async () => {
-    mockFetch(false);
+    mockExecute.mockResolvedValue(false);
     const UI = await ResetPasswordPage({ searchParams: Promise.resolve({ token: 'expired-token' }) });
     render(UI);
 
@@ -57,8 +59,8 @@ describe('ResetPasswordPage (Server Component)', () => {
     expect(screen.getByText(/Посилання для відновлення пароля вже було використано/i)).toBeInTheDocument();
   });
 
-  it('renders error if fetch throws', async () => {
-    globalThis.fetch = jest.fn().mockRejectedValue(new Error('Network error'));
+  it('renders error if use case throws', async () => {
+    mockExecute.mockRejectedValue(new Error('DB error'));
     const UI = await ResetPasswordPage({ searchParams: Promise.resolve({ token: 'some-token' }) });
     render(UI);
 

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -1,6 +1,7 @@
 import { Typography } from '@mui/material';
 import React from 'react';
 
+import { createRootContainer } from '~/container/index';
 import { AuthCardLayout } from '~/shared/components/auth-card/AuthCardLayout';
 import ResetPasswordForm from '~/shared/components/reset-password-form/ResetPasswordForm';
 
@@ -10,18 +11,9 @@ type ResetPasswordPageProps = {
 
 async function verifyToken(token: string): Promise<boolean> {
   try {
-    const appUrl = process.env.NEXT_PUBLIC_CLIENT_BASE_URL ?? 'http://localhost:3000';
-    const res = await fetch(`${appUrl}/api/graphql`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        query: 'query VerifyResetToken($token: String!) { verifyResetToken(token: $token) }',
-        variables: { token }
-      }),
-      cache: 'no-store'
-    });
-    const json = await res.json();
-    return json?.data?.verifyResetToken === true;
+    const container = createRootContainer();
+    const verifyResetTokenUseCase = container.resolve('verifyResetTokenUseCase');
+    return await verifyResetTokenUseCase.execute(token);
   } catch {
     return false;
   }


### PR DESCRIPTION
## Description
Refactored the token verification logic in the reset password page. Replaced the direct self-fetching HTTP request to `/api/graphql` with an invocation of `verifyResetTokenUseCase` via the root dependency injection container. This fixes an issue where password resetting worked on the staging environment but failed in production due to network/routing restrictions on direct internal API self-fetches.


## Type of change

- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Go to the password reset page with a valid token parameters (`/reset-password?token=YOUR_TOKEN`).
2. Verify that the system validates the token and correctly renders the change password form.



Closes: https://github.com/Liatoshynsky-Foundation/lf-admin/issues/703
