### PR TITLE
fix: fix publication actions

### DIFF
--- a/app/(logged_in)/publications/[type]/[id]/edit/page.test.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/edit/page.test.tsx
@@ -6,7 +6,7 @@ import toast from 'react-hot-toast';
 
 import { EditPublicationsViewProps } from './EditPublicationsView';
 import EditPublicationsPage from './page';
-import { CONTENT_MUTATION_RESULTS, LocalizedEditorState, MenuActionId } from '~/constants/publications';
+import { CONTENT_MUTATION_RESULTS, LocalizedEditorState, MENU_ACTION_CONFIGS, MenuActionId } from '~/constants/publications';
 import { SerializedContent } from '~/shared/components/content-editor';
 import { usePublicationManager } from '~/shared/hooks/use-publications-manager/usePublicationsManager';
 import { useUpsertPublication } from '~/shared/hooks/use-upsert-publication/useUpsertPublication';
@@ -45,8 +45,8 @@ const baseMockManager = {
   setCurrentLanguage: jest.fn(),
   editorResetKey: 0,
   resetEditorState: jest.fn(),
-  updateResource: jest.fn().mockResolvedValue({ data: { id: '1' } }),
-  deleteResource: jest.fn().mockResolvedValue({ data: { id: '1' } })
+  updateResource: jest.fn(),
+  deleteResource: jest.fn()
 };
 
 jest.mock('./EditPublicationsView', () => ({
@@ -83,7 +83,8 @@ describe('EditPublicationsPage Container', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-
+    baseMockManager.updateResource.mockResolvedValue({ data: { id: '1' } });
+    baseMockManager.deleteResource.mockResolvedValue({ data: { id: '1' } });
     (useParams as jest.Mock).mockReturnValue({ type: 'news', id: '123' });
     (useRouter as jest.Mock).mockReturnValue({ push: mockPush });
     (usePublicationManager as jest.Mock).mockReturnValue(baseMockManager);
@@ -174,7 +175,7 @@ describe('EditPublicationsPage Container', () => {
     });
   });
 
-  it('should handle delete confirmation by deleting the publication and redirecting', async () => {
+  it('should handle DELETE action confirmation by deleting the publication and redirecting', async () => {
     render(<EditPublicationsPage />);
 
     fireEvent.click(screen.getByTestId('trigger-delete'));
@@ -186,25 +187,55 @@ describe('EditPublicationsPage Container', () => {
     });
   });
 
-  it('should catch mutation errors and trigger a toast.error', async () => {
-    const errorMessage = 'Network Failure';
-    (usePublicationManager as jest.Mock).mockReturnValue({
-      ...baseMockManager,
-      updateResource: jest.fn().mockRejectedValue(new Error(errorMessage))
+  describe('when manager action handlers return data as null', () => {
+    it('should trigger toast.error and not call mockPush when PUBLISH returns data null', async () => {
+      baseMockManager.updateResource.mockResolvedValue({ data: null });
+
+      render(<EditPublicationsPage />);
+      fireEvent.click(screen.getByTestId('trigger-publish'));
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith(MENU_ACTION_CONFIGS.PUBLISH.toastErrorMessage);
+        expect(mockPush).not.toHaveBeenCalled();
+      });
     });
 
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    it('should trigger toast.error and not call mockPush when PUBLICATE_AND_EXIT returns data null', async () => {
+      baseMockManager.updateResource.mockResolvedValue({ data: null });
 
-    render(<EditPublicationsPage />);
+      render(<EditPublicationsPage />);
+      fireEvent.click(screen.getByTestId('trigger-save-exit'));
 
-    fireEvent.click(screen.getByTestId('trigger-publish'));
-
-    await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith(`Помилка: ${errorMessage}`);
-      expect(consoleSpy).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith(MENU_ACTION_CONFIGS.PUBLICATE_AND_EXIT.toastErrorMessage);
+        expect(mockPush).not.toHaveBeenCalled();
+      });
     });
 
-    consoleSpy.mockRestore();
+    it('should trigger toast.error and not call mockPush when CANCEL_PUBLICATION returns data null', async () => {
+      baseMockManager.updateResource.mockResolvedValue({ data: null });
+
+      render(<EditPublicationsPage />);
+      fireEvent.click(screen.getByTestId('trigger-cancel-publication'));
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith(MENU_ACTION_CONFIGS.CANCEL_PUBLICATION.toastErrorMessage);
+        expect(mockPush).not.toHaveBeenCalled();
+      });
+    });
+
+    it('should trigger toast.error and not call mockPush when DELETE returns data null', async () => {
+      baseMockManager.deleteResource.mockResolvedValue({ data: null });
+
+      render(<EditPublicationsPage />);
+      fireEvent.click(screen.getByTestId('trigger-delete'));
+
+      await waitFor(() => {
+        expect(baseMockManager.deleteResource).toHaveBeenCalledTimes(1);
+        expect(toast.error).toHaveBeenCalledWith('Виникла помилка при видаленні публікації. Спробуйте ще раз.');
+        expect(mockPush).not.toHaveBeenCalled();
+      });
+    });
   });
 
   it('should handle CANCEL_PUBLICATION action, show toast success and redirect', async () => {

--- a/app/(logged_in)/publications/[type]/[id]/edit/page.test.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/edit/page.test.tsx
@@ -156,7 +156,7 @@ describe('EditPublicationsPage Container', () => {
       expect(baseMockManager.updateResource).toHaveBeenCalledWith(BaseContentStatuses.Published, {
         content: baseMockManager.editedContent
       });
-      expect(toast.success).toHaveBeenCalledWith(CONTENT_MUTATION_RESULTS.draftPublished);
+      expect(toast.success).toHaveBeenCalledWith(CONTENT_MUTATION_RESULTS.publicationPublished);
     });
   });
 
@@ -166,10 +166,10 @@ describe('EditPublicationsPage Container', () => {
     fireEvent.click(screen.getByTestId('trigger-save-exit'));
 
     await waitFor(() => {
-      expect(baseMockManager.updateResource).toHaveBeenCalledWith(BaseContentStatuses.Draft, {
+      expect(baseMockManager.updateResource).toHaveBeenCalledWith(BaseContentStatuses.Published, {
         content: baseMockManager.editedContent
       });
-      expect(toast.success).toHaveBeenCalledWith(CONTENT_MUTATION_RESULTS.draftSaved);
+      expect(toast.success).toHaveBeenCalledWith(CONTENT_MUTATION_RESULTS.publicationPublished);
       expect(mockPush).toHaveBeenCalledWith('/publications');
     });
   });

--- a/app/(logged_in)/publications/[type]/[id]/edit/page.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/edit/page.tsx
@@ -8,6 +8,7 @@ import CreatePublicationsView from '../../create/CreatePublicationsView';
 import { EditPublicationsView } from './EditPublicationsView';
 import {
   CONTENT_MUTATION_RESULTS,
+  MENU_ACTION_CONFIGS,
   MenuActionId,
   PUBLICATIONS_BASE_PATH,
   PublicationsItemType
@@ -17,7 +18,6 @@ import { useNavigationGuard } from '~/shared/hooks/use-navigation-guard/useNavig
 import { usePublicationManager } from '~/shared/hooks/use-publications-manager/usePublicationsManager';
 import { useUnsavedChanges } from '~/shared/hooks/use-unsaved-changes/useUnsavedChanges';
 import { useUpsertPublication } from '~/shared/hooks/use-upsert-publication/useUpsertPublication';
-import { BaseContentStatuses } from '~/types/enums/common.enums';
 
 type Params = {
   type: PublicationsItemType;
@@ -70,15 +70,19 @@ export default function EditPublicationsPage() {
     try {
       switch (actionId) {
       case MenuActionId.PUBLISH: {
-        const { data } = await manager.updateResource(BaseContentStatuses.Published, contentPayload);
-        if (data) toast.success(CONTENT_MUTATION_RESULTS.publicationPublished);
+        const { status, toastMessage } = MENU_ACTION_CONFIGS.PUBLISH;
+
+        const { data } = await manager.updateResource(status, contentPayload);
+        if (data) toast.success(toastMessage);
         break;
       }
 
       case MenuActionId.PUBLICATE_AND_EXIT: {
-        const { data } = await manager.updateResource(BaseContentStatuses.Published, contentPayload);
+        const { status, toastMessage } = MENU_ACTION_CONFIGS.PUBLICATE_AND_EXIT;
+
+        const { data } = await manager.updateResource(status, contentPayload);
         if (data) {
-          toast.success(CONTENT_MUTATION_RESULTS.publicationPublished);
+          toast.success(toastMessage);
           router.push(PUBLICATIONS_BASE_PATH);
         }
         break;
@@ -94,9 +98,11 @@ export default function EditPublicationsPage() {
       }
 
       case MenuActionId.CANCEL_PUBLICATION: {
-        const { data } = await manager.updateResource(BaseContentStatuses.Draft, contentPayload);
+        const { status, toastMessage } = MENU_ACTION_CONFIGS.CANCEL_PUBLICATION;
+
+        const { data } = await manager.updateResource(status, contentPayload);
         if (data) {
-          toast.success(CONTENT_MUTATION_RESULTS.publicationUnpublished);
+          toast.success(toastMessage);
           router.push(PUBLICATIONS_BASE_PATH);
         }
         break;

--- a/app/(logged_in)/publications/[type]/[id]/edit/page.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/edit/page.tsx
@@ -70,20 +70,26 @@ export default function EditPublicationsPage() {
     try {
       switch (actionId) {
       case MenuActionId.PUBLISH: {
-        const { status, toastMessage } = MENU_ACTION_CONFIGS.PUBLISH;
+        const { status, toastMessage, toastErrorMessage } = MENU_ACTION_CONFIGS.PUBLISH;
 
         const { data } = await manager.updateResource(status, contentPayload);
-        if (data) toast.success(toastMessage);
+        if (data) {
+          toast.success(toastMessage);
+        } else {
+          toast.error(toastErrorMessage);
+        }
         break;
       }
 
       case MenuActionId.PUBLICATE_AND_EXIT: {
-        const { status, toastMessage } = MENU_ACTION_CONFIGS.PUBLICATE_AND_EXIT;
+        const { status, toastMessage, toastErrorMessage } = MENU_ACTION_CONFIGS.PUBLICATE_AND_EXIT;
 
         const { data } = await manager.updateResource(status, contentPayload);
         if (data) {
           toast.success(toastMessage);
           router.push(PUBLICATIONS_BASE_PATH);
+        } else {
+          toast.error(toastErrorMessage);
         }
         break;
       }
@@ -93,17 +99,21 @@ export default function EditPublicationsPage() {
         if (data) {
           toast.success(CONTENT_MUTATION_RESULTS.publicationDeleted);
           router.push(PUBLICATIONS_BASE_PATH);
+        } else {
+          toast.error('Виникла помилка при видаленні публікації. Спробуйте ще раз.');
         }
         break;
       }
 
       case MenuActionId.CANCEL_PUBLICATION: {
-        const { status, toastMessage } = MENU_ACTION_CONFIGS.CANCEL_PUBLICATION;
+        const { status, toastMessage, toastErrorMessage } = MENU_ACTION_CONFIGS.CANCEL_PUBLICATION;
 
         const { data } = await manager.updateResource(status, contentPayload);
         if (data) {
           toast.success(toastMessage);
           router.push(PUBLICATIONS_BASE_PATH);
+        } else {
+          toast.error(toastErrorMessage);
         }
         break;
       }

--- a/app/(logged_in)/publications/[type]/[id]/edit/page.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/edit/page.tsx
@@ -71,14 +71,14 @@ export default function EditPublicationsPage() {
       switch (actionId) {
       case MenuActionId.PUBLISH: {
         const { data } = await manager.updateResource(BaseContentStatuses.Published, contentPayload);
-        if (data) toast.success(CONTENT_MUTATION_RESULTS.draftPublished);
+        if (data) toast.success(CONTENT_MUTATION_RESULTS.publicationPublished);
         break;
       }
 
       case MenuActionId.PUBLICATE_AND_EXIT: {
-        const { data } = await manager.updateResource(BaseContentStatuses.Draft, contentPayload);
+        const { data } = await manager.updateResource(BaseContentStatuses.Published, contentPayload);
         if (data) {
-          toast.success(CONTENT_MUTATION_RESULTS.draftSaved);
+          toast.success(CONTENT_MUTATION_RESULTS.publicationPublished);
           router.push(PUBLICATIONS_BASE_PATH);
         }
         break;

--- a/app/(logged_in)/publications/[type]/[id]/edit/page.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/edit/page.tsx
@@ -64,59 +64,40 @@ export default function EditPublicationsPage() {
     }, 500);
   };
 
+  const performUpdateAction = async (actionId: keyof typeof MENU_ACTION_CONFIGS) => {
+    const { status, toastMessage, toastErrorMessage } = MENU_ACTION_CONFIGS[actionId];
+    const { data } = await manager.updateResource(status, { content: manager.editedContent });
+    return { data, toastMessage, toastErrorMessage };
+  };
+
+  const performDeleteAction = async () => {
+    const { data } = await manager.deleteResource();
+    return {
+      data,
+      toastMessage: CONTENT_MUTATION_RESULTS.publicationDeleted,
+      toastErrorMessage: 'Виникла помилка при видаленні публікації. Спробуйте ще раз.',
+    };
+  };
+
+  const NAVIGATE_AFTER_ACTIONS = new Set<MenuActionId>([
+    MenuActionId.PUBLICATE_AND_EXIT,
+    MenuActionId.DELETE,
+    MenuActionId.CANCEL_PUBLICATION,
+  ]);
+
   const handleMenuAction = async (actionId: MenuActionId) => {
-    const contentPayload = { content: manager.editedContent };
-
     try {
-      switch (actionId) {
-      case MenuActionId.PUBLISH: {
-        const { status, toastMessage, toastErrorMessage } = MENU_ACTION_CONFIGS.PUBLISH;
+      const { data, toastErrorMessage, toastMessage } = actionId === MenuActionId.DELETE ? await performDeleteAction() : await performUpdateAction(actionId);
 
-        const { data } = await manager.updateResource(status, contentPayload);
-        if (data) {
-          toast.success(toastMessage);
-        } else {
-          toast.error(toastErrorMessage);
-        }
-        break;
+      if (!data) {
+        toast.error(toastErrorMessage);
+        return;
       }
 
-      case MenuActionId.PUBLICATE_AND_EXIT: {
-        const { status, toastMessage, toastErrorMessage } = MENU_ACTION_CONFIGS.PUBLICATE_AND_EXIT;
-
-        const { data } = await manager.updateResource(status, contentPayload);
-        if (data) {
-          toast.success(toastMessage);
-          router.push(PUBLICATIONS_BASE_PATH);
-        } else {
-          toast.error(toastErrorMessage);
-        }
-        break;
-      }
-
-      case MenuActionId.DELETE: {
-        const { data } = await manager.deleteResource();
-        if (data) {
-          toast.success(CONTENT_MUTATION_RESULTS.publicationDeleted);
-          router.push(PUBLICATIONS_BASE_PATH);
-        } else {
-          toast.error('Виникла помилка при видаленні публікації. Спробуйте ще раз.');
-        }
-        break;
-      }
-
-      case MenuActionId.CANCEL_PUBLICATION: {
-        const { status, toastMessage, toastErrorMessage } = MENU_ACTION_CONFIGS.CANCEL_PUBLICATION;
-
-        const { data } = await manager.updateResource(status, contentPayload);
-        if (data) {
-          toast.success(toastMessage);
-          router.push(PUBLICATIONS_BASE_PATH);
-        } else {
-          toast.error(toastErrorMessage);
-        }
-        break;
-      }
+      toast.success(toastMessage);
+      
+      if (NAVIGATE_AFTER_ACTIONS.has(actionId)) {
+        router.push(PUBLICATIONS_BASE_PATH);
       }
     } catch (err) {
       toast.error(`Помилка: ${err instanceof Error ? err.message : String(err)}`);

--- a/app/(logged_in)/publications/[type]/[id]/seo/page.test.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/seo/page.test.tsx
@@ -1,11 +1,11 @@
 import { Box, Button, Menu, MenuItem } from '@mui/material';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { notFound, useParams, useRouter } from 'next/navigation';
 import React, { MouseEvent, ReactNode } from 'react';
 import toast from 'react-hot-toast';
 
 import PublicatiosSeoPage from './page';
-import { CONTENT_MUTATION_RESULTS, PUBLICATIONS_BASE_PATH } from '~/constants/publications';
+import { CONTENT_MUTATION_RESULTS, MENU_ACTION_CONFIGS, PUBLICATIONS_BASE_PATH } from '~/constants/publications';
 import { ActionMenuGroups, MenuGroup } from '~/shared/components/dropdown-menu/ActionMenu';
 import { useUpsertPublication } from '~/shared/hooks/use-upsert-publication/useUpsertPublication';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
@@ -113,6 +113,7 @@ describe('PublicatiosSeoPage Container', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockHandleSave.mockResolvedValue('123');
     (useRouter as jest.Mock).mockReturnValue({ push: mockPush });
     (useUpsertPublication as jest.Mock).mockReturnValue({
       handleSave: mockHandleSave
@@ -136,29 +137,35 @@ describe('PublicatiosSeoPage Container', () => {
       expect(screen.getByTestId('mock-title-dropdown')).toHaveTextContent('Редагування Новини');
     });
 
-    it('should show publicationPublished toast when publish is triggered', () => {
+    it('should show publicationPublished toast when publish is triggered', async () => {
       fireEvent.click(screen.getByTestId('btn-publish'));
 
-      expect(mockHandleSave).toHaveBeenCalledWith(BaseContentStatuses.Published);
-      expect(toast.success).toHaveBeenCalledWith(CONTENT_MUTATION_RESULTS.publicationPublished);
+      await waitFor(() => {
+        expect(mockHandleSave).toHaveBeenCalledWith(BaseContentStatuses.Published);
+        expect(toast.success).toHaveBeenCalledWith(CONTENT_MUTATION_RESULTS.publicationPublished);
+      });
     });
 
-    it('should show publicationPublished toast and redirect on publish and exit', () => {
+    it('should show publicationPublished toast and redirect on publish and exit', async () => {
       fireEvent.click(screen.getByTestId('btn-open-publish-menu'));
       fireEvent.click(screen.getByText('Опублікувати і вийти'));
 
-      expect(mockHandleSave).toHaveBeenCalledWith(BaseContentStatuses.Published);
-      expect(toast.success).toHaveBeenCalledWith(CONTENT_MUTATION_RESULTS.publicationPublished);
-      expect(mockPush).toHaveBeenCalledWith(PUBLICATIONS_BASE_PATH);
+      await waitFor(() => {
+        expect(mockHandleSave).toHaveBeenCalledWith(BaseContentStatuses.Published);
+        expect(toast.success).toHaveBeenCalledWith(CONTENT_MUTATION_RESULTS.publicationPublished);
+        expect(mockPush).toHaveBeenCalledWith(PUBLICATIONS_BASE_PATH);
+      });
     });
 
-    it('should handle unpublish action from publication menu', () => {
+    it('should handle unpublish action from publication menu', async () => {
       fireEvent.click(screen.getByTestId('btn-open-publish-menu'));
       fireEvent.click(screen.getByText('Скасувати публікацію'));
 
-      expect(mockHandleSave).toHaveBeenCalledWith(BaseContentStatuses.Draft);
-      expect(toast.success).toHaveBeenCalledWith(CONTENT_MUTATION_RESULTS.publicationUnpublished);
-      expect(mockPush).toHaveBeenCalledWith(PUBLICATIONS_BASE_PATH);
+      await waitFor(() => {
+        expect(mockHandleSave).toHaveBeenCalledWith(BaseContentStatuses.Draft);
+        expect(toast.success).toHaveBeenCalledWith(CONTENT_MUTATION_RESULTS.publicationUnpublished);
+        expect(mockPush).toHaveBeenCalledWith(PUBLICATIONS_BASE_PATH);
+      });
     });
 
     it('should redirect to edit page when editing content from navigation menu', () => {
@@ -179,8 +186,50 @@ describe('PublicatiosSeoPage Container', () => {
 
       expect(screen.queryByRole('menu')).not.toBeInTheDocument();
     });
-  });
 
+  });
+  describe('when handleSave returns undefined', () => {
+    it.each([
+      {
+        name: 'publish',
+        trigger: () => fireEvent.click(screen.getByTestId('btn-publish')),
+        status: BaseContentStatuses.Published,
+        errorToast: MENU_ACTION_CONFIGS.PUBLISH.toastErrorMessage
+      },
+      {
+        name: 'publish and exit',
+        trigger: () => {
+          fireEvent.click(screen.getByTestId('btn-open-publish-menu'));
+          fireEvent.click(screen.getByText('Опублікувати і вийти'));
+        },
+        status: BaseContentStatuses.Published,
+        errorToast: MENU_ACTION_CONFIGS.PUBLICATE_AND_EXIT.toastErrorMessage
+      },
+      {
+        name: 'cancel publication',
+        trigger: () => {
+          fireEvent.click(screen.getByTestId('btn-open-publish-menu'));
+          fireEvent.click(screen.getByText('Скасувати публікацію'));
+        },
+        status: BaseContentStatuses.Draft,
+        errorToast: MENU_ACTION_CONFIGS.CANCEL_PUBLICATION.toastErrorMessage
+      }
+    ])(
+      'should show toast.error with $errorToast and not redirect on $name',
+      async ({ trigger, status, errorToast }) => {
+        mockHandleSave.mockResolvedValue(undefined);
+        setup('news');
+        trigger();
+
+        await waitFor(() => {
+          expect(mockHandleSave).toHaveBeenCalledWith(status);
+          expect(toast.error).toHaveBeenCalledWith(errorToast);
+          expect(mockPush).not.toHaveBeenCalled();
+        });
+      }
+    );
+  });
+   
   describe('when publicationData is missing (null/undefined)', () => {
     it('should not throw and should not redirect when data is missing', () => {
       (useUpsertPublication as jest.Mock).mockReturnValue(undefined);

--- a/app/(logged_in)/publications/[type]/[id]/seo/page.test.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/seo/page.test.tsx
@@ -136,16 +136,6 @@ describe('PublicatiosSeoPage Container', () => {
       expect(screen.getByTestId('mock-title-dropdown')).toHaveTextContent('Редагування Новини');
     });
 
-    it('should handle save and cancel actions by routing to base path', () => {
-      fireEvent.click(screen.getByTestId('btn-save'));
-      expect(mockHandleSave).toHaveBeenCalledTimes(1);
-
-      fireEvent.click(screen.getByTestId('btn-cancel'));
-
-      expect(mockPush).toHaveBeenCalledTimes(2);
-      expect(mockPush).toHaveBeenCalledWith(PUBLICATIONS_BASE_PATH);
-    });
-
     it('should show publicationPublished toast when publish is triggered', () => {
       fireEvent.click(screen.getByTestId('btn-publish'));
 
@@ -167,6 +157,7 @@ describe('PublicatiosSeoPage Container', () => {
       fireEvent.click(screen.getByText('Скасувати публікацію'));
 
       expect(mockHandleSave).toHaveBeenCalledWith(BaseContentStatuses.Draft);
+      expect(toast.success).toHaveBeenCalledWith(CONTENT_MUTATION_RESULTS.publicationUnpublished);
       expect(mockPush).toHaveBeenCalledWith(PUBLICATIONS_BASE_PATH);
     });
 
@@ -191,12 +182,12 @@ describe('PublicatiosSeoPage Container', () => {
   });
 
   describe('when publicationData is missing (null/undefined)', () => {
-    it('should not throw and should still redirect when data is missing', () => {
+    it('should not throw and should not redirect when data is missing', () => {
       (useUpsertPublication as jest.Mock).mockReturnValue(undefined);
       setup('news');
 
       fireEvent.click(screen.getByTestId('btn-save'));
-      expect(mockPush).toHaveBeenCalledWith(PUBLICATIONS_BASE_PATH);
+      expect(mockPush).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/(logged_in)/publications/[type]/[id]/seo/page.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/seo/page.tsx
@@ -8,7 +8,7 @@ import toast from 'react-hot-toast';
 import { NavigationMenuItems, PublishMenuItems } from './SeoMenuItems';
 import CreatePublicationView from '~/(logged_in)/publications/[type]/create/CreatePublicationsView';
 import {
-  CONTENT_MUTATION_RESULTS,
+  MENU_ACTION_CONFIGS,
   PAGE_TITLES,
   PUBLICATIONS_BASE_PATH,
   PUBLICATIONS_TYPES,
@@ -19,7 +19,6 @@ import HeaderRightActions from '~/shared/components/divided-header/header-right-
 import { TitleDropdown } from '~/shared/components/divided-header/title-dropdown/TitleDropdown';
 import ActionMenu from '~/shared/components/dropdown-menu/ActionMenu';
 import { useUpsertPublication } from '~/shared/hooks/use-upsert-publication/useUpsertPublication';
-import { BaseContentStatuses } from '~/types/enums/common.enums';
 
 type Params = {
   type: PublicationsItemType;
@@ -43,19 +42,23 @@ export default function PublicatiosSeoPage() {
   const handleClosePublish = () => setPublishAnchor(null);
 
   const handlePublishAndExit = () => {
-    publicationData?.handleSave(BaseContentStatuses.Published);
-    toast.success(CONTENT_MUTATION_RESULTS.publicationPublished);
+    const { status, toastMessage } = MENU_ACTION_CONFIGS.PUBLICATE_AND_EXIT;
+    publicationData?.handleSave(status);
+    toast.success(toastMessage);
     router.push(PUBLICATIONS_BASE_PATH);
   };
 
   const handlePublish = () => {
-    publicationData?.handleSave(BaseContentStatuses.Published);
-    toast.success(CONTENT_MUTATION_RESULTS.publicationPublished);
+    const { status, toastMessage } = MENU_ACTION_CONFIGS.PUBLISH;
+    publicationData?.handleSave(status);
+    toast.success(toastMessage);
   };
 
   const handleUnpublish = () => {
-    publicationData?.handleSave(BaseContentStatuses.Draft);
+    const { status, toastMessage } = MENU_ACTION_CONFIGS.CANCEL_PUBLICATION;
+    publicationData?.handleSave(status);
     handleClosePublish();
+    toast.success(toastMessage);
     router.push(PUBLICATIONS_BASE_PATH);
   };
 
@@ -71,12 +74,6 @@ export default function PublicatiosSeoPage() {
     router.push(`${PUBLICATIONS_BASE_PATH}/${type}/${id}/edit`);
   };
 
-  const handleCancel = () => router.push(PUBLICATIONS_BASE_PATH);
-  const handleSave = () => {
-    publicationData?.handleSave(BaseContentStatuses.Draft);
-    router.push(PUBLICATIONS_BASE_PATH);
-  };
-
   const handlePublishExitClick = () => {
     handlePublishAndExit();
     handleClosePublish();
@@ -89,8 +86,6 @@ export default function PublicatiosSeoPage() {
         rightActionsComponent={
           <HeaderRightActions
             mode="seo"
-            onSave={handleSave}
-            onCancel={handleCancel}
             onPublish={handlePublish}
             onMenuOpen={handleOpenPublish}
           />

--- a/app/(logged_in)/publications/[type]/[id]/seo/page.tsx
+++ b/app/(logged_in)/publications/[type]/[id]/seo/page.tsx
@@ -32,7 +32,7 @@ export default function PublicatiosSeoPage() {
   const publicationData = useUpsertPublication({ type, id });
 
   const [navigationAnchor, setNavigationAnchor] = useState<HTMLButtonElement | null>(null);
-  const [publishAnchor, setPublishAnchor] = useState<HTMLButtonElement | null>(null); // +
+  const [publishAnchor, setPublishAnchor] = useState<HTMLButtonElement | null>(null);
 
   if (!PUBLICATIONS_TYPES.includes(type)) notFound();
 
@@ -41,25 +41,37 @@ export default function PublicatiosSeoPage() {
   };
   const handleClosePublish = () => setPublishAnchor(null);
 
-  const handlePublishAndExit = () => {
-    const { status, toastMessage } = MENU_ACTION_CONFIGS.PUBLICATE_AND_EXIT;
-    publicationData?.handleSave(status);
-    toast.success(toastMessage);
-    router.push(PUBLICATIONS_BASE_PATH);
+  const handlePublishAndExit = async () => {
+    const { status, toastMessage, toastErrorMessage } = MENU_ACTION_CONFIGS.PUBLICATE_AND_EXIT;
+    const id = await publicationData?.handleSave(status);
+    if (id) {
+      toast.success(toastMessage);
+      router.push(PUBLICATIONS_BASE_PATH);
+    } else {
+      toast.error(toastErrorMessage);
+    }
   };
 
-  const handlePublish = () => {
-    const { status, toastMessage } = MENU_ACTION_CONFIGS.PUBLISH;
-    publicationData?.handleSave(status);
-    toast.success(toastMessage);
+  const handlePublish = async () => {
+    const { status, toastMessage, toastErrorMessage } = MENU_ACTION_CONFIGS.PUBLISH;
+    const id = await publicationData?.handleSave(status);
+    if (id) {
+      toast.success(toastMessage);
+    } else {
+      toast.error(toastErrorMessage);
+    }
   };
 
-  const handleUnpublish = () => {
-    const { status, toastMessage } = MENU_ACTION_CONFIGS.CANCEL_PUBLICATION;
-    publicationData?.handleSave(status);
-    handleClosePublish();
-    toast.success(toastMessage);
-    router.push(PUBLICATIONS_BASE_PATH);
+  const handleUnpublish = async () => {
+    const { status, toastMessage, toastErrorMessage } = MENU_ACTION_CONFIGS.CANCEL_PUBLICATION;
+    const id = await publicationData?.handleSave(status);
+    if (id) {
+      handleClosePublish();
+      toast.success(toastMessage);
+      router.push(PUBLICATIONS_BASE_PATH);
+    } else {
+      toast.error(toastErrorMessage);
+    }
   };
 
   const handleOpenNavigation = (event: MouseEvent<HTMLElement>) => {
@@ -74,8 +86,8 @@ export default function PublicatiosSeoPage() {
     router.push(`${PUBLICATIONS_BASE_PATH}/${type}/${id}/edit`);
   };
 
-  const handlePublishExitClick = () => {
-    handlePublishAndExit();
+  const handlePublishExitClick = async () => {
+    await handlePublishAndExit();
     handleClosePublish();
   };
 

--- a/app/(logged_in)/publications/[type]/create/CreatePublicationsView.test.tsx
+++ b/app/(logged_in)/publications/[type]/create/CreatePublicationsView.test.tsx
@@ -355,7 +355,7 @@ describe('CreatePublicationsView Component', () => {
       expect(mockPush).not.toHaveBeenCalled();
     });
 
-    it('should show draftSaved toast and redirect on cancel publication', async () => {
+    it('should show publication unpublished toast and redirect on cancel publication', async () => {
       const handleSave = jest.fn().mockResolvedValue('media-123');
       const mockData = createMockData({ publicationType: 'media', handleSave });
       render(<CreatePublicationsView data={mockData} />);
@@ -363,7 +363,7 @@ describe('CreatePublicationsView Component', () => {
       fireEvent.click(screen.getByText('Скасувати публікацію'));
       await waitFor(() => {
         expect(handleSave).toHaveBeenCalledWith(BaseContentStatuses.Draft);
-        expect(toast.success).toHaveBeenCalledWith(CONTENT_MUTATION_RESULTS.draftSaved);
+        expect(toast.success).toHaveBeenCalledWith(CONTENT_MUTATION_RESULTS.publicationUnpublished);
         expect(mockPush).toHaveBeenCalledWith(PUBLICATIONS_BASE_PATH);
       });
     });

--- a/app/(logged_in)/publications/[type]/create/CreatePublicationsView.test.tsx
+++ b/app/(logged_in)/publications/[type]/create/CreatePublicationsView.test.tsx
@@ -8,6 +8,7 @@ import CreatePublicationsView from './CreatePublicationsView';
 import {
   CONTENT_MUTATION_RESULTS,
   initialSeoValue,
+  MENU_ACTION_CONFIGS,
   MenuActionId,
   PAGE_TITLES,
   PUBLICATIONS_BASE_PATH,
@@ -318,7 +319,7 @@ describe('CreatePublicationsView Component', () => {
       });
     });
 
-    it('should not show toast when media publish returns no id', async () => {
+    it('should show toast.error when media publish returns no id', async () => {
       const handleSave = jest.fn().mockResolvedValue(null);
       const mockData = createMockData({ publicationType: 'media', handleSave });
       render(<CreatePublicationsView data={mockData} />);
@@ -326,6 +327,7 @@ describe('CreatePublicationsView Component', () => {
       await waitFor(() => {
         expect(handleSave).toHaveBeenCalledWith(BaseContentStatuses.Published);
       });
+      expect(toast.error).toHaveBeenCalledWith(MENU_ACTION_CONFIGS.PUBLISH.toastErrorMessage);
       expect(toast.success).not.toHaveBeenCalled();
     });
 
@@ -342,7 +344,7 @@ describe('CreatePublicationsView Component', () => {
       });
     });
 
-    it('should not toast or redirect on publish and exit when no id is returned', async () => {
+    it('should show toast.error and not redirect on publish and exit when no id is returned', async () => {
       const handleSave = jest.fn().mockResolvedValue(null);
       const mockData = createMockData({ publicationType: 'media', handleSave });
       render(<CreatePublicationsView data={mockData} />);
@@ -351,6 +353,7 @@ describe('CreatePublicationsView Component', () => {
       await waitFor(() => {
         expect(handleSave).toHaveBeenCalledWith(BaseContentStatuses.Published);
       });
+      expect(toast.error).toHaveBeenCalledWith(MENU_ACTION_CONFIGS.PUBLICATE_AND_EXIT.toastErrorMessage);
       expect(toast.success).not.toHaveBeenCalled();
       expect(mockPush).not.toHaveBeenCalled();
     });
@@ -368,7 +371,7 @@ describe('CreatePublicationsView Component', () => {
       });
     });
 
-    it('should not toast or redirect on cancel publication when no id is returned', async () => {
+    it('should show toast.error and not redirect on cancel publication when no id is returned', async () => {
       const handleSave = jest.fn().mockResolvedValue(null);
       const mockData = createMockData({ publicationType: 'media', handleSave });
       render(<CreatePublicationsView data={mockData} />);
@@ -377,6 +380,7 @@ describe('CreatePublicationsView Component', () => {
       await waitFor(() => {
         expect(handleSave).toHaveBeenCalledWith(BaseContentStatuses.Draft);
       });
+      expect(toast.error).toHaveBeenCalledWith(MENU_ACTION_CONFIGS.CANCEL_PUBLICATION.toastErrorMessage);
       expect(toast.success).not.toHaveBeenCalled();
       expect(mockPush).not.toHaveBeenCalled();
     });

--- a/app/(logged_in)/publications/[type]/create/CreatePublicationsView.tsx
+++ b/app/(logged_in)/publications/[type]/create/CreatePublicationsView.tsx
@@ -104,33 +104,39 @@ export default function CreatePublicationsView({
     try {
       switch (actionId) {
       case MenuActionId.PUBLISH: {
-        const { status, toastMessage } = MENU_ACTION_CONFIGS.PUBLISH;
+        const { status, toastMessage, toastErrorMessage } = MENU_ACTION_CONFIGS.PUBLISH;
         const id = await handleSave(status);
 
         if (id) {
           toast.success(toastMessage);
+        } else {
+          toast.error(toastErrorMessage);
         }
         break;
       }
 
       case MenuActionId.PUBLICATE_AND_EXIT: {
-        const { status, toastMessage } = MENU_ACTION_CONFIGS.PUBLICATE_AND_EXIT;
+        const { status, toastMessage, toastErrorMessage } = MENU_ACTION_CONFIGS.PUBLICATE_AND_EXIT;
         const id = await handleSave(status);
 
         if (id) {
           toast.success(toastMessage);
           router.push(PUBLICATIONS_BASE_PATH);
+        } else {
+          toast.error(toastErrorMessage);
         }
         break;
       }
 
       case MenuActionId.CANCEL_PUBLICATION: {
-        const { status, toastMessage } = MENU_ACTION_CONFIGS.CANCEL_PUBLICATION;
+        const { status, toastMessage, toastErrorMessage } = MENU_ACTION_CONFIGS.CANCEL_PUBLICATION;
 
         const id = await handleSave(status);
         if (id) {
           toast.success(toastMessage);
           router.push(PUBLICATIONS_BASE_PATH);
+        } else {
+          toast.error(toastErrorMessage);
         }
         break;
       }

--- a/app/(logged_in)/publications/[type]/create/CreatePublicationsView.tsx
+++ b/app/(logged_in)/publications/[type]/create/CreatePublicationsView.tsx
@@ -123,7 +123,7 @@ export default function CreatePublicationsView({
       case MenuActionId.CANCEL_PUBLICATION: {
         const id = await handleSave(BaseContentStatuses.Draft);
         if (id) {
-          toast.success(CONTENT_MUTATION_RESULTS.draftSaved);
+          toast.success(CONTENT_MUTATION_RESULTS.publicationUnpublished);
           router.push(PUBLICATIONS_BASE_PATH);
         }
         break;

--- a/app/(logged_in)/publications/[type]/create/CreatePublicationsView.tsx
+++ b/app/(logged_in)/publications/[type]/create/CreatePublicationsView.tsx
@@ -11,7 +11,7 @@ import { styles } from './CreatePublicationsView.styles';
 import DeleteCardModal from '~/components/delete-card-modal/DeleteCardModal';
 import {
   ADMIN_TITLE_LABELS,
-  CONTENT_MUTATION_RESULTS,
+  MENU_ACTION_CONFIGS,
   MenuActionId,
   PAGE_TITLES,
   PUBLICATIONS_BASE_PATH
@@ -84,7 +84,7 @@ export default function CreatePublicationsView({
       <SeoCanonicalUrlField
         value={value.canonicalUrl ?? ''}
         onChange={(val) => onChange({ ...value, canonicalUrl: val })}
-        onBlur={() => {}}
+        onBlur={() => { }}
         forceShowErrors={forceShowErrors}
       />
     ),
@@ -104,26 +104,32 @@ export default function CreatePublicationsView({
     try {
       switch (actionId) {
       case MenuActionId.PUBLISH: {
-        const id = await handleSave(BaseContentStatuses.Published);
+        const { status, toastMessage } = MENU_ACTION_CONFIGS.PUBLISH;
+        const id = await handleSave(status);
+
         if (id) {
-          toast.success(CONTENT_MUTATION_RESULTS.publicationPublished);
+          toast.success(toastMessage);
         }
         break;
       }
 
       case MenuActionId.PUBLICATE_AND_EXIT: {
-        const id = await handleSave(BaseContentStatuses.Published);
+        const { status, toastMessage } = MENU_ACTION_CONFIGS.PUBLICATE_AND_EXIT;
+        const id = await handleSave(status);
+
         if (id) {
-          toast.success(CONTENT_MUTATION_RESULTS.publicationPublished);
+          toast.success(toastMessage);
           router.push(PUBLICATIONS_BASE_PATH);
         }
         break;
       }
 
       case MenuActionId.CANCEL_PUBLICATION: {
-        const id = await handleSave(BaseContentStatuses.Draft);
+        const { status, toastMessage } = MENU_ACTION_CONFIGS.CANCEL_PUBLICATION;
+
+        const id = await handleSave(status);
         if (id) {
-          toast.success(CONTENT_MUTATION_RESULTS.publicationUnpublished);
+          toast.success(toastMessage);
           router.push(PUBLICATIONS_BASE_PATH);
         }
         break;

--- a/app/constants/publications.ts
+++ b/app/constants/publications.ts
@@ -144,6 +144,8 @@ export enum MenuActionId {
   DELETE = 'DELETE'
 } 
 
+
+
 export type ACTIONS_TYPE = {
   id: MenuActionId;
   label: string;
@@ -155,6 +157,29 @@ export const CONTENT_MUTATION_RESULTS: MUTATION_RESULT = {
   publicationDeleted: 'Публікацію видалено',
   publicationUnpublished: 'Публікацію скасовано',
   publicationPublished: 'Публікацію опубліковано успішно'
+} as const;
+
+export type MenuActionConfig = {
+  status: BaseContentStatuses;
+  toastMessage: string;
+};
+
+export const MENU_ACTION_CONFIGS: Record<
+  Exclude<MenuActionId, MenuActionId.DELETE>,
+  MenuActionConfig
+> = {
+  [MenuActionId.PUBLISH]: {
+    status: BaseContentStatuses.Published,
+    toastMessage: CONTENT_MUTATION_RESULTS.publicationPublished
+  },
+  [MenuActionId.PUBLICATE_AND_EXIT]: {
+    status: BaseContentStatuses.Published,
+    toastMessage: CONTENT_MUTATION_RESULTS.publicationPublished
+  },
+  [MenuActionId.CANCEL_PUBLICATION]: {
+    status: BaseContentStatuses.Draft,
+    toastMessage: CONTENT_MUTATION_RESULTS.publicationUnpublished
+  },
 } as const;
 
 

--- a/app/constants/publications.ts
+++ b/app/constants/publications.ts
@@ -139,11 +139,10 @@ export const PublicationsChipLabels: Record<PublicationsItemType, string> = {
 
 export enum MenuActionId {
   PUBLISH = 'PUBLISH',
-  SAVE_DRAFT = 'SAVE_DRAFT',
   PUBLICATE_AND_EXIT = 'PUBLICATE_AND_EXIT',
   CANCEL_PUBLICATION = 'CANCEL_PUBLICATION',
   DELETE = 'DELETE'
-}
+} 
 
 export type ACTIONS_TYPE = {
   id: MenuActionId;
@@ -153,13 +152,11 @@ export type ACTIONS_TYPE = {
 export type MUTATION_RESULT = Record<string, string>;
 
 export const CONTENT_MUTATION_RESULTS: MUTATION_RESULT = {
-  draftPublished: 'Чернетку опубліковано успішно',
-  draftSaved: 'Чернетку збережено успішно',
-  draftDeleted: 'Чернетку видалено успішно',
   publicationDeleted: 'Публікацію видалено',
   publicationUnpublished: 'Публікацію скасовано',
   publicationPublished: 'Публікацію опубліковано успішно'
-};
+} as const;
+
 
 export const DEFAULT_EMPTY_DOCUMENT: SerializedContent = {
   blocks: [],
@@ -228,7 +225,7 @@ export const PAGE_TITLES: Record<PublicationsItemType, string> = {
   events: 'Події',
   news: 'Новини',
   media: 'Ми у ЗМІ'
-};
+} as const;
 
 export const initialSeoValue: SeoBlockValue = {
   meta: {
@@ -243,7 +240,7 @@ export const ADMIN_TITLE_LABELS: Record<PublicationsItemType, string> = {
   events: 'Назва події в адмінці',
   news: 'Назва новини в адмінці',
   media: 'Назва публікації в адмінці'
-};
+} as const;
 
 export const CROP_RATIOS = {
   HERO_BANNER: 816 / 300,

--- a/app/constants/publications.ts
+++ b/app/constants/publications.ts
@@ -153,15 +153,19 @@ export type ACTIONS_TYPE = {
 
 export type MUTATION_RESULT = Record<string, string>;
 
+
 export const CONTENT_MUTATION_RESULTS: MUTATION_RESULT = {
   publicationDeleted: 'Публікацію видалено',
   publicationUnpublished: 'Публікацію скасовано',
-  publicationPublished: 'Публікацію опубліковано успішно'
+  publicationPublished: 'Публікацію опубліковано успішно',
+  publicationPublishError: 'Виникла помилка при публікації. Спробуйте ще раз.',
+  publicationUnpublishError: 'Виникла помилка при скасуванні публікації. Спробуйте ще раз.'
 } as const;
 
 export type MenuActionConfig = {
   status: BaseContentStatuses;
   toastMessage: string;
+  toastErrorMessage: string;
 };
 
 export const MENU_ACTION_CONFIGS: Record<
@@ -170,15 +174,18 @@ export const MENU_ACTION_CONFIGS: Record<
 > = {
   [MenuActionId.PUBLISH]: {
     status: BaseContentStatuses.Published,
-    toastMessage: CONTENT_MUTATION_RESULTS.publicationPublished
+    toastMessage: CONTENT_MUTATION_RESULTS.publicationPublished,
+    toastErrorMessage: CONTENT_MUTATION_RESULTS.publicationPublishError
   },
   [MenuActionId.PUBLICATE_AND_EXIT]: {
     status: BaseContentStatuses.Published,
-    toastMessage: CONTENT_MUTATION_RESULTS.publicationPublished
+    toastMessage: CONTENT_MUTATION_RESULTS.publicationPublished,
+    toastErrorMessage: CONTENT_MUTATION_RESULTS.publicationPublishError
   },
   [MenuActionId.CANCEL_PUBLICATION]: {
     status: BaseContentStatuses.Draft,
-    toastMessage: CONTENT_MUTATION_RESULTS.publicationUnpublished
+    toastMessage: CONTENT_MUTATION_RESULTS.publicationUnpublished,
+    toastErrorMessage: CONTENT_MUTATION_RESULTS.publicationUnpublishError
   },
 } as const;
 

--- a/app/shared/components/divided-header/header-right-actions/HeaderRightActions.tsx
+++ b/app/shared/components/divided-header/header-right-actions/HeaderRightActions.tsx
@@ -26,8 +26,6 @@ type EditModeProps = BaseProps & {
 
 type SeoModeProps = BaseProps & {
   mode: 'seo';
-  onSave?: () => void;
-  onCancel?: () => void;
   onPublish?: () => void;
   onMenuOpen?: (event: MouseEvent<HTMLButtonElement>) => void;
 };


### PR DESCRIPTION
### Description

This PR resolves issue by refactoring and unifying the publication action logic (publishing, saving & exiting, and canceling publication) across the creation and editing workflows. 

Previously, some actions (like `PUBLICATE_AND_EXIT` in the edit page) had mismatched statuses and toast notifications, saving publications as `Draft` instead of `Published`. By centralizing these action mappings in publications.ts under a new configuration object `MENU_ACTION_CONFIGS`, we ensure consistency and correctness in how content status updates and success notifications are handled.

### Key Changes

#### 1. Configuration & constants
- **publications.ts**:
  - removed unused `MenuActionId.SAVE_DRAFT` and obsolete toast labels from `CONTENT_MUTATION_RESULTS`.
  - Introduced `MENU_ACTION_CONFIGS` mapping each relevant `MenuActionId` to its designated `BaseContentStatuses` and localized `toastMessage`.
  - marked `PAGE_TITLES` and `ADMIN_TITLE_LABELS` objects `as const` for better type safety.

#### 2. Publications creation, editing, & SEO views
- **(logged_in/publications/[type]/[id]/edit/page.tsx)**:
  - refactored `handleMenuAction` to leverage `MENU_ACTION_CONFIGS`.
  - fixed a bug where `PUBLICATE_AND_EXIT` incorrectly saved the publication as `BaseContentStatuses.Draft` with `draftSaved` toast, changing it to save as `BaseContentStatuses.Published` with `publicationPublished` toast.
- **(logged_in/publications/[type]/create/CreatePublicationsView.tsx)**:
  - updated `handleMenuAction` to fetch action configs from `MENU_ACTION_CONFIGS`, removing local duplication of status/toast definitions.
- **(logged_in/publications/[type]/[id]/seo/page.tsx)**:
  - refactored `handlePublishAndExit`, `handlePublish`, and `handleUnpublish` to use `MENU_ACTION_CONFIGS` for consistent status updates and toast notifications.
  - removed unused `handleSave` and `handleCancel` functions, as direct saving/canceling drafts on the SEO settings view is no longer needed.
- **HeaderRightActions.tsx**:
  - removed unused `onSave` and `onCancel` props from `SeoModeProps` to match the streamlined actions on the SEO page.

#### 3. Test Suites
- **page.test.tsx**:
  - updated test assertions for `PUBLISH` and `PUBLICATE_AND_EXIT` actions to verify the correct status and toast outputs.
- **CreatePublicationsView.test.tsx**:
  - corrected test cases for cancelling a publication to verify the correct success notification message.
- **(logged_in/publications/[type]/[id]/seo/page.test.tsx)**:
  - removed obsolete test assertions checking save/cancel actions from the SEO settings view.
  - updated publication cancellation test to expect the correct success notification message.
  - fixed edge-case test suite for missing `publicationData` to reflect the removal of save/cancel redirects.

Closes #705

## Type of change

- [ ] New feature
- [x] Bug fix
- [x] Refactoring/tech debt
- [ ] Documentation update
- [ ] Other

## How to test

1. Open admin panel
2. Go to the creation page (`/publications/[type]/create`) or edit page (`/publications/[type]/[id]/edit`) of a publication item.
3. Perform the following actions and verify:
   - **Publish**: Check that the publication is successfully updated/created with status `Published` and shows the success toast `"Публікацію опубліковано успішно"`.
   - **Publicate & Exit**: Verify that the publication is saved with status `Published`, displays the correct success toast, and redirects to the publications list.
   - **Cancel publication**: Verify that the publication is saved as `Draft`, shows the success toast `"Публікацію скасовано"`, and redirects.
4. Run tests using `npm run test` or `jest` to ensure all tests pass

## Video / Screenshots
test event: publish and exit upon creation

https://github.com/user-attachments/assets/b8220229-21ab-43d5-989f-43e2a134cea4

test news: publish and exit upon creation

https://github.com/user-attachments/assets/d164ff94-7b03-4ef0-aa1a-061cfbea283f

test media: publish and exit upon creation
note: here you can see an error on the client, this is error with some image urls - this is not related to the current PR

https://github.com/user-attachments/assets/c688207c-bcd0-4837-b1d4-143efbe00338

test news: hiding upon editing

https://github.com/user-attachments/assets/72b8347f-3065-4d67-a7c9-a0badad0e281

test news: hiding upon editing

https://github.com/user-attachments/assets/4d4205d9-f1a3-4465-9a15-f2ff72fd1a13

test media hiding upon editing
https://github.com/user-attachments/assets/8fd1fbc3-b364-452d-9bbf-d2f04976828d

test to see if the post is republished when only the 'Publish' button is clicked
https://github.com/user-attachments/assets/799692ee-7430-4d90-95b5-9b935a8c281a

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [X] Linting checks are clean
- [X] No Sonar issues
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [ ] Task moved to the review column on the board