### PR TITLE
feature: implement drag-and-drop sorting for performances within a group

### DIFF
--- a/app/constants/creativity.ts
+++ b/app/constants/creativity.ts
@@ -115,7 +115,7 @@ export interface GroupPhoto {
 }
 
 export interface GroupPerformance {
-  id: string;
+  id?: string;
   url?: string;
   caption?: { uk: string; en: string };
 }

--- a/app/constants/creativity.ts
+++ b/app/constants/creativity.ts
@@ -115,7 +115,7 @@ export interface GroupPhoto {
 }
 
 export interface GroupPerformance {
-  id?: string;
+  id: string;
   url?: string;
   caption?: { uk: string; en: string };
 }

--- a/app/constants/creativity.ts
+++ b/app/constants/creativity.ts
@@ -120,6 +120,8 @@ export interface GroupPerformance {
   caption?: { uk: string; en: string };
 }
 
+export type NormalizedGroupPerformance = GroupPerformance & { id: string };
+
 export interface GroupData {
   titlePrefix: string;
   groupNumber: string;

--- a/app/shared/components/creativity/group/performances-section/GroupPerformancesSection.styles.ts
+++ b/app/shared/components/creativity/group/performances-section/GroupPerformancesSection.styles.ts
@@ -9,7 +9,7 @@ export const styles = {
   typographyTitle: { fontWeight: 500 },
   divider: { flexGrow: 1},
   performancesList: { display: 'flex', flexDirection: 'column', gap: 4 },
-  performanceItemRow: { display: 'flex', alignItems: 'start', gap: 2 },
+  performanceItemRow: { display: 'flex', alignItems: 'start', gap: 2 , flexGrow: 1 },
   inputsWrapper: { display: 'flex', flexDirection: 'column', gap: 2, flexGrow: 1 },
   tooltipBox: {padding: '8px', backgroundColor: 'gray.800'},
   actionIcon: { color: 'black', width: '34px', height: '34px' },

--- a/app/shared/components/creativity/group/performances-section/GroupPerformancesSection.test.tsx
+++ b/app/shared/components/creativity/group/performances-section/GroupPerformancesSection.test.tsx
@@ -1,16 +1,85 @@
+import { DragEndEvent } from '@dnd-kit/core';
 import { fireEvent, render, screen } from '@testing-library/react';
-import React, { ChangeEvent, ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 
 import { GroupPerformancesSection } from './GroupPerformancesSection';
+import { PerformanceRowProps } from './PerformanceRow';
+import { handleSortableDragEnd } from '~/lib/utils/sortableDragEndHelper';
 
-type MockCustomTextFieldProps = {
-  label: string;
-  value?: unknown;
-  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
+const MOCK_UUID = 'mock-uuid-1234';
+
+const MOCK_TEXTS = {
+  sectionTitle: 'Тестовий заголовок виступів',
+  newSectionTitle: 'Нова назва секції',
+  updatedCaption: 'updated caption',
+  updatedUrl: 'updated-url'
 };
 
+const MOCK_URLS = {
+  youtube: 'https://youtube.com',
+  example: 'https://example.com',
+  youtubeWatch: 'https://youtube.com/watch?v=abc123',
+  youtubeShort: 'https://youtu.be/xyz789',
+  plainText: 'example.com/page',
+  expectedPlainLink: 'https://example.com/page'
+};
+
+const MOCK_YOUTUBE_IDS = {
+  watch: 'abc123',
+  short: 'xyz789'
+};
+
+let capturedRenderLinkPreview: ((url: string) => React.ReactNode) | null = null;
+let capturedOnDragEnd: ((event: DragEndEvent) => void) | null = null;
+
+jest.mock('./PerformanceRow', () => ({
+  PerformanceRow: ({ item, onUpdateUrl, onUpdateCaption, onDeleteRequest, renderLinkPreview }: PerformanceRowProps) => {
+    capturedRenderLinkPreview = renderLinkPreview;
+    return (
+      <div data-testid={`mock-performance-row-${item.id}`}>
+        <button
+          data-testid={`mock-update-url-${item.id}`}
+          onClick={() => onUpdateUrl(item.id ?? '', MOCK_TEXTS.updatedUrl)}
+        >
+          update url
+        </button>
+        <button
+          data-testid={`mock-update-caption-${item.id}`}
+          onClick={() => onUpdateCaption(item.id ?? '', MOCK_TEXTS.updatedCaption)}
+        >
+          update caption
+        </button>
+        <button data-testid={`mock-delete-${item.id}`} onClick={() => onDeleteRequest(item.id ?? '')}>
+          delete
+        </button>
+      </div>
+    );
+  }
+}));
+
+jest.mock('~/shared/components/sortable-list/SortableList', () => ({
+  SortableList: ({ children, onDragEnd }: { children: ReactNode; onDragEnd: (event: DragEndEvent) => void }) => {
+    capturedOnDragEnd = onDragEnd;
+    return <div data-testid="mock-sortable-list">{children}</div>;
+  }
+}));
+
+jest.mock('~/shared/components/sortable-item-wrapper/SortableItemWrapper', () => ({
+  SortableItemWrapper: ({ children, id }: { children: ReactNode; id: string }) => (
+    <div data-testid={`mock-sortable-item-${id}`}>{children}</div>
+  )
+}));
+
 jest.mock('~/shared/components/design-system/text-field/TextField', () => ({
-  CustomTextField: ({ label, value, onChange }: MockCustomTextFieldProps) => (
+  CustomTextField: ({
+    label,
+    value,
+    onChange
+  }: {
+    label: string;
+    value?: unknown;
+    onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  }) => (
     <div data-testid={`mock-field-wrapper-${label}`}>
       <label htmlFor={`input-${label}`}>{label}</label>
       <input
@@ -52,9 +121,12 @@ jest.mock('~/public/icons/plus.svg', () => ({
   default: () => <span data-testid="icon-plus" />
 }));
 
-jest.mock('~/public/icons/trash.svg', () => ({
-  __esModule: true,
-  default: () => <span data-testid="icon-trash" />
+jest.mock('~/lib/utils/generateUniqueId', () => ({
+  generateUniqueId: () => 'mock-uuid-1234'
+}));
+
+jest.mock('~/lib/utils/sortableDragEndHelper', () => ({
+  handleSortableDragEnd: jest.fn()
 }));
 
 const mockOnChangeSectionTitle = jest.fn();
@@ -62,121 +134,90 @@ const mockOnChangePerformances = jest.fn();
 
 const defaultProps = {
   currentLanguage: 'UA' as const,
-  sectionTitle: 'Тестовий заголовок виступів',
+  sectionTitle: MOCK_TEXTS.sectionTitle,
   performances: [
-    { id: '1', url: 'https://youtube.com/watch?v=123', caption: { uk: 'Перший виступ', en: 'First performance' } },
-    { id: '2', url: 'https://example.com', caption: { uk: 'Другий виступ', en: 'Second performance' } }
+    { id: '1', url: MOCK_URLS.youtube, caption: { uk: 'Перший виступ', en: 'First performance' } },
+    { id: '2', url: MOCK_URLS.example, caption: { uk: 'Другий виступ', en: 'Second performance' } }
   ],
   onChangeSectionTitle: mockOnChangeSectionTitle,
   onChangePerformances: mockOnChangePerformances
 };
 
 describe('GroupPerformancesSection Component', () => {
-  const originalCrypto = global.crypto;
-
-  beforeAll(() => {
-    Object.defineProperty(global, 'crypto', {
-      value: { randomUUID: () => 'mock-uuid-1234' },
-      configurable: true
-    });
-  });
-
-  afterAll(() => {
-    Object.defineProperty(global, 'crypto', {
-      value: originalCrypto,
-      configurable: true
-    });
-  });
-
   beforeEach(() => {
     jest.clearAllMocks();
+    capturedRenderLinkPreview = null;
+    capturedOnDragEnd = null;
   });
 
-  it('should render correctly with initial props', () => {
+  it('should render section title and a row for each performance', () => {
     render(<GroupPerformancesSection {...defaultProps} />);
 
-    expect(screen.getByTestId('mock-input-Заголовок секції')).toHaveValue('Тестовий заголовок виступів');
-
-    const urlInputs = screen.getAllByTestId('mock-input-Canonical URL');
-    const captionInputs = screen.getAllByTestId('mock-input-Підпис');
-
-    expect(urlInputs).toHaveLength(2);
-    expect(urlInputs[0]).toHaveValue('https://youtube.com/watch?v=123');
-    expect(urlInputs[1]).toHaveValue('https://example.com');
-
-    expect(captionInputs).toHaveLength(2);
-    expect(captionInputs[0]).toHaveValue('Перший виступ');
-    expect(captionInputs[1]).toHaveValue('Другий виступ');
+    expect(screen.getByTestId('mock-input-Заголовок секції')).toHaveValue(MOCK_TEXTS.sectionTitle);
+    expect(screen.getByTestId('mock-performance-row-1')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-performance-row-2')).toBeInTheDocument();
   });
 
   it('should call onChangeSectionTitle when section title input changes', () => {
     render(<GroupPerformancesSection {...defaultProps} />);
 
-    const titleInput = screen.getByTestId('mock-input-Заголовок секції');
-    fireEvent.change(titleInput, { target: { value: 'Нова назва секції' } });
+    fireEvent.change(screen.getByTestId('mock-input-Заголовок секції'), {
+      target: { value: MOCK_TEXTS.newSectionTitle }
+    });
 
     expect(mockOnChangeSectionTitle).toHaveBeenCalledTimes(1);
-    expect(mockOnChangeSectionTitle).toHaveBeenCalledWith('Нова назва секції');
+    expect(mockOnChangeSectionTitle).toHaveBeenCalledWith(MOCK_TEXTS.newSectionTitle);
   });
 
   it('should add a new performance when "Додати пункт" is clicked', () => {
     render(<GroupPerformancesSection {...defaultProps} />);
 
-    const addButton = screen.getByTestId('mock-button-add');
-    fireEvent.click(addButton);
+    fireEvent.click(screen.getByTestId('mock-button-add'));
 
     expect(mockOnChangePerformances).toHaveBeenCalledTimes(1);
     expect(mockOnChangePerformances).toHaveBeenCalledWith([
       ...defaultProps.performances,
-      { id: 'mock-uuid-1234', url: '', caption: { uk: '', en: '' } }
+      { id: MOCK_UUID, url: '', caption: { uk: '', en: '' } }
     ]);
   });
 
-  it('should update performance URL correctly', () => {
+  it('should update performance URL correctly via PerformanceRow callback', () => {
     render(<GroupPerformancesSection {...defaultProps} />);
 
-    const urlInputs = screen.getAllByTestId('mock-input-Canonical URL');
-    fireEvent.change(urlInputs[0], { target: { value: 'https://new-link.com' } });
+    fireEvent.click(screen.getByTestId('mock-update-url-1'));
 
     expect(mockOnChangePerformances).toHaveBeenCalledTimes(1);
     expect(mockOnChangePerformances).toHaveBeenCalledWith([
-      { id: '1', url: 'https://new-link.com', caption: { uk: 'Перший виступ', en: 'First performance' } },
+      { ...defaultProps.performances[0], url: MOCK_TEXTS.updatedUrl },
       defaultProps.performances[1]
     ]);
   });
 
-  it('should update performance caption correctly', () => {
+  it('should update performance caption correctly via PerformanceRow callback', () => {
     render(<GroupPerformancesSection {...defaultProps} />);
 
-    const captionInputs = screen.getAllByTestId('mock-input-Підпис');
-    fireEvent.change(captionInputs[1], { target: { value: 'Оновлений підпис' } });
+    fireEvent.click(screen.getByTestId('mock-update-caption-2'));
 
     expect(mockOnChangePerformances).toHaveBeenCalledTimes(1);
     expect(mockOnChangePerformances).toHaveBeenCalledWith([
       defaultProps.performances[0],
-      { id: '2', url: 'https://example.com', caption: { uk: 'Оновлений підпис', en: 'Second performance' } }
+      { ...defaultProps.performances[1], caption: { uk: MOCK_TEXTS.updatedCaption, en: 'Second performance' } }
     ]);
   });
 
-  it('should open delete modal when trash icon is clicked', () => {
+  it('should open delete modal when delete is requested from a row', () => {
     render(<GroupPerformancesSection {...defaultProps} />);
 
     expect(screen.queryByTestId('mock-delete-modal')).not.toBeInTheDocument();
-
-    const trashIcons = screen.getAllByTestId('icon-trash');
-    fireEvent.click(trashIcons[1]);
-
+    fireEvent.click(screen.getByTestId('mock-delete-2'));
     expect(screen.getByTestId('mock-delete-modal')).toBeInTheDocument();
   });
 
   it('should delete performance when confirmed in the modal', () => {
     render(<GroupPerformancesSection {...defaultProps} />);
 
-    const trashIcons = screen.getAllByTestId('icon-trash');
-    fireEvent.click(trashIcons[0]);
-
-    const confirmButton = screen.getByTestId('modal-confirm');
-    fireEvent.click(confirmButton);
+    fireEvent.click(screen.getByTestId('mock-delete-1'));
+    fireEvent.click(screen.getByTestId('modal-confirm'));
 
     expect(mockOnChangePerformances).toHaveBeenCalledTimes(1);
     expect(mockOnChangePerformances).toHaveBeenCalledWith([defaultProps.performances[1]]);
@@ -185,77 +226,84 @@ describe('GroupPerformancesSection Component', () => {
   it('should close delete modal without deleting when canceled', () => {
     render(<GroupPerformancesSection {...defaultProps} />);
 
-    const trashIcons = screen.getAllByTestId('icon-trash');
-    fireEvent.click(trashIcons[0]);
-
-    const cancelButton = screen.getByTestId('modal-cancel');
-    fireEvent.click(cancelButton);
+    fireEvent.click(screen.getByTestId('mock-delete-1'));
+    fireEvent.click(screen.getByTestId('modal-cancel'));
 
     expect(mockOnChangePerformances).not.toHaveBeenCalled();
     expect(screen.queryByTestId('mock-delete-modal')).not.toBeInTheDocument();
   });
 
-  it('should handle empty URL and URL without HTTP protocol correctly', () => {
-    const propsWithEdgeCaseUrls = {
-      ...defaultProps,
-      performances: [
-        { id: '3', url: '', caption: { uk: 'Порожній', en: 'Empty' } },
-        { id: '4', url: 'example.com/video', caption: { uk: 'Без HTTP', en: 'No HTTP' } }
-      ]
-    };
+  it('should call handleSortableDragEnd with event, performances and onChangePerformances', () => {
+    render(<GroupPerformancesSection {...defaultProps} />);
 
-    render(<GroupPerformancesSection {...propsWithEdgeCaseUrls} />);
+    const dragEvent = { active: { id: '1' }, over: { id: '2' } } as DragEndEvent;
+    capturedOnDragEnd?.(dragEvent);
 
-    const urlInputs = screen.getAllByTestId('mock-input-Canonical URL');
-    expect(urlInputs).toHaveLength(2);
-    expect(urlInputs[0]).toHaveValue('');
-    expect(urlInputs[1]).toHaveValue('example.com/video');
+    expect(handleSortableDragEnd).toHaveBeenCalledTimes(1);
+    expect(handleSortableDragEnd).toHaveBeenCalledWith(dragEvent, defaultProps.performances, mockOnChangePerformances);
   });
 
-  it('should update caption in English and handle missing caption objects', () => {
-    const propsWithEnglish = {
+  it('should fallback caption.uk to empty string when item.caption is missing (langKey=uk)', () => {
+    const propsWithoutCaption = {
       ...defaultProps,
-      currentLanguage: 'EN' as const,
-      performances: [{ id: '3', url: 'https://youtube.com' }]
+      performances: [{ id: '3', url: MOCK_URLS.youtube }]
     };
 
-    render(<GroupPerformancesSection {...propsWithEnglish} />);
+    render(<GroupPerformancesSection {...propsWithoutCaption} />);
+    fireEvent.click(screen.getByTestId('mock-update-caption-3'));
 
-    const captionInputs = screen.getAllByTestId('mock-input-Підпис');
-    expect(captionInputs[0]).toHaveValue('');
-    fireEvent.change(captionInputs[0], { target: { value: 'Updated EN Caption' } });
     expect(mockOnChangePerformances).toHaveBeenCalledWith([
-      {
-        id: '3',
-        url: 'https://youtube.com',
-        caption: {
-          uk: '',
-          en: 'Updated EN Caption'
-        }
-      }
+      { id: '3', url: MOCK_URLS.youtube, caption: { uk: MOCK_TEXTS.updatedCaption, en: '' } }
     ]);
   });
 
-  it('should handle undefined item.id correctly (fallback to empty string)', () => {
-    const propsWithoutId = {
+  it('should fallback caption.en to empty string when item.caption is missing (langKey=en)', () => {
+    const propsWithoutCaption = {
       ...defaultProps,
-      performances: [
-        {
-          id: undefined,
-          url: 'https://test.com',
-          caption: { uk: 'Тест', en: 'Test' }
-        }
-      ]
+      currentLanguage: 'EN' as const,
+      performances: [{ id: '3', url: MOCK_URLS.youtube }]
     };
 
-    render(<GroupPerformancesSection {...propsWithoutId} />);
+    render(<GroupPerformancesSection {...propsWithoutCaption} />);
+    fireEvent.click(screen.getByTestId('mock-update-caption-3'));
 
-    const urlInput = screen.getByTestId('mock-input-Canonical URL');
-    fireEvent.change(urlInput, { target: { value: 'https://test.com/new' } });
-    const captionInput = screen.getByTestId('mock-input-Підпис');
-    fireEvent.change(captionInput, { target: { value: 'Новий підпис' } });
-    const trashIcon = screen.getByTestId('icon-trash');
-    fireEvent.click(trashIcon);
-    expect(mockOnChangePerformances).toHaveBeenCalled();
+    expect(mockOnChangePerformances).toHaveBeenCalledWith([
+      { id: '3', url: MOCK_URLS.youtube, caption: { uk: '', en: MOCK_TEXTS.updatedCaption } }
+    ]);
+  });
+
+  describe('renderLinkPreview', () => {
+    it('should return null for empty url', () => {
+      render(<GroupPerformancesSection {...defaultProps} />);
+      expect(capturedRenderLinkPreview?.('')).toBeNull();
+    });
+
+    it('should render YouTube preview for youtube.com/watch url', () => {
+      render(<GroupPerformancesSection {...defaultProps} />);
+
+      const { container } = render(<>{capturedRenderLinkPreview?.(MOCK_URLS.youtubeWatch)}</>);
+
+      const img = container.querySelector('img[alt="YouTube Preview"]');
+      expect(img).toHaveAttribute('src', `https://img.youtube.com/vi/${MOCK_YOUTUBE_IDS.watch}/mqdefault.jpg`);
+      expect(screen.getByText('Відкрити відео')).toBeInTheDocument();
+    });
+
+    it('should render YouTube preview for youtu.be short url', () => {
+      render(<GroupPerformancesSection {...defaultProps} />);
+
+      const { container } = render(<>{capturedRenderLinkPreview?.(MOCK_URLS.youtubeShort)}</>);
+
+      const img = container.querySelector('img[alt="YouTube Preview"]');
+      expect(img).toHaveAttribute('src', `https://img.youtube.com/vi/${MOCK_YOUTUBE_IDS.short}/mqdefault.jpg`);
+    });
+
+    it('should render plain link preview for non-YouTube url', () => {
+      render(<GroupPerformancesSection {...defaultProps} />);
+
+      render(<>{capturedRenderLinkPreview?.(MOCK_URLS.plainText)}</>);
+
+      const link = screen.getByText('Перейти за посиланням');
+      expect(link).toHaveAttribute('href', MOCK_URLS.expectedPlainLink);
+    });
   });
 });

--- a/app/shared/components/creativity/group/performances-section/GroupPerformancesSection.test.tsx
+++ b/app/shared/components/creativity/group/performances-section/GroupPerformancesSection.test.tsx
@@ -272,6 +272,17 @@ describe('GroupPerformancesSection Component', () => {
     ]);
   });
 
+  it('should generate missing IDs for legacy performances', () => {
+    const propsWithMissingIds = {
+      ...defaultProps,
+      performances: [{ url: MOCK_URLS.youtube, caption: { uk: 'Без ID', en: '' } }]
+    };
+
+    render(<GroupPerformancesSection {...propsWithMissingIds} />);
+
+    expect(screen.getByTestId(`mock-performance-row-${MOCK_UUID}`)).toBeInTheDocument();
+  });
+
   describe('renderLinkPreview', () => {
     it('should return null for empty url', () => {
       render(<GroupPerformancesSection {...defaultProps} />);

--- a/app/shared/components/creativity/group/performances-section/GroupPerformancesSection.tsx
+++ b/app/shared/components/creativity/group/performances-section/GroupPerformancesSection.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState } from 'react';
 
 import { styles } from './GroupPerformancesSection.styles';
 import { PerformanceRow } from './PerformanceRow';
-import { GroupPerformance } from '~/constants/creativity';
+import { GroupPerformance, NormalizedGroupPerformance } from '~/constants/creativity';
 import { EditorLanguage } from '~/constants/publications';
 import { generateUniqueId } from '~/lib/utils/generateUniqueId';
 import { handleSortableDragEnd } from '~/lib/utils/sortableDragEndHelper';
@@ -71,6 +71,7 @@ export const GroupPerformancesSection = ({
   const langKey = currentLanguage === 'UA' ? 'uk' : 'en';
   const [performanceIdToDelete, setPerformanceIdToDelete] = useState<string | null>(null);
 
+  console.log('performances', performances);
   const preparedPerformances = useMemo(() => {
     return performances.map((item) => ({
       ...item,
@@ -79,7 +80,7 @@ export const GroupPerformancesSection = ({
   }, [performances]);
 
   const handleAddPerformance = () => {
-    const newPerformance: GroupPerformance = {
+    const newPerformance: NormalizedGroupPerformance = {
       id: generateUniqueId(),
       url: '',
       caption: { uk: '', en: '' }

--- a/app/shared/components/creativity/group/performances-section/GroupPerformancesSection.tsx
+++ b/app/shared/components/creativity/group/performances-section/GroupPerformancesSection.tsx
@@ -1,15 +1,19 @@
-import { Box, Divider, IconButton, Tooltip, Typography } from '@mui/material';
+import { DragEndEvent } from '@dnd-kit/core';
+import { Box, Divider, Typography } from '@mui/material';
 import { useState } from 'react';
 
 import { styles } from './GroupPerformancesSection.styles';
+import { PerformanceRow } from './PerformanceRow';
 import { GroupPerformance } from '~/constants/creativity';
 import { EditorLanguage } from '~/constants/publications';
 import { generateUniqueId } from '~/lib/utils/generateUniqueId';
+import { handleSortableDragEnd } from '~/lib/utils/sortableDragEndHelper';
 import PlusIcon from '~/public/icons/plus.svg';
-import TrashIcon from '~/public/icons/trash.svg';
 import DeleteCardModal from '~/shared/components/delete-card-modal/DeleteCardModal';
 import Button from '~/shared/components/design-system/button/Button';
 import { CustomTextField } from '~/shared/components/design-system/text-field/TextField';
+import { SortableItemWrapper } from '~/shared/components/sortable-item-wrapper/SortableItemWrapper';
+import { SortableList } from '~/shared/components/sortable-list/SortableList';
 
 type GroupPerformancesSectionProps = {
   currentLanguage: EditorLanguage;
@@ -65,7 +69,6 @@ export const GroupPerformancesSection = ({
   onChangePerformances
 }: GroupPerformancesSectionProps) => {
   const langKey = currentLanguage === 'UA' ? 'uk' : 'en';
-
   const [performanceIdToDelete, setPerformanceIdToDelete] = useState<string | null>(null);
 
   const handleAddPerformance = () => {
@@ -85,9 +88,7 @@ export const GroupPerformancesSection = ({
   };
 
   const handleUpdateUrl = (idToUpdate: string, value: string) => {
-    onChangePerformances(
-      performances.map((item) => (item.id === idToUpdate ? { ...item, url: value } : item))
-    );
+    onChangePerformances(performances.map((item) => (item.id === idToUpdate ? { ...item, url: value } : item)));
   };
 
   const handleUpdateCaption = (idToUpdate: string, value: string) => {
@@ -99,12 +100,16 @@ export const GroupPerformancesSection = ({
             caption: {
               uk: item.caption?.uk || '',
               en: item.caption?.en || '',
-              [langKey]: value           
+              [langKey]: value
             }
           }
           : item
       )
     );
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    handleSortableDragEnd(event, performances, onChangePerformances);
   };
 
   return (
@@ -116,52 +121,34 @@ export const GroupPerformancesSection = ({
           onChange={(e) => onChangeSectionTitle(e.target.value)}
           fullWidth
         />
-
         <Box sx={styles.headerRow}>
           <Typography variant="body2" color="text.secondary" sx={styles.typographyTitle}>
             Пункти секції:
           </Typography>
           <Divider sx={styles.divider} />
         </Box>
-
+        
         <Box sx={styles.performancesList}>
-          {performances.map((item) => (
-            <Box key={item.id} sx={styles.performanceItemRow}>
-              <Box sx={styles.inputsWrapper}>
-                <Tooltip
-                  title={renderLinkPreview(item.url || '')}
-                  placement="top-start"
-                  enterDelay={400}
-                  slotProps={{
-                    tooltip: {
-                      sx: styles.tooltipBox
-                    }
-                  }}
-                >
-                  <Box sx={{ width: '100%' }}>
-                    {' '}
-                    <CustomTextField
-                      label="Canonical URL"
-                      value={item.url}
-                      onChange={(e) => handleUpdateUrl(item.id || '', e.target.value)}
-                      fullWidth
-                    />
-                  </Box>
-                </Tooltip>
-
-                <CustomTextField
-                  label="Підпис"
-                  value={item.caption?.[langKey] || ''}
-                  onChange={(e) => handleUpdateCaption(item.id || '', e.target.value)}
-                  fullWidth
-                />
-              </Box>
-
-              <IconButton onClick={() => setPerformanceIdToDelete(item.id || '')} sx={styles.actionIcon}>
-                <TrashIcon />
-              </IconButton>
-            </Box>
-          ))}
+          <SortableList
+            id="group-performances-list"
+            items={performances.map((item) => item.id)}
+            onDragEnd={handleDragEnd}
+          >
+            {performances.map((item) => (
+              <SortableItemWrapper key={item.id} id={item.id} gripPosition="top" gripHandle>
+                <Box sx={styles.performanceItemRow}>
+                  <PerformanceRow
+                    item={item}
+                    langKey={langKey}
+                    renderLinkPreview={renderLinkPreview}
+                    onUpdateUrl={handleUpdateUrl}
+                    onUpdateCaption={handleUpdateCaption}
+                    onDeleteRequest={setPerformanceIdToDelete}
+                  />
+                </Box>
+              </SortableItemWrapper>
+            ))}
+          </SortableList>
         </Box>
 
         <Box sx={styles.addBtnWrapper}>

--- a/app/shared/components/creativity/group/performances-section/GroupPerformancesSection.tsx
+++ b/app/shared/components/creativity/group/performances-section/GroupPerformancesSection.tsx
@@ -1,6 +1,6 @@
 import { DragEndEvent } from '@dnd-kit/core';
 import { Box, Divider, Typography } from '@mui/material';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { styles } from './GroupPerformancesSection.styles';
 import { PerformanceRow } from './PerformanceRow';
@@ -71,29 +71,36 @@ export const GroupPerformancesSection = ({
   const langKey = currentLanguage === 'UA' ? 'uk' : 'en';
   const [performanceIdToDelete, setPerformanceIdToDelete] = useState<string | null>(null);
 
+  const preparedPerformances = useMemo(() => {
+    return performances.map((item) => ({
+      ...item,
+      id: item.id || generateUniqueId()
+    }));
+  }, [performances]);
+
   const handleAddPerformance = () => {
     const newPerformance: GroupPerformance = {
       id: generateUniqueId(),
       url: '',
       caption: { uk: '', en: '' }
     };
-    onChangePerformances([...performances, newPerformance]);
+    onChangePerformances([...preparedPerformances, newPerformance]);
   };
 
   const handleConfirmDelete = () => {
     if (performanceIdToDelete) {
-      onChangePerformances(performances.filter((item) => item.id !== performanceIdToDelete));
+      onChangePerformances(preparedPerformances.filter((item) => item.id !== performanceIdToDelete));
       setPerformanceIdToDelete(null);
     }
   };
 
   const handleUpdateUrl = (idToUpdate: string, value: string) => {
-    onChangePerformances(performances.map((item) => (item.id === idToUpdate ? { ...item, url: value } : item)));
+    onChangePerformances(preparedPerformances.map((item) => (item.id === idToUpdate ? { ...item, url: value } : item)));
   };
 
   const handleUpdateCaption = (idToUpdate: string, value: string) => {
     onChangePerformances(
-      performances.map((item) =>
+      preparedPerformances.map((item) =>
         item.id === idToUpdate
           ? {
             ...item,
@@ -109,7 +116,7 @@ export const GroupPerformancesSection = ({
   };
 
   const handleDragEnd = (event: DragEndEvent) => {
-    handleSortableDragEnd(event, performances, onChangePerformances);
+    handleSortableDragEnd(event, preparedPerformances, onChangePerformances);
   };
 
   return (
@@ -127,14 +134,14 @@ export const GroupPerformancesSection = ({
           </Typography>
           <Divider sx={styles.divider} />
         </Box>
-        
+
         <Box sx={styles.performancesList}>
           <SortableList
             id="group-performances-list"
-            items={performances.map((item) => item.id)}
+            items={preparedPerformances.map((item) => item.id)}
             onDragEnd={handleDragEnd}
           >
-            {performances.map((item) => (
+            {preparedPerformances.map((item) => (
               <SortableItemWrapper key={item.id} id={item.id} gripPosition="top" gripHandle>
                 <Box sx={styles.performanceItemRow}>
                   <PerformanceRow

--- a/app/shared/components/creativity/group/performances-section/GroupPerformancesSection.tsx
+++ b/app/shared/components/creativity/group/performances-section/GroupPerformancesSection.tsx
@@ -71,7 +71,6 @@ export const GroupPerformancesSection = ({
   const langKey = currentLanguage === 'UA' ? 'uk' : 'en';
   const [performanceIdToDelete, setPerformanceIdToDelete] = useState<string | null>(null);
 
-  console.log('performances', performances);
   const preparedPerformances = useMemo(() => {
     return performances.map((item) => ({
       ...item,

--- a/app/shared/components/creativity/group/performances-section/PerformanceRow.test.tsx
+++ b/app/shared/components/creativity/group/performances-section/PerformanceRow.test.tsx
@@ -1,0 +1,173 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React, { ChangeEvent } from 'react';
+
+import { PerformanceRow, PerformanceRowProps } from './PerformanceRow';
+import type { GroupPerformance } from '~/constants/creativity';
+
+const LABELS = {
+  canonicalUrl: 'Canonical URL',
+  caption: 'Підпис',
+  deleteButton: 'Видалити'
+};
+
+const MOCK_IDS = {
+  base: '1',
+  missingCaption: '3'
+};
+
+const MOCK_URLS = {
+  base: 'https://youtube.com/watch?v=123',
+  new: 'https://new-link.com',
+  noProtocol: 'example.com/video',
+  missingCaption: 'https://youtube.com',
+  testUndefined: 'https://test.com',
+  testUndefinedNew: 'https://test.com/new'
+};
+
+const MOCK_CAPTIONS = {
+  uk: 'Перший виступ',
+  en: 'First performance',
+  updated: 'Оновлений підпис',
+  testUndefinedUk: 'Тест',
+  testUndefinedEn: 'Test',
+  testUndefinedNew: 'Новий підпис'
+};
+
+const LANGUAGES = {
+  uk: 'uk' as const,
+  en: 'en' as const
+};
+
+type MockCustomTextFieldProps = {
+  label: string;
+  value?: unknown;
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
+};
+
+jest.mock('~/shared/components/design-system/text-field/TextField', () => ({
+  CustomTextField: ({ label, value, onChange }: MockCustomTextFieldProps) => (
+    <div data-testid={`mock-field-wrapper-${label}`}>
+      <label htmlFor={`input-${label}`}>{label}</label>
+      <input
+        id={`input-${label}`}
+        data-testid={`mock-input-${label}`}
+        value={(value as string) || ''}
+        onChange={onChange}
+      />
+    </div>
+  )
+}));
+
+const mockOnUpdateUrl = jest.fn();
+const mockOnUpdateCaption = jest.fn();
+const mockOnDeleteRequest = jest.fn();
+const mockRenderLinkPreview = jest.fn(() => <span data-testid="mock-link-preview" />);
+
+const baseItem: GroupPerformance = {
+  id: MOCK_IDS.base,
+  url: MOCK_URLS.base,
+  caption: { uk: MOCK_CAPTIONS.uk, en: MOCK_CAPTIONS.en }
+};
+
+const renderRow = (overrides: Partial<PerformanceRowProps> = {}) => {
+  const props: PerformanceRowProps = {
+    item: baseItem,
+    langKey: LANGUAGES.uk,
+    renderLinkPreview: mockRenderLinkPreview,
+    onUpdateUrl: mockOnUpdateUrl,
+    onUpdateCaption: mockOnUpdateCaption,
+    onDeleteRequest: mockOnDeleteRequest,
+    ...overrides
+  };
+  return render(<PerformanceRow {...props} />);
+};
+
+describe('PerformanceRow Component', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render url and caption for the given langKey', () => {
+    renderRow();
+
+    expect(screen.getByTestId(`mock-input-${LABELS.canonicalUrl}`)).toHaveValue(MOCK_URLS.base);
+    expect(screen.getByTestId(`mock-input-${LABELS.caption}`)).toHaveValue(MOCK_CAPTIONS.uk);
+  });
+
+  it('should render caption for "en" langKey', () => {
+    renderRow({ langKey: LANGUAGES.en });
+
+    expect(screen.getByTestId(`mock-input-${LABELS.caption}`)).toHaveValue(MOCK_CAPTIONS.en);
+  });
+
+  it('should call onUpdateUrl with item id and new value', () => {
+    renderRow();
+
+    fireEvent.change(screen.getByTestId(`mock-input-${LABELS.canonicalUrl}`), {
+      target: { value: MOCK_URLS.new }
+    });
+
+    expect(mockOnUpdateUrl).toHaveBeenCalledTimes(1);
+    expect(mockOnUpdateUrl).toHaveBeenCalledWith(MOCK_IDS.base, MOCK_URLS.new);
+  });
+
+  it('should call onUpdateCaption with item id and new value', () => {
+    renderRow();
+
+    fireEvent.change(screen.getByTestId(`mock-input-${LABELS.caption}`), {
+      target: { value: MOCK_CAPTIONS.updated }
+    });
+
+    expect(mockOnUpdateCaption).toHaveBeenCalledTimes(1);
+    expect(mockOnUpdateCaption).toHaveBeenCalledWith(MOCK_IDS.base, MOCK_CAPTIONS.updated);
+  });
+
+  it('should call onDeleteRequest with item id when trash icon is clicked', () => {
+    renderRow();
+
+    fireEvent.click(screen.getByLabelText(LABELS.deleteButton));
+
+    expect(mockOnDeleteRequest).toHaveBeenCalledTimes(1);
+    expect(mockOnDeleteRequest).toHaveBeenCalledWith(MOCK_IDS.base);
+  });
+
+  it('should handle empty URL', () => {
+    renderRow({ item: { ...baseItem, url: '' } });
+
+    expect(screen.getByTestId(`mock-input-${LABELS.canonicalUrl}`)).toHaveValue('');
+  });
+
+  it('should handle URL without HTTP protocol via renderLinkPreview call', () => {
+    renderRow({ item: { ...baseItem, url: MOCK_URLS.noProtocol } });
+
+    expect(mockRenderLinkPreview).toHaveBeenCalledWith(MOCK_URLS.noProtocol);
+  });
+
+  it('should handle missing caption object gracefully', () => {
+    renderRow({ item: { id: MOCK_IDS.missingCaption, url: MOCK_URLS.missingCaption } });
+
+    expect(screen.getByTestId(`mock-input-${LABELS.caption}`)).toHaveValue('');
+  });
+
+  it('should handle undefined item.id correctly (fallback to empty string)', () => {
+    renderRow({
+      item: {
+        id: undefined as unknown as string,
+        url: MOCK_URLS.testUndefined,
+        caption: { uk: MOCK_CAPTIONS.testUndefinedUk, en: MOCK_CAPTIONS.testUndefinedEn }
+      }
+    });
+
+    fireEvent.change(screen.getByTestId(`mock-input-${LABELS.canonicalUrl}`), {
+      target: { value: MOCK_URLS.testUndefinedNew }
+    });
+    fireEvent.change(screen.getByTestId(`mock-input-${LABELS.caption}`), {
+      target: { value: MOCK_CAPTIONS.testUndefinedNew }
+    });
+    fireEvent.click(screen.getByLabelText(LABELS.deleteButton));
+
+    expect(mockOnUpdateUrl).toHaveBeenCalledWith(undefined, MOCK_URLS.testUndefinedNew);
+    expect(mockOnUpdateCaption).toHaveBeenCalledWith(undefined, MOCK_CAPTIONS.testUndefinedNew);
+    expect(mockOnDeleteRequest).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/app/shared/components/creativity/group/performances-section/PerformanceRow.test.tsx
+++ b/app/shared/components/creativity/group/performances-section/PerformanceRow.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import React, { ChangeEvent } from 'react';
 
 import { PerformanceRow, PerformanceRowProps } from './PerformanceRow';
-import type { GroupPerformance } from '~/constants/creativity';
+import type { NormalizedGroupPerformance } from '~/constants/creativity';
 
 const LABELS = {
   canonicalUrl: 'Canonical URL',
@@ -63,7 +63,7 @@ const mockOnUpdateCaption = jest.fn();
 const mockOnDeleteRequest = jest.fn();
 const mockRenderLinkPreview = jest.fn(() => <span data-testid="mock-link-preview" />);
 
-const baseItem: GroupPerformance = {
+const baseItem: NormalizedGroupPerformance = {
   id: MOCK_IDS.base,
   url: MOCK_URLS.base,
   caption: { uk: MOCK_CAPTIONS.uk, en: MOCK_CAPTIONS.en }

--- a/app/shared/components/creativity/group/performances-section/PerformanceRow.tsx
+++ b/app/shared/components/creativity/group/performances-section/PerformanceRow.tsx
@@ -1,0 +1,57 @@
+import { Box, IconButton, Tooltip } from '@mui/material';
+import { Trash2 } from 'lucide-react';
+
+import { styles } from './GroupPerformancesSection.styles';
+import type { GroupPerformance } from '~/constants/creativity';
+import { CustomTextField } from '~/shared/components/design-system/text-field/TextField';
+
+export type PerformanceRowProps = {
+  item: GroupPerformance;
+  langKey: 'uk' | 'en';
+  renderLinkPreview: (url: string) => React.ReactNode;
+  onUpdateUrl: (id: string, value: string) => void;
+  onUpdateCaption: (id: string, value: string) => void;
+  onDeleteRequest: (id: string) => void;
+};
+
+export const PerformanceRow = ({
+  item,
+  langKey,
+  renderLinkPreview,
+  onUpdateUrl,
+  onUpdateCaption,
+  onDeleteRequest
+}: PerformanceRowProps) => {
+  return (
+    <>
+      <Box sx={styles.inputsWrapper}>
+        <Tooltip
+          title={renderLinkPreview(item.url || '')}
+          placement="top-start"
+          enterDelay={400}
+          slotProps={{ tooltip: { sx: styles.tooltipBox } }}
+        >
+          <Box sx={{ width: '100%' }}>
+            <CustomTextField
+              label="Canonical URL"
+              value={item.url}
+              onChange={(e) => onUpdateUrl(item.id, e.target.value)}
+              fullWidth
+            />
+          </Box>
+        </Tooltip>
+
+        <CustomTextField
+          label="Підпис"
+          value={item.caption?.[langKey] || ''}
+          onChange={(e) => onUpdateCaption(item.id, e.target.value)}
+          fullWidth
+        />
+      </Box>
+
+      <IconButton aria-label="Видалити" onClick={() => onDeleteRequest(item.id)} sx={styles.actionIcon}>
+        <Trash2 size={18} strokeWidth={1.5} />
+      </IconButton>
+    </>
+  );
+};

--- a/app/shared/components/creativity/group/performances-section/PerformanceRow.tsx
+++ b/app/shared/components/creativity/group/performances-section/PerformanceRow.tsx
@@ -2,11 +2,11 @@ import { Box, IconButton, Tooltip } from '@mui/material';
 import { Trash2 } from 'lucide-react';
 
 import { styles } from './GroupPerformancesSection.styles';
-import type { GroupPerformance } from '~/constants/creativity';
+import { NormalizedGroupPerformance } from '~/constants/creativity';
 import { CustomTextField } from '~/shared/components/design-system/text-field/TextField';
 
 export type PerformanceRowProps = {
-  item: GroupPerformance;
+  item: NormalizedGroupPerformance;
   langKey: 'uk' | 'en';
   renderLinkPreview: (url: string) => React.ReactNode;
   onUpdateUrl: (id: string, value: string) => void;

--- a/app/types/opus.ts
+++ b/app/types/opus.ts
@@ -93,7 +93,7 @@ export interface FetchedOpusData {
   }> | null;
   performancesTitle?: { uk?: string | null; en?: string | null } | null;
   performances?: Array<{
-    id?: string;
+    id: string;
     title?: { uk?: string | null; en?: string | null } | null;
     videoUrl?: string | null;
   }> | null;


### PR DESCRIPTION
## Description

Added drag-and-drop reordering support to the GroupPerformancesSection component.

### Changes

- Reused the existing `SortableList` component in `GroupPerformancesSection` to provide a consistent drag-and-drop experience.
- Reused the existing `handleSortableDragEnd` utility for performance reordering.
- Extracted the performance row into a dedicated `PerformanceRow` component.
- Wrapped each row in `SortableItemWrapper` for drag interactions.
- Increased test coverage 

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Check out this branch
2. Open the `/creativity` page
3. Create a new group via 'Створити' - 'Група'
4. In the 'Всі версії виконання опису' section, add several performances using the 'Додати пункт' button
5. Verify that performances can be reordered using drag-and-drop while creating the group
6. Save the group
7. Open the created group for editing and verify that performances can still be reordered
8. Save the changes and confirm that the performance order is preserved and displayed correctly

## Video / Screenshots

https://github.com/user-attachments/assets/3e5bcc29-b0cc-405a-be55-bc1fb6dd39d6

## Checklist

- [ ] Code compiles and runs correctly
- [ ] Tests pass successfully
- [ ] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [ ] Linked issue/task included
- [ ] Task moved to the review column on the board

---
Closes #711 