### PR TITLE
feat: implement functionality for group dropdown

### DIFF
--- a/app/(logged_in)/creativity/WorksTable.test.tsx
+++ b/app/(logged_in)/creativity/WorksTable.test.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@mui/material';
-import { fireEvent,render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 
 import { useWorksTableActions } from './useWorksTableActions';
@@ -330,6 +330,20 @@ describe('WorksTable', () => {
         const groupHeader = row.groupData as GroupHeaderData;
         if (groupHeader.menuActions?.menuItems) {
           triggerMenuClicks(groupHeader.menuActions.menuItems);
+        }
+
+        if (row.subRows) {
+          row.subRows.forEach((subRow: OpusWork) => {
+            if (subRow.menuActions?.menuItems) {
+              triggerMenuClicks(subRow.menuActions.menuItems);
+            }
+          });
+        }
+      }
+
+      if (row.type === 'individual' && row.plainData) {
+        if (row.plainData.menuActions?.menuItems) {
+          triggerMenuClicks(row.plainData.menuActions.menuItems);
         }
       }
     });

--- a/app/(logged_in)/creativity/WorksTable.test.tsx
+++ b/app/(logged_in)/creativity/WorksTable.test.tsx
@@ -1,7 +1,8 @@
 import { Box } from '@mui/material';
-import { render } from '@testing-library/react';
+import { fireEvent,render, screen } from '@testing-library/react';
 import React from 'react';
 
+import { useWorksTableActions } from './useWorksTableActions';
 import {
   columns as originalColumns,
   GroupHeaderData,
@@ -20,6 +21,25 @@ jest.mock('~/shared/components/table-layout/TableLayout', () => ({
     mockTableLayout(props);
     return <Box data-testid="table-layout" />;
   }
+}));
+
+jest.mock('~/shared/components/delete-card-modal/DeleteCardModal', () => ({
+  __esModule: true,
+  default: ({ open, onClose, onDelete }: { open: boolean; onClose: () => void; onDelete: () => void }) =>
+    open ? (
+      <div data-testid="delete-card-modal">
+        <button data-testid="modal-close" onClick={onClose}>
+          Close
+        </button>
+        <button data-testid="modal-delete" onClick={onDelete}>
+          Delete
+        </button>
+      </div>
+    ) : null
+}));
+
+jest.mock('./useWorksTableActions', () => ({
+  useWorksTableActions: jest.fn()
 }));
 
 const group: GroupRowData = {
@@ -49,8 +69,20 @@ const individualWork: IndividualWork = {
 };
 
 describe('WorksTable', () => {
+  const mockSetGroupToUngroup = jest.fn();
+  const mockHandlePublishStatusChange = jest.fn();
+  const mockHandleConfirmUngroup = jest.fn();
+  const mockHandleShareGroup = jest.fn();
+
   beforeEach(() => {
     jest.clearAllMocks();
+    (useWorksTableActions as jest.Mock).mockReturnValue({
+      groupToUngroup: null,
+      setGroupToUngroup: mockSetGroupToUngroup,
+      handlePublishStatusChange: mockHandlePublishStatusChange,
+      handleConfirmUngroup: mockHandleConfirmUngroup,
+      handleShareGroup: mockHandleShareGroup
+    });
   });
 
   it('should render opus groups when showOpus is true', () => {
@@ -264,10 +296,13 @@ describe('WorksTable', () => {
     expect(data[0].groupData.status).toBe(BaseContentStatuses.Published);
   });
 
-  it('covers menu item clicks for published and draft states', () => {
+  it('covers menu item clicks for published and draft states and triggers hook actions', () => {
     render(
       <WorksTable
-        visibleOpusGroups={[{ ...group, status: BaseContentStatuses.Published }]}
+        visibleOpusGroups={[
+          { ...group, id: 'group-draft', status: BaseContentStatuses.Draft },
+          { ...group, id: 'group-published', status: BaseContentStatuses.Published }
+        ]}
         visibleUngroupedGroups={[]}
         visibleUngroupedWorks={[{ ...individualWork, status: BaseContentStatuses.Draft }]}
         showOpus
@@ -299,6 +334,39 @@ describe('WorksTable', () => {
       }
     });
 
-    expect(mockTableLayout).toHaveBeenCalled();
+    expect(mockHandleShareGroup).toHaveBeenCalled();
+    expect(mockSetGroupToUngroup).toHaveBeenCalled();
+
+    expect(mockHandlePublishStatusChange).toHaveBeenCalledWith('group-draft', 'published');
+    expect(mockHandlePublishStatusChange).toHaveBeenCalledWith('group-published', 'draft');
+  });
+
+  it('renders DeleteCardModal and handles modal actions when groupToUngroup is set', () => {
+    (useWorksTableActions as jest.Mock).mockReturnValue({
+      groupToUngroup: 'group-1',
+      setGroupToUngroup: mockSetGroupToUngroup,
+      handlePublishStatusChange: mockHandlePublishStatusChange,
+      handleConfirmUngroup: mockHandleConfirmUngroup,
+      handleShareGroup: mockHandleShareGroup
+    });
+
+    render(
+      <WorksTable
+        visibleOpusGroups={[group]}
+        visibleUngroupedGroups={[]}
+        visibleUngroupedWorks={[]}
+        showOpus
+        showUngrouped={false}
+        showIndividualWorks={false}
+      />
+    );
+
+    expect(screen.getByTestId('delete-card-modal')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('modal-close'));
+    expect(mockSetGroupToUngroup).toHaveBeenCalledWith(null);
+
+    fireEvent.click(screen.getByTestId('modal-delete'));
+    expect(mockHandleConfirmUngroup).toHaveBeenCalled();
   });
 });

--- a/app/(logged_in)/creativity/WorksTable.tsx
+++ b/app/(logged_in)/creativity/WorksTable.tsx
@@ -3,15 +3,18 @@
 import { Box } from '@mui/material';
 import React from 'react';
 
+import { useWorksTableActions } from './useWorksTableActions';
 import { styles } from './WorksTable.styles';
 import { GroupMenuItems, WorkMenuItems } from './WorksTableMenuItems';
 import { WORKS_BASE_PATH, WorksStatusValue } from '~/constants/creativity';
+import DeleteCardModal from '~/shared/components/delete-card-modal/DeleteCardModal';
 import { ActionMenuGroups } from '~/shared/components/dropdown-menu/ActionMenu';
 import { RowActions } from '~/shared/components/table-layout/components/RowActions';
 import { StatusBadge } from '~/shared/components/table-layout/components/StatusBadge';
 import { BaseRowData, ColumnDef } from '~/shared/components/table-layout/row-variants/Row.types';
 import { TableLayout } from '~/shared/components/table-layout/TableLayout';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
+import { OpusStatus } from '~/types/graphql/generated/graphql';
 
 type ActionFields = {
   editAction?: { editHref: string; editLabel: string };
@@ -128,6 +131,15 @@ export function WorksTable({
   showUngrouped,
   showIndividualWorks
 }: WorksTableProps) {
+
+  const {
+    groupToUngroup,
+    setGroupToUngroup,
+    handlePublishStatusChange,
+    handleConfirmUngroup,
+    handleShareGroup
+  } = useWorksTableActions();
+
   function groupsRow(group: GroupRowData): BaseRowData<GroupHeaderData, OpusWork, IndividualWork> {
     const isPublished = group.status === BaseContentStatuses.Published;
 
@@ -150,8 +162,10 @@ export function WorksTable({
           menuItems: GroupMenuItems({
             id: group.id,
             isPublished,
-            setHideModalOpen: modalMock,
-            setPublicationModalOpen: modalMock
+            onPublish: (id) => handlePublishStatusChange(id, OpusStatus.Published),
+            onUnpublish: (id) => handlePublishStatusChange(id, OpusStatus.Draft),
+            onUngroup: (id) => setGroupToUngroup(id),
+            onShare: (id) => handleShareGroup(id)
           }),
           menuTriggerLabel: `Дії групи ${group.title}`
         }
@@ -220,6 +234,14 @@ export function WorksTable({
   return (
     <Box sx={styles.worksListContainer}>
       <TableLayout data={rows} columns={columns} />
+      <DeleteCardModal
+        open={!!groupToUngroup} 
+        onClose={() => setGroupToUngroup(null)} 
+        onDelete={handleConfirmUngroup}
+        title="Підтвердити розгрупування" 
+        confirmButtonText="Розгрупувати"
+        description="Ви впевнені, що хочете розгрупувати цю групу?"
+      />
     </Box>
   );
 }

--- a/app/(logged_in)/creativity/WorksTable.tsx
+++ b/app/(logged_in)/creativity/WorksTable.tsx
@@ -240,7 +240,7 @@ export function WorksTable({
         onDelete={handleConfirmUngroup}
         title="Підтвердити розгрупування" 
         confirmButtonText="Розгрупувати"
-        description="Ви впевнені, що хочете розгрупувати цю групу?"
+        description="Ви впевнені, що хочете розгрупувати групу? Опис сторінки буде видалено, але композиції залишаться в системі."
       />
     </Box>
   );

--- a/app/(logged_in)/creativity/WorksTableMenuItems.test.ts
+++ b/app/(logged_in)/creativity/WorksTableMenuItems.test.ts
@@ -11,58 +11,72 @@ describe('WorksTableMenusItems', () => {
     });
   };
 
-  it('should build GroupMenuItems with correct static menu items', () => {
+  const mockOnPublish = jest.fn();
+  const mockOnUnpublish = jest.fn();
+  const mockOnUngroup = jest.fn();
+  const mockOnShare = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should build GroupMenuItems with correct static menu items and handle ungroup/share clicks', () => {
     const groups = GroupMenuItems({
       id: 'group-1',
       isPublished: true,
-      setHideModalOpen: jest.fn(),
-      setPublicationModalOpen: jest.fn(),
+      onPublish: mockOnPublish,
+      onUnpublish: mockOnUnpublish,
+      onUngroup: mockOnUngroup,
+      onShare: mockOnShare
     });
 
-    expect(groups[0].items).toEqual(
+    const firstGroupItems = groups[0].items;
+    expect(firstGroupItems).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ id: 'edit-seo', href: `${WORKS_BASE_PATH}/group/group-1/seo` }),
+        expect.objectContaining({ id: 'edit-seo', href: `${WORKS_BASE_PATH}/group/group-1/edit` }),
         expect.objectContaining({ id: 'edit-content', href: `${WORKS_BASE_PATH}/group/group-1/content` }),
-        expect.objectContaining({ id: 'share', href: `${WORKS_BASE_PATH}/group/group-1/share` }),
-        expect.objectContaining({ id: 'ungroup', href: `${WORKS_BASE_PATH}/group/group-1/ungroup` }),
+        expect.objectContaining({ id: 'share' }),
+        expect.objectContaining({ id: 'ungroup' })
       ])
     );
+
+    triggerItemClicks(firstGroupItems);
+    expect(mockOnShare).toHaveBeenCalledWith('group-1');
+    expect(mockOnUngroup).toHaveBeenCalledWith('group-1');
   });
 
   it('should build GroupMenuItems with unpublish action when isPublished is true', () => {
-    const setHideModalOpen = jest.fn();
-    const setPublicationModalOpen = jest.fn();
-
     const groups = GroupMenuItems({
       id: 'group-1',
       isPublished: true,
-      setHideModalOpen,
-      setPublicationModalOpen,
+      onPublish: mockOnPublish,
+      onUnpublish: mockOnUnpublish,
+      onUngroup: mockOnUngroup,
+      onShare: mockOnShare
     });
 
     expect(groups[1].items[0].id).toBe('unpublish');
 
     triggerItemClicks(groups[1].items);
-    expect(setHideModalOpen).toHaveBeenCalledWith(true);
-    expect(setPublicationModalOpen).not.toHaveBeenCalled();
+    expect(mockOnUnpublish).toHaveBeenCalledWith('group-1');
+    expect(mockOnPublish).not.toHaveBeenCalled();
   });
 
   it('should build GroupMenuItems with publish action when isPublished is false', () => {
-    const setHideModalOpen = jest.fn();
-    const setPublicationModalOpen = jest.fn();
-
     const groups = GroupMenuItems({
       id: 'group-2',
       isPublished: false,
-      setHideModalOpen,
-      setPublicationModalOpen,
+      onPublish: mockOnPublish,
+      onUnpublish: mockOnUnpublish,
+      onUngroup: mockOnUngroup,
+      onShare: mockOnShare
     });
 
     expect(groups[1].items[0].id).toBe('publish');
 
     triggerItemClicks(groups[1].items);
-    expect(setPublicationModalOpen).toHaveBeenCalledWith(true);
-    expect(setHideModalOpen).not.toHaveBeenCalled();
+    expect(mockOnPublish).toHaveBeenCalledWith('group-2');
+    expect(mockOnUnpublish).not.toHaveBeenCalled();
   });
 
   it('should build WorkMenuItems with edit, share and delete actions', () => {
@@ -71,7 +85,7 @@ describe('WorksTableMenusItems', () => {
     const groups = WorkMenuItems({
       id: 'work-1',
       isPublished: true,
-      setDeleteModalOpen,
+      setDeleteModalOpen
     });
 
     expect(groups).toHaveLength(2);
@@ -79,7 +93,7 @@ describe('WorksTableMenusItems', () => {
     expect(groups[0].items).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ id: 'edit', href: `${WORKS_BASE_PATH}/work-1/edit` }),
-        expect.objectContaining({ id: 'share', href: `${WORKS_BASE_PATH}/work-1/share` }),
+        expect.objectContaining({ id: 'share', href: `${WORKS_BASE_PATH}/work-1/share` })
       ])
     );
 

--- a/app/(logged_in)/creativity/WorksTableMenuItems.ts
+++ b/app/(logged_in)/creativity/WorksTableMenuItems.ts
@@ -4,8 +4,10 @@ import { ActionMenuGroups } from '~/shared/components/dropdown-menu/ActionMenu';
 interface GroupMenuProps {
   id: string;
   isPublished: boolean;
-  setHideModalOpen: (open: boolean) => void;
-  setPublicationModalOpen: (open: boolean) => void;
+  onPublish: (id: string) => void;
+  onUnpublish: (id: string) => void;
+  onUngroup: (id: string) => void;
+  onShare: (id: string) => void;
 }
 
 interface WorkMenuProps {
@@ -17,22 +19,24 @@ interface WorkMenuProps {
 export const GroupMenuItems = ({
   id,
   isPublished,
-  setHideModalOpen,
-  setPublicationModalOpen,
+  onPublish,
+  onUnpublish,
+  onUngroup,
+  onShare,
 }: GroupMenuProps): ActionMenuGroups => [
   {
     items: [
-      { id: 'edit-seo', text: { name: 'Редагувати групу (SEO)' }, href: `${WORKS_BASE_PATH}/group/${id}/seo` },
+      { id: 'edit-seo', text: { name: 'Редагувати групу (SEO)' }, href: `${WORKS_BASE_PATH}/group/${id}/edit` },
       { id: 'edit-content', text: { name: 'Редагувати контент' }, href: `${WORKS_BASE_PATH}/group/${id}/content` },
-      { id: 'share', text: { name: 'Поширити' }, href: `${WORKS_BASE_PATH}/group/${id}/share` },
-      { id: 'ungroup', text: { name: 'Розгрупувати' }, href: `${WORKS_BASE_PATH}/group/${id}/ungroup` },
+      { id: 'share', text: { name: 'Поширити' }, onClick: () => onShare(id) },
+      { id: 'ungroup', text: { name: 'Розгрупувати' }, onClick: () => onUngroup(id) },
     ],
   },
   {
     items: [
       isPublished
-        ? { id: 'unpublish', text: { name: 'Зняти з публікації' }, onClick: () => setHideModalOpen(true) }
-        : { id: 'publish', text: { name: 'Опублікувати' }, onClick: () => setPublicationModalOpen(true) },
+        ? { id: 'unpublish', text: { name: 'Зняти з публікації' }, onClick: () => onUnpublish(id) }
+        : { id: 'publish', text: { name: 'Опублікувати' }, onClick: () => onPublish(id) },
     ],
   },
 ];

--- a/app/(logged_in)/creativity/page.test.tsx
+++ b/app/(logged_in)/creativity/page.test.tsx
@@ -77,6 +77,15 @@ jest.mock('~/shared/components/filtering-toolbar', () => ({
   )
 }));
 
+jest.mock('./useWorksTableActions', () => ({
+  useWorksTableActions: jest.fn(() => ({
+    groupToUngroup: null,
+    setGroupToUngroup: jest.fn(),
+    handlePublishStatusChange: jest.fn(),
+    handleConfirmUngroup: jest.fn(),
+    handleShareGroup: jest.fn(),
+  })),
+}));
 interface TabItem {
   value: string;
   label: string;

--- a/app/(logged_in)/creativity/useWorksTableActions.test.ts
+++ b/app/(logged_in)/creativity/useWorksTableActions.test.ts
@@ -1,0 +1,199 @@
+import { act, renderHook } from '@testing-library/react';
+import toast from 'react-hot-toast';
+
+import { useWorksTableActions } from './useWorksTableActions';
+import { OpusStatus, useDeleteOpusMutation, useUpdateOpusMutation } from '~/types/graphql/generated/graphql';
+
+jest.mock('react-hot-toast', () => ({
+  success: jest.fn(),
+  error: jest.fn()
+}));
+
+jest.mock('~/types/graphql/generated/graphql', () => ({
+  useUpdateOpusMutation: jest.fn(),
+  useDeleteOpusMutation: jest.fn(),
+  OpusStatus: {
+    Published: 'PUBLISHED',
+    Draft: 'DRAFT'
+  }
+}));
+
+jest.mock('~/constants/creativity', () => ({
+  WORKS_BASE_PATH: '/creativity/works'
+}));
+
+describe('useWorksTableActions', () => {
+  const mockUpdateOpus = jest.fn();
+  const mockDeleteOpus = jest.fn();
+
+  const originalClipboard = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: jest.fn() },
+      configurable: true,
+      writable: true
+    });
+  });
+
+  afterAll(() => {
+    if (originalClipboard) {
+      Object.defineProperty(navigator, 'clipboard', originalClipboard);
+    } else {
+      // @ts-expect-error - clean up the mock if it didn't exist
+      delete navigator.clipboard;
+    }
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useUpdateOpusMutation as jest.Mock).mockReturnValue([mockUpdateOpus]);
+    (useDeleteOpusMutation as jest.Mock).mockReturnValue([mockDeleteOpus]);
+
+    // Mute console.error for tests that expect errors to keep the console clean
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe('Initial State & Setters', () => {
+    it('should initialize with groupToUngroup as null', () => {
+      const { result } = renderHook(() => useWorksTableActions());
+      expect(result.current.groupToUngroup).toBeNull();
+    });
+
+    it('should update groupToUngroup state when setGroupToUngroup is called', () => {
+      const { result } = renderHook(() => useWorksTableActions());
+
+      act(() => {
+        result.current.setGroupToUngroup('group-123');
+      });
+
+      expect(result.current.groupToUngroup).toBe('group-123');
+    });
+  });
+
+  describe('handlePublishStatusChange', () => {
+    it('should call updateOpus and show success toast when publishing', async () => {
+      mockUpdateOpus.mockResolvedValueOnce({ data: { updateOpus: { id: '1' } } });
+      const { result } = renderHook(() => useWorksTableActions());
+
+      await act(async () => {
+        await result.current.handlePublishStatusChange('group-1', OpusStatus.Published);
+      });
+
+      expect(mockUpdateOpus).toHaveBeenCalledWith({
+        variables: { id: 'group-1', input: { status: OpusStatus.Published } }
+      });
+      expect(toast.success).toHaveBeenCalledWith('Групу опубліковано');
+    });
+
+    it('should call updateOpus and show success toast when unpublishing', async () => {
+      mockUpdateOpus.mockResolvedValueOnce({ data: { updateOpus: { id: '1' } } });
+      const { result } = renderHook(() => useWorksTableActions());
+
+      await act(async () => {
+        await result.current.handlePublishStatusChange('group-1', OpusStatus.Draft);
+      });
+
+      expect(mockUpdateOpus).toHaveBeenCalledWith({
+        variables: { id: 'group-1', input: { status: OpusStatus.Draft } }
+      });
+      expect(toast.success).toHaveBeenCalledWith('Групу знято з публікації');
+    });
+
+    it('should catch error, log it, and show error toast when update fails', async () => {
+      const mockError = new Error('GraphQL Error');
+      mockUpdateOpus.mockRejectedValueOnce(mockError);
+
+      const { result } = renderHook(() => useWorksTableActions());
+
+      await act(async () => {
+        await result.current.handlePublishStatusChange('group-1', OpusStatus.Published);
+      });
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(mockError);
+      expect(toast.error).toHaveBeenCalledWith('Помилка при зміні статусу');
+    });
+  });
+
+  describe('handleConfirmUngroup', () => {
+    it('should return early and do nothing if groupToUngroup is null', async () => {
+      const { result } = renderHook(() => useWorksTableActions());
+
+      await act(async () => {
+        await result.current.handleConfirmUngroup();
+      });
+
+      expect(mockDeleteOpus).not.toHaveBeenCalled();
+    });
+
+    it('should call deleteOpus, show success toast, and clear state on success', async () => {
+      mockDeleteOpus.mockResolvedValueOnce({ data: { deleteOpus: true } });
+      const { result } = renderHook(() => useWorksTableActions());
+
+      act(() => {
+        result.current.setGroupToUngroup('group-123');
+      });
+
+      await act(async () => {
+        await result.current.handleConfirmUngroup();
+      });
+
+      expect(mockDeleteOpus).toHaveBeenCalledWith({
+        variables: { id: 'group-123' },
+        refetchQueries: ['AllOpuses', 'AllCompositions']
+      });
+      expect(toast.success).toHaveBeenCalledWith('Групу успішно розгруповано');
+      expect(result.current.groupToUngroup).toBeNull();
+    });
+
+    it('should catch error, log it, and show error toast when delete fails', async () => {
+      const mockError = new Error('Deletion Failed');
+      mockDeleteOpus.mockRejectedValueOnce(mockError);
+      const { result } = renderHook(() => useWorksTableActions());
+
+      act(() => {
+        result.current.setGroupToUngroup('group-123');
+      });
+
+      await act(async () => {
+        await result.current.handleConfirmUngroup();
+      });
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(mockError);
+      expect(toast.error).toHaveBeenCalledWith('Помилка при розгрупуванні групи');
+    });
+  });
+
+  describe('handleShareGroup', () => {
+    it('should write URL to clipboard and show success toast', async () => {
+      (navigator.clipboard.writeText as jest.Mock).mockResolvedValueOnce(undefined);
+      const { result } = renderHook(() => useWorksTableActions());
+
+      await act(async () => {
+        await result.current.handleShareGroup('group-1');
+      });
+
+      const expectedUrl = `${window.location.origin}/creativity/works/group/group-1/edit`;
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(expectedUrl);
+      expect(toast.success).toHaveBeenCalledWith('Посилання скопійовано в буфер обміну.');
+    });
+
+    it('should catch error, log it, and show error toast when clipboard access fails', async () => {
+      const mockError = new Error('Clipboard Denied');
+      (navigator.clipboard.writeText as jest.Mock).mockRejectedValueOnce(mockError);
+      const { result } = renderHook(() => useWorksTableActions());
+
+      await act(async () => {
+        await result.current.handleShareGroup('group-1');
+      });
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Помилка копіювання: ', mockError);
+      expect(toast.error).toHaveBeenCalledWith('Не вдалося скопіювати посилання. Спробуйте ще раз.');
+    });
+  });
+});

--- a/app/(logged_in)/creativity/useWorksTableActions.ts
+++ b/app/(logged_in)/creativity/useWorksTableActions.ts
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import toast from 'react-hot-toast';
+
+import { WORKS_BASE_PATH } from '~/constants/creativity';
+import { OpusStatus, useDeleteOpusMutation, useUpdateOpusMutation } from '~/types/graphql/generated/graphql';
+
+export function useWorksTableActions() {
+  const [updateOpus] = useUpdateOpusMutation();
+  const [deleteOpus] = useDeleteOpusMutation();
+  
+  const [groupToUngroup, setGroupToUngroup] = useState<string | null>(null);
+
+  const handlePublishStatusChange = async (id: string, newStatus: OpusStatus) => {
+    try {
+      await updateOpus({
+        variables: {
+          id,
+          input: { status: newStatus }
+        }
+      });
+      toast.success(newStatus === OpusStatus.Published ? 'Групу опубліковано' : 'Групу знято з публікації');
+    } catch (error) {
+      console.error(error);
+      toast.error('Помилка при зміні статусу');
+    }
+  };
+
+  const handleConfirmUngroup = async () => {
+    if (!groupToUngroup) return;
+    
+    try {
+      await deleteOpus({ 
+        variables: { id: groupToUngroup },
+        refetchQueries: ['AllOpuses', 'AllCompositions'] 
+      });
+      toast.success('Групу успішно розгруповано');
+      setGroupToUngroup(null); 
+    } catch (error) {
+      console.error(error);
+      toast.error('Помилка при розгрупуванні групи');
+    }
+  };
+
+  const handleShareGroup = async (id: string) => {
+    try {
+      const shareUrl = `${window.location.origin}${WORKS_BASE_PATH}/group/${id}/edit`;
+      
+      await navigator.clipboard.writeText(shareUrl);
+      
+      toast.success('Посилання скопійовано в буфер обміну.');
+    } catch (error) {
+      console.error('Помилка копіювання: ', error);
+      toast.error('Не вдалося скопіювати посилання. Спробуйте ще раз.');
+    }
+  };
+
+  return {
+    groupToUngroup,
+    setGroupToUngroup,
+    handlePublishStatusChange,
+    handleConfirmUngroup,
+    handleShareGroup
+  };
+}

--- a/app/(logged_in)/creativity/useWorksTableActions.ts
+++ b/app/(logged_in)/creativity/useWorksTableActions.ts
@@ -7,8 +7,17 @@ import { OpusStatus, useDeleteOpusMutation, useUpdateOpusMutation } from '~/type
 export function useWorksTableActions() {
   const [updateOpus] = useUpdateOpusMutation();
   const [deleteOpus] = useDeleteOpusMutation();
-  
+
   const [groupToUngroup, setGroupToUngroup] = useState<string | null>(null);
+
+  const handleError = (error: unknown, toastMessage: string, logPrefix?: string) => {
+    if (logPrefix) {
+      console.error(logPrefix, error);
+    } else {
+      console.error(error);
+    }
+    toast.error(toastMessage);
+  };
 
   const handlePublishStatusChange = async (id: string, newStatus: OpusStatus) => {
     try {
@@ -20,37 +29,34 @@ export function useWorksTableActions() {
       });
       toast.success(newStatus === OpusStatus.Published ? 'Групу опубліковано' : 'Групу знято з публікації');
     } catch (error) {
-      console.error(error);
-      toast.error('Помилка при зміні статусу');
+      handleError(error, 'Помилка при зміні статусу');
     }
   };
 
   const handleConfirmUngroup = async () => {
     if (!groupToUngroup) return;
-    
+
     try {
-      await deleteOpus({ 
+      await deleteOpus({
         variables: { id: groupToUngroup },
-        refetchQueries: ['AllOpuses', 'AllCompositions'] 
+        refetchQueries: ['AllOpuses', 'AllCompositions']
       });
       toast.success('Групу успішно розгруповано');
-      setGroupToUngroup(null); 
+      setGroupToUngroup(null);
     } catch (error) {
-      console.error(error);
-      toast.error('Помилка при розгрупуванні групи');
+      handleError(error, 'Помилка при розгрупуванні групи');
     }
   };
 
   const handleShareGroup = async (id: string) => {
     try {
       const shareUrl = `${window.location.origin}${WORKS_BASE_PATH}/group/${id}/edit`;
-      
+
       await navigator.clipboard.writeText(shareUrl);
-      
+
       toast.success('Посилання скопійовано в буфер обміну.');
     } catch (error) {
-      console.error('Помилка копіювання: ', error);
-      toast.error('Не вдалося скопіювати посилання. Спробуйте ще раз.');
+      handleError(error, 'Не вдалося скопіювати посилання. Спробуйте ще раз.', 'Помилка копіювання: ');
     }
   };
 

--- a/app/shared/components/delete-card-modal/DeleteCardModal.tsx
+++ b/app/shared/components/delete-card-modal/DeleteCardModal.tsx
@@ -9,24 +9,35 @@ interface DeleteCardModalProps {
   onClose: () => void;
   onDelete: () => void;
   description?: string;
+  title?: string;
+  confirmButtonText?: string;
+  cancelButtonText?: string;
 }
 
-const DeleteCardModal = ({ open, onClose, onDelete, description }: DeleteCardModalProps) => {
+const DeleteCardModal = ({
+  open,
+  onClose,
+  onDelete,
+  description,
+  title = 'Підтвердити видалення',
+  confirmButtonText = 'Видалити',
+  cancelButtonText = 'Скасувати'
+}: DeleteCardModalProps) => {
   return (
     <Dialog open={open} onClose={onClose}>
       <Box sx={styles.closeIcon} onClick={onClose}>
         <X></X>
       </Box>
-      <DialogTitle>Підтвердити видалення</DialogTitle>
+      <DialogTitle>{title}</DialogTitle>
       <DialogContent>
         <Typography>{description || 'Ви впевнені, що хочете видалити цю картку?'} </Typography>
       </DialogContent>
       <DialogActions sx={styles.actions}>
         <Button variant="filled" size="medium" sx={styles.deleteBtn} onClick={onDelete}>
-          Видалити
+          {confirmButtonText}
         </Button>
         <Button variant="outlined" size="medium" color="primary" onClick={onClose}>
-          Скасувати
+          {cancelButtonText}
         </Button>
       </DialogActions>
     </Dialog>


### PR DESCRIPTION
## Description

This pull request implements the logic of menu items for the group. The path for SEO editing has been changed, logic has been added for the "Поширити", "Розгрупувати", and "Зняти з публікації / Опублікувати" items. By clicking on "Поширити", the admin will be able to share a link to the edit page of a specific group. The link is copied to the clipboard and a message is displayed whether the link was saved correctly. When you click "Розгрупувати", a modal confirmation window should appear; if confirmed, the group is deleted and the compositions attached to it are unlinked. When you click "Опублікувати", the unpublished group becomes published (the status changes from published to draft). The opposite is true for an published group.

Closes #675 

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Log in to the admin panel
2. Open a creativity page
3. Click on the three dots next to any group
4. Make sure that all items work correctly according to the description

## Video / Screenshots


https://github.com/user-attachments/assets/00673f23-048b-4bcf-a855-492a80fa123b


## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
