### PR TITLE
feat(content): allow renaming and hiding/showing sections

### DIFF
--- a/app/(logged_in)/__mocks__/edit-pages-factory.tsx
+++ b/app/(logged_in)/__mocks__/edit-pages-factory.tsx
@@ -6,6 +6,7 @@ const saveMock = jest.fn();
 const setLocaleMock = jest.fn();
 const discardChangesMock = jest.fn();
 export const setBlocksOrderMock = jest.fn();
+export const setFieldValidityMock = jest.fn();
 
 jest.mock('~/store', () => ({
   useStore: (
@@ -14,6 +15,7 @@ jest.mock('~/store', () => ({
       discardChanges: (slug: string) => void;
       blocksOrder: Record<string, string[]>;
       setBlocksOrder: jest.Mock;
+      setFieldValidity: jest.Mock;
     }) => unknown
   ) =>
     selector({
@@ -23,7 +25,8 @@ jest.mock('~/store', () => ({
         'about-us': ['intro', 'foundation', 'mission', 'goals', 'office', 'what-we-do', 'founders'],
         'privacy-policy': ['IntroSection', 'DataWeCollect', 'DataUsage', 'Cookies', 'GoogleAuth', 'SocialNetworks', 'TargetedAds', 'NewsletterSubscription', 'DataRetention', 'UserRights', 'ContactUs']
       },
-      setBlocksOrder: setBlocksOrderMock
+      setBlocksOrder: setBlocksOrderMock,
+      setFieldValidity: setFieldValidityMock
     })
 }));
 

--- a/app/lib/utils/prose.ts
+++ b/app/lib/utils/prose.ts
@@ -19,11 +19,6 @@ export const textToProse = (text: string): ProseDoc => ({
   content: text ? [{ type: 'paragraph', content: [{ type: 'text', text }] }] : []
 });
 
-/**
- * Plain, single-line text for UI labels (e.g. a CollapsibleBlock/accordion
- * header) that must live-reflect an editable rich-text title. Falls back to
- * `fallback` when the doc is empty, so section headers never render blank.
- */
 export const proseToHeaderText = (doc?: ProseDoc, fallback = ''): string => {
   const text = proseToText(doc).replace(/\s+/g, ' ').trim();
   return text || fallback;

--- a/app/lib/utils/prose.ts
+++ b/app/lib/utils/prose.ts
@@ -18,3 +18,13 @@ export const textToProse = (text: string): ProseDoc => ({
   type: 'doc',
   content: text ? [{ type: 'paragraph', content: [{ type: 'text', text }] }] : []
 });
+
+/**
+ * Plain, single-line text for UI labels (e.g. a CollapsibleBlock/accordion
+ * header) that must live-reflect an editable rich-text title. Falls back to
+ * `fallback` when the doc is empty, so section headers never render blank.
+ */
+export const proseToHeaderText = (doc?: ProseDoc, fallback = ''): string => {
+  const text = proseToText(doc).replace(/\s+/g, ' ').trim();
+  return text || fallback;
+};

--- a/app/shared/components/about-us/Intro-section/IntroSection.test.tsx
+++ b/app/shared/components/about-us/Intro-section/IntroSection.test.tsx
@@ -96,7 +96,7 @@ describe('IntroSection', () => {
   it('should render all fields with type-safe structural JSON states', () => {
     runSimulation();
 
-    expect(screen.getByText('Вступна секція')).toBeInTheDocument();
+    expect(screen.getByText('Initial Title')).toBeInTheDocument();
     expect(screen.getByTestId(`textfield-json-${titles.page}`)).toHaveTextContent(JSON.stringify(mockNodes.title));
     expect(screen.getByTestId(`textfield-json-${titles.caption}`)).toHaveTextContent(JSON.stringify(mockNodes.caption));
     expect(screen.getByTestId('quote-title-json')).toHaveTextContent(JSON.stringify(mockNodes.author));

--- a/app/shared/components/about-us/Intro-section/IntroSection.tsx
+++ b/app/shared/components/about-us/Intro-section/IntroSection.tsx
@@ -9,10 +9,11 @@ import { BLOCK_IDS, PAGE_IDS } from '~/constants/pageBlocks';
 import { CROP_RATIOS } from '~/constants/publications';
 import { ImagePreviewBlock } from '~/ds-components/photo-block/PhotoBlock';
 import { CustomTextField } from '~/ds-components/text-field/TextField';
+import { proseToHeaderText } from '~/lib/utils/prose';
 import type { MediaModalResult } from '~/shared/components/media-modal/MediaModal.types';
 import { usePageBlock } from '~/shared/hooks/use-page-block/usePageBlock';
 import { useStore } from '~/store';
-import { LocalizedString } from '~/types/common';
+import { LocalizedString, ProseDoc } from '~/types/common';
 import { getImageUrl } from '~/utils/getImageUrl';
 
 export const IntroSection = () => {
@@ -26,8 +27,10 @@ export const IntroSection = () => {
 
   if (!block) return <EditBlockSkeleton />;
 
+  const headerTitle = proseToHeaderText(block.title[currentLocale] as ProseDoc, 'Вступна секція');
+
   return (
-    <CollapsibleBlock title="Вступна секція">
+    <CollapsibleBlock title={headerTitle}>
       <CustomTextField
         fieldType="formatting"
         title="Заголовок сторінки"

--- a/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.test.tsx
+++ b/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 import { LiatoshynskyFoundation } from './LiatoshynskyFoundation';
 import { createDocNode } from '~/__mocks__/utils';
+import { BLOCK_IDS, PAGE_IDS } from '~/constants/pageBlocks';
 import { CropRect } from '~/types/graphql/generated/graphql';
 
 interface MockParagraph {
@@ -22,11 +23,12 @@ interface MockFoundationBlockProps {
 }
 
 const setFieldMock = jest.fn();
+const toggleBlockVisibilityMock = jest.fn();
 const usePageBlockMock = jest.fn();
 
 jest.mock('~/store', () => ({
-  useStore: (selector: (state: { readonly locale: 'uk'; readonly setField: typeof setFieldMock }) => unknown) =>
-    selector({ locale: 'uk', setField: setFieldMock })
+  useStore: (selector: (state: { readonly locale: 'uk'; readonly setField: typeof setFieldMock; readonly toggleBlockVisibility: typeof toggleBlockVisibilityMock }) => unknown) =>
+    selector({ locale: 'uk', setField: setFieldMock, toggleBlockVisibility: toggleBlockVisibilityMock })
 }));
 
 jest.mock('~/shared/hooks/use-page-block/usePageBlock', () => ({
@@ -92,7 +94,22 @@ jest.mock('./foundation-block/FoundationBlock', () => ({
 
 jest.mock('~/ds-components/collapsible-block/CollapsibleBlock', () => ({
   __esModule: true,
-  default: ({ children }: { children: React.ReactNode }) => <div data-testid="collapsible-block">{children}</div>
+  default: ({
+    children,
+    onToggleVisibility
+  }: {
+    children: React.ReactNode;
+    onToggleVisibility?: () => void;
+  }) => (
+    <div data-testid="collapsible-block">
+      {onToggleVisibility && (
+        <button data-testid="collapsible-block-toggle-visibility" onClick={onToggleVisibility}>
+          Toggle visibility
+        </button>
+      )}
+      {children}
+    </div>
+  )
 }));
 
 jest.mock('~/lib/utils/prose', () => ({ proseToText: String, proseToHeaderText: (doc: unknown, fallback: string) => (doc ? String(doc) : fallback) }));
@@ -132,6 +149,15 @@ describe('LiatoshynskyFoundation', () => {
     expect(screen.getByTestId('paragraph-json-para-1')).toHaveTextContent(JSON.stringify(mockNodes.belief));
     expect(screen.getByTestId('image')).toHaveAttribute('src', '/api/blob-url?folderName=photos&blobName=image-src');
     expect(screen.getByTestId('file-name')).toHaveTextContent('Image Caption');
+  });
+
+  it('should call toggleBlockVisibility with pageId and blockId when the visibility toggle is clicked', () => {
+    usePageBlockMock.mockReturnValue({ block: mockBlock, blockId: 'FoundationInfo' });
+    render(<LiatoshynskyFoundation />);
+
+    fireEvent.click(screen.getByTestId('collapsible-block-toggle-visibility'));
+
+    expect(toggleBlockVisibilityMock).toHaveBeenCalledWith(PAGE_IDS.ABOUT_US, BLOCK_IDS.LIATOSHYNSKY_FOUNDATION);
   });
 
   it.each([

--- a/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.test.tsx
+++ b/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.test.tsx
@@ -24,16 +24,19 @@ interface MockFoundationBlockProps {
 
 const setFieldMock = jest.fn();
 const toggleBlockVisibilityMock = jest.fn();
+const setFieldValidityMock = jest.fn();
 const usePageBlockMock = jest.fn();
 
 jest.mock('~/store', () => ({
-  useStore: (selector: (state: { readonly locale: 'uk'; readonly setField: typeof setFieldMock; readonly toggleBlockVisibility: typeof toggleBlockVisibilityMock }) => unknown) =>
-    selector({ locale: 'uk', setField: setFieldMock, toggleBlockVisibility: toggleBlockVisibilityMock })
+  useStore: (selector: (state: { readonly locale: 'uk'; readonly setField: typeof setFieldMock; readonly toggleBlockVisibility: typeof toggleBlockVisibilityMock; readonly setFieldValidity: typeof setFieldValidityMock }) => unknown) =>
+    selector({ locale: 'uk', setField: setFieldMock, toggleBlockVisibility: toggleBlockVisibilityMock, setFieldValidity: setFieldValidityMock })
 }));
 
 jest.mock('~/shared/hooks/use-page-block/usePageBlock', () => ({
   usePageBlock: (pageId: string, blockId: string) => usePageBlockMock(pageId, blockId)
 }));
+
+jest.mock('~/ds-components/text-field/TextField');
 
 jest.mock('../../edit-block-skeleton/EditBlockSkeleton', () => ({
   EditBlockSkeleton: () => <div data-testid="edit-block-skeleton" />
@@ -158,6 +161,27 @@ describe('LiatoshynskyFoundation', () => {
     fireEvent.click(screen.getByTestId('collapsible-block-toggle-visibility'));
 
     expect(toggleBlockVisibilityMock).toHaveBeenCalledWith(PAGE_IDS.ABOUT_US, BLOCK_IDS.LIATOSHYNSKY_FOUNDATION);
+  });
+
+  it('should mark the title as invalid after blur when it is empty, and clear the flag on unmount', () => {
+    usePageBlockMock.mockReturnValue({ block: { ...mockBlock, title: { uk: '' } }, blockId: 'FoundationInfo' });
+
+    const { unmount } = render(<LiatoshynskyFoundation />);
+
+    fireEvent.click(screen.getByTestId('trigger-blur-Заголовок секції'));
+
+    expect(screen.getByTestId('textfield-error-Заголовок секції')).toBeInTheDocument();
+    expect(setFieldValidityMock).toHaveBeenCalledWith(
+      `${PAGE_IDS.ABOUT_US}:${BLOCK_IDS.LIATOSHYNSKY_FOUNDATION}:title`,
+      true
+    );
+
+    unmount();
+
+    expect(setFieldValidityMock).toHaveBeenLastCalledWith(
+      `${PAGE_IDS.ABOUT_US}:${BLOCK_IDS.LIATOSHYNSKY_FOUNDATION}:title`,
+      false
+    );
   });
 
   it.each([

--- a/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.test.tsx
+++ b/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.test.tsx
@@ -95,7 +95,7 @@ jest.mock('~/ds-components/collapsible-block/CollapsibleBlock', () => ({
   default: ({ children }: { children: React.ReactNode }) => <div data-testid="collapsible-block">{children}</div>
 }));
 
-jest.mock('~/lib/utils/prose', () => ({ proseToText: String }));
+jest.mock('~/lib/utils/prose', () => ({ proseToText: String, proseToHeaderText: (doc: unknown, fallback: string) => (doc ? String(doc) : fallback) }));
 
 const mockNodes = {
   org: createDocNode('Organisation Text'),

--- a/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.tsx
+++ b/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.tsx
@@ -11,6 +11,7 @@ import { CustomTextField } from '~/ds-components/text-field/TextField';
 import { proseToHeaderText, proseToText } from '~/lib/utils/prose';
 import type { MediaModalResult } from '~/shared/components/media-modal/MediaModal.types';
 import { usePageBlock } from '~/shared/hooks/use-page-block/usePageBlock';
+import { useTitleValidation } from '~/shared/hooks/use-title-validation/useTitleValidation';
 import { useStore } from '~/store';
 import { ProseDoc } from '~/types/common';
 import { getImageUrl } from '~/utils/getImageUrl';
@@ -24,6 +25,8 @@ export const LiatoshynskyFoundation = () => {
   const toggleBlockVisibility = useStore((state) => state.toggleBlockVisibility);
 
   const currentLocale: 'uk' | 'en' = useStore((state) => state.locale);
+
+  const titleValidation = useTitleValidation(`${pageId}:${blockId}:title`, block?.title?.[currentLocale] as ProseDoc);
 
   if (!block) return <EditBlockSkeleton />;
 
@@ -76,6 +79,9 @@ export const LiatoshynskyFoundation = () => {
         label="Текст заголовку"
         value={block.title?.[currentLocale]}
         onChange={handleTitleChange}
+        onBlur={titleValidation.onBlur}
+        error={titleValidation.error}
+        helperText={titleValidation.helperText}
       />
       <FoundationBlock
         mainText={mainText}

--- a/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.tsx
+++ b/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.tsx
@@ -44,7 +44,7 @@ export const LiatoshynskyFoundation = () => {
 
   type LocalizedProse = Record<'uk' | 'en', JSONContent>;
 
-  const paragraphKeys: (keyof typeof block)[] = ['ourName', 'ourBelief'];
+  const paragraphKeys: ('ourName' | 'ourBelief')[] = ['ourName', 'ourBelief'];
 
   const paragraphs = paragraphKeys.map((key) => {
     const localized = block[key] as LocalizedProse;

--- a/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.tsx
+++ b/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.tsx
@@ -7,7 +7,8 @@ import { EditBlockSkeleton } from '../../edit-block-skeleton/EditBlockSkeleton';
 import { FoundationBlock } from './foundation-block/FoundationBlock';
 import { BLOCK_IDS, PAGE_IDS } from '~/constants/pageBlocks';
 import CollapsibleBlock from '~/ds-components/collapsible-block/CollapsibleBlock';
-import { proseToText } from '~/lib/utils/prose';
+import { CustomTextField } from '~/ds-components/text-field/TextField';
+import { proseToHeaderText, proseToText } from '~/lib/utils/prose';
 import type { MediaModalResult } from '~/shared/components/media-modal/MediaModal.types';
 import { usePageBlock } from '~/shared/hooks/use-page-block/usePageBlock';
 import { useStore } from '~/store';
@@ -20,10 +21,18 @@ export const LiatoshynskyFoundation = () => {
   const { block } = usePageBlock(pageId, blockId);
 
   const setField = useStore((state) => state.setField);
+  const toggleBlockVisibility = useStore((state) => state.toggleBlockVisibility);
 
   const currentLocale: 'uk' | 'en' = useStore((state) => state.locale);
 
   if (!block) return <EditBlockSkeleton />;
+
+  const handleTitleChange = (val: JSONContent) => {
+    setField(pageId, blockId, 'title', {
+      ...block.title,
+      [currentLocale]: val
+    });
+  };
 
   const mainText = block.ourOrganisation?.[currentLocale];
   const handleMainTextChange = (val: JSONContent) => {
@@ -52,8 +61,22 @@ export const LiatoshynskyFoundation = () => {
     });
   };
 
+  const headerTitle = proseToHeaderText(block.title?.[currentLocale] as ProseDoc, 'Фундація Лятошинського');
+
   return (
-    <CollapsibleBlock title="Фундація Лятошинського" grip>
+    <CollapsibleBlock
+      title={headerTitle}
+      grip
+      hidden={block.hidden}
+      onToggleVisibility={() => toggleBlockVisibility(pageId, blockId)}
+    >
+      <CustomTextField
+        fieldType="formatting"
+        title="Заголовок секції"
+        label="Текст заголовку"
+        value={block.title?.[currentLocale]}
+        onChange={handleTitleChange}
+      />
       <FoundationBlock
         mainText={mainText}
         paragraphs={paragraphs}

--- a/app/shared/components/about-us/Liatoshynsky-office/Liatoshynsky-office.test.tsx
+++ b/app/shared/components/about-us/Liatoshynsky-office/Liatoshynsky-office.test.tsx
@@ -1,13 +1,15 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import { LiatoshynskyOffice } from './Liatoshynsky-office';
+import { createDocNode } from '~/__mocks__/utils';
 import { BLOCK_IDS, PAGE_IDS } from '~/constants/pageBlocks';
 
 const setFieldMock = jest.fn();
+const toggleBlockVisibilityMock = jest.fn();
 
 jest.mock('~/store', () => ({
-  useStore: (selector: (s: { locale: 'uk'; setField: typeof setFieldMock }) => unknown) =>
-    selector({ locale: 'uk', setField: setFieldMock })
+  useStore: (selector: (s: { locale: 'uk'; setField: typeof setFieldMock; toggleBlockVisibility: typeof toggleBlockVisibilityMock }) => unknown) =>
+    selector({ locale: 'uk', setField: setFieldMock, toggleBlockVisibility: toggleBlockVisibilityMock })
 }));
 
 const usePageBlockMock = jest.fn();
@@ -17,9 +19,22 @@ jest.mock('~/shared/hooks/use-page-block/usePageBlock', () => ({
 
 jest.mock('~/ds-components/collapsible-block/CollapsibleBlock', () => ({
   __esModule: true,
-  default: ({ title, children }: { title: string; children: React.ReactNode }) => (
+  default: ({
+    title,
+    children,
+    onToggleVisibility
+  }: {
+    title: string;
+    children: React.ReactNode;
+    onToggleVisibility?: () => void;
+  }) => (
     <div data-testid="collapsible-block">
       <div>{title}</div>
+      {onToggleVisibility && (
+        <button data-testid="collapsible-block-toggle-visibility" onClick={onToggleVisibility}>
+          Toggle visibility
+        </button>
+      )}
       {children}
     </div>
   )
@@ -28,6 +43,7 @@ jest.mock('../../edit-block-skeleton/EditBlockSkeleton', () => ({
   EditBlockSkeleton: () => <div data-testid="edit-block-skeleton" />
 }));
 jest.mock('~/components/grip/Grip');
+jest.mock('~/ds-components/text-field/TextField');
 
 jest.mock('./quote-block/QuoteBlock', () => ({
   QuoteBlock: ({
@@ -123,6 +139,30 @@ describe('LiatoshynskyOffice', () => {
       expect.objectContaining({
         source: expect.any(Object),
         text: expect.objectContaining({ uk: 'Новий опис' })
+      })
+    );
+  });
+
+  it('should call toggleBlockVisibility with pageId and blockId when the visibility toggle is clicked', () => {
+    renderComponent();
+
+    fireEvent.click(screen.getByTestId('collapsible-block-toggle-visibility'));
+
+    expect(toggleBlockVisibilityMock).toHaveBeenCalledWith(PAGE_IDS.ABOUT_US, BLOCK_IDS.LIATOSHYNSKY_OFFICE);
+  });
+
+  it('should update the section title, falling back to an empty localized doc when block.title is missing', () => {
+    renderComponent();
+
+    fireEvent.click(screen.getByTestId('trigger-change-Заголовок секції'));
+
+    expect(setFieldMock).toHaveBeenCalledWith(
+      PAGE_IDS.ABOUT_US,
+      BLOCK_IDS.LIATOSHYNSKY_OFFICE,
+      'title',
+      expect.objectContaining({
+        uk: createDocNode('Updated Заголовок секції'),
+        en: {}
       })
     );
   });

--- a/app/shared/components/about-us/Liatoshynsky-office/Liatoshynsky-office.test.tsx
+++ b/app/shared/components/about-us/Liatoshynsky-office/Liatoshynsky-office.test.tsx
@@ -6,10 +6,11 @@ import { BLOCK_IDS, PAGE_IDS } from '~/constants/pageBlocks';
 
 const setFieldMock = jest.fn();
 const toggleBlockVisibilityMock = jest.fn();
+const setFieldValidityMock = jest.fn();
 
 jest.mock('~/store', () => ({
-  useStore: (selector: (s: { locale: 'uk'; setField: typeof setFieldMock; toggleBlockVisibility: typeof toggleBlockVisibilityMock }) => unknown) =>
-    selector({ locale: 'uk', setField: setFieldMock, toggleBlockVisibility: toggleBlockVisibilityMock })
+  useStore: (selector: (s: { locale: 'uk'; setField: typeof setFieldMock; toggleBlockVisibility: typeof toggleBlockVisibilityMock; setFieldValidity: typeof setFieldValidityMock }) => unknown) =>
+    selector({ locale: 'uk', setField: setFieldMock, toggleBlockVisibility: toggleBlockVisibilityMock, setFieldValidity: setFieldValidityMock })
 }));
 
 const usePageBlockMock = jest.fn();
@@ -164,6 +165,25 @@ describe('LiatoshynskyOffice', () => {
         uk: createDocNode('Updated Заголовок секції'),
         en: {}
       })
+    );
+  });
+
+  it('should mark the title as invalid after blur when it is empty, and clear the flag on unmount', () => {
+    const { unmount } = renderComponent();
+
+    fireEvent.click(screen.getByTestId('trigger-blur-Заголовок секції'));
+
+    expect(screen.getByTestId('textfield-error-Заголовок секції')).toBeInTheDocument();
+    expect(setFieldValidityMock).toHaveBeenCalledWith(
+      `${PAGE_IDS.ABOUT_US}:${BLOCK_IDS.LIATOSHYNSKY_OFFICE}:title`,
+      true
+    );
+
+    unmount();
+
+    expect(setFieldValidityMock).toHaveBeenLastCalledWith(
+      `${PAGE_IDS.ABOUT_US}:${BLOCK_IDS.LIATOSHYNSKY_OFFICE}:title`,
+      false
     );
   });
 });

--- a/app/shared/components/about-us/Liatoshynsky-office/Liatoshynsky-office.tsx
+++ b/app/shared/components/about-us/Liatoshynsky-office/Liatoshynsky-office.tsx
@@ -25,8 +25,10 @@ export const LiatoshynskyOffice = () => {
   if (!block) return <EditBlockSkeleton />;
 
   const handleSectionTitleChange = (val: JSONContent) => {
+    const fallbackTitle: Record<'uk' | 'en', JSONContent> = { uk: {} as JSONContent, en: {} as JSONContent };
+
     setField(pageId, blockId, 'title', {
-      ...block.title,
+      ...(block.title ?? fallbackTitle),
       [currentLocale]: val
     });
   };

--- a/app/shared/components/about-us/Liatoshynsky-office/Liatoshynsky-office.tsx
+++ b/app/shared/components/about-us/Liatoshynsky-office/Liatoshynsky-office.tsx
@@ -6,9 +6,11 @@ import { EditBlockSkeleton } from '../../edit-block-skeleton/EditBlockSkeleton';
 import { QuoteBlock } from './quote-block/QuoteBlock';
 import { BLOCK_IDS, PAGE_IDS } from '~/constants/pageBlocks';
 import CollapsibleBlock from '~/ds-components/collapsible-block/CollapsibleBlock';
+import { CustomTextField } from '~/ds-components/text-field/TextField';
+import { proseToHeaderText } from '~/lib/utils/prose';
 import { usePageBlock } from '~/shared/hooks/use-page-block/usePageBlock';
 import { useStore } from '~/store';
-import { LocalizedString } from '~/types/common';
+import { LocalizedString, ProseDoc } from '~/types/common';
 
 export const LiatoshynskyOffice = () => {
   const pageId = PAGE_IDS.ABOUT_US;
@@ -16,10 +18,18 @@ export const LiatoshynskyOffice = () => {
 
   const { block } = usePageBlock(pageId, blockId);
   const setField = useStore((state) => state.setField);
+  const toggleBlockVisibility = useStore((state) => state.toggleBlockVisibility);
 
   const currentLocale: keyof LocalizedString = useStore((state) => state.locale);
 
   if (!block) return <EditBlockSkeleton />;
+
+  const handleSectionTitleChange = (val: JSONContent) => {
+    setField(pageId, blockId, 'title', {
+      ...block.title,
+      [currentLocale]: val
+    });
+  };
 
   const handleTitleChange = (val: JSONContent) => {
     setField(pageId, blockId, 'quote', {
@@ -41,8 +51,22 @@ export const LiatoshynskyOffice = () => {
     });
   };
 
+  const headerTitle = proseToHeaderText(block.title?.[currentLocale] as ProseDoc, 'Кабінет Лятошинського');
+
   return (
-    <CollapsibleBlock title="Кабінет Лятошинського" grip>
+    <CollapsibleBlock
+      title={headerTitle}
+      grip
+      hidden={block.hidden}
+      onToggleVisibility={() => toggleBlockVisibility(pageId, blockId)}
+    >
+      <CustomTextField
+        fieldType="formatting"
+        title="Заголовок секції"
+        label="Текст заголовку"
+        value={block.title?.[currentLocale]}
+        onChange={handleSectionTitleChange}
+      />
       <QuoteBlock
         title={block.quote.source[currentLocale]}
         description={block.quote.text[currentLocale]}

--- a/app/shared/components/about-us/Liatoshynsky-office/Liatoshynsky-office.tsx
+++ b/app/shared/components/about-us/Liatoshynsky-office/Liatoshynsky-office.tsx
@@ -9,6 +9,7 @@ import CollapsibleBlock from '~/ds-components/collapsible-block/CollapsibleBlock
 import { CustomTextField } from '~/ds-components/text-field/TextField';
 import { proseToHeaderText } from '~/lib/utils/prose';
 import { usePageBlock } from '~/shared/hooks/use-page-block/usePageBlock';
+import { useTitleValidation } from '~/shared/hooks/use-title-validation/useTitleValidation';
 import { useStore } from '~/store';
 import { LocalizedString, ProseDoc } from '~/types/common';
 
@@ -21,6 +22,8 @@ export const LiatoshynskyOffice = () => {
   const toggleBlockVisibility = useStore((state) => state.toggleBlockVisibility);
 
   const currentLocale: keyof LocalizedString = useStore((state) => state.locale);
+
+  const titleValidation = useTitleValidation(`${pageId}:${blockId}:title`, block?.title?.[currentLocale] as ProseDoc);
 
   if (!block) return <EditBlockSkeleton />;
 
@@ -68,6 +71,9 @@ export const LiatoshynskyOffice = () => {
         label="Текст заголовку"
         value={block.title?.[currentLocale]}
         onChange={handleSectionTitleChange}
+        onBlur={titleValidation.onBlur}
+        error={titleValidation.error}
+        helperText={titleValidation.helperText}
       />
       <QuoteBlock
         title={block.quote.source[currentLocale]}

--- a/app/shared/components/about-us/foundation-founders/FoundationFounders.test.tsx
+++ b/app/shared/components/about-us/foundation-founders/FoundationFounders.test.tsx
@@ -13,10 +13,11 @@ export interface MockContributorCardProps {
 }
 
 const setFieldMock = jest.fn();
+const toggleBlockVisibilityMock = jest.fn();
 const usePageBlockMock = jest.fn();
 jest.mock('~/store', () => ({
-  useStore: (selector: (state: { readonly locale: 'uk'; readonly setField: typeof setFieldMock }) => unknown) =>
-    selector({ locale: 'uk', setField: setFieldMock })
+  useStore: (selector: (state: { readonly locale: 'uk'; readonly setField: typeof setFieldMock; readonly toggleBlockVisibility: typeof toggleBlockVisibilityMock }) => unknown) =>
+    selector({ locale: 'uk', setField: setFieldMock, toggleBlockVisibility: toggleBlockVisibilityMock })
 }));
 jest.mock('~/shared/hooks/use-page-block/usePageBlock', () => ({
   usePageBlock: () => usePageBlockMock()
@@ -89,6 +90,12 @@ describe('FoundationFounders', () => {
 
     expect(screen.getByTestId('textfield-json-Вступний текст секції')).toHaveTextContent(JSON.stringify(mockIntroJson));
     expect(screen.getByTestId('textfield-json-Заголовок секції')).toHaveTextContent(JSON.stringify(mockListTitleJson));
+  });
+
+  it('should call toggleBlockVisibility with pageId and blockId when the visibility toggle is clicked', () => {
+    runSimulation(defaultMockBlock, 'collapsible-block-toggle-visibility');
+
+    expect(toggleBlockVisibilityMock).toHaveBeenCalledWith(PAGE_IDS.ABOUT_US, BLOCK_IDS.FOUNDATION_FOUNDERS);
   });
 
   it.each([

--- a/app/shared/components/about-us/foundation-founders/FoundationFounders.test.tsx
+++ b/app/shared/components/about-us/foundation-founders/FoundationFounders.test.tsx
@@ -10,14 +10,18 @@ import { TeamMemberWithId } from '~/types/store/pages/about-us/blocks/foundation
 export interface MockContributorCardProps {
   readonly contributor: TeamMemberWithId;
   readonly currentLocale: 'uk' | 'en';
+  readonly onChangeName: (value: unknown) => void;
+  readonly onChangeDescription: (value: unknown) => void;
+  readonly onChangePhoto: (value: unknown) => void;
 }
 
 const setFieldMock = jest.fn();
 const toggleBlockVisibilityMock = jest.fn();
+const setFieldValidityMock = jest.fn();
 const usePageBlockMock = jest.fn();
 jest.mock('~/store', () => ({
-  useStore: (selector: (state: { readonly locale: 'uk'; readonly setField: typeof setFieldMock; readonly toggleBlockVisibility: typeof toggleBlockVisibilityMock }) => unknown) =>
-    selector({ locale: 'uk', setField: setFieldMock, toggleBlockVisibility: toggleBlockVisibilityMock })
+  useStore: (selector: (state: { readonly locale: 'uk'; readonly setField: typeof setFieldMock; readonly toggleBlockVisibility: typeof toggleBlockVisibilityMock; readonly setFieldValidity: typeof setFieldValidityMock }) => unknown) =>
+    selector({ locale: 'uk', setField: setFieldMock, toggleBlockVisibility: toggleBlockVisibilityMock, setFieldValidity: setFieldValidityMock })
 }));
 jest.mock('~/shared/hooks/use-page-block/usePageBlock', () => ({
   usePageBlock: () => usePageBlockMock()
@@ -29,11 +33,29 @@ jest.mock('~/components/grip/Grip');
 jest.mock('~/components/configurable-list/ConfigurableList');
 jest.mock('~/components/contributor-card/ContributorCard', () => ({
   __esModule: true,
-  ContributorCard: ({ contributor, currentLocale }: MockContributorCardProps) => (
+  ContributorCard: ({ contributor, currentLocale, onChangeName, onChangeDescription, onChangePhoto }: MockContributorCardProps) => (
     <div data-testid={`contributor-card-${contributor.id}`}>
       <span data-testid={`contributor-name-json-${contributor.id}`}>
         {JSON.stringify(contributor.name[currentLocale])}
       </span>
+      <button
+        data-testid={`trigger-member-name-change-${contributor.id}`}
+        onClick={() => onChangeName(createDocNode('Updated Member Name'))}
+      >
+        Change Name
+      </button>
+      <button
+        data-testid={`trigger-member-desc-change-${contributor.id}`}
+        onClick={() => onChangeDescription(createDocNode('Updated Member Description'))}
+      >
+        Change Description
+      </button>
+      <button
+        data-testid={`trigger-member-photo-change-${contributor.id}`}
+        onClick={() => onChangePhoto({ src: 'new-photo.jpg', alt: {}, caption: {}, generatedSrc: '' })}
+      >
+        Change Photo
+      </button>
     </div>
   )
 }));
@@ -96,6 +118,105 @@ describe('FoundationFounders', () => {
     runSimulation(defaultMockBlock, 'collapsible-block-toggle-visibility');
 
     expect(toggleBlockVisibilityMock).toHaveBeenCalledWith(PAGE_IDS.ABOUT_US, BLOCK_IDS.FOUNDATION_FOUNDERS);
+  });
+
+  it.each([
+    ['titleText', 'Вступний текст секції', 'titleText'],
+    ['listTitle', 'Заголовок секції', 'listTitle']
+  ])('should mark %s as invalid after blur when it is empty, and clear the flag on unmount', (_label, fieldLabel, blockField) => {
+    const emptyBlock = { ...defaultMockBlock, [blockField]: { uk: { type: 'doc', content: [] } } };
+    usePageBlockMock.mockReturnValue({ block: emptyBlock });
+
+    const { unmount } = render(<FoundationFounders />);
+
+    fireEvent.click(screen.getByTestId(`trigger-blur-${fieldLabel}`));
+
+    expect(screen.getByTestId(`textfield-error-${fieldLabel}`)).toBeInTheDocument();
+    expect(setFieldValidityMock).toHaveBeenCalledWith(
+      `${PAGE_IDS.ABOUT_US}:${BLOCK_IDS.FOUNDATION_FOUNDERS}:${blockField}`,
+      true
+    );
+
+    unmount();
+
+    expect(setFieldValidityMock).toHaveBeenCalledWith(
+      `${PAGE_IDS.ABOUT_US}:${BLOCK_IDS.FOUNDATION_FOUNDERS}:${blockField}`,
+      false
+    );
+  });
+
+  it('should update member name, description, and photo via ContributorCard callbacks', () => {
+    usePageBlockMock.mockReturnValue({ block: populatedMockBlock });
+    render(<FoundationFounders />);
+
+    fireEvent.click(screen.getByTestId(`trigger-member-name-change-${TARGET_MEMBER_ID}`));
+    expect(setFieldMock).toHaveBeenCalledWith(
+      PAGE_IDS.ABOUT_US,
+      BLOCK_IDS.FOUNDATION_FOUNDERS,
+      'members',
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: TARGET_MEMBER_ID,
+          name: expect.objectContaining({ uk: createDocNode('Updated Member Name') })
+        })
+      ])
+    );
+
+    fireEvent.click(screen.getByTestId(`trigger-member-desc-change-${TARGET_MEMBER_ID}`));
+    expect(setFieldMock).toHaveBeenCalledWith(
+      PAGE_IDS.ABOUT_US,
+      BLOCK_IDS.FOUNDATION_FOUNDERS,
+      'members',
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: TARGET_MEMBER_ID,
+          description: expect.objectContaining({ uk: createDocNode('Updated Member Description') })
+        })
+      ])
+    );
+
+    fireEvent.click(screen.getByTestId(`trigger-member-photo-change-${TARGET_MEMBER_ID}`));
+    expect(setFieldMock).toHaveBeenCalledWith(
+      PAGE_IDS.ABOUT_US,
+      BLOCK_IDS.FOUNDATION_FOUNDERS,
+      'members',
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: TARGET_MEMBER_ID,
+          photo: expect.objectContaining({ src: 'new-photo.jpg' })
+        })
+      ])
+    );
+  });
+
+  it('should leave unrelated members untouched when updating a single member in a multi-member list', () => {
+    const otherMember = {
+      id: 'other-member-id',
+      name: { uk: mockMemberNameJson, en: {} },
+      description: { uk: {}, en: {} },
+      photo: { src: '', alt: {}, caption: {}, generatedSrc: '' }
+    };
+    const multiMemberBlock = {
+      ...defaultMockBlock,
+      members: [populatedMockBlock.members[0], otherMember] as TeamMemberWithId[]
+    };
+    usePageBlockMock.mockReturnValue({ block: multiMemberBlock });
+
+    render(<FoundationFounders />);
+    fireEvent.click(screen.getByTestId(`trigger-member-name-change-${TARGET_MEMBER_ID}`));
+
+    expect(setFieldMock).toHaveBeenCalledWith(
+      PAGE_IDS.ABOUT_US,
+      BLOCK_IDS.FOUNDATION_FOUNDERS,
+      'members',
+      [
+        expect.objectContaining({
+          id: TARGET_MEMBER_ID,
+          name: expect.objectContaining({ uk: createDocNode('Updated Member Name') })
+        }),
+        otherMember
+      ]
+    );
   });
 
   it.each([

--- a/app/shared/components/about-us/foundation-founders/FoundationFounders.tsx
+++ b/app/shared/components/about-us/foundation-founders/FoundationFounders.tsx
@@ -10,9 +10,10 @@ import { BLOCK_IDS, PAGE_IDS } from '~/constants/pageBlocks';
 import CollapsibleBlock from '~/ds-components/collapsible-block/CollapsibleBlock';
 import { CustomTextField } from '~/ds-components/text-field/TextField';
 import { ensureIds } from '~/lib/utils/ensureIds';
+import { proseToHeaderText } from '~/lib/utils/prose';
 import { usePageBlock } from '~/shared/hooks/use-page-block/usePageBlock';
 import { useStore } from '~/store';
-import { ImageType, LocalizedString } from '~/types/common';
+import { ImageType, LocalizedString, ProseDoc } from '~/types/common';
 import { TeamMemberWithId } from '~/types/store/pages/about-us/blocks/foundationFounderBlock';
 export const FoundationFounders = () => {
   const pageId = PAGE_IDS.ABOUT_US;
@@ -21,6 +22,7 @@ export const FoundationFounders = () => {
   const { block } = usePageBlock(pageId, blockId);
   const currentLocale: keyof LocalizedString = useStore((state) => state.locale);
   const setField = useStore((state) => state.setField);
+  const toggleBlockVisibility = useStore((state) => state.toggleBlockVisibility);
 
   if (!block) return <EditBlockSkeleton />;
 
@@ -69,8 +71,15 @@ export const FoundationFounders = () => {
     });
   };
 
+  const headerTitle = proseToHeaderText(block.listTitle?.[currentLocale] as ProseDoc, 'Команда Фундації');
+
   return (
-    <CollapsibleBlock title="Команда Фундації" grip>
+    <CollapsibleBlock
+      title={headerTitle}
+      grip
+      hidden={block.hidden}
+      onToggleVisibility={() => toggleBlockVisibility(pageId, blockId)}
+    >
       <CustomTextField
         fieldType="formatting"
         title="Вступний текст секції"

--- a/app/shared/components/about-us/foundation-founders/FoundationFounders.tsx
+++ b/app/shared/components/about-us/foundation-founders/FoundationFounders.tsx
@@ -12,6 +12,7 @@ import { CustomTextField } from '~/ds-components/text-field/TextField';
 import { ensureIds } from '~/lib/utils/ensureIds';
 import { proseToHeaderText } from '~/lib/utils/prose';
 import { usePageBlock } from '~/shared/hooks/use-page-block/usePageBlock';
+import { useTitleValidation } from '~/shared/hooks/use-title-validation/useTitleValidation';
 import { useStore } from '~/store';
 import { ImageType, LocalizedString, ProseDoc } from '~/types/common';
 import { TeamMemberWithId } from '~/types/store/pages/about-us/blocks/foundationFounderBlock';
@@ -23,6 +24,9 @@ export const FoundationFounders = () => {
   const currentLocale: keyof LocalizedString = useStore((state) => state.locale);
   const setField = useStore((state) => state.setField);
   const toggleBlockVisibility = useStore((state) => state.toggleBlockVisibility);
+
+  const titleTextValidation = useTitleValidation(`${pageId}:${blockId}:titleText`, block?.titleText?.[currentLocale] as ProseDoc);
+  const listTitleValidation = useTitleValidation(`${pageId}:${blockId}:listTitle`, block?.listTitle?.[currentLocale] as ProseDoc);
 
   if (!block) return <EditBlockSkeleton />;
 
@@ -86,6 +90,9 @@ export const FoundationFounders = () => {
         label="Текст заголовку"
         value={block.titleText[currentLocale]}
         onChange={(value) => handleChangeTitleText(value)}
+        onBlur={titleTextValidation.onBlur}
+        error={titleTextValidation.error}
+        helperText={titleTextValidation.helperText}
       />
 
       <CustomTextField
@@ -94,6 +101,9 @@ export const FoundationFounders = () => {
         label="Текст заголовку"
         value={block.listTitle[currentLocale]}
         onChange={(value) => handleChangeListTitle(value)}
+        onBlur={listTitleValidation.onBlur}
+        error={listTitleValidation.error}
+        helperText={listTitleValidation.helperText}
       />
 
       <Typography sx={styles.contributorsTitle} variant="subtitle1">

--- a/app/shared/components/about-us/our-goals/OurGoals.test.tsx
+++ b/app/shared/components/about-us/our-goals/OurGoals.test.tsx
@@ -8,10 +8,11 @@ import { GoalItemWithId } from '~/types/store/pages/about-us/blocks/ourGoalsBloc
 
 const setFieldMock = jest.fn();
 const toggleBlockVisibilityMock = jest.fn();
+const setFieldValidityMock = jest.fn();
 const usePageBlockMock = jest.fn();
 jest.mock('~/store', () => ({
-  useStore: (selector: (state: { readonly locale: 'uk'; readonly setField: typeof setFieldMock; readonly toggleBlockVisibility: typeof toggleBlockVisibilityMock }) => unknown) =>
-    selector({ locale: 'uk', setField: setFieldMock, toggleBlockVisibility: toggleBlockVisibilityMock })
+  useStore: (selector: (state: { readonly locale: 'uk'; readonly setField: typeof setFieldMock; readonly toggleBlockVisibility: typeof toggleBlockVisibilityMock; readonly setFieldValidity: typeof setFieldValidityMock }) => unknown) =>
+    selector({ locale: 'uk', setField: setFieldMock, toggleBlockVisibility: toggleBlockVisibilityMock, setFieldValidity: setFieldValidityMock })
 }));
 jest.mock('~/shared/hooks/use-page-block/usePageBlock', () => ({
   usePageBlock: () => usePageBlockMock()
@@ -122,6 +123,49 @@ describe('OurGoals', () => {
     setupTest('collapsible-block-toggle-visibility');
 
     expect(toggleBlockVisibilityMock).toHaveBeenCalledWith(PAGE_IDS.ABOUT_US, BLOCK_IDS.OUR_GOALS);
+  });
+
+  it('should leave unrelated goal items untouched when updating a single item in a multi-item list', () => {
+    const otherGoal = {
+      id: 'other-id',
+      title: { uk: mockGoalTitleJson, en: { type: 'doc', content: [] } },
+      description: { uk: mockGoalDescJson, en: { type: 'doc', content: [] } }
+    };
+    const multiItemBlock = {
+      title: { uk: mockBlockTitleJson },
+      goals: [mockBlock.goals[0], otherGoal] as GoalItemWithId[]
+    };
+    usePageBlockMock.mockReturnValue({ block: multiItemBlock });
+
+    render(<OurGoals />);
+    fireEvent.click(screen.getByTestId(`trigger-item-title-change-${TARGET_ID}`));
+
+    expect(setFieldMock).toHaveBeenCalledWith(
+      PAGE_IDS.ABOUT_US,
+      BLOCK_IDS.OUR_GOALS,
+      'goals',
+      [
+        expect.objectContaining({ id: TARGET_ID, title: expect.objectContaining({ uk: createDocNode('Updated Item Title') }) }),
+        otherGoal
+      ]
+    );
+  });
+
+  it('should mark the title as invalid after blur when it is empty, and clear the flag on unmount', () => {
+    usePageBlockMock.mockReturnValue({
+      block: { ...mockBlock, title: { uk: { type: 'doc', content: [] } } }
+    });
+
+    const { unmount } = render(<OurGoals />);
+
+    fireEvent.click(screen.getByTestId('trigger-main-title-blur'));
+
+    expect(screen.getByTestId('main-title-error')).toBeInTheDocument();
+    expect(setFieldValidityMock).toHaveBeenCalledWith(`${PAGE_IDS.ABOUT_US}:${BLOCK_IDS.OUR_GOALS}:title`, true);
+
+    unmount();
+
+    expect(setFieldValidityMock).toHaveBeenLastCalledWith(`${PAGE_IDS.ABOUT_US}:${BLOCK_IDS.OUR_GOALS}:title`, false);
   });
 
   it('should render the grip handle and handle drag-and-drop reordering', () => {

--- a/app/shared/components/about-us/our-goals/OurGoals.test.tsx
+++ b/app/shared/components/about-us/our-goals/OurGoals.test.tsx
@@ -7,10 +7,11 @@ import { BLOCK_IDS, PAGE_IDS } from '~/constants/pageBlocks';
 import { GoalItemWithId } from '~/types/store/pages/about-us/blocks/ourGoalsBlock';
 
 const setFieldMock = jest.fn();
+const toggleBlockVisibilityMock = jest.fn();
 const usePageBlockMock = jest.fn();
 jest.mock('~/store', () => ({
-  useStore: (selector: (state: { readonly locale: 'uk'; readonly setField: typeof setFieldMock }) => unknown) =>
-    selector({ locale: 'uk', setField: setFieldMock })
+  useStore: (selector: (state: { readonly locale: 'uk'; readonly setField: typeof setFieldMock; readonly toggleBlockVisibility: typeof toggleBlockVisibilityMock }) => unknown) =>
+    selector({ locale: 'uk', setField: setFieldMock, toggleBlockVisibility: toggleBlockVisibilityMock })
 }));
 jest.mock('~/shared/hooks/use-page-block/usePageBlock', () => ({
   usePageBlock: () => usePageBlockMock()
@@ -116,6 +117,12 @@ describe('OurGoals', () => {
       );
     }
   );
+
+  it('should call toggleBlockVisibility with pageId and blockId when the visibility toggle is clicked', () => {
+    setupTest('collapsible-block-toggle-visibility');
+
+    expect(toggleBlockVisibilityMock).toHaveBeenCalledWith(PAGE_IDS.ABOUT_US, BLOCK_IDS.OUR_GOALS);
+  });
 
   it('should render the grip handle and handle drag-and-drop reordering', () => {
     const doubleMockBlock = {

--- a/app/shared/components/about-us/our-goals/OurGoals.tsx
+++ b/app/shared/components/about-us/our-goals/OurGoals.tsx
@@ -9,6 +9,7 @@ import { ensureIds } from '~/lib/utils/ensureIds';
 import { proseToHeaderText } from '~/lib/utils/prose';
 import { handleSortableDragEnd } from '~/lib/utils/sortableDragEndHelper';
 import { usePageBlock } from '~/shared/hooks/use-page-block/usePageBlock';
+import { useTitleValidation } from '~/shared/hooks/use-title-validation/useTitleValidation';
 import { useStore } from '~/store';
 import { LocalizedString, ProseDoc } from '~/types/common';
 import type { GoalItemWithId } from '~/types/store/pages/about-us/blocks/ourGoalsBlock';
@@ -24,6 +25,8 @@ const OurGoals = () => {
   const toggleBlockVisibility = useStore((state) => state.toggleBlockVisibility);
 
   const goalList: GoalItemWithId[] = block ? ensureIds(block.goals) : [];
+
+  const titleValidation = useTitleValidation(`${pageId}:${blockId}:title`, block?.title?.[currentLocale] as ProseDoc);
 
   const handleDragEnd = (event: DragEndEvent) => {
     handleSortableDragEnd(event, goalList, (reordered) => {
@@ -91,6 +94,9 @@ const OurGoals = () => {
       <EditableSectionList
         title={block.title[currentLocale]}
         onTitleChange={handleTitleChange}
+        onTitleBlur={titleValidation.onBlur}
+        titleError={titleValidation.error}
+        titleHelperText={titleValidation.helperText}
         items={goalPoints}
         onChangeItem={handleChangeItem}
         onCreateItem={handleCreateItem}

--- a/app/shared/components/about-us/our-goals/OurGoals.tsx
+++ b/app/shared/components/about-us/our-goals/OurGoals.tsx
@@ -6,10 +6,11 @@ import { EditBlockSkeleton } from '../../edit-block-skeleton/EditBlockSkeleton';
 import { BLOCK_IDS, PAGE_IDS } from '~/constants/pageBlocks';
 import CollapsibleBlock from '~/ds-components/collapsible-block/CollapsibleBlock';
 import { ensureIds } from '~/lib/utils/ensureIds';
+import { proseToHeaderText } from '~/lib/utils/prose';
 import { handleSortableDragEnd } from '~/lib/utils/sortableDragEndHelper';
 import { usePageBlock } from '~/shared/hooks/use-page-block/usePageBlock';
 import { useStore } from '~/store';
-import { LocalizedString } from '~/types/common';
+import { LocalizedString, ProseDoc } from '~/types/common';
 import type { GoalItemWithId } from '~/types/store/pages/about-us/blocks/ourGoalsBlock';
 
 const OurGoals = () => {
@@ -20,6 +21,7 @@ const OurGoals = () => {
 
   const currentLocale: keyof LocalizedString = useStore((state) => state.locale);
   const setField = useStore((state) => state.setField);
+  const toggleBlockVisibility = useStore((state) => state.toggleBlockVisibility);
 
   const goalList: GoalItemWithId[] = block ? ensureIds(block.goals) : [];
 
@@ -77,8 +79,15 @@ const OurGoals = () => {
       goalList.filter((item) => item.id !== id)
     );
 
+  const headerTitle = proseToHeaderText(block.title?.[currentLocale] as ProseDoc, 'Наші цілі');
+
   return (
-    <CollapsibleBlock title="Наші цілі" grip>
+    <CollapsibleBlock
+      title={headerTitle}
+      grip
+      hidden={block.hidden}
+      onToggleVisibility={() => toggleBlockVisibility(pageId, blockId)}
+    >
       <EditableSectionList
         title={block.title[currentLocale]}
         onTitleChange={handleTitleChange}

--- a/app/shared/components/about-us/our-mission/OurMission.test.tsx
+++ b/app/shared/components/about-us/our-mission/OurMission.test.tsx
@@ -10,17 +10,18 @@ import { MissionListItemWithId } from '~/types/store/pages/about-us/blocks/missi
 interface MockImagePreviewBlockProps {
   readonly title: string;
   readonly imageUrl: string;
-  readonly onChangeImage: (url: string) => void;
+  readonly onChangeImage: (url: string, crop?: unknown) => void;
 }
 
 const setFieldMock = jest.fn();
 const toggleBlockVisibilityMock = jest.fn();
+const setFieldValidityMock = jest.fn();
 const usePageBlockMock = jest.fn();
 jest.mock('~/utils/uploadToTmpFolder', () => ({ handleUploadImage: jest.fn() }));
 jest.mock('~/types/graphql/generated/graphql', () => ({ useUploadBlobMutation: () => [jest.fn()] }));
 jest.mock('~/store', () => ({
-  useStore: (selector: (state: { readonly locale: 'uk'; readonly setField: typeof setFieldMock; readonly toggleBlockVisibility: typeof toggleBlockVisibilityMock }) => unknown) =>
-    selector({ locale: 'uk', setField: setFieldMock, toggleBlockVisibility: toggleBlockVisibilityMock })
+  useStore: (selector: (state: { readonly locale: 'uk'; readonly setField: typeof setFieldMock; readonly toggleBlockVisibility: typeof toggleBlockVisibilityMock; readonly setFieldValidity: typeof setFieldValidityMock }) => unknown) =>
+    selector({ locale: 'uk', setField: setFieldMock, toggleBlockVisibility: toggleBlockVisibilityMock, setFieldValidity: setFieldValidityMock })
 }));
 jest.mock('~/shared/hooks/use-page-block/usePageBlock', () => ({
   usePageBlock: () => usePageBlockMock()
@@ -38,6 +39,12 @@ jest.mock('~/ds-components/photo-block/PhotoBlock', () => ({
       <button data-testid={`upload-${title}`} onClick={() => onChangeImage('new-image-path.jpg')}>
         Upload
       </button>
+      <button
+        data-testid={`upload-with-crop-${title}`}
+        onClick={() => onChangeImage('new-image-path.jpg', { rect: { x: 0, y: 0, width: 10, height: 10 } })}
+      >
+        Upload With Crop
+      </button>
     </div>
   )
 }));
@@ -49,7 +56,9 @@ const keys = {
   title: 'Заголовок секції',
   item: 'Пункт місії',
   caption: 'Підпис до зображення (Перше зображення секції)',
-  upload: 'Перше зображення секції'
+  upload: 'Перше зображення секції',
+  bigCaption: 'Підпис до зображення (Друге зображення секції)',
+  bigUpload: 'Друге зображення секції'
 };
 
 beforeAll(() => {
@@ -99,6 +108,27 @@ describe('OurMission', () => {
     expect(screen.getByTestId(`textfield-json-${keys.item}`)).toHaveTextContent(JSON.stringify(mockItemJson));
   });
 
+  it('should render skeleton when no block exists', () => {
+    usePageBlockMock.mockReturnValue({ block: null });
+
+    render(<OurMission />);
+
+    expect(screen.queryByTestId('collapsible-block')).not.toBeInTheDocument();
+    expect(document.querySelector('.MuiSkeleton-root')).toBeInTheDocument();
+  });
+
+  it('should still render the image block when the image src is an empty string', () => {
+    const blockWithEmptySrc = {
+      ...mockBlock,
+      smallImage: { ...mockBlock.smallImage, src: '' }
+    };
+    usePageBlockMock.mockReturnValue({ block: blockWithEmptySrc });
+
+    render(<OurMission />);
+
+    expect(screen.getByTestId(`image-block-${keys.upload}`)).toBeInTheDocument();
+  });
+
   it.each([
     [
       'section title changes',
@@ -142,6 +172,20 @@ describe('OurMission', () => {
       `upload-${keys.upload}`,
       'smallImage',
       expect.objectContaining({ src: 'new-image-path.jpg', isTmp: false, crop: null })
+    ],
+    [
+      'editing layout image configuration captions for the second image',
+      `trigger-change-${keys.bigCaption}`,
+      'bigImage',
+      expect.objectContaining({
+        caption: expect.objectContaining({ uk: createDocNode(`Updated ${keys.bigCaption}`) })
+      })
+    ],
+    [
+      'propagating new asset paths through upload channels for the second image',
+      `upload-${keys.bigUpload}`,
+      'bigImage',
+      expect.objectContaining({ src: 'new-image-path.jpg', isTmp: false, crop: null })
     ]
   ])(
     'should correctly invoke setField upon %s',
@@ -161,6 +205,23 @@ describe('OurMission', () => {
     runSimulation('collapsible-block-toggle-visibility');
 
     expect(toggleBlockVisibilityMock).toHaveBeenCalledWith(PAGE_IDS.ABOUT_US, BLOCK_IDS.OUR_MISSION);
+  });
+
+  it('should mark the title as invalid after blur when it is empty, and clear the flag on unmount', () => {
+    usePageBlockMock.mockReturnValue({
+      block: { ...mockBlock, title: { uk: { type: 'doc', content: [] } } }
+    });
+
+    const { unmount } = render(<OurMission />);
+
+    fireEvent.click(screen.getByTestId(`trigger-blur-${keys.title}`));
+
+    expect(screen.getByTestId(`textfield-error-${keys.title}`)).toBeInTheDocument();
+    expect(setFieldValidityMock).toHaveBeenCalledWith(`${PAGE_IDS.ABOUT_US}:${BLOCK_IDS.OUR_MISSION}:title`, true);
+
+    unmount();
+
+    expect(setFieldValidityMock).toHaveBeenLastCalledWith(`${PAGE_IDS.ABOUT_US}:${BLOCK_IDS.OUR_MISSION}:title`, false);
   });
 
   it('should render the grip handle and handle drag-and-drop reordering', () => {
@@ -187,5 +248,62 @@ describe('OurMission', () => {
       'list',
       [doubleMockBlock.list[1], doubleMockBlock.list[0]]
     );
+  });
+
+  it('should leave unrelated mission points untouched when updating a single point in a multi-point list', () => {
+    const doubleMockBlock = {
+      title: { uk: mockTitleJson },
+      list: [
+        { id: '1', uk: mockItemJson, en: { type: 'doc', content: [] } },
+        { id: '2', uk: mockItemJson, en: { type: 'doc', content: [] } }
+      ] as MissionListItemWithId[],
+      smallImage: mockBlock.smallImage,
+      bigImage: mockBlock.bigImage
+    };
+    usePageBlockMock.mockReturnValue({ block: doubleMockBlock });
+
+    render(<OurMission />);
+    fireEvent.click(screen.getAllByTestId(`trigger-change-${keys.item}`)[0]);
+
+    expect(setFieldMock).toHaveBeenCalledWith(
+      PAGE_IDS.ABOUT_US,
+      BLOCK_IDS.OUR_MISSION,
+      'list',
+      [
+        expect.objectContaining({ id: '1', uk: createDocNode(`Updated ${keys.item}`) }),
+        doubleMockBlock.list[1]
+      ]
+    );
+  });
+
+  it('should propagate a provided crop through onChangeImage instead of falling back to null', () => {
+    runSimulation(`upload-with-crop-${keys.upload}`);
+
+    expect(setFieldMock).toHaveBeenCalledWith(
+      PAGE_IDS.ABOUT_US,
+      BLOCK_IDS.OUR_MISSION,
+      'smallImage',
+      expect.objectContaining({ src: 'new-image-path.jpg', isTmp: false, crop: { rect: { x: 0, y: 0, width: 10, height: 10 } } })
+    );
+  });
+
+  it('should not render the mission points list when there are no points', () => {
+    usePageBlockMock.mockReturnValue({
+      block: { ...mockBlock, list: [] }
+    });
+
+    render(<OurMission />);
+
+    expect(screen.queryByTestId('configurable-list')).not.toBeInTheDocument();
+  });
+
+  it('should not render image blocks when smallImage and bigImage are absent', () => {
+    const { smallImage: _smallImage, bigImage: _bigImage, ...blockWithoutImages } = mockBlock;
+    usePageBlockMock.mockReturnValue({ block: blockWithoutImages });
+
+    render(<OurMission />);
+
+    expect(screen.queryByTestId(`image-block-${keys.upload}`)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(`image-block-${keys.bigUpload}`)).not.toBeInTheDocument();
   });
 });

--- a/app/shared/components/about-us/our-mission/OurMission.test.tsx
+++ b/app/shared/components/about-us/our-mission/OurMission.test.tsx
@@ -14,12 +14,13 @@ interface MockImagePreviewBlockProps {
 }
 
 const setFieldMock = jest.fn();
+const toggleBlockVisibilityMock = jest.fn();
 const usePageBlockMock = jest.fn();
 jest.mock('~/utils/uploadToTmpFolder', () => ({ handleUploadImage: jest.fn() }));
 jest.mock('~/types/graphql/generated/graphql', () => ({ useUploadBlobMutation: () => [jest.fn()] }));
 jest.mock('~/store', () => ({
-  useStore: (selector: (state: { readonly locale: 'uk'; readonly setField: typeof setFieldMock }) => unknown) =>
-    selector({ locale: 'uk', setField: setFieldMock })
+  useStore: (selector: (state: { readonly locale: 'uk'; readonly setField: typeof setFieldMock; readonly toggleBlockVisibility: typeof toggleBlockVisibilityMock }) => unknown) =>
+    selector({ locale: 'uk', setField: setFieldMock, toggleBlockVisibility: toggleBlockVisibilityMock })
 }));
 jest.mock('~/shared/hooks/use-page-block/usePageBlock', () => ({
   usePageBlock: () => usePageBlockMock()
@@ -155,6 +156,12 @@ describe('OurMission', () => {
       );
     }
   );
+
+  it('should call toggleBlockVisibility with pageId and blockId when the visibility toggle is clicked', () => {
+    runSimulation('collapsible-block-toggle-visibility');
+
+    expect(toggleBlockVisibilityMock).toHaveBeenCalledWith(PAGE_IDS.ABOUT_US, BLOCK_IDS.OUR_MISSION);
+  });
 
   it('should render the grip handle and handle drag-and-drop reordering', () => {
     const doubleMockBlock = {

--- a/app/shared/components/about-us/our-mission/OurMission.tsx
+++ b/app/shared/components/about-us/our-mission/OurMission.tsx
@@ -17,11 +17,12 @@ import CollapsibleBlock from '~/ds-components/collapsible-block/CollapsibleBlock
 import { ImagePreviewBlock } from '~/ds-components/photo-block/PhotoBlock';
 import { CustomTextField } from '~/ds-components/text-field/TextField';
 import { ensureIds } from '~/lib/utils/ensureIds';
+import { proseToHeaderText } from '~/lib/utils/prose';
 import { handleSortableDragEnd } from '~/lib/utils/sortableDragEndHelper';
 import { usePageBlock } from '~/shared/hooks/use-page-block/usePageBlock';
 import { useStore } from '~/store';
 import { ConfigurableListItem } from '~/types/accordionBlocks';
-import { CropResult, LocalizedJSON } from '~/types/common';
+import { CropResult, LocalizedJSON, ProseDoc } from '~/types/common';
 import { MissionListItemWithId } from '~/types/store/pages/about-us/blocks/missionBlock';
 import { getImageUrl } from '~/utils/getImageUrl';
 
@@ -71,8 +72,9 @@ const OurMission = () => {
 
   const { block } = usePageBlock(pageId, blockId);
   const setField = useStore((state) => state.setField);
+  const toggleBlockVisibility = useStore((state) => state.toggleBlockVisibility);
   const missionList: MissionListItemWithId[] = block ? ensureIds(block.list) : [];
-  
+
   const handleDragEnd = (event: DragEndEvent) => {
     handleSortableDragEnd(event, missionList, (reordered) => {
       setField(pageId, blockId, 'list', reordered);
@@ -132,8 +134,15 @@ const OurMission = () => {
   };
 
 
+  const headerTitle = proseToHeaderText(block.title?.[currentLocale] as ProseDoc, 'Наша місія');
+
   return (
-    <CollapsibleBlock title="Наша місія" grip>
+    <CollapsibleBlock
+      title={headerTitle}
+      grip
+      hidden={block.hidden}
+      onToggleVisibility={() => toggleBlockVisibility(pageId, blockId)}
+    >
       <Box sx={styles.wrapper}>
         <CustomTextField
           fieldType="formatting"

--- a/app/shared/components/about-us/our-mission/OurMission.tsx
+++ b/app/shared/components/about-us/our-mission/OurMission.tsx
@@ -20,6 +20,7 @@ import { ensureIds } from '~/lib/utils/ensureIds';
 import { proseToHeaderText } from '~/lib/utils/prose';
 import { handleSortableDragEnd } from '~/lib/utils/sortableDragEndHelper';
 import { usePageBlock } from '~/shared/hooks/use-page-block/usePageBlock';
+import { useTitleValidation } from '~/shared/hooks/use-title-validation/useTitleValidation';
 import { useStore } from '~/store';
 import { ConfigurableListItem } from '~/types/accordionBlocks';
 import { CropResult, LocalizedJSON, ProseDoc } from '~/types/common';
@@ -74,6 +75,8 @@ const OurMission = () => {
   const setField = useStore((state) => state.setField);
   const toggleBlockVisibility = useStore((state) => state.toggleBlockVisibility);
   const missionList: MissionListItemWithId[] = block ? ensureIds(block.list) : [];
+
+  const titleValidation = useTitleValidation(`${pageId}:${blockId}:title`, block?.title?.[currentLocale] as ProseDoc);
 
   const handleDragEnd = (event: DragEndEvent) => {
     handleSortableDragEnd(event, missionList, (reordered) => {
@@ -150,6 +153,9 @@ const OurMission = () => {
           label="Текст заголовка"
           value={block.title?.[currentLocale]}
           onChange={(value) => setField(pageId, blockId, 'title', { ...block.title, [currentLocale]: value })}
+          onBlur={titleValidation.onBlur}
+          error={titleValidation.error}
+          helperText={titleValidation.helperText}
         />
       </Box>
 

--- a/app/shared/components/about-us/what-we-do/WhatWeDo.test.tsx
+++ b/app/shared/components/about-us/what-we-do/WhatWeDo.test.tsx
@@ -8,10 +8,11 @@ import { WhatWeDolItemWithId } from '~/types/store/pages/about-us/blocks/whatWeD
 
 const setFieldMock = jest.fn();
 const toggleBlockVisibilityMock = jest.fn();
+const setFieldValidityMock = jest.fn();
 const usePageBlockMock = jest.fn();
 jest.mock('~/store', () => ({
-  useStore: (selector: (state: { readonly locale: 'uk'; readonly setField: typeof setFieldMock; readonly toggleBlockVisibility: typeof toggleBlockVisibilityMock }) => unknown) =>
-    selector({ locale: 'uk', setField: setFieldMock, toggleBlockVisibility: toggleBlockVisibilityMock })
+  useStore: (selector: (state: { readonly locale: 'uk'; readonly setField: typeof setFieldMock; readonly toggleBlockVisibility: typeof toggleBlockVisibilityMock; readonly setFieldValidity: typeof setFieldValidityMock }) => unknown) =>
+    selector({ locale: 'uk', setField: setFieldMock, toggleBlockVisibility: toggleBlockVisibilityMock, setFieldValidity: setFieldValidityMock })
 }));
 jest.mock('~/ds-components/collapsible-block/CollapsibleBlock');
 jest.mock('~/components/accordion-blocks/editable-section-list/EditableSectionList');
@@ -126,6 +127,52 @@ describe('WhatWeDo', () => {
     runSimulation('collapsible-block-toggle-visibility');
 
     expect(toggleBlockVisibilityMock).toHaveBeenCalledWith(PAGE_IDS.ABOUT_US, BLOCK_IDS.WHAT_WE_DO);
+  });
+
+  it('should leave unrelated items untouched when updating a single item in a multi-item list', () => {
+    const otherItem = {
+      id: 'other-item-id',
+      title: { uk: mockItemTitleJson, en: {} },
+      description: { uk: mockItemDescJson, en: { type: 'doc', content: [] } }
+    };
+    const multiItemBlock = {
+      title: { uk: mockBlockTitleJson },
+      items: [mockBlock.items[0], otherItem] as WhatWeDolItemWithId[]
+    };
+    usePageBlockMock.mockReturnValue({ block: multiItemBlock });
+
+    render(<WhatWeDo />);
+    fireEvent.click(screen.getByTestId(`trigger-item-title-change-${ITEM_ID}`));
+
+    expect(setFieldMock).toHaveBeenCalledWith(
+      PAGE_IDS.ABOUT_US,
+      BLOCK_IDS.WHAT_WE_DO,
+      'items',
+      [
+        expect.objectContaining({
+          id: ITEM_ID,
+          title: expect.objectContaining({ uk: createDocNode('Updated Item Title') })
+        }),
+        otherItem
+      ]
+    );
+  });
+
+  it('should mark the title as invalid after blur when it is empty, and clear the flag on unmount', () => {
+    usePageBlockMock.mockReturnValue({
+      block: { ...mockBlock, title: { uk: { type: 'doc', content: [] } } }
+    });
+
+    const { unmount } = render(<WhatWeDo />);
+
+    fireEvent.click(screen.getByTestId('trigger-main-title-blur'));
+
+    expect(screen.getByTestId('main-title-error')).toBeInTheDocument();
+    expect(setFieldValidityMock).toHaveBeenCalledWith(`${PAGE_IDS.ABOUT_US}:${BLOCK_IDS.WHAT_WE_DO}:title`, true);
+
+    unmount();
+
+    expect(setFieldValidityMock).toHaveBeenLastCalledWith(`${PAGE_IDS.ABOUT_US}:${BLOCK_IDS.WHAT_WE_DO}:title`, false);
   });
 
   it('should render the grip handle and handle drag-and-drop reordering', () => {

--- a/app/shared/components/about-us/what-we-do/WhatWeDo.test.tsx
+++ b/app/shared/components/about-us/what-we-do/WhatWeDo.test.tsx
@@ -7,10 +7,11 @@ import { BLOCK_IDS, PAGE_IDS } from '~/constants/pageBlocks';
 import { WhatWeDolItemWithId } from '~/types/store/pages/about-us/blocks/whatWeDoBlock';
 
 const setFieldMock = jest.fn();
+const toggleBlockVisibilityMock = jest.fn();
 const usePageBlockMock = jest.fn();
 jest.mock('~/store', () => ({
-  useStore: (selector: (state: { readonly locale: 'uk'; readonly setField: typeof setFieldMock }) => unknown) =>
-    selector({ locale: 'uk', setField: setFieldMock })
+  useStore: (selector: (state: { readonly locale: 'uk'; readonly setField: typeof setFieldMock; readonly toggleBlockVisibility: typeof toggleBlockVisibilityMock }) => unknown) =>
+    selector({ locale: 'uk', setField: setFieldMock, toggleBlockVisibility: toggleBlockVisibilityMock })
 }));
 jest.mock('~/ds-components/collapsible-block/CollapsibleBlock');
 jest.mock('~/components/accordion-blocks/editable-section-list/EditableSectionList');
@@ -119,6 +120,12 @@ describe('WhatWeDo', () => {
     runSimulation(triggerId);
 
     expect(setFieldMock).toHaveBeenCalledWith(PAGE_IDS.ABOUT_US, BLOCK_IDS.WHAT_WE_DO, storeKey, expectedPayload);
+  });
+
+  it('should call toggleBlockVisibility with pageId and blockId when the visibility toggle is clicked', () => {
+    runSimulation('collapsible-block-toggle-visibility');
+
+    expect(toggleBlockVisibilityMock).toHaveBeenCalledWith(PAGE_IDS.ABOUT_US, BLOCK_IDS.WHAT_WE_DO);
   });
 
   it('should render the grip handle and handle drag-and-drop reordering', () => {

--- a/app/shared/components/about-us/what-we-do/WhatWeDo.tsx
+++ b/app/shared/components/about-us/what-we-do/WhatWeDo.tsx
@@ -9,6 +9,7 @@ import { ensureIds } from '~/lib/utils/ensureIds';
 import { proseToHeaderText } from '~/lib/utils/prose';
 import { handleSortableDragEnd } from '~/lib/utils/sortableDragEndHelper';
 import { usePageBlock } from '~/shared/hooks/use-page-block/usePageBlock';
+import { useTitleValidation } from '~/shared/hooks/use-title-validation/useTitleValidation';
 import { useStore } from '~/store';
 import { LocalizedString, ProseDoc } from '~/types/common';
 import type { WhatWeDolItemWithId } from '~/types/store/pages/about-us/blocks/whatWeDoBlock';
@@ -24,6 +25,8 @@ const WhatWeDo = () => {
   const toggleBlockVisibility = useStore((state) => state.toggleBlockVisibility);
 
   const itemList: WhatWeDolItemWithId[] = block ? ensureIds(block.items) : [];
+
+  const titleValidation = useTitleValidation(`${pageId}:${blockId}:title`, block?.title?.[currentLocale] as ProseDoc);
 
   const handleDragEnd = (event: DragEndEvent) => {
     handleSortableDragEnd(event, itemList, (reordered) => {
@@ -81,6 +84,9 @@ const WhatWeDo = () => {
       <EditableSectionList
         title={block.title[currentLocale]}
         onTitleChange={handleTitleChange}
+        onTitleBlur={titleValidation.onBlur}
+        titleError={titleValidation.error}
+        titleHelperText={titleValidation.helperText}
         items={points}
         onChangeItem={handleChangeItem}
         onCreateItem={handleCreateItem}

--- a/app/shared/components/about-us/what-we-do/WhatWeDo.tsx
+++ b/app/shared/components/about-us/what-we-do/WhatWeDo.tsx
@@ -6,10 +6,11 @@ import { EditBlockSkeleton } from '../../edit-block-skeleton/EditBlockSkeleton';
 import { BLOCK_IDS, PAGE_IDS } from '~/constants/pageBlocks';
 import CollapsibleBlock from '~/ds-components/collapsible-block/CollapsibleBlock';
 import { ensureIds } from '~/lib/utils/ensureIds';
+import { proseToHeaderText } from '~/lib/utils/prose';
 import { handleSortableDragEnd } from '~/lib/utils/sortableDragEndHelper';
 import { usePageBlock } from '~/shared/hooks/use-page-block/usePageBlock';
 import { useStore } from '~/store';
-import { LocalizedString } from '~/types/common';
+import { LocalizedString, ProseDoc } from '~/types/common';
 import type { WhatWeDolItemWithId } from '~/types/store/pages/about-us/blocks/whatWeDoBlock';
 
 const WhatWeDo = () => {
@@ -20,15 +21,16 @@ const WhatWeDo = () => {
 
   const currentLocale: keyof LocalizedString = useStore((state) => state.locale);
   const setField = useStore((state) => state.setField);
+  const toggleBlockVisibility = useStore((state) => state.toggleBlockVisibility);
 
   const itemList: WhatWeDolItemWithId[] = block ? ensureIds(block.items) : [];
-  
+
   const handleDragEnd = (event: DragEndEvent) => {
     handleSortableDragEnd(event, itemList, (reordered) => {
       setField(pageId, blockId, 'items', reordered);
     });
   };
-  
+
   if (!block) return <EditBlockSkeleton />;
 
   const points: SectionListItem[] = itemList.map((item) => ({
@@ -67,8 +69,15 @@ const WhatWeDo = () => {
       itemList.filter((item) => item.id !== id)
     );
 
+  const headerTitle = proseToHeaderText(block.title?.[currentLocale] as ProseDoc, 'Що ми робимо');
+
   return (
-    <CollapsibleBlock title="Що ми робимо" grip>
+    <CollapsibleBlock
+      title={headerTitle}
+      grip
+      hidden={block.hidden}
+      onToggleVisibility={() => toggleBlockVisibility(pageId, blockId)}
+    >
       <EditableSectionList
         title={block.title[currentLocale]}
         onTitleChange={handleTitleChange}

--- a/app/shared/components/accordion-blocks/editable-section-list/EditableBlocks.test.tsx
+++ b/app/shared/components/accordion-blocks/editable-section-list/EditableBlocks.test.tsx
@@ -5,10 +5,12 @@ import WhatWeDo from '../../about-us/what-we-do/WhatWeDo';
 import { BLOCK_IDS, PAGE_IDS } from '~/constants/pageBlocks';
 
 const setFieldMock = jest.fn();
+const setFieldValidityMock = jest.fn();
 
-type StoreState = { locale: 'uk'; setField: typeof setFieldMock };
+type StoreState = { locale: 'uk'; setField: typeof setFieldMock; setFieldValidity: typeof setFieldValidityMock };
 jest.mock('~/store', () => ({
-  useStore: (selector: (state: StoreState) => unknown) => selector({ locale: 'uk', setField: setFieldMock })
+  useStore: (selector: (state: StoreState) => unknown) =>
+    selector({ locale: 'uk', setField: setFieldMock, setFieldValidity: setFieldValidityMock })
 }));
 
 const usePageBlockMock = jest.fn();

--- a/app/shared/components/accordion-blocks/editable-section-list/EditableSectionList.test.tsx
+++ b/app/shared/components/accordion-blocks/editable-section-list/EditableSectionList.test.tsx
@@ -117,4 +117,28 @@ describe('EditableSectionList', () => {
     fireEvent.click(screen.getByTestId('trigger-configurable-list-change'));
     expect(onChangeItem).toHaveBeenCalledWith('1', 'title', { type: 'doc', content: [] });
   });
+
+  it('should forward onTitleBlur, titleError and titleHelperText to the title text field', () => {
+    const onTitleBlur = jest.fn();
+    render(
+      <EditableSectionList
+        title={mockTitleJson}
+        onTitleChange={onTitleChange}
+        onTitleBlur={onTitleBlur}
+        titleError
+        titleHelperText="Заголовок не може бути порожнім"
+        items={mockItems}
+        onChangeItem={onChangeItem}
+        onCreateItem={onCreateItem}
+        onDeleteItem={onDeleteItem}
+        sectionLabel="Test Label"
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('trigger-blur-Заголовок секції'));
+    expect(onTitleBlur).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('textfield-error-Заголовок секції')).toHaveTextContent(
+      'Заголовок не може бути порожнім'
+    );
+  });
 });

--- a/app/shared/components/accordion-blocks/editable-section-list/EditableSectionList.tsx
+++ b/app/shared/components/accordion-blocks/editable-section-list/EditableSectionList.tsx
@@ -17,6 +17,9 @@ export type SectionListItem = ConfigurableListItem & {
 type EditableSectionListProps<ItemType extends SectionListItem> = {
   title: JSONContent;
   onTitleChange: (value: JSONContent) => void;
+  onTitleBlur?: () => void;
+  titleError?: boolean;
+  titleHelperText?: string;
   items: ItemType[];
   onChangeItem: (id: string, field: 'title' | 'description', value: JSONContent) => void;
   onCreateItem: () => ItemType;
@@ -28,6 +31,9 @@ type EditableSectionListProps<ItemType extends SectionListItem> = {
 export const EditableSectionList = <ItemType extends SectionListItem>({
   title,
   onTitleChange,
+  onTitleBlur,
+  titleError,
+  titleHelperText,
   items,
   onChangeItem,
   onCreateItem,
@@ -63,6 +69,9 @@ export const EditableSectionList = <ItemType extends SectionListItem>({
         label="Текст заголовку"
         value={title}
         onChange={(value) => onTitleChange(value)}
+        onBlur={onTitleBlur}
+        error={titleError}
+        helperText={titleHelperText}
       />
       <Box>
         <Typography variant="subtitle1" sx={styles.title}>

--- a/app/shared/components/accordion-blocks/editable-section-list/__mocks__/EditableSectionList.tsx
+++ b/app/shared/components/accordion-blocks/editable-section-list/__mocks__/EditableSectionList.tsx
@@ -11,6 +11,9 @@ export interface MockSectionListItem {
 export interface MockEditableSectionListProps {
   readonly title: JSONContent;
   readonly onTitleChange: (value: JSONContent) => void;
+  readonly onTitleBlur?: () => void;
+  readonly titleError?: boolean;
+  readonly titleHelperText?: string;
   readonly items: readonly MockSectionListItem[];
   readonly onChangeItem: (id: string, field: 'title' | 'description', value: JSONContent) => void;
   readonly onCreateItem: () => { readonly id: string };
@@ -22,6 +25,9 @@ export interface MockEditableSectionListProps {
 export const EditableSectionList = ({
   title,
   onTitleChange,
+  onTitleBlur,
+  titleError,
+  titleHelperText,
   items,
   onChangeItem,
   onCreateItem,
@@ -37,6 +43,15 @@ export const EditableSectionList = ({
     >
       Change Main Title
     </button>
+    <button data-testid="trigger-main-title-clear" onClick={() => onTitleChange({ type: 'doc', content: [] })}>
+      Clear Main Title
+    </button>
+    {onTitleBlur && (
+      <button data-testid="trigger-main-title-blur" onClick={onTitleBlur}>
+        Blur Main Title
+      </button>
+    )}
+    {titleError && <span data-testid="main-title-error">{titleHelperText}</span>}
     {onDragEnd && (
       <button
         data-testid="trigger-drag-end"

--- a/app/shared/components/custom-formatting-field/CustomFormattingField.style.ts
+++ b/app/shared/components/custom-formatting-field/CustomFormattingField.style.ts
@@ -29,18 +29,18 @@ export const styles = {
     }
   },
 
-  label: (isActive: boolean | null) => ({
+  label: (isActive: boolean | null, hasError: boolean = false) => ({
     position: 'absolute',
     left: '14px',
     top: isActive ? '-6px' : '14px',
     fontSize: isActive ? '12px' : '16px',
-    color: 'text.secondary',
+    color: hasError ? 'error.main' : 'text.secondary',
     pointerEvents: isActive ? 'none' : 'auto',
     cursor: 'text',
     transition: 'all 0.2s ease-out'
   }),
 
-  fieldset: (isFocused: boolean | null) => ({
+  fieldset: (isFocused: boolean | null, hasError: boolean = false) => ({
     position: 'absolute',
     top: -5,
     bottom: 0,
@@ -50,8 +50,15 @@ export const styles = {
     borderStyle: 'solid',
     borderWidth: '1px',
     pl: '12px',
-    borderColor: isFocused ? 'blue.500' : 'gray',
+    borderColor: hasError ? 'error.main' : isFocused ? 'blue.500' : 'gray',
   }),
+
+  helperText: {
+    color: 'error.main',
+    fontSize: '12px',
+    mt: '4px',
+    ml: '14px'
+  },
 
   legend: (isActive: boolean) => ({
     display: 'block',

--- a/app/shared/components/custom-formatting-field/CustomFormattingField.style.ts
+++ b/app/shared/components/custom-formatting-field/CustomFormattingField.style.ts
@@ -1,3 +1,17 @@
+type BorderState = 'hasError' | 'isFocused' | 'default';
+
+const BORDER_COLORS: Record<BorderState, string> = {
+  hasError: 'error.main',
+  isFocused: 'blue.500',
+  default: 'gray'
+};
+
+const getBorderState = (isFocused: boolean | null, hasError: boolean): BorderState => {
+  if (hasError) return 'hasError';
+  if (isFocused) return 'isFocused';
+  return 'default';
+};
+
 export const styles = {
   container: {
     position: 'relative',
@@ -40,27 +54,18 @@ export const styles = {
     transition: 'all 0.2s ease-out'
   }),
 
-  fieldset: (isFocused: boolean | null, hasError: boolean = false) => {
-    let borderColor = 'gray';
-    if (hasError) {
-      borderColor = 'error.main';
-    } else if (isFocused) {
-      borderColor = 'blue.500';
-    }
-
-    return {
-      position: 'absolute',
-      top: -5,
-      bottom: 0,
-      left: 0,
-      right: 0,
-      borderRadius: '8px',
-      borderStyle: 'solid',
-      borderWidth: '1px',
-      pl: '12px',
-      borderColor
-    };
-  },
+  fieldset: (isFocused: boolean | null, hasError: boolean = false) => ({
+    position: 'absolute',
+    top: -5,
+    bottom: 0,
+    left: 0,
+    right: 0,
+    borderRadius: '8px',
+    borderStyle: 'solid',
+    borderWidth: '1px',
+    pl: '12px',
+    borderColor: BORDER_COLORS[getBorderState(isFocused, hasError)]
+  }),
 
   helperText: {
     color: 'error.main',

--- a/app/shared/components/custom-formatting-field/CustomFormattingField.style.ts
+++ b/app/shared/components/custom-formatting-field/CustomFormattingField.style.ts
@@ -41,7 +41,12 @@ export const styles = {
   }),
 
   fieldset: (isFocused: boolean | null, hasError: boolean = false) => {
-    const borderColor = hasError ? 'error.main' : isFocused ? 'blue.500' : 'gray';
+    let borderColor = 'gray';
+    if (hasError) {
+      borderColor = 'error.main';
+    } else if (isFocused) {
+      borderColor = 'blue.500';
+    }
 
     return {
       position: 'absolute',

--- a/app/shared/components/custom-formatting-field/CustomFormattingField.style.ts
+++ b/app/shared/components/custom-formatting-field/CustomFormattingField.style.ts
@@ -40,18 +40,22 @@ export const styles = {
     transition: 'all 0.2s ease-out'
   }),
 
-  fieldset: (isFocused: boolean | null, hasError: boolean = false) => ({
-    position: 'absolute',
-    top: -5,
-    bottom: 0,
-    left: 0,
-    right: 0,
-    borderRadius: '8px',
-    borderStyle: 'solid',
-    borderWidth: '1px',
-    pl: '12px',
-    borderColor: hasError ? 'error.main' : isFocused ? 'blue.500' : 'gray',
-  }),
+  fieldset: (isFocused: boolean | null, hasError: boolean = false) => {
+    const borderColor = hasError ? 'error.main' : isFocused ? 'blue.500' : 'gray';
+
+    return {
+      position: 'absolute',
+      top: -5,
+      bottom: 0,
+      left: 0,
+      right: 0,
+      borderRadius: '8px',
+      borderStyle: 'solid',
+      borderWidth: '1px',
+      pl: '12px',
+      borderColor
+    };
+  },
 
   helperText: {
     color: 'error.main',

--- a/app/shared/components/custom-formatting-field/CustomFormattingField.test.tsx
+++ b/app/shared/components/custom-formatting-field/CustomFormattingField.test.tsx
@@ -103,9 +103,46 @@ describe('CustomFormattingField', () => {
       const editorContent = screen.getByTestId('editor-content');
 
       fireEvent.focus(editorContent);
-      
-      
+
+
       fireEvent.blur(editorContent);
+    });
+
+    it('should call the external onBlur prop when the editor loses focus', () => {
+      const mockOnBlur = jest.fn();
+      render(<CustomFormattingField value={defaultJSON} onChange={mockOnChange} onBlur={mockOnBlur} />);
+      const editorContent = screen.getByTestId('editor-content');
+
+      fireEvent.blur(editorContent);
+
+      expect(mockOnBlur).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not throw when the editor loses focus without an onBlur prop', () => {
+      render(<CustomFormattingField value={defaultJSON} onChange={mockOnChange} />);
+      const editorContent = screen.getByTestId('editor-content');
+
+      expect(() => fireEvent.blur(editorContent)).not.toThrow();
+    });
+  });
+
+  describe('4. Validation state', () => {
+    it('should not render helper text when error is false', () => {
+      render(<CustomFormattingField value={defaultJSON} onChange={mockOnChange} error={false} helperText="Заголовок не може бути порожнім" />);
+
+      expect(screen.queryByTestId('formatting-field-error')).not.toBeInTheDocument();
+    });
+
+    it('should render helper text when error is true', () => {
+      render(<CustomFormattingField value={defaultJSON} onChange={mockOnChange} error helperText="Заголовок не може бути порожнім" />);
+
+      expect(screen.getByTestId('formatting-field-error')).toHaveTextContent('Заголовок не може бути порожнім');
+    });
+
+    it('should not render helper text when error is true but no helperText is provided', () => {
+      render(<CustomFormattingField value={defaultJSON} onChange={mockOnChange} error />);
+
+      expect(screen.queryByTestId('formatting-field-error')).not.toBeInTheDocument();
     });
   });
 

--- a/app/shared/components/custom-formatting-field/CustomFormattingField.tsx
+++ b/app/shared/components/custom-formatting-field/CustomFormattingField.tsx
@@ -20,12 +20,15 @@ export interface Props {
   onChange: (value: JSONContent) => void;
   label?: string;
   sx?: SxProps<Theme>;
+  error?: boolean;
+  helperText?: string;
+  onBlur?: () => void;
 }
 const OneLineDoc = Document.extend({
   content: 'paragraph'
 });
 
-export const CustomFormattingField = ({ value, onChange, label = 'Текст', sx }: Props) => {
+export const CustomFormattingField = ({ value, onChange, label = 'Текст', sx, error = false, helperText, onBlur }: Props) => {
   const [isFocused, setIsFocused] = useState(false);
 
   const editor = useEditor({
@@ -51,7 +54,10 @@ export const CustomFormattingField = ({ value, onChange, label = 'Текст', s
       onChange(editor.getJSON());
     },
     onFocus: () => setIsFocused(true),
-    onBlur: () => setIsFocused(false)
+    onBlur: () => {
+      setIsFocused(false);
+      onBlur?.();
+    }
   });
 
   useEffect(() => {
@@ -68,11 +74,11 @@ export const CustomFormattingField = ({ value, onChange, label = 'Текст', s
 
   return (
     <Box sx={[styles.container, ...sxToArray(sx)]}>
-      <Box component="label" onClick={() => editor?.commands.focus()} sx={styles.label(isActive)}>
+      <Box component="label" onClick={() => editor?.commands.focus()} sx={styles.label(isActive, error)}>
         {label}
       </Box>
 
-      <Box component="fieldset" sx={styles.fieldset(isFocused)}>
+      <Box component="fieldset" sx={styles.fieldset(isFocused, error)}>
         <Box
           component="legend"
           sx={styles.legend(isActive)}
@@ -94,6 +100,12 @@ export const CustomFormattingField = ({ value, onChange, label = 'Текст', s
           <EditorContent editor={editor} />
         </Box>
       </Box>
+
+      {error && helperText && (
+        <Box sx={styles.helperText} data-testid="formatting-field-error">
+          {helperText}
+        </Box>
+      )}
     </Box>
   );
 };

--- a/app/shared/components/design-system/collapsible-block/CollapsibleBlock.styles.ts
+++ b/app/shared/components/design-system/collapsible-block/CollapsibleBlock.styles.ts
@@ -1,66 +1,76 @@
 import { SxProps, Theme } from '@mui/material';
 
-export const getStyles = (hasGrip: boolean, isHidden: boolean = false): Record<string, SxProps<Theme>> => ({
-  root: {
-    alignItems: hasGrip ? 'center' : 'end',
-    opacity: isHidden ? 0.5 : 1,
-    transition: 'opacity 0.2s ease',
-    overflow: 'visible'
-  },
-  summary: {
-    alignItems: 'flex-end',
-    overflow: 'visible',
-    '& .MuiAccordionSummary-content': {
-      display: 'flex',
-      flexDirection: 'column',
-      justifyContent: 'center',
-      gap: '11.5px',
-      margin: '12px 0',
+export const getStyles = (hasGrip: boolean, isHidden: boolean = false, isSaving: boolean = false): Record<string, SxProps<Theme>> => {
+  let opacity = 1;
+  if (isSaving) {
+    opacity = 0.6;
+  } else if (isHidden) {
+    opacity = 0.5;
+  }
+
+  return {
+    root: {
+      alignItems: hasGrip ? 'center' : 'end',
+      opacity,
+      pointerEvents: isSaving ? 'none' : 'auto',
+      transition: 'opacity 0.2s ease',
       overflow: 'visible'
     },
+    summary: {
+      alignItems: 'flex-end',
+      overflow: 'visible',
+      '& .MuiAccordionSummary-content': {
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        gap: '11.5px',
+        margin: '12px 0',
+        overflow: 'visible'
+      },
 
-    '& .MuiAccordionSummary-expandIconWrapper': {
-      marginBottom: '13px',
-    }
-  },
-  gripWrapper: {
-    width: '100%',
-    display: 'flex',
-    justifyContent: 'center',
-  },
-  titleRow: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '8px',
-    minWidth: 0,
-    overflow: 'visible'
-  },
-  titleText: {
-    minWidth: 0,
-    overflow: 'visible',
-    whiteSpace: 'normal'
-  },
-  visibilityToggle: {
-    flexShrink: 0,
-    display: 'inline-flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: '24px',
-    height: '24px',
-    padding: 0,
-    margin: 0,
-    boxSizing: 'border-box',
-    overflow: 'visible',
-    lineHeight: 0,
-    borderRadius: '50%',
-    cursor: 'pointer',
-    color: 'inherit',
-    '&:hover': {
-      backgroundColor: 'rgba(0, 0, 0, 0.04)'
+      '& .MuiAccordionSummary-expandIconWrapper': {
+        marginBottom: '13px',
+      }
     },
-    '&:focus-visible': {
-      outline: '2px solid currentColor',
-      outlineOffset: '1px'
+    gripWrapper: {
+      width: '100%',
+      display: 'flex',
+      justifyContent: 'center',
+    },
+    titleRow: {
+      display: 'flex',
+      alignItems: 'center',
+      gap: '8px',
+      minWidth: 0,
+      overflow: 'visible'
+    },
+    titleText: {
+      minWidth: 0,
+      overflow: 'visible',
+      whiteSpace: 'normal'
+    },
+    visibilityToggle: {
+      flexShrink: 0,
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      width: '24px',
+      height: '24px',
+      padding: 0,
+      margin: 0,
+      boxSizing: 'border-box',
+      overflow: 'visible',
+      lineHeight: 0,
+      borderRadius: '50%',
+      cursor: 'pointer',
+      color: 'inherit',
+      '&:hover': {
+        backgroundColor: 'rgba(0, 0, 0, 0.04)'
+      },
+      '&:focus-visible': {
+        outline: '2px solid currentColor',
+        outlineOffset: '1px'
+      }
     }
-  }
-});
+  };
+};

--- a/app/shared/components/design-system/collapsible-block/CollapsibleBlock.styles.ts
+++ b/app/shared/components/design-system/collapsible-block/CollapsibleBlock.styles.ts
@@ -1,26 +1,36 @@
 import { SxProps, Theme } from '@mui/material';
 
-export const getStyles = (hasGrip: boolean): Record<string, SxProps<Theme>> => ({
+export const getStyles = (hasGrip: boolean, isHidden: boolean = false): Record<string, SxProps<Theme>> => ({
   root: {
-    alignItems: hasGrip ? 'center' : 'end', 
-  }, 
+    alignItems: hasGrip ? 'center' : 'end',
+    opacity: isHidden ? 0.5 : 1,
+    transition: 'opacity 0.2s ease'
+  },
   summary: {
-    alignItems: 'flex-end', 
+    alignItems: 'flex-end',
     '& .MuiAccordionSummary-content': {
       display: 'flex',
       flexDirection: 'column',
       justifyContent: 'center',
       gap: '11.5px',
-      margin: '12px 0', 
+      margin: '12px 0',
     },
 
     '& .MuiAccordionSummary-expandIconWrapper': {
-      marginBottom: '13px', 
+      marginBottom: '13px',
     }
   },
   gripWrapper: {
     width: '100%',
     display: 'flex',
     justifyContent: 'center',
+  },
+  titleRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px'
+  },
+  visibilityToggle: {
+    padding: '2px'
   }
 });

--- a/app/shared/components/design-system/collapsible-block/CollapsibleBlock.styles.ts
+++ b/app/shared/components/design-system/collapsible-block/CollapsibleBlock.styles.ts
@@ -4,16 +4,19 @@ export const getStyles = (hasGrip: boolean, isHidden: boolean = false): Record<s
   root: {
     alignItems: hasGrip ? 'center' : 'end',
     opacity: isHidden ? 0.5 : 1,
-    transition: 'opacity 0.2s ease'
+    transition: 'opacity 0.2s ease',
+    overflow: 'visible'
   },
   summary: {
     alignItems: 'flex-end',
+    overflow: 'visible',
     '& .MuiAccordionSummary-content': {
       display: 'flex',
       flexDirection: 'column',
       justifyContent: 'center',
       gap: '11.5px',
       margin: '12px 0',
+      overflow: 'visible'
     },
 
     '& .MuiAccordionSummary-expandIconWrapper': {
@@ -28,9 +31,36 @@ export const getStyles = (hasGrip: boolean, isHidden: boolean = false): Record<s
   titleRow: {
     display: 'flex',
     alignItems: 'center',
-    gap: '8px'
+    gap: '8px',
+    minWidth: 0,
+    overflow: 'visible'
+  },
+  titleText: {
+    minWidth: 0,
+    overflow: 'visible',
+    whiteSpace: 'normal'
   },
   visibilityToggle: {
-    padding: '2px'
+    flexShrink: 0,
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '24px',
+    height: '24px',
+    padding: 0,
+    margin: 0,
+    boxSizing: 'border-box',
+    overflow: 'visible',
+    lineHeight: 0,
+    borderRadius: '50%',
+    cursor: 'pointer',
+    color: 'inherit',
+    '&:hover': {
+      backgroundColor: 'rgba(0, 0, 0, 0.04)'
+    },
+    '&:focus-visible': {
+      outline: '2px solid currentColor',
+      outlineOffset: '1px'
+    }
   }
 });

--- a/app/shared/components/design-system/collapsible-block/CollapsibleBlock.test.tsx
+++ b/app/shared/components/design-system/collapsible-block/CollapsibleBlock.test.tsx
@@ -56,4 +56,61 @@ describe('CollapsibleBlock', () => {
     );
     expect(screen.getByTestId('grip-mock')).toBeInTheDocument();
   });
+
+  it('should not render the visibility toggle when onToggleVisibility is not provided', () => {
+    render(
+      <CollapsibleBlock title={titleText}>
+        <div>Child Content</div>
+      </CollapsibleBlock>
+    );
+
+    expect(screen.queryByRole('button', { name: /розділ/ })).not.toBeInTheDocument();
+  });
+
+  it('should call onToggleVisibility when the toggle is clicked, without expanding/collapsing the accordion', () => {
+    const onToggleVisibility = jest.fn();
+    render(
+      <CollapsibleBlock title={titleText} onToggleVisibility={onToggleVisibility}>
+        <div>Child Content</div>
+      </CollapsibleBlock>
+    );
+
+    const cont = screen.getByTestId('inserted-container');
+    expect(cont).toHaveStyle('visibility: hidden');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Приховати розділ' }));
+
+    expect(onToggleVisibility).toHaveBeenCalledTimes(1);
+    expect(cont).toHaveStyle('visibility: hidden');
+  });
+
+  it('should reflect hidden=true in the toggle aria-label and icon', () => {
+    render(
+      <CollapsibleBlock title={titleText} hidden onToggleVisibility={jest.fn()}>
+        <div>Child Content</div>
+      </CollapsibleBlock>
+    );
+
+    expect(screen.getByRole('button', { name: 'Показати розділ' })).toBeInTheDocument();
+  });
+
+  it('should call onToggleVisibility on Enter and Space key presses, and ignore other keys', () => {
+    const onToggleVisibility = jest.fn();
+    render(
+      <CollapsibleBlock title={titleText} onToggleVisibility={onToggleVisibility}>
+        <div>Child Content</div>
+      </CollapsibleBlock>
+    );
+
+    const toggle = screen.getByRole('button', { name: 'Приховати розділ' });
+
+    fireEvent.keyDown(toggle, { key: 'a' });
+    expect(onToggleVisibility).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(toggle, { key: 'Enter' });
+    expect(onToggleVisibility).toHaveBeenCalledTimes(1);
+
+    fireEvent.keyDown(toggle, { key: ' ' });
+    expect(onToggleVisibility).toHaveBeenCalledTimes(2);
+  });
 });

--- a/app/shared/components/design-system/collapsible-block/CollapsibleBlock.test.tsx
+++ b/app/shared/components/design-system/collapsible-block/CollapsibleBlock.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 
 import CollapsibleBlock from './CollapsibleBlock';
+import { useStore } from '~/store';
 
 jest.mock('~/public/icons/chevron-down.svg', () => {
   const DummyChevron = () => <svg data-testid="chevron-icon" />;
@@ -25,6 +26,10 @@ jest.mock('../../grip/Grip');
 
 describe('CollapsibleBlock', () => {
   const titleText = 'Test Block';
+
+  afterEach(() => {
+    useStore.setState({ isSaving: false });
+  });
 
   it('should render the title', () => {
     render(
@@ -124,5 +129,33 @@ describe('CollapsibleBlock', () => {
 
     fireEvent.keyDown(toggle, { key: ' ' });
     expect(onToggleVisibility).toHaveBeenCalledTimes(2);
+  });
+
+  it('should lock its own pointer events and dim itself when a save is in progress', () => {
+    useStore.setState({ isSaving: true });
+
+    const { container } = render(
+      <CollapsibleBlock title={titleText}>
+        <div>Child Content</div>
+      </CollapsibleBlock>
+    );
+
+    const accordionRoot = container.firstChild as HTMLElement;
+    expect(accordionRoot).toHaveStyle('pointer-events: none');
+    expect(accordionRoot).toHaveStyle('opacity: 0.6');
+  });
+
+  it('should keep pointer events enabled when not saving', () => {
+    useStore.setState({ isSaving: false });
+
+    const { container } = render(
+      <CollapsibleBlock title={titleText}>
+        <div>Child Content</div>
+      </CollapsibleBlock>
+    );
+
+    const accordionRoot = container.firstChild as HTMLElement;
+    expect(accordionRoot).toHaveStyle('pointer-events: auto');
+    expect(accordionRoot).toHaveStyle('opacity: 1');
   });
 });

--- a/app/shared/components/design-system/collapsible-block/CollapsibleBlock.test.tsx
+++ b/app/shared/components/design-system/collapsible-block/CollapsibleBlock.test.tsx
@@ -9,6 +9,18 @@ jest.mock('~/public/icons/chevron-down.svg', () => {
   return DummyChevron;
 });
 
+jest.mock('~/public/icons/eye.svg', () => {
+  const Eye = () => <span>eye</span>;
+  Eye.displayName = 'Eye';
+  return Eye;
+});
+
+jest.mock('~/public/icons/eye-closed.svg', () => {
+  const EyeClosed = () => <span>closed eye</span>;
+  EyeClosed.displayName = 'EyeClosed';
+  return EyeClosed;
+});
+
 jest.mock('../../grip/Grip');
 
 describe('CollapsibleBlock', () => {

--- a/app/shared/components/design-system/collapsible-block/CollapsibleBlock.tsx
+++ b/app/shared/components/design-system/collapsible-block/CollapsibleBlock.tsx
@@ -1,12 +1,55 @@
-import { Accordion, AccordionDetails, AccordionProps, AccordionSummary, Box, IconButton } from '@mui/material';
+import { Accordion, AccordionDetails, AccordionProps, AccordionSummary, Box } from '@mui/material';
 import React from 'react';
 
 import { Grip } from '../../grip/Grip';
 import { getStyles } from './CollapsibleBlock.styles';
 import { sxToArray } from '~/lib/utils/sxToArray';
 import ChevronIcon from '~/public/icons/chevron-down.svg';
-import EyeIcon from '~/public/icons/eye.svg';
-import EyeClosedIcon from '~/public/icons/eye-closed.svg';
+
+const EyeIcon = () => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    style={{ display: 'block', overflow: 'visible' }}
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M2.06202 12.3481C1.97868 12.1236 1.97868 11.8766 2.06202 11.6521C2.87372 9.68397 4.25153 8.00116 6.02079 6.81701C7.79004 5.63287 9.87106 5.00073 12 5.00073C14.129 5.00073 16.21 5.63287 17.9792 6.81701C19.7485 8.00116 21.1263 9.68397 21.938 11.6521C22.0214 11.8766 22.0214 12.1236 21.938 12.3481C21.1263 14.3163 19.7485 15.9991 17.9792 17.1832C16.21 18.3674 14.129 18.9995 12 18.9995C9.87106 18.9995 7.79004 18.3674 6.02079 17.1832C4.25153 15.9991 2.87372 14.3163 2.06202 12.3481Z"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M12 15C13.6569 15 15 13.6569 15 12C15 10.3431 13.6569 9 12 9C10.3431 9 9 10.3431 9 12C9 13.6569 10.3431 15 12 15Z"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const EyeClosedIcon = () => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    style={{ display: 'block', overflow: 'visible' }}
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M15.0001 18L14.2781 14.75M2 8C2.74835 10.0508 4.10913 11.8219 5.8979 13.0733C7.68667 14.3247 9.81695 14.9959 12 14.9959C14.1831 14.9959 16.3133 14.3247 18.1021 13.0733C19.8909 11.8219 21.2516 10.0508 22 8M19.9999 15L18.2739 12.95M4 15L5.726 12.95M9 18L9.722 14.75"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
 
 interface CollapsibleBlockProps extends AccordionProps {
   title: string;
@@ -38,23 +81,29 @@ const CollapsibleBlock = ({
           </Box>
         )}
         <Box sx={styles.titleRow}>
-          {title}
+          <Box component="span" sx={styles.titleText}>
+            {title}
+          </Box>
           {onToggleVisibility && (
-            <IconButton
+            <Box
+              component="span"
+              role="button"
+              tabIndex={0}
               aria-label={hidden ? 'Показати розділ' : 'Приховати розділ'}
               onClick={(event) => {
                 event.stopPropagation();
                 onToggleVisibility();
               }}
-              size="small"
+              onKeyDown={(event) => {
+                if (event.key !== 'Enter' && event.key !== ' ') return;
+                event.preventDefault();
+                event.stopPropagation();
+                onToggleVisibility();
+              }}
               sx={styles.visibilityToggle}
             >
-              {hidden ? (
-                <EyeClosedIcon width={20} height={20} />
-              ) : (
-                <EyeIcon width={20} height={20} />
-              )}
-            </IconButton>
+              {hidden ? <EyeClosedIcon /> : <EyeIcon />}
+            </Box>
           )}
         </Box>
       </AccordionSummary>

--- a/app/shared/components/design-system/collapsible-block/CollapsibleBlock.tsx
+++ b/app/shared/components/design-system/collapsible-block/CollapsibleBlock.tsx
@@ -1,19 +1,33 @@
-import { Accordion, AccordionDetails, AccordionProps, AccordionSummary, Box } from '@mui/material';
+import { Accordion, AccordionDetails, AccordionProps, AccordionSummary, Box, IconButton } from '@mui/material';
 import React from 'react';
 
 import { Grip } from '../../grip/Grip';
 import { getStyles } from './CollapsibleBlock.styles';
 import { sxToArray } from '~/lib/utils/sxToArray';
 import ChevronIcon from '~/public/icons/chevron-down.svg';
+import EyeIcon from '~/public/icons/eye.svg';
+import EyeClosedIcon from '~/public/icons/eye-closed.svg';
+
 interface CollapsibleBlockProps extends AccordionProps {
   title: string;
   childrenContainerSx?: object;
   grip?: boolean;
+  hidden?: boolean;
+  onToggleVisibility?: () => void;
 }
 
-const CollapsibleBlock = ({ title, children, sx, grip = false, childrenContainerSx, ...props }: CollapsibleBlockProps) => {
-  
-  const styles = getStyles(grip);
+const CollapsibleBlock = ({
+  title,
+  children,
+  sx,
+  grip = false,
+  childrenContainerSx,
+  hidden = false,
+  onToggleVisibility,
+  ...props
+}: CollapsibleBlockProps) => {
+
+  const styles = getStyles(grip, hidden);
 
   return (
     <Accordion {...props} sx={[styles.root, ...(sxToArray(sx))]}>
@@ -23,7 +37,26 @@ const CollapsibleBlock = ({ title, children, sx, grip = false, childrenContainer
             <Grip orientation='horizontal'/>
           </Box>
         )}
-        {title}
+        <Box sx={styles.titleRow}>
+          {title}
+          {onToggleVisibility && (
+            <IconButton
+              aria-label={hidden ? 'Показати розділ' : 'Приховати розділ'}
+              onClick={(event) => {
+                event.stopPropagation();
+                onToggleVisibility();
+              }}
+              size="small"
+              sx={styles.visibilityToggle}
+            >
+              {hidden ? (
+                <EyeClosedIcon width={20} height={20} />
+              ) : (
+                <EyeIcon width={20} height={20} />
+              )}
+            </IconButton>
+          )}
+        </Box>
       </AccordionSummary>
       <AccordionDetails data-testid="inserted-container" sx={childrenContainerSx}>
         {children}

--- a/app/shared/components/design-system/collapsible-block/CollapsibleBlock.tsx
+++ b/app/shared/components/design-system/collapsible-block/CollapsibleBlock.tsx
@@ -5,51 +5,8 @@ import { Grip } from '../../grip/Grip';
 import { getStyles } from './CollapsibleBlock.styles';
 import { sxToArray } from '~/lib/utils/sxToArray';
 import ChevronIcon from '~/public/icons/chevron-down.svg';
-
-const EyeIcon = () => (
-  <svg
-    width="20"
-    height="20"
-    viewBox="0 0 24 24"
-    fill="none"
-    style={{ display: 'block', overflow: 'visible' }}
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      d="M2.06202 12.3481C1.97868 12.1236 1.97868 11.8766 2.06202 11.6521C2.87372 9.68397 4.25153 8.00116 6.02079 6.81701C7.79004 5.63287 9.87106 5.00073 12 5.00073C14.129 5.00073 16.21 5.63287 17.9792 6.81701C19.7485 8.00116 21.1263 9.68397 21.938 11.6521C22.0214 11.8766 22.0214 12.1236 21.938 12.3481C21.1263 14.3163 19.7485 15.9991 17.9792 17.1832C16.21 18.3674 14.129 18.9995 12 18.9995C9.87106 18.9995 7.79004 18.3674 6.02079 17.1832C4.25153 15.9991 2.87372 14.3163 2.06202 12.3481Z"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <path
-      d="M12 15C13.6569 15 15 13.6569 15 12C15 10.3431 13.6569 9 12 9C10.3431 9 9 10.3431 9 12C9 13.6569 10.3431 15 12 15Z"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-  </svg>
-);
-
-const EyeClosedIcon = () => (
-  <svg
-    width="20"
-    height="20"
-    viewBox="0 0 24 24"
-    fill="none"
-    style={{ display: 'block', overflow: 'visible' }}
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      d="M15.0001 18L14.2781 14.75M2 8C2.74835 10.0508 4.10913 11.8219 5.8979 13.0733C7.68667 14.3247 9.81695 14.9959 12 14.9959C14.1831 14.9959 16.3133 14.3247 18.1021 13.0733C19.8909 11.8219 21.2516 10.0508 22 8M19.9999 15L18.2739 12.95M4 15L5.726 12.95M9 18L9.722 14.75"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-  </svg>
-);
+import EyeIcon from '~/public/icons/eye.svg';
+import EyeClosedIcon from '~/public/icons/eye-closed.svg';
 
 interface CollapsibleBlockProps extends AccordionProps {
   title: string;

--- a/app/shared/components/design-system/collapsible-block/CollapsibleBlock.tsx
+++ b/app/shared/components/design-system/collapsible-block/CollapsibleBlock.tsx
@@ -7,6 +7,7 @@ import { sxToArray } from '~/lib/utils/sxToArray';
 import ChevronIcon from '~/public/icons/chevron-down.svg';
 import EyeIcon from '~/public/icons/eye.svg';
 import EyeClosedIcon from '~/public/icons/eye-closed.svg';
+import { useStore } from '~/store';
 
 interface CollapsibleBlockProps extends AccordionProps {
   title: string;
@@ -26,8 +27,9 @@ const CollapsibleBlock = ({
   onToggleVisibility,
   ...props
 }: CollapsibleBlockProps) => {
+  const isSaving = useStore((state) => state.isSaving);
 
-  const styles = getStyles(grip, hidden);
+  const styles = getStyles(grip, hidden, isSaving);
 
   return (
     <Accordion {...props} sx={[styles.root, ...(sxToArray(sx))]}>

--- a/app/shared/components/design-system/collapsible-block/__mocks__/CollapsibleBlock.tsx
+++ b/app/shared/components/design-system/collapsible-block/__mocks__/CollapsibleBlock.tsx
@@ -2,16 +2,30 @@ interface CollapsibleBlockMockProps {
   children: React.ReactNode;
   title: string;
   grip?: boolean;
+  hidden?: boolean;
+  onToggleVisibility?: () => void;
 }
 
 const CollapsibleBlock = ({
   children,
   title,
-  grip = false
+  grip = false,
+  hidden = false,
+  onToggleVisibility
 }: CollapsibleBlockMockProps) => (
-  <section data-testid="collapsible-block">
+  <section data-testid="collapsible-block" data-hidden={hidden}>
     <h2>{title}</h2>
     {grip && <div data-testid="collapsible-block-grip">Grip</div>}
+    {onToggleVisibility && (
+      <button
+        type="button"
+        data-testid="collapsible-block-toggle-visibility"
+        aria-label={hidden ? 'Показати розділ' : 'Приховати розділ'}
+        onClick={onToggleVisibility}
+      >
+        Toggle visibility
+      </button>
+    )}
     {children}
   </section>
 );

--- a/app/shared/components/design-system/text-field/__mocks__/TextField.tsx
+++ b/app/shared/components/design-system/text-field/__mocks__/TextField.tsx
@@ -8,11 +8,14 @@ export interface MockTextFieldProps {
   readonly label?: string;
   readonly value: JSONContent;
   readonly onChange: (value: JSONContent) => void;
+  readonly onBlur?: () => void;
+  readonly error?: boolean;
+  readonly helperText?: string;
 }
 
-export const CustomTextField = ({ title, label, value, onChange }: MockTextFieldProps) => {
+export const CustomTextField = ({ title, label, value, onChange, onBlur, error, helperText }: MockTextFieldProps) => {
   const selectorKey = title || label || 'default';
-  
+
   return (
     <div data-testid={`textfield-wrapper-${selectorKey}`}>
       <span data-testid={`textfield-json-${selectorKey}`}>{JSON.stringify(value)}</span>
@@ -22,6 +25,15 @@ export const CustomTextField = ({ title, label, value, onChange }: MockTextField
       >
         Change {selectorKey}
       </button>
+      <button data-testid={`trigger-clear-${selectorKey}`} onClick={() => onChange({ type: 'doc', content: [] })}>
+        Clear {selectorKey}
+      </button>
+      {onBlur && (
+        <button data-testid={`trigger-blur-${selectorKey}`} onClick={onBlur}>
+          Blur {selectorKey}
+        </button>
+      )}
+      {error && <span data-testid={`textfield-error-${selectorKey}`}>{helperText}</span>}
     </div>
   );
 };

--- a/app/shared/components/editable-page-layout/EditablePageLayout.styles.ts
+++ b/app/shared/components/editable-page-layout/EditablePageLayout.styles.ts
@@ -1,3 +1,5 @@
+import { SxProps, Theme } from '@mui/material';
+
 export const styles = {
   pageContainer: {
     display: 'flex',
@@ -7,5 +9,10 @@ export const styles = {
     height: '100%',
     overflow: 'hidden',
     gap: '32px'
-  }
+  },
+  contentWrapper: (isSaving: boolean): SxProps<Theme> => ({
+    pointerEvents: isSaving ? 'none' : 'auto',
+    opacity: isSaving ? 0.6 : 1,
+    transition: 'opacity 0.15s ease'
+  })
 };

--- a/app/shared/components/editable-page-layout/EditablePageLayout.styles.ts
+++ b/app/shared/components/editable-page-layout/EditablePageLayout.styles.ts
@@ -1,5 +1,3 @@
-import { SxProps, Theme } from '@mui/material';
-
 export const styles = {
   pageContainer: {
     display: 'flex',
@@ -9,10 +7,5 @@ export const styles = {
     height: '100%',
     overflow: 'hidden',
     gap: '32px'
-  },
-  contentWrapper: (isSaving: boolean): SxProps<Theme> => ({
-    pointerEvents: isSaving ? 'none' : 'auto',
-    opacity: isSaving ? 0.6 : 1,
-    transition: 'opacity 0.15s ease'
-  })
+  }
 };

--- a/app/shared/components/editable-page-layout/EditablePageLayout.test.tsx
+++ b/app/shared/components/editable-page-layout/EditablePageLayout.test.tsx
@@ -226,9 +226,6 @@ describe('EditablePageLayout', () => {
   });
 
   describe('Saving state sync', () => {
-    // The wrapper itself no longer locks pointer-events (that broke the dnd-kit
-    // SortableList layout on about-us/privacy-policy edit pages). Instead, isSaving is
-    // mirrored into the store so each CollapsibleBlock can lock itself individually.
     it('should push isSaving=true into the store when a save is in progress', () => {
       (useSavePageBlocks as jest.Mock).mockReturnValue({
         save: mockSave,

--- a/app/shared/components/editable-page-layout/EditablePageLayout.test.tsx
+++ b/app/shared/components/editable-page-layout/EditablePageLayout.test.tsx
@@ -10,11 +10,13 @@ import { useGetPageQuery } from '~/types/graphql/generated/graphql';
 const mockSetLocale = jest.fn();
 const mockDiscardChanges = jest.fn();
 const mockSetPageData = jest.fn();
+const mockSetIsSaving = jest.fn();
 
 const defaultStoreState = {
   setLocale: mockSetLocale,
   discardChanges: mockDiscardChanges,
   setPageData: mockSetPageData,
+  setIsSaving: mockSetIsSaving,
   isChanged: false,
   invalidFields: {},
 };
@@ -223,8 +225,11 @@ describe('EditablePageLayout', () => {
     });
   });
 
-  describe('Content lock while saving', () => {
-    it('should disable pointer events on the content when saving is in progress', () => {
+  describe('Saving state sync', () => {
+    // The wrapper itself no longer locks pointer-events (that broke the dnd-kit
+    // SortableList layout on about-us/privacy-policy edit pages). Instead, isSaving is
+    // mirrored into the store so each CollapsibleBlock can lock itself individually.
+    it('should push isSaving=true into the store when a save is in progress', () => {
       (useSavePageBlocks as jest.Mock).mockReturnValue({
         save: mockSave,
         loading: true,
@@ -232,13 +237,24 @@ describe('EditablePageLayout', () => {
 
       runSimulation();
 
-      expect(screen.getByTestId('editable-page-content')).toHaveStyle('pointer-events: none');
+      expect(mockSetIsSaving).toHaveBeenCalledWith(true);
     });
 
-    it('should keep pointer events enabled on the content when not saving', () => {
+    it('should push isSaving=true into the store when the editor/preview is loading', () => {
+      (usePageEditor as jest.Mock).mockReturnValue({
+        preview: mockPreview,
+        loading: true,
+      });
+
       runSimulation();
 
-      expect(screen.getByTestId('editable-page-content')).toHaveStyle('pointer-events: auto');
+      expect(mockSetIsSaving).toHaveBeenCalledWith(true);
+    });
+
+    it('should push isSaving=false into the store when neither is loading', () => {
+      runSimulation();
+
+      expect(mockSetIsSaving).toHaveBeenCalledWith(false);
     });
   });
 });

--- a/app/shared/components/editable-page-layout/EditablePageLayout.test.tsx
+++ b/app/shared/components/editable-page-layout/EditablePageLayout.test.tsx
@@ -16,6 +16,7 @@ const defaultStoreState = {
   discardChanges: mockDiscardChanges,
   setPageData: mockSetPageData,
   isChanged: false,
+  invalidFields: {},
 };
 
 let mockStoreState = { ...defaultStoreState };
@@ -206,6 +207,38 @@ describe('EditablePageLayout', () => {
 
       fireEvent.click(screen.getByTestId('lang-en'));
       expect(mockSetLocale).toHaveBeenCalledWith('en');
+    });
+  });
+
+  describe('Save disabled on invalid titles', () => {
+    it('should pass isSaveDisabled as false when there are no invalid fields', () => {
+      runSimulation();
+      expect(screen.getByTestId('save-disabled-flag')).toHaveTextContent('false');
+    });
+
+    it('should pass isSaveDisabled as true when at least one field is invalid', () => {
+      mockStoreState.invalidFields = { 'privacy-policy:Cookies:title': true };
+      runSimulation();
+      expect(screen.getByTestId('save-disabled-flag')).toHaveTextContent('true');
+    });
+  });
+
+  describe('Content lock while saving', () => {
+    it('should disable pointer events on the content when saving is in progress', () => {
+      (useSavePageBlocks as jest.Mock).mockReturnValue({
+        save: mockSave,
+        loading: true,
+      });
+
+      runSimulation();
+
+      expect(screen.getByTestId('editable-page-content')).toHaveStyle('pointer-events: none');
+    });
+
+    it('should keep pointer events enabled on the content when not saving', () => {
+      runSimulation();
+
+      expect(screen.getByTestId('editable-page-content')).toHaveStyle('pointer-events: auto');
     });
   });
 });

--- a/app/shared/components/editable-page-layout/EditablePageLayout.tsx
+++ b/app/shared/components/editable-page-layout/EditablePageLayout.tsx
@@ -26,6 +26,7 @@ export const EditablePageLayout = ({
   const setLocale = useStore((s) => s.setLocale);
   const isChanged = useStore((s) => s.isChanged);
   const discardChanges = useStore((s) => s.discardChanges);
+  const hasInvalidFields = useStore((s) => Object.values(s.invalidFields).some(Boolean));
 
   const { data, loading: queryLoading } = useGetPageQuery({
     variables: { slug: pageSlug }
@@ -42,6 +43,7 @@ export const EditablePageLayout = ({
 
   const { preview, loading: editorLoading } = usePageEditor(pageSlug);
   const { save, loading: saveLoading } = useSavePageBlocks(pageSlug);
+  const isSaving = editorLoading || saveLoading;
 
   useEffect(() => {
     setIsMounted(true);
@@ -58,11 +60,12 @@ export const EditablePageLayout = ({
         onPreview={preview}
         onSave={save}
         isActionsDisabled={!isChanged}
+        isSaveDisabled={hasInvalidFields}
         onCancel={() => discardChanges(pageSlug)}
-        isSaving={editorLoading || saveLoading}
+        isSaving={isSaving}
         onLanguageChange={(lang: 'uk' | 'en') => setLocale(lang)}
       />
-      {children}
+      <Box data-testid="editable-page-content" sx={styles.contentWrapper(isSaving)}>{children}</Box>
     </Box>
   );
 };

--- a/app/shared/components/editable-page-layout/EditablePageLayout.tsx
+++ b/app/shared/components/editable-page-layout/EditablePageLayout.tsx
@@ -27,6 +27,7 @@ export const EditablePageLayout = ({
   const isChanged = useStore((s) => s.isChanged);
   const discardChanges = useStore((s) => s.discardChanges);
   const hasInvalidFields = useStore((s) => Object.values(s.invalidFields).some(Boolean));
+  const setIsSaving = useStore((s) => s.setIsSaving);
 
   const { data, loading: queryLoading } = useGetPageQuery({
     variables: { slug: pageSlug }
@@ -49,6 +50,12 @@ export const EditablePageLayout = ({
     setIsMounted(true);
   }, []);
 
+  // Mirrored into the store (instead of locking the whole content wrapper here) so each
+  // CollapsibleBlock can lock itself individually without disrupting the dnd-kit SortableList layout.
+  useEffect(() => {
+    setIsSaving(isSaving);
+  }, [isSaving, setIsSaving]);
+
   if (!isMounted || queryLoading) {
     return null;
   }
@@ -65,7 +72,7 @@ export const EditablePageLayout = ({
         isSaving={isSaving}
         onLanguageChange={(lang: 'uk' | 'en') => setLocale(lang)}
       />
-      <Box data-testid="editable-page-content" sx={styles.contentWrapper(isSaving)}>{children}</Box>
+      {children}
     </Box>
   );
 };

--- a/app/shared/components/editable-page-layout/EditablePageLayout.tsx
+++ b/app/shared/components/editable-page-layout/EditablePageLayout.tsx
@@ -50,8 +50,6 @@ export const EditablePageLayout = ({
     setIsMounted(true);
   }, []);
 
-  // Mirrored into the store (instead of locking the whole content wrapper here) so each
-  // CollapsibleBlock can lock itself individually without disrupting the dnd-kit SortableList layout.
   useEffect(() => {
     setIsSaving(isSaving);
   }, [isSaving, setIsSaving]);

--- a/app/shared/components/header/Header.test.tsx
+++ b/app/shared/components/header/Header.test.tsx
@@ -138,5 +138,25 @@ describe('Header', () => {
       expect(cancelButton).toBeDisabled();
       expect(saveButton).toBeDisabled();
     });
+
+    it('should disable only the "Зберегти" button when isSaveDisabled is true, leaving "Скасувати зміни" enabled', () => {
+      render(<Header {...defaultProps} isActionsDisabled={false} isSaveDisabled={true} />);
+
+      const cancelButton = screen.getByRole('button', { name: /Скасувати зміни/i });
+      const saveButton = screen.getByRole('button', { name: /Зберегти/i });
+
+      expect(cancelButton).not.toBeDisabled();
+      expect(saveButton).toBeDisabled();
+      expect(saveButton).toHaveAttribute('title', 'Виправте порожні заголовки розділів перед збереженням');
+    });
+
+    it('should keep the "Зберегти" button enabled when isSaveDisabled is false', () => {
+      render(<Header {...defaultProps} isActionsDisabled={false} isSaveDisabled={false} />);
+
+      const saveButton = screen.getByRole('button', { name: /Зберегти/i });
+
+      expect(saveButton).not.toBeDisabled();
+      expect(saveButton).not.toHaveAttribute('title');
+    });
   });
 });

--- a/app/shared/components/header/Header.tsx
+++ b/app/shared/components/header/Header.tsx
@@ -15,9 +15,19 @@ type HeaderProps = {
   isSaving: boolean;
   onLanguageChange: (lang: 'uk' | 'en') => void;
   isActionsDisabled?: boolean;
+  isSaveDisabled?: boolean;
 };
 
-export const Header = ({ title, onPreview, onSave, onCancel, isSaving, onLanguageChange, isActionsDisabled }: HeaderProps) => {
+export const Header = ({
+  title,
+  onPreview,
+  onSave,
+  onCancel,
+  isSaving,
+  onLanguageChange,
+  isActionsDisabled,
+  isSaveDisabled
+}: HeaderProps) => {
   return (
     <Box sx={styles.container}>
       <Box>
@@ -48,7 +58,14 @@ export const Header = ({ title, onPreview, onSave, onCancel, isSaving, onLanguag
           <Button variant="outlined" color="primary" sx={styles.actionButton} onClick={onCancel} disabled={isActionsDisabled}>
             Скасувати зміни
           </Button>
-          <Button variant="filled" color="primary" sx={styles.actionButton} onClick={onSave} disabled={isSaving || isActionsDisabled}>
+          <Button
+            variant="filled"
+            color="primary"
+            sx={styles.actionButton}
+            onClick={onSave}
+            disabled={isSaving || isActionsDisabled || isSaveDisabled}
+            title={isSaveDisabled ? 'Виправте порожні заголовки розділів перед збереженням' : undefined}
+          >
             Зберегти
           </Button>
         </Stack>

--- a/app/shared/components/header/__mocks__/Header.tsx
+++ b/app/shared/components/header/__mocks__/Header.tsx
@@ -7,7 +7,8 @@ export const Header = ({
   onCancel,
   isSaving,
   onLanguageChange,
-  isActionsDisabled
+  isActionsDisabled,
+  isSaveDisabled
 }: {
   title: string;
   onPreview: () => void;
@@ -16,6 +17,7 @@ export const Header = ({
   isSaving: boolean;
   onLanguageChange: (lang: 'uk' | 'en') => void;
   isActionsDisabled?: boolean;
+  isSaveDisabled?: boolean;
 }) => (
   <div data-testid="header">
     <span data-testid="title">{title}</span>
@@ -30,6 +32,7 @@ export const Header = ({
     </button>
     <span data-testid="saving-flag">{String(isSaving)}</span>
     <span data-testid="actions-disabled-flag">{String(isActionsDisabled)}</span>
+    <span data-testid="save-disabled-flag">{String(isSaveDisabled)}</span>
     <button data-testid="lang-en" onClick={() => onLanguageChange('en')}>
       set-en
     </button>

--- a/app/shared/components/privacy-policy/__mocks__/setup-mocks.ts
+++ b/app/shared/components/privacy-policy/__mocks__/setup-mocks.ts
@@ -4,6 +4,7 @@ export const useSectionListMock = jest.fn();
 export const usePointsListMock = jest.fn();
 export const mockSetField = jest.fn();
 export const mockToggleBlockVisibility = jest.fn();
+export const mockSetFieldValidity = jest.fn();
 
 export const mockAddPoint = jest.fn();
 export const mockRemovePoint = jest.fn();
@@ -12,7 +13,8 @@ export const mockUpdatePoint = jest.fn();
 export const mockStoreState = {
   locale: 'uk',
   setField: mockSetField,
-  toggleBlockVisibility: mockToggleBlockVisibility
+  toggleBlockVisibility: mockToggleBlockVisibility,
+  setFieldValidity: mockSetFieldValidity
 };
 
 export const setMockLocale = (locale: 'uk' | 'en') => {

--- a/app/shared/components/privacy-policy/__mocks__/setup-mocks.ts
+++ b/app/shared/components/privacy-policy/__mocks__/setup-mocks.ts
@@ -3,6 +3,7 @@ export const usePageBlockMock = jest.fn();
 export const useSectionListMock = jest.fn();
 export const usePointsListMock = jest.fn();
 export const mockSetField = jest.fn();
+export const mockToggleBlockVisibility = jest.fn();
 
 export const mockAddPoint = jest.fn();
 export const mockRemovePoint = jest.fn();
@@ -10,7 +11,8 @@ export const mockUpdatePoint = jest.fn();
 
 export const mockStoreState = {
   locale: 'uk',
-  setField: mockSetField
+  setField: mockSetField,
+  toggleBlockVisibility: mockToggleBlockVisibility
 };
 
 export const setMockLocale = (locale: 'uk' | 'en') => {

--- a/app/shared/components/privacy-policy/components/edit-description-list-note-block/EditDescriptionListNoteBlock.tsx
+++ b/app/shared/components/privacy-policy/components/edit-description-list-note-block/EditDescriptionListNoteBlock.tsx
@@ -60,7 +60,7 @@ export const EditDescriptionListNoteBlock = <T extends BlockWithDescriptionListN
   };
 
   const handleTextChange = (fieldName: 'title' | 'description' | 'note', value: JSONContent) => {
-    const currentValue = (block as Record<string, Record<'uk' | 'en', JSONContent>>)[fieldName];
+    const currentValue = (block as unknown as Record<string, Record<'uk' | 'en', JSONContent>>)[fieldName];
     setField(pageId, blockId, fieldName as Extract<keyof BlocksMap[T], string>, {
       ...currentValue,
       [currentLocale]: value
@@ -77,7 +77,7 @@ export const EditDescriptionListNoteBlock = <T extends BlockWithDescriptionListN
     <CollapsibleBlock
       title={headerTitle}
       grip
-      hidden={block.hidden}
+      hidden={(block as { hidden?: boolean }).hidden}
       onToggleVisibility={() => toggleBlockVisibility(pageId, blockId)}
     >
       {sectionTitleBlock && (

--- a/app/shared/components/privacy-policy/components/edit-description-list-note-block/EditDescriptionListNoteBlock.tsx
+++ b/app/shared/components/privacy-policy/components/edit-description-list-note-block/EditDescriptionListNoteBlock.tsx
@@ -9,6 +9,7 @@ import CollapsibleBlock from '~/shared/components/design-system/collapsible-bloc
 import { CustomTextField } from '~/shared/components/design-system/text-field/TextField';
 import { PointsList } from '~/shared/components/privacy-policy/components/points-list/PointsList';
 import { usePointsList } from '~/shared/hooks/use-points-list/usePointsList';
+import { useTitleValidation } from '~/shared/hooks/use-title-validation/useTitleValidation';
 import { useStore } from '~/store';
 import { LocalizedJSON, ProseDoc } from '~/types/common';
 import { BlocksMap } from '~/types/store/pages';
@@ -72,6 +73,7 @@ export const EditDescriptionListNoteBlock = <T extends BlockWithDescriptionListN
   const noteBlock = block.note;
 
   const headerTitle = proseToHeaderText(sectionTitleBlock?.[currentLocale] as ProseDoc, title);
+  const titleValidation = useTitleValidation(`${pageId}:${blockId}:title`, sectionTitleBlock?.[currentLocale] as ProseDoc);
 
   return (
     <CollapsibleBlock
@@ -87,6 +89,9 @@ export const EditDescriptionListNoteBlock = <T extends BlockWithDescriptionListN
           label="Текст заголовку"
           value={sectionTitleBlock[currentLocale]}
           onChange={(value) => handleTextChange('title', value)}
+          onBlur={titleValidation.onBlur}
+          error={titleValidation.error}
+          helperText={titleValidation.helperText}
         />
       )}
 

--- a/app/shared/components/privacy-policy/components/edit-description-list-note-block/EditDescriptionListNoteBlock.tsx
+++ b/app/shared/components/privacy-policy/components/edit-description-list-note-block/EditDescriptionListNoteBlock.tsx
@@ -24,7 +24,7 @@ export type BlockWithDescriptionListNote = {
 
 interface EditDescriptionListNoteBlockProps<T extends BlockWithDescriptionListNote> {
   blockId: T;
-  block: BlocksMap[T] & DescriptionListNoteStructure;
+  block: BlocksMap[T] & DescriptionListNoteStructure & { title?: LocalizedJSON; hidden?: boolean };
   title: string;
   listFieldName: Extract<keyof BlocksMap[T], string>
 }
@@ -60,14 +60,14 @@ export const EditDescriptionListNoteBlock = <T extends BlockWithDescriptionListN
   };
 
   const handleTextChange = (fieldName: 'title' | 'description' | 'note', value: JSONContent) => {
-    const currentValue = (block as unknown as Record<string, Record<'uk' | 'en', JSONContent>>)[fieldName];
+    const currentValue = block[fieldName];
     setField(pageId, blockId, fieldName as Extract<keyof BlocksMap[T], string>, {
       ...currentValue,
       [currentLocale]: value
     } as BlocksMap[T][Extract<keyof BlocksMap[T], string>]);
   };
 
-  const sectionTitleBlock = 'title' in block ? (block as { title?: Record<'uk' | 'en', JSONContent> }).title : undefined;
+  const sectionTitleBlock = block.title;
   const descriptionBlock = block.description;
   const noteBlock = block.note;
 
@@ -77,7 +77,7 @@ export const EditDescriptionListNoteBlock = <T extends BlockWithDescriptionListN
     <CollapsibleBlock
       title={headerTitle}
       grip
-      hidden={(block as { hidden?: boolean }).hidden}
+      hidden={block.hidden}
       onToggleVisibility={() => toggleBlockVisibility(pageId, blockId)}
     >
       {sectionTitleBlock && (

--- a/app/shared/components/privacy-policy/components/edit-description-list-note-block/EditDescriptionListNoteBlock.tsx
+++ b/app/shared/components/privacy-policy/components/edit-description-list-note-block/EditDescriptionListNoteBlock.tsx
@@ -3,13 +3,14 @@ import { JSONContent } from '@tiptap/react';
 
 import { PAGE_IDS } from '~/constants/pageBlocks';
 import { ensureIds } from '~/lib/utils/ensureIds';
+import { proseToHeaderText } from '~/lib/utils/prose';
 import { handleSortableDragEnd } from '~/lib/utils/sortableDragEndHelper';
 import CollapsibleBlock from '~/shared/components/design-system/collapsible-block/CollapsibleBlock';
 import { CustomTextField } from '~/shared/components/design-system/text-field/TextField';
 import { PointsList } from '~/shared/components/privacy-policy/components/points-list/PointsList';
 import { usePointsList } from '~/shared/hooks/use-points-list/usePointsList';
 import { useStore } from '~/store';
-import { LocalizedJSON } from '~/types/common';
+import { LocalizedJSON, ProseDoc } from '~/types/common';
 import { BlocksMap } from '~/types/store/pages';
 
 export interface DescriptionListNoteStructure {
@@ -38,6 +39,7 @@ export const EditDescriptionListNoteBlock = <T extends BlockWithDescriptionListN
 
   const currentLocale = useStore((state) => state.locale);
   const setField = useStore((state) => state.setField);
+  const toggleBlockVisibility = useStore((state) => state.toggleBlockVisibility);
 
   const rawList = block[listFieldName] as Array<LocalizedJSON & { id?: string }>;
   const list = ensureIds(rawList);
@@ -57,19 +59,37 @@ export const EditDescriptionListNoteBlock = <T extends BlockWithDescriptionListN
     });
   };
 
-  const handleTextChange = (fieldName: 'description' | 'note', value: JSONContent) => {
-    const currentValue = block[fieldName];
-    setField(pageId, blockId, fieldName, {
+  const handleTextChange = (fieldName: 'title' | 'description' | 'note', value: JSONContent) => {
+    const currentValue = (block as Record<string, Record<'uk' | 'en', JSONContent>>)[fieldName];
+    setField(pageId, blockId, fieldName as Extract<keyof BlocksMap[T], string>, {
       ...currentValue,
       [currentLocale]: value
-    });
+    } as BlocksMap[T][Extract<keyof BlocksMap[T], string>]);
   };
 
+  const sectionTitleBlock = 'title' in block ? (block as { title?: Record<'uk' | 'en', JSONContent> }).title : undefined;
   const descriptionBlock = block.description;
   const noteBlock = block.note;
 
+  const headerTitle = proseToHeaderText(sectionTitleBlock?.[currentLocale] as ProseDoc, title);
+
   return (
-    <CollapsibleBlock title={title} grip>
+    <CollapsibleBlock
+      title={headerTitle}
+      grip
+      hidden={block.hidden}
+      onToggleVisibility={() => toggleBlockVisibility(pageId, blockId)}
+    >
+      {sectionTitleBlock && (
+        <CustomTextField
+          fieldType="formatting"
+          title="Заголовок секції"
+          label="Текст заголовку"
+          value={sectionTitleBlock[currentLocale]}
+          onChange={(value) => handleTextChange('title', value)}
+        />
+      )}
+
       {descriptionBlock && (
         <CustomTextField
           fieldType="formatting"

--- a/app/shared/components/privacy-policy/components/edit-paragraphs-block/EditParagraphsBlock.test.tsx
+++ b/app/shared/components/privacy-policy/components/edit-paragraphs-block/EditParagraphsBlock.test.tsx
@@ -18,10 +18,11 @@ describe('EditParagraphsBlock', () => {
     checkGrip: true,
   });
   it('should render a correct title if provided', () => {
-    usePageBlockMock.mockReturnValue({ block: createStandardMockBlock().block });
+    const blockWithoutTitle = { ...createStandardMockBlock().block, title: undefined };
+    usePageBlockMock.mockReturnValue({ block: blockWithoutTitle });
 
     render(<EditParagraphsBlock blockId={mockBlockId} title={mockTitle} />);
-    expect(screen.getByText('Initial title')).toBeInTheDocument();
+    expect(screen.getByText(mockTitle)).toBeInTheDocument();
   });
   it('should return null if block does not have description or content is empty', () => {
     usePageBlockMock.mockReturnValue({

--- a/app/shared/components/privacy-policy/components/edit-paragraphs-block/EditParagraphsBlock.test.tsx
+++ b/app/shared/components/privacy-policy/components/edit-paragraphs-block/EditParagraphsBlock.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 
-import { mockSetField, usePageBlockMock } from '../../__mocks__/setup-mocks';
+import { mockSetField, mockSetFieldValidity, usePageBlockMock } from '../../__mocks__/setup-mocks';
 import { createStandardMockBlock, runCommonBlockTests } from '../../test-utils/block-test-factory';
 import { EditParagraphsBlock } from './EditParagraphsBlock';
 import { createDocNode } from '~/__mocks__/utils';
@@ -41,6 +41,41 @@ describe('EditParagraphsBlock', () => {
       'title',
       expect.objectContaining({ uk: createDocNode('Updated Заголовок секції') })
     );
+  });
+
+  it('should update a paragraph via onChange, merging the updated value into the description content array', () => {
+    usePageBlockMock.mockReturnValue({ block: createStandardMockBlock().block });
+
+    render(<EditParagraphsBlock blockId={mockBlockId} title={mockTitle} />);
+    fireEvent.click(screen.getByTestId('trigger-change-Текст 1 абзацу'));
+
+    expect(mockSetField).toHaveBeenCalledWith(
+      PAGE_IDS.PRIVACY_POLICY,
+      mockBlockId,
+      'description',
+      expect.objectContaining({
+        uk: expect.objectContaining({
+          content: [createDocNode('Updated Текст 1 абзацу')]
+        })
+      })
+    );
+  });
+
+  it('should mark the title as invalid after blur when it is empty, and clear the flag on unmount', () => {
+    usePageBlockMock.mockReturnValue({
+      block: { ...createStandardMockBlock().block, title: { uk: { type: 'doc', content: [] } } }
+    });
+
+    const { unmount } = render(<EditParagraphsBlock blockId={mockBlockId} title={mockTitle} />);
+
+    fireEvent.click(screen.getByTestId('trigger-blur-Заголовок секції'));
+
+    expect(screen.getByTestId('textfield-error-Заголовок секції')).toBeInTheDocument();
+    expect(mockSetFieldValidity).toHaveBeenCalledWith(`${PAGE_IDS.PRIVACY_POLICY}:${mockBlockId}:title`, true);
+
+    unmount();
+
+    expect(mockSetFieldValidity).toHaveBeenLastCalledWith(`${PAGE_IDS.PRIVACY_POLICY}:${mockBlockId}:title`, false);
   });
 
   it('should return null if block does not have description or content is empty', () => {

--- a/app/shared/components/privacy-policy/components/edit-paragraphs-block/EditParagraphsBlock.test.tsx
+++ b/app/shared/components/privacy-policy/components/edit-paragraphs-block/EditParagraphsBlock.test.tsx
@@ -1,8 +1,10 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
-import { usePageBlockMock } from '../../__mocks__/setup-mocks';
+import { mockSetField, usePageBlockMock } from '../../__mocks__/setup-mocks';
 import { createStandardMockBlock, runCommonBlockTests } from '../../test-utils/block-test-factory';
 import { EditParagraphsBlock } from './EditParagraphsBlock';
+import { createDocNode } from '~/__mocks__/utils';
+import { PAGE_IDS } from '~/constants/pageBlocks';
 
 
 const mockBlockId = 'intro_block' as any;
@@ -16,6 +18,8 @@ describe('EditParagraphsBlock', () => {
     mockBlock: createStandardMockBlock().block,
     checkParagraph: true,
     checkGrip: true,
+    checkToggleVisibility: true,
+    blockId: mockBlockId,
   });
   it('should render a correct title if provided', () => {
     const blockWithoutTitle = { ...createStandardMockBlock().block, title: undefined };
@@ -24,6 +28,21 @@ describe('EditParagraphsBlock', () => {
     render(<EditParagraphsBlock blockId={mockBlockId} title={mockTitle} />);
     expect(screen.getByText(mockTitle)).toBeInTheDocument();
   });
+  it('should update the section title via onTitleChange, merging into the existing localized title', () => {
+    usePageBlockMock.mockReturnValue({ block: createStandardMockBlock().block });
+
+    render(<EditParagraphsBlock blockId={mockBlockId} title={mockTitle} />);
+
+    fireEvent.click(screen.getByTestId('trigger-change-Заголовок секції'));
+
+    expect(mockSetField).toHaveBeenCalledWith(
+      PAGE_IDS.PRIVACY_POLICY,
+      mockBlockId,
+      'title',
+      expect.objectContaining({ uk: createDocNode('Updated Заголовок секції') })
+    );
+  });
+
   it('should return null if block does not have description or content is empty', () => {
     usePageBlockMock.mockReturnValue({
       block: { description: { uk: { type: 'doc', content: [] }, en: { type: 'doc', content: [] } } }

--- a/app/shared/components/privacy-policy/components/edit-paragraphs-block/EditParagraphsBlock.test.tsx
+++ b/app/shared/components/privacy-policy/components/edit-paragraphs-block/EditParagraphsBlock.test.tsx
@@ -21,7 +21,7 @@ describe('EditParagraphsBlock', () => {
     usePageBlockMock.mockReturnValue({ block: createStandardMockBlock().block });
 
     render(<EditParagraphsBlock blockId={mockBlockId} title={mockTitle} />);
-    expect(screen.getByText(mockTitle)).toBeInTheDocument();
+    expect(screen.getByText('Initial title')).toBeInTheDocument();
   });
   it('should return null if block does not have description or content is empty', () => {
     usePageBlockMock.mockReturnValue({

--- a/app/shared/components/privacy-policy/components/edit-paragraphs-block/EditParagraphsBlock.tsx
+++ b/app/shared/components/privacy-policy/components/edit-paragraphs-block/EditParagraphsBlock.tsx
@@ -59,10 +59,18 @@ export const EditParagraphsBlock = <T extends BlockIdsWithDescription>({ blockId
   const blockTitle = 'title' in block ? (block as { title?: Record<'uk' | 'en', JSONContent> }).title : undefined;
 
   const onTitleChange = (value: JSONContent) => {
-    setField(pageId, blockId, 'title', {
-      ...blockTitle,
+    const fallbackTitle: Record<'uk' | 'en', JSONContent> = { uk: {} as JSONContent, en: {} as JSONContent };
+    const newTitle = {
+      ...(blockTitle ?? fallbackTitle),
       [currentLocale]: value
-    });
+    };
+
+    setField(
+      pageId,
+      blockId,
+      'title' as Extract<keyof BlocksMap[T], string>,
+      newTitle as BlocksMap[T][Extract<keyof BlocksMap[T], string>]
+    );
   };
 
   if (!paragraphs || paragraphs.length === 0) return null;
@@ -73,7 +81,7 @@ export const EditParagraphsBlock = <T extends BlockIdsWithDescription>({ blockId
     <CollapsibleBlock
       title={headerTitle}
       grip
-      hidden={block.hidden}
+      hidden={(block as { hidden?: boolean }).hidden}
       onToggleVisibility={() => toggleBlockVisibility(pageId, blockId)}
     >
       {blockTitle && (

--- a/app/shared/components/privacy-policy/components/edit-paragraphs-block/EditParagraphsBlock.tsx
+++ b/app/shared/components/privacy-policy/components/edit-paragraphs-block/EditParagraphsBlock.tsx
@@ -2,11 +2,13 @@ import { JSONContent } from '@tiptap/react';
 import { useRef } from 'react';
 
 import { PAGE_IDS } from '~/constants/pageBlocks';
+import { proseToHeaderText } from '~/lib/utils/prose';
 import CollapsibleBlock from '~/shared/components/design-system/collapsible-block/CollapsibleBlock';
 import { CustomTextField } from '~/shared/components/design-system/text-field/TextField';
 import { EditBlockSkeleton } from '~/shared/components/edit-block-skeleton/EditBlockSkeleton';
 import { usePageBlock } from '~/shared/hooks/use-page-block/usePageBlock';
 import { useStore } from '~/store';
+import { ProseDoc } from '~/types/common';
 import { BlocksMap } from '~/types/store/pages';
 
 type BlockIdsWithDescription = {
@@ -26,10 +28,11 @@ export const EditParagraphsBlock = <T extends BlockIdsWithDescription>({ blockId
   const { block } = usePageBlock(pageId, blockId);
   const currentLocale = useStore((state) => state.locale);
   const setField = useStore((state) => state.setField);
+  const toggleBlockVisibility = useStore((state) => state.toggleBlockVisibility);
 
   const paragraphs = block?.description[currentLocale].content || [];
   const stableIds = useRef<string[]>([]);
-  
+
   if (stableIds.current.length === 0) {
     stableIds.current = paragraphs.map(() => crypto.randomUUID());
   }
@@ -53,10 +56,36 @@ export const EditParagraphsBlock = <T extends BlockIdsWithDescription>({ blockId
     setField(pageId, blockId, 'description', newDescription);
   };
 
+  const blockTitle = 'title' in block ? (block as { title?: Record<'uk' | 'en', JSONContent> }).title : undefined;
+
+  const onTitleChange = (value: JSONContent) => {
+    setField(pageId, blockId, 'title', {
+      ...blockTitle,
+      [currentLocale]: value
+    });
+  };
+
   if (!paragraphs || paragraphs.length === 0) return null;
 
+  const headerTitle = proseToHeaderText(blockTitle?.[currentLocale] as ProseDoc, title);
+
   return (
-    <CollapsibleBlock title={title} grip>
+    <CollapsibleBlock
+      title={headerTitle}
+      grip
+      hidden={block.hidden}
+      onToggleVisibility={() => toggleBlockVisibility(pageId, blockId)}
+    >
+      {blockTitle && (
+        <CustomTextField
+          fieldType="formatting"
+          title="Заголовок секції"
+          label="Текст заголовку"
+          value={blockTitle[currentLocale]}
+          onChange={onTitleChange}
+        />
+      )}
+
       {paragraphs.map((paragraphNode, i) =>
         (
           <CustomTextField

--- a/app/shared/components/privacy-policy/components/edit-paragraphs-block/EditParagraphsBlock.tsx
+++ b/app/shared/components/privacy-policy/components/edit-paragraphs-block/EditParagraphsBlock.tsx
@@ -7,6 +7,7 @@ import CollapsibleBlock from '~/shared/components/design-system/collapsible-bloc
 import { CustomTextField } from '~/shared/components/design-system/text-field/TextField';
 import { EditBlockSkeleton } from '~/shared/components/edit-block-skeleton/EditBlockSkeleton';
 import { usePageBlock } from '~/shared/hooks/use-page-block/usePageBlock';
+import { useTitleValidation } from '~/shared/hooks/use-title-validation/useTitleValidation';
 import { useStore } from '~/store';
 import { ProseDoc } from '~/types/common';
 import { BlocksMap } from '~/types/store/pages';
@@ -33,6 +34,9 @@ export const EditParagraphsBlock = <T extends BlockIdsWithDescription>({ blockId
   const paragraphs = block?.description[currentLocale].content || [];
   const stableIds = useRef<string[]>([]);
 
+  const blockTitle = block && 'title' in block ? (block as { title?: Record<'uk' | 'en', JSONContent> }).title : undefined;
+  const titleValidation = useTitleValidation(`${pageId}:${blockId}:title`, blockTitle?.[currentLocale] as ProseDoc);
+
   if (stableIds.current.length === 0) {
     stableIds.current = paragraphs.map(() => crypto.randomUUID());
   }
@@ -55,8 +59,6 @@ export const EditParagraphsBlock = <T extends BlockIdsWithDescription>({ blockId
 
     setField(pageId, blockId, 'description', newDescription);
   };
-
-  const blockTitle = 'title' in block ? (block as { title?: Record<'uk' | 'en', JSONContent> }).title : undefined;
 
   const onTitleChange = (value: JSONContent) => {
     const fallbackTitle: Record<'uk' | 'en', JSONContent> = { uk: {} as JSONContent, en: {} as JSONContent };
@@ -91,6 +93,9 @@ export const EditParagraphsBlock = <T extends BlockIdsWithDescription>({ blockId
           label="Текст заголовку"
           value={blockTitle[currentLocale]}
           onChange={onTitleChange}
+          onBlur={titleValidation.onBlur}
+          error={titleValidation.error}
+          helperText={titleValidation.helperText}
         />
       )}
 

--- a/app/shared/components/privacy-policy/cookies/Cookies.test.tsx
+++ b/app/shared/components/privacy-policy/cookies/Cookies.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 
-import { mockSetField, usePageBlockMock, usePointsListMock } from '../__mocks__/setup-mocks';
+import { mockSetField, mockSetFieldValidity, usePageBlockMock, usePointsListMock } from '../__mocks__/setup-mocks';
 import { createStandardMockBlock, runCommonBlockTests } from '../test-utils/block-test-factory';
 import { Cookies } from './Cookies';
 import { createDocNode } from '~/__mocks__/utils';
@@ -32,6 +32,23 @@ describe('Cookies', () => {
       'title',
       expect.objectContaining({ uk: createDocNode('Updated Заголовок секції') })
     );
+  });
+
+  it('should mark the title as invalid after blur when it is empty, and clear the flag on unmount', () => {
+    usePageBlockMock.mockReturnValue({
+      block: { ...createStandardMockBlock().block, title: { uk: { type: 'doc', content: [] } } }
+    });
+
+    const { unmount } = render(<Cookies />);
+
+    fireEvent.click(screen.getByTestId('trigger-blur-Заголовок секції'));
+
+    expect(screen.getByTestId('textfield-error-Заголовок секції')).toBeInTheDocument();
+    expect(mockSetFieldValidity).toHaveBeenCalledWith(`${PAGE_IDS.PRIVACY_POLICY}:${BLOCK_IDS.COOKIES}:title`, true);
+
+    unmount();
+
+    expect(mockSetFieldValidity).toHaveBeenLastCalledWith(`${PAGE_IDS.PRIVACY_POLICY}:${BLOCK_IDS.COOKIES}:title`, false);
   });
 });
 

--- a/app/shared/components/privacy-policy/cookies/Cookies.test.tsx
+++ b/app/shared/components/privacy-policy/cookies/Cookies.test.tsx
@@ -1,7 +1,10 @@
+import { fireEvent, render, screen } from '@testing-library/react';
 
-import { usePointsListMock } from '../__mocks__/setup-mocks';
+import { mockSetField, usePageBlockMock, usePointsListMock } from '../__mocks__/setup-mocks';
 import { createStandardMockBlock, runCommonBlockTests } from '../test-utils/block-test-factory';
 import { Cookies } from './Cookies';
+import { createDocNode } from '~/__mocks__/utils';
+import { BLOCK_IDS, PAGE_IDS } from '~/constants/pageBlocks';
 
 describe('Cookies', () => {
   runCommonBlockTests({
@@ -12,6 +15,23 @@ describe('Cookies', () => {
     checkList: true,
     usePointsListMock,
     checkGrip: true,
+    checkToggleVisibility: true,
+    blockId: BLOCK_IDS.COOKIES,
+  });
+
+  it('should update the section title, merging into the existing localized title', () => {
+    usePageBlockMock.mockReturnValue({ block: createStandardMockBlock().block });
+
+    render(<Cookies />);
+
+    fireEvent.click(screen.getByTestId('trigger-change-Заголовок секції'));
+
+    expect(mockSetField).toHaveBeenCalledWith(
+      PAGE_IDS.PRIVACY_POLICY,
+      BLOCK_IDS.COOKIES,
+      'title',
+      expect.objectContaining({ uk: createDocNode('Updated Заголовок секції') })
+    );
   });
 });
 

--- a/app/shared/components/privacy-policy/data-usage/DataUsage.test.tsx
+++ b/app/shared/components/privacy-policy/data-usage/DataUsage.test.tsx
@@ -14,6 +14,8 @@ describe('DataUsage', () => {
     usePointsListMock,
     mockBlock: createStandardMockBlock().block,
     checkGrip: true,
+    checkToggleVisibility: true,
+    blockId: BLOCK_IDS.DATA_USAGE,
   });
 
   it('should handle drag-and-drop reordering', () => {

--- a/app/shared/components/privacy-policy/data-usage/DataUsage.test.tsx
+++ b/app/shared/components/privacy-policy/data-usage/DataUsage.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 
-import { mockSetField,usePageBlockMock, usePointsListMock } from '../__mocks__/setup-mocks';
+import { mockSetField, mockSetFieldValidity, usePageBlockMock, usePointsListMock } from '../__mocks__/setup-mocks';
 import { createStandardMockBlock, runCommonBlockTests } from '../test-utils/block-test-factory';
 import { DataUsage } from './DataUsage';
 import { createDocNode } from '~/__mocks__/utils';
@@ -38,5 +38,36 @@ describe('DataUsage', () => {
       'list',
       [doubleMockBlock.list[1], doubleMockBlock.list[0]]
     );
+  });
+
+  it('should update the section title via onChange, merging into the existing localized title', () => {
+    usePageBlockMock.mockReturnValue({ block: createStandardMockBlock().block });
+
+    render(<DataUsage />);
+    fireEvent.click(screen.getByTestId('trigger-change-Вступний текст секції'));
+
+    expect(mockSetField).toHaveBeenCalledWith(
+      PAGE_IDS.PRIVACY_POLICY,
+      BLOCK_IDS.DATA_USAGE,
+      'title',
+      expect.objectContaining({ uk: createDocNode('Updated Вступний текст секції') })
+    );
+  });
+
+  it('should mark the title as invalid after blur when it is empty, and clear the flag on unmount', () => {
+    usePageBlockMock.mockReturnValue({
+      block: { ...createStandardMockBlock().block, title: { uk: { type: 'doc', content: [] } } }
+    });
+
+    const { unmount } = render(<DataUsage />);
+
+    fireEvent.click(screen.getByTestId('trigger-blur-Вступний текст секції'));
+
+    expect(screen.getByTestId('textfield-error-Вступний текст секції')).toBeInTheDocument();
+    expect(mockSetFieldValidity).toHaveBeenCalledWith(`${PAGE_IDS.PRIVACY_POLICY}:${BLOCK_IDS.DATA_USAGE}:title`, true);
+
+    unmount();
+
+    expect(mockSetFieldValidity).toHaveBeenLastCalledWith(`${PAGE_IDS.PRIVACY_POLICY}:${BLOCK_IDS.DATA_USAGE}:title`, false);
   });
 });

--- a/app/shared/components/privacy-policy/data-usage/DataUsage.tsx
+++ b/app/shared/components/privacy-policy/data-usage/DataUsage.tsx
@@ -13,6 +13,7 @@ import { proseToHeaderText } from '~/lib/utils/prose';
 import { handleSortableDragEnd } from '~/lib/utils/sortableDragEndHelper';
 import { usePageBlock } from '~/shared/hooks/use-page-block/usePageBlock';
 import { usePointsList } from '~/shared/hooks/use-points-list/usePointsList';
+import { useTitleValidation } from '~/shared/hooks/use-title-validation/useTitleValidation';
 import { useStore } from '~/store';
 import { ProseDoc } from '~/types/common';
 import { DataUsageItemWithId } from '~/types/store/pages/privacy-policy';
@@ -37,6 +38,8 @@ export const DataUsage = () => {
     pageId,
     blockId
   });
+
+  const titleValidation = useTitleValidation(`${pageId}:${blockId}:title`, block?.title?.[currentLocale] as ProseDoc);
 
   const handleDragEnd = (event: DragEndEvent) => {
     handleSortableDragEnd(event, points, (reordered) => {
@@ -67,6 +70,9 @@ export const DataUsage = () => {
         title="Вступний текст секції"
         value={block.title[currentLocale]}
         onChange={(value) => handleChangeTitleText(value)}
+        onBlur={titleValidation.onBlur}
+        error={titleValidation.error}
+        helperText={titleValidation.helperText}
       />
 
       {points.length > 0 && (

--- a/app/shared/components/privacy-policy/data-usage/DataUsage.tsx
+++ b/app/shared/components/privacy-policy/data-usage/DataUsage.tsx
@@ -9,10 +9,12 @@ import { EditBlockSkeleton } from '../../edit-block-skeleton/EditBlockSkeleton';
 import { PointsList } from '../components/points-list/PointsList';
 import { BLOCK_IDS, PAGE_IDS } from '~/constants/pageBlocks';
 import { ensureIds } from '~/lib/utils/ensureIds';
+import { proseToHeaderText } from '~/lib/utils/prose';
 import { handleSortableDragEnd } from '~/lib/utils/sortableDragEndHelper';
 import { usePageBlock } from '~/shared/hooks/use-page-block/usePageBlock';
 import { usePointsList } from '~/shared/hooks/use-points-list/usePointsList';
 import { useStore } from '~/store';
+import { ProseDoc } from '~/types/common';
 import { DataUsageItemWithId } from '~/types/store/pages/privacy-policy';
 
 
@@ -23,6 +25,7 @@ export const DataUsage = () => {
   const { block } = usePageBlock(pageId, blockId);
   const currentLocale = useStore((state) => state.locale);
   const setField = useStore((state) => state.setField);
+  const toggleBlockVisibility = useStore((state) => state.toggleBlockVisibility);
 
   const rawList = block?.list || [];
   const list: DataUsageItemWithId[] = ensureIds(rawList);
@@ -50,8 +53,15 @@ export const DataUsage = () => {
     });
   };
 
+  const headerTitle = proseToHeaderText(block.title?.[currentLocale] as ProseDoc, 'Як ми використовуємо ваші дані');
+
   return (
-    <CollapsibleBlock title="Як ми використовуємо ваші дані" grip>
+    <CollapsibleBlock
+      title={headerTitle}
+      grip
+      hidden={block.hidden}
+      onToggleVisibility={() => toggleBlockVisibility(pageId, blockId)}
+    >
       <CustomTextField
         fieldType="formatting"
         title="Вступний текст секції"

--- a/app/shared/components/privacy-policy/data-we-collect/DataWeCollect.test.tsx
+++ b/app/shared/components/privacy-policy/data-we-collect/DataWeCollect.test.tsx
@@ -1,10 +1,10 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 
-import { usePageBlockMock,useSectionListMock } from '../__mocks__/setup-mocks';
+import { mockSetField, mockSetFieldValidity, usePageBlockMock,useSectionListMock } from '../__mocks__/setup-mocks';
 import { createStandardMockBlock, runCommonBlockTests } from '../test-utils/block-test-factory';
 import { DataWeCollect } from './DataWeCollect';
 import { createDocNode } from '~/__mocks__/utils';
-import { BLOCK_IDS } from '~/constants/pageBlocks';
+import { BLOCK_IDS, PAGE_IDS } from '~/constants/pageBlocks';
 import { DataWeCollectBlock } from '~/types/store/pages/privacy-policy';
 
 jest.mock('~/components/configurable-list/ConfigurableList');
@@ -63,5 +63,40 @@ describe('DataWeCollect', () => {
       'section-1',
       [point2, point1]
     );
+  });
+
+  it.each([
+    ['title', 'Заголовок секції', 'title'],
+    ['description', 'Вступний текст секції', 'description'],
+    ['note', 'Додаткова інформація', 'note']
+  ])('should update the %s via onChange, merging into the existing localized value', (_label, fieldLabel, storeKey) => {
+    usePageBlockMock.mockReturnValue({ block: mockBlock });
+
+    render(<DataWeCollect />);
+    fireEvent.click(screen.getByTestId(`trigger-change-${fieldLabel}`));
+
+    expect(mockSetField).toHaveBeenCalledWith(
+      PAGE_IDS.PRIVACY_POLICY,
+      BLOCK_IDS.DATA_WE_COLLECT,
+      storeKey,
+      expect.objectContaining({ uk: createDocNode(`Updated ${fieldLabel}`) })
+    );
+  });
+
+  it('should mark the title as invalid after blur when it is empty, and clear the flag on unmount', () => {
+    usePageBlockMock.mockReturnValue({
+      block: { ...mockBlock, title: { uk: { type: 'doc', content: [] } } }
+    });
+
+    const { unmount } = render(<DataWeCollect />);
+
+    fireEvent.click(screen.getByTestId('trigger-blur-Заголовок секції'));
+
+    expect(screen.getByTestId('textfield-error-Заголовок секції')).toBeInTheDocument();
+    expect(mockSetFieldValidity).toHaveBeenCalledWith(`${PAGE_IDS.PRIVACY_POLICY}:${BLOCK_IDS.DATA_WE_COLLECT}:title`, true);
+
+    unmount();
+
+    expect(mockSetFieldValidity).toHaveBeenLastCalledWith(`${PAGE_IDS.PRIVACY_POLICY}:${BLOCK_IDS.DATA_WE_COLLECT}:title`, false);
   });
 });

--- a/app/shared/components/privacy-policy/data-we-collect/DataWeCollect.test.tsx
+++ b/app/shared/components/privacy-policy/data-we-collect/DataWeCollect.test.tsx
@@ -4,6 +4,7 @@ import { usePageBlockMock,useSectionListMock } from '../__mocks__/setup-mocks';
 import { createStandardMockBlock, runCommonBlockTests } from '../test-utils/block-test-factory';
 import { DataWeCollect } from './DataWeCollect';
 import { createDocNode } from '~/__mocks__/utils';
+import { BLOCK_IDS } from '~/constants/pageBlocks';
 import { DataWeCollectBlock } from '~/types/store/pages/privacy-policy';
 
 jest.mock('~/components/configurable-list/ConfigurableList');
@@ -33,6 +34,8 @@ describe('DataWeCollect', () => {
     checkList: true,
     useSectionListMock,
     checkGrip: true,
+    checkToggleVisibility: true,
+    blockId: BLOCK_IDS.DATA_WE_COLLECT,
   });
 
   it('should handle drag-and-drop reordering', () => {

--- a/app/shared/components/privacy-policy/data-we-collect/DataWeCollect.test.tsx
+++ b/app/shared/components/privacy-policy/data-we-collect/DataWeCollect.test.tsx
@@ -17,11 +17,12 @@ const mockNoteJson = createDocNode('Initial note');
 const mockSubtitleJson = createDocNode('Initial subtitle');
 const mockListItem1 = createDocNode('Initial list item 1');
 
-const mockBlock: DataWeCollectBlock = {
+const mockBlock = {
   ...standardMockBlock,
   sections: [{ id: '1', list: [{ uk: mockListItem1, en: mockListItem1 }], subtitle: { uk: mockSubtitleJson, en: mockSubtitleJson } }],
   note: { uk: mockNoteJson, en: mockNoteJson },
-};
+  hidden: false,
+} satisfies DataWeCollectBlock;
 
 describe('DataWeCollect', () => {
   runCommonBlockTests({

--- a/app/shared/components/privacy-policy/data-we-collect/DataWeCollect.tsx
+++ b/app/shared/components/privacy-policy/data-we-collect/DataWeCollect.tsx
@@ -9,9 +9,11 @@ import { EditBlockSkeleton } from '../../edit-block-skeleton/EditBlockSkeleton';
 import { DataWeCollectSection } from './DataWeCollectSection';
 import { BLOCK_IDS, PAGE_IDS } from '~/constants/pageBlocks';
 import { ensureIds } from '~/lib/utils/ensureIds';
+import { proseToHeaderText } from '~/lib/utils/prose';
 import { usePageBlock } from '~/shared/hooks/use-page-block/usePageBlock';
 import { useSectionList } from '~/shared/hooks/use-section-list/useSectionList';
 import { useStore } from '~/store';
+import { ProseDoc } from '~/types/common';
 import { DataWeCollectItemWithId } from '~/types/store/pages/privacy-policy';
 
 export const DataWeCollect = () => {
@@ -21,6 +23,7 @@ export const DataWeCollect = () => {
   const { block } = usePageBlock(pageId, blockId);
   const currentLocale = useStore((state) => state.locale);
   const setField = useStore((state) => state.setField);
+  const toggleBlockVisibility = useStore((state) => state.toggleBlockVisibility);
 
   const rawSections = block?.sections || [];
   const sectionsList: DataWeCollectItemWithId[] = ensureIds(rawSections);
@@ -28,6 +31,13 @@ export const DataWeCollect = () => {
   const { sections, addListPoint, removeListPoint, updateListPoint, updateSectionSubtitle, updateSectionList } = useSectionList({ blockId, pageId, sectionsList, currentLocale, setField });
 
   if (!block) return <EditBlockSkeleton />;
+
+  const handleChangeTitle = (value: JSONContent) => {
+    setField(pageId, blockId, 'title', {
+      ...block.title,
+      [currentLocale]: value
+    });
+  };
 
   const handleChangeDescription = (value: JSONContent) => {
     setField(pageId, blockId, 'description', {
@@ -43,8 +53,23 @@ export const DataWeCollect = () => {
     });
   };
 
+  const headerTitle = proseToHeaderText(block.title?.[currentLocale] as ProseDoc, 'Які дані ми збираємо та чому');
+
   return (
-    <CollapsibleBlock title="Які дані ми збираємо та чому" grip>
+    <CollapsibleBlock
+      title={headerTitle}
+      grip
+      hidden={block.hidden}
+      onToggleVisibility={() => toggleBlockVisibility(pageId, blockId)}
+    >
+      <CustomTextField
+        fieldType="formatting"
+        title="Заголовок секції"
+        label="Текст заголовку"
+        value={block.title?.[currentLocale]}
+        onChange={handleChangeTitle}
+      />
+
       <CustomTextField
         fieldType="formatting"
         title="Вступний текст секції"

--- a/app/shared/components/privacy-policy/data-we-collect/DataWeCollect.tsx
+++ b/app/shared/components/privacy-policy/data-we-collect/DataWeCollect.tsx
@@ -12,6 +12,7 @@ import { ensureIds } from '~/lib/utils/ensureIds';
 import { proseToHeaderText } from '~/lib/utils/prose';
 import { usePageBlock } from '~/shared/hooks/use-page-block/usePageBlock';
 import { useSectionList } from '~/shared/hooks/use-section-list/useSectionList';
+import { useTitleValidation } from '~/shared/hooks/use-title-validation/useTitleValidation';
 import { useStore } from '~/store';
 import { ProseDoc } from '~/types/common';
 import { DataWeCollectItemWithId } from '~/types/store/pages/privacy-policy';
@@ -29,6 +30,8 @@ export const DataWeCollect = () => {
   const sectionsList: DataWeCollectItemWithId[] = ensureIds(rawSections);
 
   const { sections, addListPoint, removeListPoint, updateListPoint, updateSectionSubtitle, updateSectionList } = useSectionList({ blockId, pageId, sectionsList, currentLocale, setField });
+
+  const titleValidation = useTitleValidation(`${pageId}:${blockId}:title`, block?.title?.[currentLocale] as ProseDoc);
 
   if (!block) return <EditBlockSkeleton />;
 
@@ -68,6 +71,9 @@ export const DataWeCollect = () => {
         label="Текст заголовку"
         value={block.title?.[currentLocale]}
         onChange={handleChangeTitle}
+        onBlur={titleValidation.onBlur}
+        error={titleValidation.error}
+        helperText={titleValidation.helperText}
       />
 
       <CustomTextField

--- a/app/shared/components/privacy-policy/test-utils/block-test-factory.tsx
+++ b/app/shared/components/privacy-policy/test-utils/block-test-factory.tsx
@@ -1,7 +1,8 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 
-import { mockAddPoint, mockRemovePoint, mockUpdatePoint, usePageBlockMock } from '../__mocks__/setup-mocks';
+import { mockAddPoint, mockRemovePoint, mockToggleBlockVisibility, mockUpdatePoint, usePageBlockMock } from '../__mocks__/setup-mocks';
 import { createDocNode } from '~/__mocks__/utils';
+import { PAGE_IDS } from '~/constants/pageBlocks';
 import { LocalizedJSON } from '~/types/common';
 
 
@@ -52,6 +53,8 @@ interface CommonTestProps {
   checkList?: boolean;
   checkParagraph?: boolean;
   checkGrip?: boolean;
+  checkToggleVisibility?: boolean;
+  blockId?: string;
   usePointsListMock?: jest.Mock;
   useSectionListMock?: jest.Mock;
 }
@@ -65,6 +68,8 @@ export const runCommonBlockTests = ({
   checkList,
   checkParagraph,
   checkGrip,
+  checkToggleVisibility,
+  blockId,
   usePointsListMock,
   useSectionListMock
 }: CommonTestProps) => {
@@ -125,6 +130,16 @@ export const runCommonBlockTests = ({
       } else {
         expect(screen.queryByTestId('collapsible-block-grip')).not.toBeInTheDocument();
       }
+    });
+  }
+
+  if (checkToggleVisibility && blockId) {
+    it('should call toggleBlockVisibility with pageId and blockId when the visibility toggle is clicked', () => {
+      runSimulation();
+
+      fireEvent.click(screen.getByTestId('collapsible-block-toggle-visibility'));
+
+      expect(mockToggleBlockVisibility).toHaveBeenCalledWith(PAGE_IDS.PRIVACY_POLICY, blockId);
     });
   }
 

--- a/app/shared/hooks/use-title-validation/useTitleValidation.test.ts
+++ b/app/shared/hooks/use-title-validation/useTitleValidation.test.ts
@@ -2,6 +2,7 @@ import { act, renderHook } from '@testing-library/react';
 
 import { useTitleValidation } from './useTitleValidation';
 import { createDocNode } from '~/__mocks__/utils';
+import { ProseDoc } from '~/types/common';
 
 const mockSetFieldValidity = jest.fn();
 
@@ -11,7 +12,7 @@ jest.mock('~/store', () => ({
 }));
 
 const KEY = 'privacy-policy:Cookies:title';
-const emptyDoc = { type: 'doc', content: [] };
+const emptyDoc: ProseDoc = { type: 'doc', content: [] };
 
 describe('useTitleValidation', () => {
   beforeEach(() => {
@@ -52,7 +53,7 @@ describe('useTitleValidation', () => {
     rerender({ value: emptyDoc });
     expect(result.current.error).toBe(true);
 
-    rerender({ value: createDocNode('Some title') });
+    rerender({ value: createDocNode('Some title') as ProseDoc });
     expect(result.current.error).toBe(false);
     expect(mockSetFieldValidity).toHaveBeenLastCalledWith(KEY, false);
   });

--- a/app/shared/hooks/use-title-validation/useTitleValidation.test.ts
+++ b/app/shared/hooks/use-title-validation/useTitleValidation.test.ts
@@ -1,0 +1,85 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useTitleValidation } from './useTitleValidation';
+import { createDocNode } from '~/__mocks__/utils';
+
+const mockSetFieldValidity = jest.fn();
+
+jest.mock('~/store', () => ({
+  useStore: (selector: (state: { setFieldValidity: typeof mockSetFieldValidity }) => unknown) =>
+    selector({ setFieldValidity: mockSetFieldValidity })
+}));
+
+const KEY = 'privacy-policy:Cookies:title';
+const emptyDoc = { type: 'doc', content: [] };
+
+describe('useTitleValidation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should report no error before the field is touched, even when the value is empty', () => {
+    const { result } = renderHook(() => useTitleValidation(KEY, emptyDoc));
+
+    expect(result.current.error).toBe(false);
+    expect(result.current.helperText).toBeUndefined();
+    expect(mockSetFieldValidity).toHaveBeenLastCalledWith(KEY, false);
+  });
+
+  it('should report an error after blur when the value is empty', () => {
+    const { result, rerender } = renderHook(({ value }) => useTitleValidation(KEY, value), {
+      initialProps: { value: emptyDoc }
+    });
+
+    act(() => {
+      result.current.onBlur();
+    });
+    rerender({ value: emptyDoc });
+
+    expect(result.current.error).toBe(true);
+    expect(result.current.helperText).toBe('Заголовок не може бути порожнім');
+    expect(mockSetFieldValidity).toHaveBeenLastCalledWith(KEY, true);
+  });
+
+  it('should clear the error once the value becomes non-empty after being touched', () => {
+    const { result, rerender } = renderHook(({ value }) => useTitleValidation(KEY, value), {
+      initialProps: { value: emptyDoc }
+    });
+
+    act(() => {
+      result.current.onBlur();
+    });
+    rerender({ value: emptyDoc });
+    expect(result.current.error).toBe(true);
+
+    rerender({ value: createDocNode('Some title') });
+    expect(result.current.error).toBe(false);
+    expect(mockSetFieldValidity).toHaveBeenLastCalledWith(KEY, false);
+  });
+
+  it('should clear the invalid flag in the store on unmount', () => {
+    const { result, rerender, unmount } = renderHook(({ value }) => useTitleValidation(KEY, value), {
+      initialProps: { value: emptyDoc }
+    });
+
+    act(() => {
+      result.current.onBlur();
+    });
+    rerender({ value: emptyDoc });
+    expect(mockSetFieldValidity).toHaveBeenLastCalledWith(KEY, true);
+
+    unmount();
+
+    expect(mockSetFieldValidity).toHaveBeenLastCalledWith(KEY, false);
+  });
+
+  it('should treat an undefined value as empty', () => {
+    const { result } = renderHook(() => useTitleValidation(KEY, undefined));
+
+    act(() => {
+      result.current.onBlur();
+    });
+
+    expect(result.current.error).toBe(true);
+  });
+});

--- a/app/shared/hooks/use-title-validation/useTitleValidation.ts
+++ b/app/shared/hooks/use-title-validation/useTitleValidation.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+
+import { proseToText } from '~/lib/utils/prose';
+import { useStore } from '~/store';
+import { ProseDoc } from '~/types/common';
+
+const EMPTY_TITLE_MESSAGE = 'Заголовок не може бути порожнім';
+
+/**
+ * Tracks emptiness validation for a single rich-text title field and mirrors
+ * the result into the shared store so the page-level Save button can be
+ * disabled while any title on the page is invalid.
+ *
+ * `key` must be unique per field across the whole app, e.g. `${pageId}:${blockId}:title`.
+ */
+export const useTitleValidation = (key: string, value?: ProseDoc) => {
+  const setFieldValidity = useStore((state) => state.setFieldValidity);
+  const [touched, setTouched] = useState(false);
+
+  const isEmpty = proseToText(value).trim() === '';
+  const error = touched && isEmpty;
+
+  useEffect(() => {
+    setFieldValidity(key, error);
+  }, [key, error, setFieldValidity]);
+
+  useEffect(() => () => setFieldValidity(key, false), [key, setFieldValidity]);
+
+  return {
+    error,
+    helperText: error ? EMPTY_TITLE_MESSAGE : undefined,
+    onBlur: () => setTouched(true)
+  };
+};

--- a/app/shared/hooks/use-title-validation/useTitleValidation.ts
+++ b/app/shared/hooks/use-title-validation/useTitleValidation.ts
@@ -6,13 +6,6 @@ import { ProseDoc } from '~/types/common';
 
 const EMPTY_TITLE_MESSAGE = 'Заголовок не може бути порожнім';
 
-/**
- * Tracks emptiness validation for a single rich-text title field and mirrors
- * the result into the shared store so the page-level Save button can be
- * disabled while any title on the page is invalid.
- *
- * `key` must be unique per field across the whole app, e.g. `${pageId}:${blockId}:title`.
- */
 export const useTitleValidation = (key: string, value?: ProseDoc) => {
   const setFieldValidity = useStore((state) => state.setFieldValidity);
   const [touched, setTouched] = useState(false);

--- a/app/store/slices/editSlice.test.ts
+++ b/app/store/slices/editSlice.test.ts
@@ -33,6 +33,30 @@ describe('editSlice', () => {
     expect(state.blocksOrder).toEqual({});
     expect(state.originalBlocksOrder).toEqual({});
     expect(state.locale).toBe('uk');
+    expect(state.invalidFields).toEqual({});
+  });
+
+  describe('setFieldValidity', () => {
+    const KEY = `${PAGE_ID}:${BLOCK_ID}:title`;
+
+    it('should add a key to invalidFields when marked invalid', () => {
+      store.getState().setFieldValidity(KEY, true);
+      expect(store.getState().invalidFields).toEqual({ [KEY]: true });
+    });
+
+    it('should remove the key from invalidFields when marked valid again', () => {
+      store.getState().setFieldValidity(KEY, true);
+      store.getState().setFieldValidity(KEY, false);
+      expect(store.getState().invalidFields).toEqual({});
+    });
+
+    it('should be a no-op when setting the same validity twice', () => {
+      store.getState().setFieldValidity(KEY, false);
+      const stateBefore = store.getState().invalidFields;
+
+      store.getState().setFieldValidity(KEY, false);
+      expect(store.getState().invalidFields).toBe(stateBefore);
+    });
   });
 
   describe('setField', () => {
@@ -209,6 +233,31 @@ describe('editSlice', () => {
     expect(state.blocks[PAGE_ID]).toEqual(initBlocks);
     expect(state.blocksOrder[PAGE_ID]).toEqual([BLOCK_ID]);
     expect(state.isChanged).toBe(false);
+  });
+
+  it('should clear invalidFields for the page on discardChanges, but keep other pages untouched', () => {
+    const key = `${PAGE_ID}:${BLOCK_ID}:title`;
+    const otherPageKey = 'other-page:OtherBlock:title';
+
+    store.getState().setFieldValidity(key, true);
+    store.getState().setFieldValidity(otherPageKey, true);
+
+    store.getState().discardChanges(PAGE_ID);
+
+    expect(store.getState().invalidFields).toEqual({ [otherPageKey]: true });
+  });
+
+  it('should clear invalidFields for the page when setPageData is called with isInit=true', () => {
+    const key = `${PAGE_ID}:${BLOCK_ID}:title`;
+    const otherPageKey = 'other-page:OtherBlock:title';
+
+    store.getState().setFieldValidity(key, true);
+    store.getState().setFieldValidity(otherPageKey, true);
+
+    const initBlocks = { [BLOCK_ID as string]: { v: 1 } } as unknown as SetPageDataPayload;
+    store.getState().setPageData(PAGE_ID, initBlocks, [BLOCK_ID as string], true);
+
+    expect(store.getState().invalidFields).toEqual({ [otherPageKey]: true });
   });
 
   it('should handle discard changes when no original data exists', () => {

--- a/app/store/slices/editSlice.test.ts
+++ b/app/store/slices/editSlice.test.ts
@@ -34,6 +34,7 @@ describe('editSlice', () => {
     expect(state.originalBlocksOrder).toEqual({});
     expect(state.locale).toBe('uk');
     expect(state.invalidFields).toEqual({});
+    expect(state.isSaving).toBe(false);
   });
 
   describe('setFieldValidity', () => {
@@ -56,6 +57,27 @@ describe('editSlice', () => {
 
       store.getState().setFieldValidity(KEY, false);
       expect(store.getState().invalidFields).toBe(stateBefore);
+    });
+  });
+
+  describe('setIsSaving', () => {
+    it('should set isSaving to true', () => {
+      store.getState().setIsSaving(true);
+      expect(store.getState().isSaving).toBe(true);
+    });
+
+    it('should set isSaving back to false', () => {
+      store.getState().setIsSaving(true);
+      store.getState().setIsSaving(false);
+      expect(store.getState().isSaving).toBe(false);
+    });
+
+    it('should be a no-op when setting the same value twice', () => {
+      store.getState().setIsSaving(false);
+      const stateBefore = store.getState();
+
+      store.getState().setIsSaving(false);
+      expect(store.getState()).toBe(stateBefore);
     });
   });
 

--- a/app/store/slices/editSlice.ts
+++ b/app/store/slices/editSlice.ts
@@ -7,6 +7,11 @@ const clone = <T>(v: T): T => JSON.parse(JSON.stringify(v));
 
 const IMAGE_FIELDS = new Set(['image', 'smallImage', 'bigImage', 'photo']);
 
+const clearInvalidFieldsForPage = (invalidFields: Record<string, boolean>, pageId: string): Record<string, boolean> => {
+  const prefix = `${pageId}:`;
+  return Object.fromEntries(Object.entries(invalidFields).filter(([key]) => !key.startsWith(prefix)));
+};
+
 const resolveIsTmp = (field: string, value: unknown): boolean | undefined => {
   if (!IMAGE_FIELDS.has(field)) return undefined;
   if (!value || typeof value !== 'object') return undefined;
@@ -22,6 +27,20 @@ export const createEditSlice: StateCreator<EditState> = (set, get) => ({
   isChanged: false,
   isInitialized: false,
   initializedPages: {},
+
+  invalidFields: {},
+  setFieldValidity: (key: string, isInvalid: boolean) => {
+    const current = get().invalidFields;
+    if (Boolean(current[key]) === isInvalid) return;
+
+    const next = { ...current };
+    if (isInvalid) {
+      next[key] = true;
+    } else {
+      delete next[key];
+    }
+    set({ invalidFields: next });
+  },
 
   blocks: {},
   originalBlocks: {},
@@ -130,6 +149,7 @@ export const createEditSlice: StateCreator<EditState> = (set, get) => ({
         ...get().initializedPages,
         [pageId]: true
       };
+      nextState.invalidFields = clearInvalidFieldsForPage(get().invalidFields, pageId);
     }
     set(nextState as EditState);
   },
@@ -200,6 +220,7 @@ export const createEditSlice: StateCreator<EditState> = (set, get) => ({
         [pageId]: [...originalOrder]
       },
       initializedPages: remainingInitialized,
+      invalidFields: clearInvalidFieldsForPage(get().invalidFields, pageId),
       isChanged: false
     });
   },

--- a/app/store/slices/editSlice.ts
+++ b/app/store/slices/editSlice.ts
@@ -42,6 +42,12 @@ export const createEditSlice: StateCreator<EditState> = (set, get) => ({
     set({ invalidFields: next });
   },
 
+  isSaving: false,
+  setIsSaving: (isSaving: boolean) => {
+    if (get().isSaving === isSaving) return;
+    set({ isSaving });
+  },
+
   blocks: {},
   originalBlocks: {},
 

--- a/app/store/slices/editSlice.ts
+++ b/app/store/slices/editSlice.ts
@@ -150,9 +150,6 @@ export const createEditSlice: StateCreator<EditState> = (set, get) => ({
 
     if (!prevBlock) return;
 
-    // `hidden` is an optional, block-agnostic flag: not every block type in
-    // BlocksMap declares it (account-related blocks intentionally don't),
-    // so we narrow it locally instead of widening the shared type union.
     const isHidden = (prevBlock as { hidden?: boolean }).hidden;
 
     const newBlock = {

--- a/app/store/slices/editSlice.ts
+++ b/app/store/slices/editSlice.ts
@@ -144,6 +144,34 @@ export const createEditSlice: StateCreator<EditState> = (set, get) => ({
     });
   },
 
+  toggleBlockVisibility: <K extends keyof BlocksMap>(pageId: string, blockId: K) => {
+    const prevPageBlocks = get().blocks[pageId] || {};
+    const prevBlock = prevPageBlocks[blockId];
+
+    if (!prevBlock) return;
+
+    // `hidden` is an optional, block-agnostic flag: not every block type in
+    // BlocksMap declares it (account-related blocks intentionally don't),
+    // so we narrow it locally instead of widening the shared type union.
+    const isHidden = (prevBlock as { hidden?: boolean }).hidden;
+
+    const newBlock = {
+      ...prevBlock,
+      hidden: !isHidden
+    } as BlocksMap[K];
+
+    set({
+      blocks: {
+        ...get().blocks,
+        [pageId]: {
+          ...prevPageBlocks,
+          [blockId]: newBlock
+        }
+      },
+      isChanged: true
+    });
+  },
+
   saveAsDraft: (_pageId: string) => {
     const newBlocks = get().blocks[_pageId];
     const newBlocksOrder = get().blocksOrder[_pageId];

--- a/app/store/types.ts
+++ b/app/store/types.ts
@@ -64,6 +64,7 @@ export interface EditState {
   ) => void;
   setPageData: <T extends Record<string, BlockData>>(pageId: string, blocks: T, blocksOrder: string[], isInit?: boolean) => void;
   setBlocksOrder: (pageId: string, blocksOrder: string[]) => void;
+  toggleBlockVisibility: <P extends string, K extends keyof BlocksMap>(pageId: P, blockId: K) => void;
   saveAsDraft: (pageId: string) => void;
   publishPage: (pageId: string) => void;
   discardChanges: (pageId: string) => void;

--- a/app/store/types.ts
+++ b/app/store/types.ts
@@ -31,6 +31,9 @@ export interface EditState {
   invalidFields: Record<string, boolean>;
   setFieldValidity: (key: string, isInvalid: boolean) => void;
 
+  isSaving: boolean;
+  setIsSaving: (isSaving: boolean) => void;
+
   blocks: {
     [pageId: string]: {
       [blockId in keyof BlocksMap]?: BlocksMap[blockId];

--- a/app/store/types.ts
+++ b/app/store/types.ts
@@ -28,6 +28,9 @@ export interface EditState {
   isInitialized: boolean;
   initializedPages: Record<string, boolean>;
 
+  invalidFields: Record<string, boolean>;
+  setFieldValidity: (key: string, isInvalid: boolean) => void;
+
   blocks: {
     [pageId: string]: {
       [blockId in keyof BlocksMap]?: BlocksMap[blockId];

--- a/app/types/common.ts
+++ b/app/types/common.ts
@@ -109,3 +109,7 @@ export const WrapError = <T>(err: ErrorMessage): Result<T> => ({ ok: false, erro
 
 export const isSuccess = <T>(r: Result<T>): r is { ok: true; value: T } => r.ok;
 export const isError = <T>(r: Result<T>): r is { ok: false; error: ErrorMessage } => !r.ok;
+
+export interface WithHidden {
+  hidden: boolean;
+}

--- a/app/types/store/pages/about-us/blocks/foundationFounderBlock.ts
+++ b/app/types/store/pages/about-us/blocks/foundationFounderBlock.ts
@@ -1,4 +1,4 @@
-import { ImageType, LocalizedJSON } from '~/types/common';
+import { ImageType, LocalizedJSON, WithHidden } from '~/types/common';
 
 export type TeamMember = {
   photo: ImageType;
@@ -14,5 +14,4 @@ export type FoundationFoundersBlock = {
   titleText: LocalizedJSON;
   listTitle: LocalizedJSON;
   members: TeamMember[];
-  hidden?: boolean;
-};
+} & WithHidden;

--- a/app/types/store/pages/about-us/blocks/foundationFounderBlock.ts
+++ b/app/types/store/pages/about-us/blocks/foundationFounderBlock.ts
@@ -14,4 +14,5 @@ export type FoundationFoundersBlock = {
   titleText: LocalizedJSON;
   listTitle: LocalizedJSON;
   members: TeamMember[];
+  hidden?: boolean;
 };

--- a/app/types/store/pages/about-us/blocks/introSectionBlock.ts
+++ b/app/types/store/pages/about-us/blocks/introSectionBlock.ts
@@ -1,10 +1,9 @@
 import { JSONContent } from '@tiptap/react';
 
-import { ImageBlock, TipTapQuoteBlock } from '~/types/common';
+import { ImageBlock, TipTapQuoteBlock, WithHidden } from '~/types/common';
 
-export interface IntroSectionBlock {
+export interface IntroSectionBlock extends WithHidden {
   title: JSONContent;
   image: ImageBlock;
   quote: TipTapQuoteBlock;
-  hidden?: boolean;
 }

--- a/app/types/store/pages/about-us/blocks/introSectionBlock.ts
+++ b/app/types/store/pages/about-us/blocks/introSectionBlock.ts
@@ -6,4 +6,5 @@ export interface IntroSectionBlock {
   title: JSONContent;
   image: ImageBlock;
   quote: TipTapQuoteBlock;
+  hidden?: boolean;
 }

--- a/app/types/store/pages/about-us/blocks/liatoshynskyFoundationBlock.ts
+++ b/app/types/store/pages/about-us/blocks/liatoshynskyFoundationBlock.ts
@@ -1,6 +1,6 @@
 import { JSONContent } from '@tiptap/react';
 
-import { ImageType } from '~/types/common';
+import { ImageType, WithHidden } from '~/types/common';
 
 export type FoundationInfo = {
   title: Record<'uk' | 'en', JSONContent>;
@@ -15,5 +15,4 @@ export type FoundationInfo = {
     bigImage: ImageType;
     list: Record<'uk' | 'en', JSONContent>[];
   };
-  hidden?: boolean;
-};
+} & WithHidden;

--- a/app/types/store/pages/about-us/blocks/liatoshynskyFoundationBlock.ts
+++ b/app/types/store/pages/about-us/blocks/liatoshynskyFoundationBlock.ts
@@ -3,6 +3,7 @@ import { JSONContent } from '@tiptap/react';
 import { ImageType } from '~/types/common';
 
 export type FoundationInfo = {
+  title: Record<'uk' | 'en', JSONContent>;
   ourOrganisation: Record<'uk' | 'en', JSONContent>;
   ourName: Record<'uk' | 'en', JSONContent
   >;
@@ -14,4 +15,5 @@ export type FoundationInfo = {
     bigImage: ImageType;
     list: Record<'uk' | 'en', JSONContent>[];
   };
+  hidden?: boolean;
 };

--- a/app/types/store/pages/about-us/blocks/liatoshynskyOfficeBlock.ts
+++ b/app/types/store/pages/about-us/blocks/liatoshynskyOfficeBlock.ts
@@ -1,9 +1,8 @@
 import { JSONContent } from '@tiptap/react';
 
-import { TipTapQuoteBlock } from '~/types/common';
+import { TipTapQuoteBlock, WithHidden } from '~/types/common';
 
-export interface LiatoshynskyOfficeBlock {
+export interface LiatoshynskyOfficeBlock extends WithHidden {
   quote: TipTapQuoteBlock;
   title?: Record<'uk' | 'en', JSONContent>;
-  hidden?: boolean;
 }

--- a/app/types/store/pages/about-us/blocks/liatoshynskyOfficeBlock.ts
+++ b/app/types/store/pages/about-us/blocks/liatoshynskyOfficeBlock.ts
@@ -2,4 +2,5 @@ import { TipTapQuoteBlock } from '~/types/common';
 
 export interface LiatoshynskyOfficeBlock {
   quote: TipTapQuoteBlock;
+  hidden?: boolean;
 }

--- a/app/types/store/pages/about-us/blocks/liatoshynskyOfficeBlock.ts
+++ b/app/types/store/pages/about-us/blocks/liatoshynskyOfficeBlock.ts
@@ -1,6 +1,9 @@
+import { JSONContent } from '@tiptap/react';
+
 import { TipTapQuoteBlock } from '~/types/common';
 
 export interface LiatoshynskyOfficeBlock {
   quote: TipTapQuoteBlock;
+  title?: Record<'uk' | 'en', JSONContent>;
   hidden?: boolean;
 }

--- a/app/types/store/pages/about-us/blocks/missionBlock.ts
+++ b/app/types/store/pages/about-us/blocks/missionBlock.ts
@@ -14,4 +14,5 @@ export type OurMissionBlock = {
   smallImage: ImageType;
   bigImage: ImageType;
   list: MissionListItem[];
+  hidden?: boolean;
 };

--- a/app/types/store/pages/about-us/blocks/missionBlock.ts
+++ b/app/types/store/pages/about-us/blocks/missionBlock.ts
@@ -1,4 +1,4 @@
-import { ImageType, ProseDoc } from '~/types/common';
+import { ImageType, ProseDoc, WithHidden } from '~/types/common';
 
 export type MissionListItem = {
   uk: ProseDoc;
@@ -14,5 +14,4 @@ export type OurMissionBlock = {
   smallImage: ImageType;
   bigImage: ImageType;
   list: MissionListItem[];
-  hidden?: boolean;
-};
+} & WithHidden;

--- a/app/types/store/pages/about-us/blocks/ourGoalsBlock.ts
+++ b/app/types/store/pages/about-us/blocks/ourGoalsBlock.ts
@@ -1,4 +1,4 @@
-import type { LocalizedJSON } from '~/types/common';
+import type { LocalizedJSON, WithHidden } from '~/types/common';
 
 export type GoalItem = {
   title: LocalizedJSON;
@@ -12,5 +12,4 @@ export type GoalItemWithId = {
 export type OurGoalsBlock = {
   title: LocalizedJSON;
   goals: GoalItemWithId[];
-  hidden?: boolean;
-};
+} & WithHidden;

--- a/app/types/store/pages/about-us/blocks/ourGoalsBlock.ts
+++ b/app/types/store/pages/about-us/blocks/ourGoalsBlock.ts
@@ -12,4 +12,5 @@ export type GoalItemWithId = {
 export type OurGoalsBlock = {
   title: LocalizedJSON;
   goals: GoalItemWithId[];
+  hidden?: boolean;
 };

--- a/app/types/store/pages/about-us/blocks/whatWeDoBlock.ts
+++ b/app/types/store/pages/about-us/blocks/whatWeDoBlock.ts
@@ -12,4 +12,5 @@ export type WhatWeDolItemWithId = {
 export type WhatWeDoBlock = {
   title: LocalizedJSON;
   items: WhatWeDolItemWithId[];
+  hidden?: boolean;
 };

--- a/app/types/store/pages/about-us/blocks/whatWeDoBlock.ts
+++ b/app/types/store/pages/about-us/blocks/whatWeDoBlock.ts
@@ -1,4 +1,4 @@
-import type { LocalizedJSON } from '~/types/common';
+import type { LocalizedJSON, WithHidden } from '~/types/common';
 
 export type WhatWeDoItem = {
   title: LocalizedJSON;
@@ -12,5 +12,4 @@ export type WhatWeDolItemWithId = {
 export type WhatWeDoBlock = {
   title: LocalizedJSON;
   items: WhatWeDolItemWithId[];
-  hidden?: boolean;
-};
+} & WithHidden;

--- a/app/types/store/pages/privacy-policy/blocks/contactUs.ts
+++ b/app/types/store/pages/privacy-policy/blocks/contactUs.ts
@@ -3,4 +3,5 @@ import { LocalizedJSON } from '~/types/common';
 export type ContactUsBlock ={
     title: LocalizedJSON;
     description: LocalizedJSON;
+    hidden?: boolean;
 } 

--- a/app/types/store/pages/privacy-policy/blocks/contactUs.ts
+++ b/app/types/store/pages/privacy-policy/blocks/contactUs.ts
@@ -1,7 +1,6 @@
-import { LocalizedJSON } from '~/types/common';
+import { LocalizedJSON, WithHidden } from '~/types/common';
 
 export type ContactUsBlock ={
     title: LocalizedJSON;
     description: LocalizedJSON;
-    hidden?: boolean;
-} 
+} & WithHidden

--- a/app/types/store/pages/privacy-policy/blocks/cookiesBlock.ts
+++ b/app/types/store/pages/privacy-policy/blocks/cookiesBlock.ts
@@ -1,4 +1,4 @@
-import type { LocalizedJSON } from '~/types/common';
+import type { LocalizedJSON, WithHidden } from '~/types/common';
 
 export type CookiesItemWithId = {
   id: string;
@@ -9,5 +9,4 @@ export type CookiesBlock = {
   description: LocalizedJSON;
   list: CookiesItemWithId[];
   note: LocalizedJSON;
-  hidden?: boolean;
-};
+} & WithHidden;

--- a/app/types/store/pages/privacy-policy/blocks/cookiesBlock.ts
+++ b/app/types/store/pages/privacy-policy/blocks/cookiesBlock.ts
@@ -9,4 +9,5 @@ export type CookiesBlock = {
   description: LocalizedJSON;
   list: CookiesItemWithId[];
   note: LocalizedJSON;
+  hidden?: boolean;
 };

--- a/app/types/store/pages/privacy-policy/blocks/dataRetention.ts
+++ b/app/types/store/pages/privacy-policy/blocks/dataRetention.ts
@@ -2,5 +2,6 @@ import { LocalizedJSON } from '~/types/common';
 
 export type DataRetentionBlock = {
     title: LocalizedJSON;
-    description: LocalizedJSON
+    description: LocalizedJSON;
+    hidden?: boolean;
 }

--- a/app/types/store/pages/privacy-policy/blocks/dataRetention.ts
+++ b/app/types/store/pages/privacy-policy/blocks/dataRetention.ts
@@ -1,7 +1,6 @@
-import { LocalizedJSON } from '~/types/common';
+import { LocalizedJSON, WithHidden } from '~/types/common';
 
 export type DataRetentionBlock = {
     title: LocalizedJSON;
     description: LocalizedJSON;
-    hidden?: boolean;
-}
+} & WithHidden

--- a/app/types/store/pages/privacy-policy/blocks/dataUsageBlock.ts
+++ b/app/types/store/pages/privacy-policy/blocks/dataUsageBlock.ts
@@ -8,4 +8,5 @@ export type DataUsageBlock = {
   title: LocalizedJSON;
   description: LocalizedJSON;
   list: DataUsageItemWithId[];
+  hidden?: boolean;
 };

--- a/app/types/store/pages/privacy-policy/blocks/dataUsageBlock.ts
+++ b/app/types/store/pages/privacy-policy/blocks/dataUsageBlock.ts
@@ -1,4 +1,4 @@
-import type { LocalizedJSON } from '~/types/common';
+import type { LocalizedJSON, WithHidden } from '~/types/common';
 
 export type DataUsageItemWithId = {
   id: string;
@@ -8,5 +8,4 @@ export type DataUsageBlock = {
   title: LocalizedJSON;
   description: LocalizedJSON;
   list: DataUsageItemWithId[];
-  hidden?: boolean;
-};
+} & WithHidden;

--- a/app/types/store/pages/privacy-policy/blocks/dataWeCollectBlock.ts
+++ b/app/types/store/pages/privacy-policy/blocks/dataWeCollectBlock.ts
@@ -1,4 +1,4 @@
-import type { LocalizedJSON } from '~/types/common';
+import type { LocalizedJSON, WithHidden } from '~/types/common';
 
 export type DataWeCollectItem = {
   subtitle: LocalizedJSON;
@@ -14,5 +14,4 @@ export type DataWeCollectBlock = {
   sections: DataWeCollectItemWithId[];
   description: LocalizedJSON;
   note: LocalizedJSON;
-  hidden?: boolean;
-};
+} & WithHidden;

--- a/app/types/store/pages/privacy-policy/blocks/dataWeCollectBlock.ts
+++ b/app/types/store/pages/privacy-policy/blocks/dataWeCollectBlock.ts
@@ -14,4 +14,5 @@ export type DataWeCollectBlock = {
   sections: DataWeCollectItemWithId[];
   description: LocalizedJSON;
   note: LocalizedJSON;
+  hidden?: boolean;
 };

--- a/app/types/store/pages/privacy-policy/blocks/userRights.ts
+++ b/app/types/store/pages/privacy-policy/blocks/userRights.ts
@@ -9,4 +9,5 @@ export type UserRightsBlock = {
     description: LocalizedJSON; 
     list: UserRightsItemWithId[];
     note: LocalizedJSON; 
+    hidden?: boolean;
 }

--- a/app/types/store/pages/privacy-policy/blocks/userRights.ts
+++ b/app/types/store/pages/privacy-policy/blocks/userRights.ts
@@ -1,13 +1,12 @@
-import { LocalizedJSON } from '~/types/common';
+import { LocalizedJSON, WithHidden } from '~/types/common';
 
 export type UserRightsItemWithId = {
     id: string;
 } & LocalizedJSON
 
 export type UserRightsBlock = {
-    title: LocalizedJSON; 
-    description: LocalizedJSON; 
+    title: LocalizedJSON;
+    description: LocalizedJSON;
     list: UserRightsItemWithId[];
-    note: LocalizedJSON; 
-    hidden?: boolean;
-}
+    note: LocalizedJSON;
+} & WithHidden


### PR DESCRIPTION
## Description
Admins can now rename section titles and toggle section visibility (hide/show) on the About Us and Privacy Policy pages. Renamed titles and hidden state are stored in the existing `blocks` JSON field, synced to the public client (lf-client), and reflected there: hidden sections are skipped by `BlockRenderer`, renamed titles render in place of the static labels. Section headers in the admin panel now update live as the title is edited. Account-related sections (owned by another team) are out of scope and unchanged.

## Type of change
- [x] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other:

## How to test
1. Open the admin panel → About Us (or Privacy Policy) page in edit mode.
2. Edit a section's title field, save — confirm the accordion header updates immediately and the new title displays on the public site after publish.
3. Click the eye icon on a section header to hide it, save — confirm the section no longer renders on the public site, and the eye icon reflects the hidden state on reload.
4. Toggle the section back to visible, save — confirm it reappears on the public site.
5. Confirm account-related sections (Google Auth, Social Networks, Targeted Ads, Newsletter Subscription) are unaffected — no rename/hide controls present.

## Video / Screenshots
<img width="967" height="545" alt="image" src="https://github.com/user-attachments/assets/491b77be-5a41-4f55-84ae-edb792540b4d" />
<img width="1536" height="575" alt="image" src="https://github.com/user-attachments/assets/ff6e934d-4461-4e5e-9180-1d66ca0931b0" />
<img width="1896" height="1030" alt="image" src="https://github.com/user-attachments/assets/895c66a9-6bba-4893-90a8-f485abef16be" />
<img width="1551" height="531" alt="image" src="https://github.com/user-attachments/assets/72481873-5aca-4201-b20b-6122ff09c601" />


## Checklist
- [x] Code compiles and runs correctly
- [ ] Tests pass successfully
- [x] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [ ] Linked issue/task included
- [ ] Task moved to the review column on the board