### PR TITLE
feat: implement modal for creating and editing scientific works

### DIFF
--- a/app/(logged_in)/research/ResearchContent.test.tsx
+++ b/app/(logged_in)/research/ResearchContent.test.tsx
@@ -7,8 +7,10 @@ import { ResearchContent } from './ResearchContent';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
 
 jest.mock('./ResearchTable', () => ({
-  ResearchTable: ({ works }: { works: readonly ResearchWork[] }) => (
-    <div data-testid="mock-research-table">{works.length}</div>
+  ResearchTable: ({ works, onEditWork }: { works: readonly ResearchWork[]; onEditWork: () => void }) => (
+    <div data-testid="mock-research-table" data-has-edit-handler={String(typeof onEditWork === 'function')}>
+      {works.length}
+    </div>
   )
 }));
 
@@ -35,14 +37,14 @@ const sampleWork: ResearchWork = {
 
 describe('ResearchContent', () => {
   it('renders the research table when there are visible works', () => {
-    render(<ResearchContent visibleWorks={[sampleWork]} hasActiveCriteria={false} />);
+    render(<ResearchContent visibleWorks={[sampleWork]} hasActiveCriteria={false} onEditWork={jest.fn()} />);
 
     expect(screen.getByTestId('mock-research-table')).toHaveTextContent('1');
     expect(screen.queryByTestId('mock-empty-state')).not.toBeInTheDocument();
   });
 
   it('shows the default empty state when there are no works and no active criteria', () => {
-    render(<ResearchContent visibleWorks={[]} hasActiveCriteria={false} />);
+    render(<ResearchContent visibleWorks={[]} hasActiveCriteria={false} onEditWork={jest.fn()} />);
 
     expect(screen.getByTestId('mock-empty-state')).toBeInTheDocument();
     expect(screen.getByText('Наукових робіт ще немає.')).toBeInTheDocument();
@@ -53,7 +55,7 @@ describe('ResearchContent', () => {
   });
 
   it('shows the no-results empty state when there are no works but search or filters are active', () => {
-    render(<ResearchContent visibleWorks={[]} hasActiveCriteria />);
+    render(<ResearchContent visibleWorks={[]} hasActiveCriteria onEditWork={jest.fn()} />);
 
     expect(screen.getByTestId('mock-empty-state')).toBeInTheDocument();
     expect(screen.getByText('Нічого не знайдено')).toBeInTheDocument();

--- a/app/(logged_in)/research/ResearchContent.tsx
+++ b/app/(logged_in)/research/ResearchContent.tsx
@@ -11,9 +11,10 @@ import { EmptyState } from '~/shared/components/empty-state';
 type ResearchContentProps = Readonly<{
   visibleWorks: readonly ResearchWork[];
   hasActiveCriteria: boolean;
+  onEditWork: (work: ResearchWork) => void;
 }>;
 
-export function ResearchContent({ visibleWorks, hasActiveCriteria }: ResearchContentProps) {
+export function ResearchContent({ visibleWorks, hasActiveCriteria, onEditWork }: ResearchContentProps) {
   if (visibleWorks.length === 0) {
     return (
       <EmptyState
@@ -23,5 +24,5 @@ export function ResearchContent({ visibleWorks, hasActiveCriteria }: ResearchCon
     );
   }
 
-  return <ResearchTable works={visibleWorks} />;
+  return <ResearchTable works={visibleWorks} onEditWork={onEditWork} />;
 }

--- a/app/(logged_in)/research/ResearchCreateAction.styles.ts
+++ b/app/(logged_in)/research/ResearchCreateAction.styles.ts
@@ -20,6 +20,7 @@ export const styles = {
     alignItems: 'center',
     gap: '8px',
     textDecoration: 'none',
+    cursor: 'pointer',
     '&:hover': {
       bgcolor: 'rgb(52, 42, 33)',
       boxShadow: 'none'

--- a/app/(logged_in)/research/ResearchCreateAction.test.tsx
+++ b/app/(logged_in)/research/ResearchCreateAction.test.tsx
@@ -1,31 +1,22 @@
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 
 import { ResearchCreateAction } from './ResearchCreateAction';
 
-jest.mock('next/link', () => {
-  const MockLink = ({ children, href, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
-    <a href={String(href)} {...props}>
-      {children}
-    </a>
-  );
-  MockLink.displayName = 'MockLink';
-  return MockLink;
-});
-
 describe('ResearchCreateAction', () => {
   it('renders the button label', () => {
-    render(<ResearchCreateAction />);
+    render(<ResearchCreateAction onClick={jest.fn()} />);
 
     expect(screen.getByText('Додати роботу')).toBeInTheDocument();
   });
 
   it('links to the research create page', () => {
-    render(<ResearchCreateAction />);
+    const onClick = jest.fn();
+    render(<ResearchCreateAction onClick={onClick} />);
 
-    const link = screen.getByText('Додати роботу').closest('a');
+    fireEvent.click(screen.getByText('Додати роботу'));
 
-    expect(link).toHaveAttribute('href', '/research/create');
+    expect(onClick).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/(logged_in)/research/ResearchCreateAction.tsx
+++ b/app/(logged_in)/research/ResearchCreateAction.tsx
@@ -1,14 +1,11 @@
 import { Box } from '@mui/material';
 import { Plus } from 'lucide-react';
-import Link from 'next/link';
 
 import { styles } from './ResearchCreateAction.styles';
 
-const RESEARCH_CREATE_PATH = '/research/create';
-
-export function ResearchCreateAction() {
+export function ResearchCreateAction({ onClick }: Readonly<{ onClick: () => void }>) {
   return (
-    <Box component={Link} href={RESEARCH_CREATE_PATH} sx={styles.createButton}>
+    <Box component="button" type="button" onClick={onClick} sx={styles.createButton}>
       <Box component={Plus} sx={styles.icon} />
       Додати роботу
     </Box>

--- a/app/(logged_in)/research/ResearchPageContent.test.tsx
+++ b/app/(logged_in)/research/ResearchPageContent.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent,render, screen } from '@testing-library/react';
 import React from 'react';
 
 import { RESEARCH_WORKS_MOCK_DATA, type ResearchWork } from './research.mock';
@@ -31,15 +31,26 @@ jest.mock('~/shared/components/page-header/PageHeader', () => ({
 jest.mock('./ResearchContent', () => ({
   ResearchContent: ({
     visibleWorks,
-    hasActiveCriteria
+    hasActiveCriteria,
+    onEditWork
   }: {
-    visibleWorks: readonly { id: string }[];
+    visibleWorks: readonly { id: string; author: string }[];
     hasActiveCriteria: boolean;
+    onEditWork: (work: unknown) => void;
   }) => (
     <div data-testid="mock-research-content" data-has-active-criteria={String(hasActiveCriteria)}>
       {visibleWorks.length}
+      <button type="button" onClick={() => onEditWork(visibleWorks[0])}>
+        edit-first
+      </button>
     </div>
   )
+}));
+
+jest.mock('~/shared/components/research-modal/ResearchModal', () => ({
+  __esModule: true,
+  default: ({ isOpen, mode }: { isOpen: boolean; mode: string }) =>
+    isOpen ? <div data-testid="mock-research-modal">{mode}</div> : null
 }));
 
 const mockedUseResearchWorksFiltering = jest.mocked(useResearchWorksFiltering);
@@ -94,7 +105,7 @@ describe('ResearchPageContent', () => {
     render(<ResearchPageContent />);
 
     expect(screen.getByText('Дослідження та наукові праці')).toBeInTheDocument();
-    expect(screen.getByText('Додати роботу').closest('a')).toHaveAttribute('href', '/research/create');
+    expect(screen.getByText('Додати роботу')).toBeInTheDocument();
   });
 
   it('passes filtered works to ResearchContent when mock data matches filters', () => {
@@ -199,5 +210,28 @@ describe('ResearchPageContent', () => {
     render(<ResearchPageContent />);
 
     expect(screen.getByTestId('mock-research-content')).toHaveAttribute('data-has-active-criteria', 'true');
+  });
+  it('opens the modal in create mode when the create action is triggered', () => {
+    mockedUseResearchWorksFiltering.mockReturnValue(
+      defaultFilteringMock as unknown as ReturnType<typeof useResearchWorksFiltering>
+    );
+
+    render(<ResearchPageContent />);
+
+    fireEvent.click(screen.getByText('Додати роботу'));
+
+    expect(screen.getByTestId('mock-research-modal')).toHaveTextContent('create');
+  });
+
+  it('opens the modal in edit mode with selected work data', () => {
+    mockedUseResearchWorksFiltering.mockReturnValue(
+      defaultFilteringMock as unknown as ReturnType<typeof useResearchWorksFiltering>
+    );
+
+    render(<ResearchPageContent />);
+
+    fireEvent.click(screen.getByText('edit-first'));
+
+    expect(screen.getByTestId('mock-research-modal')).toHaveTextContent('edit');
   });
 });

--- a/app/(logged_in)/research/ResearchPageContent.tsx
+++ b/app/(logged_in)/research/ResearchPageContent.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { Box } from '@mui/material';
+import { useState } from 'react';
 
-import { RESEARCH_WORKS_MOCK_DATA } from './research.mock';
+import { RESEARCH_WORKS_MOCK_DATA, type ResearchWork } from './research.mock';
 import { ResearchContent } from './ResearchContent';
 import { ResearchCreateAction } from './ResearchCreateAction';
 import { styles } from './ResearchPageContent.styles';
@@ -10,12 +11,35 @@ import { useResearchWorksFiltering } from './useResearchWorksFiltering';
 import { RESEARCH_PAGE_TITLE } from '~/constants/research';
 import { FilteringToolbar, SortSelect } from '~/shared/components/filtering-toolbar';
 import { PageHeader } from '~/shared/components/page-header/PageHeader';
+import ResearchModal from '~/shared/components/research-modal/ResearchModal';
 import { FilterSelect } from '~/shared/components/selector/FilterSelect';
+import { BaseContentStatuses } from '~/types/enums/common.enums';
 import { normalizeSearch } from '~/utils/normalizeSearch';
 
 export function ResearchPageContent() {
   const { sortValue, selectedFilters, toolbarProps, sortProps, statusFilterProps, activeFiltersCount } =
     useResearchWorksFiltering();
+
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [modalMode, setModalMode] = useState<'create' | 'edit'>('create');
+  const [selectedWork, setSelectedWork] = useState<ResearchWork | null>(null);
+
+  const handleOpenCreate = () => {
+    setModalMode('create');
+    setSelectedWork(null);
+    setIsModalOpen(true);
+  };
+
+  const handleOpenEdit = (work: ResearchWork) => {
+    setModalMode('edit');
+    setSelectedWork(work);
+    setIsModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+    setSelectedWork(null);
+  };
 
   const searchValue = (toolbarProps.search?.search ?? '').trim().toLowerCase();
   const normalizedSearch = normalizeSearch(searchValue);
@@ -49,7 +73,7 @@ export function ResearchPageContent() {
 
   return (
     <Box sx={styles.pageContainer}>
-      <PageHeader title={RESEARCH_PAGE_TITLE} action={<ResearchCreateAction />} />
+      <PageHeader title={RESEARCH_PAGE_TITLE} action={<ResearchCreateAction onClick={handleOpenCreate} />} />
 
       <FilteringToolbar
         search={toolbarProps.search}
@@ -58,7 +82,23 @@ export function ResearchPageContent() {
         bottomTrailingContent={<SortSelect {...sortProps} minWidth={208} dataTestId="research-sort-select" />}
       />
 
-      <ResearchContent visibleWorks={visibleWorks} hasActiveCriteria={hasActiveCriteria} />
+      <ResearchContent visibleWorks={visibleWorks} hasActiveCriteria={hasActiveCriteria} onEditWork={handleOpenEdit} />
+      <ResearchModal
+        isOpen={isModalOpen}
+        mode={modalMode}
+        onClose={handleCloseModal}
+        initialData={
+          selectedWork
+            ? {
+              bibliographicDescription: selectedWork.bibliographicDescription,
+              author: selectedWork.author,
+              keywords: selectedWork.keywords,
+              caseDates: String(selectedWork.year),
+              isVisibleOnSite: selectedWork.status === BaseContentStatuses.Published
+            }
+            : undefined
+        }
+      />
     </Box>
   );
 }

--- a/app/(logged_in)/research/ResearchPageContent.tsx
+++ b/app/(logged_in)/research/ResearchPageContent.tsx
@@ -84,6 +84,7 @@ export function ResearchPageContent() {
 
       <ResearchContent visibleWorks={visibleWorks} hasActiveCriteria={hasActiveCriteria} onEditWork={handleOpenEdit} />
       <ResearchModal
+        key={selectedWork?.id ?? 'create'}
         isOpen={isModalOpen}
         mode={modalMode}
         onClose={handleCloseModal}

--- a/app/(logged_in)/research/ResearchTable.test.tsx
+++ b/app/(logged_in)/research/ResearchTable.test.tsx
@@ -52,7 +52,7 @@ describe('ResearchTable', () => {
   });
 
   it('maps each work into an individual row with correct id and plainData', () => {
-    render(<ResearchTable works={[work]} />);
+    render(<ResearchTable works={[work]} onEditWork={jest.fn()} />);
 
     const { data } = mockTableLayout.mock.calls[0][0];
 
@@ -70,32 +70,37 @@ describe('ResearchTable', () => {
   });
 
   it('builds correct edit and menu actions for each work', () => {
-    render(<ResearchTable works={[work]} />);
+    const onEditWork = jest.fn();
+    const onDeleteWork = jest.fn();
+
+    render(<ResearchTable works={[work]} onEditWork={onEditWork} onDeleteWork={onDeleteWork} />);
 
     const { data } = mockTableLayout.mock.calls[0][0];
     const { plainData } = data[0];
 
-    expect(plainData.editAction).toEqual({
-      editHref: '/research/work-1/edit',
-      editLabel: 'Редагувати роботу Архимович Лідія'
-    });
+    expect(plainData.editAction.editLabel).toBe('Редагувати роботу Архимович Лідія');
+    expect(typeof plainData.editAction.onEditClick).toBe('function');
+
+    plainData.editAction.onEditClick();
+    expect(onEditWork).toHaveBeenCalledWith(work);
 
     expect(plainData.menuActions.menuTriggerLabel).toBe('Дії для роботи Архимович Лідія');
-    expect(plainData.menuActions.menuItems).toEqual([
-      {
-        items: [
-          { id: 'edit', text: { name: 'Редагувати' }, href: '/research/work-1/edit' },
-          { id: 'share', text: { name: 'Поширити' } }
-        ]
-      },
-      {
-        items: [{ id: 'delete', text: { name: 'Видалити' } }]
-      }
-    ]);
+
+    const [editGroup, deleteGroup] = plainData.menuActions.menuItems;
+
+    expect(editGroup.items[0]).toMatchObject({ id: 'edit', text: { name: 'Редагувати' } });
+    expect(editGroup.items[1]).toMatchObject({ id: 'share', text: { name: 'Поширити' } });
+    expect(deleteGroup.items[0]).toMatchObject({ id: 'delete', text: { name: 'Видалити' } });
+
+    editGroup.items[0].onClick();
+    expect(onEditWork).toHaveBeenCalledWith(work);
+
+    deleteGroup.items[0].onClick();
+    expect(onDeleteWork).toHaveBeenCalledWith(work);
   });
 
   it('renders one row per work, preserving order', () => {
-    render(<ResearchTable works={[work, secondWork]} />);
+    render(<ResearchTable works={[work, secondWork]} onEditWork={jest.fn()} />);
 
     const { data } = mockTableLayout.mock.calls[0][0];
 
@@ -104,7 +109,7 @@ describe('ResearchTable', () => {
   });
 
   it('renders an empty table when no works are provided', () => {
-    render(<ResearchTable works={[]} />);
+    render(<ResearchTable works={[]} onEditWork={jest.fn()} />);
 
     const { data } = mockTableLayout.mock.calls[0][0];
 
@@ -112,7 +117,7 @@ describe('ResearchTable', () => {
   });
 
   it('passes the correct columns to TableLayout', () => {
-    render(<ResearchTable works={[]} />);
+    render(<ResearchTable works={[]} onEditWork={jest.fn()} />);
 
     expect(mockTableLayout).toHaveBeenCalledTimes(1);
 
@@ -132,7 +137,7 @@ describe('ResearchTable', () => {
   });
 
   it('renders status column with left and right dividers', () => {
-    render(<ResearchTable works={[]} />);
+    render(<ResearchTable works={[]} onEditWork={jest.fn()} />);
 
     const { columns } = mockTableLayout.mock.calls[0][0];
     const statusColumn = columns.find((col: { id: string }) => col.id === 'status');

--- a/app/(logged_in)/research/ResearchTable.tsx
+++ b/app/(logged_in)/research/ResearchTable.tsx
@@ -4,7 +4,6 @@ import { Box, Typography } from '@mui/material';
 
 import type { ResearchWork } from './research.mock';
 import { styles } from './ResearchTable.styles';
-import { RESEARCH_BASE_PATH } from '~/constants/research';
 import type { ActionMenuGroups } from '~/shared/components/dropdown-menu/ActionMenu';
 import { RowActions } from '~/shared/components/table-layout/components/RowActions';
 import { StatusBadge } from '~/shared/components/table-layout/components/StatusBadge';
@@ -13,7 +12,7 @@ import { TableLayout } from '~/shared/components/table-layout/TableLayout';
 import { twoLineEllipsis } from '~/shared/components/table-layout/TableLayout.styles';
 
 type PlainWork = ResearchWork & {
-  editAction?: { editHref: string; editLabel: string };
+  editAction?: { editLabel: string; onEditClick?: () => void };
   menuActions?: {
     menuItems: ActionMenuGroups;
     menuTriggerLabel: string;
@@ -69,26 +68,34 @@ const columns: readonly ColumnDef<unknown, unknown, PlainWork>[] = [
   }
 ];
 
-export function ResearchTable({ works }: Readonly<{ works: readonly ResearchWork[] }>) {
+export function ResearchTable({
+  works,
+  onEditWork,
+  onDeleteWork
+}: Readonly<{
+  works: readonly ResearchWork[];
+  onEditWork: (work: ResearchWork) => void;
+  onDeleteWork?: (work: ResearchWork) => void;
+}>) {
   const rows: BaseRowData<unknown, unknown, PlainWork>[] = works.map((work) => ({
     type: 'individual',
     id: work.id,
     plainData: {
       ...work,
       editAction: {
-        editHref: `${RESEARCH_BASE_PATH}/${work.id}/edit`,
-        editLabel: `Редагувати роботу ${work.author}`
+        editLabel: `Редагувати роботу ${work.author}`,
+        onEditClick: () => onEditWork(work)
       },
       menuActions: {
         menuItems: [
           {
             items: [
-              { id: 'edit', text: { name: 'Редагувати' }, href: `${RESEARCH_BASE_PATH}/${work.id}/edit` },
+              { id: 'edit', text: { name: 'Редагувати' }, onClick: () => onEditWork(work) },
               { id: 'share', text: { name: 'Поширити' } }
             ]
           },
           {
-            items: [{ id: 'delete', text: { name: 'Видалити' } }]
+            items: [{ id: 'delete', text: { name: 'Видалити' }, onClick: () => onDeleteWork?.(work) }]
           }
         ],
         menuTriggerLabel: `Дії для роботи ${work.author}`

--- a/app/(logged_in)/research/page.test.tsx
+++ b/app/(logged_in)/research/page.test.tsx
@@ -77,6 +77,16 @@ jest.mock('./useResearchWorksFiltering', () => ({
   })
 }));
 
+jest.mock('~/shared/components/research-modal/ResearchModal', () => ({
+  __esModule: true,
+  default: ({ isOpen, mode, initialData }: { isOpen: boolean; mode: string; initialData?: { author?: string } }) =>
+    isOpen ? (
+      <div data-testid="mock-research-modal" data-mode={mode}>
+        {initialData?.author}
+      </div>
+    ) : null
+}));
+
 describe('Research page', () => {
   it('renders the page title and the create action', () => {
     render(<ResearchPage />);
@@ -112,11 +122,14 @@ describe('Research page', () => {
     expect(within(dropdownMenu).getByText('Видалити')).toBeInTheDocument();
   });
 
-  it('links the edit action to the correct research work edit page', () => {
+  it('opens the edit modal pre-filled with row data when clicking the edit icon', () => {
     render(<ResearchPage />);
 
-    const editLinks = screen.getAllByRole('link', { name: /редагувати роботу/i });
+    const editButtons = screen.getAllByRole('button', { name: /редагувати роботу/i });
+    fireEvent.click(editButtons[0]);
 
-    expect(editLinks[0]).toHaveAttribute('href', expect.stringContaining('/research/'));
+    const modal = screen.getByTestId('mock-research-modal');
+    expect(modal).toHaveAttribute('data-mode', 'edit');
+    expect(modal).toHaveTextContent(MOCK_AUTHOR);
   });
 });

--- a/app/shared/components/research-modal/ResearchModal.test.tsx
+++ b/app/shared/components/research-modal/ResearchModal.test.tsx
@@ -1,0 +1,112 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import toast from 'react-hot-toast';
+
+import ResearchModal from './ResearchModal';
+
+jest.mock('react-hot-toast', () => ({
+  __esModule: true,
+  default: {
+    success: jest.fn(),
+    error: jest.fn()
+  }
+}));
+
+describe('ResearchModal', () => {
+  const onClose = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders with the create dialog title by default', () => {
+    render(<ResearchModal isOpen onClose={onClose} />);
+
+    expect(screen.getByText('Нова робота')).toBeInTheDocument();
+  });
+
+  it('renders with the edit dialog title when mode is edit', () => {
+    render(<ResearchModal isOpen mode="edit" onClose={onClose} />);
+
+    expect(screen.getByText('Деталі роботи')).toBeInTheDocument();
+  });
+
+  it('pre-fills fields from initialData in edit mode', () => {
+    render(
+      <ResearchModal
+        isOpen
+        mode="edit"
+        onClose={onClose}
+        initialData={{
+          bibliographicDescription: 'Опис роботи',
+          author: 'Автор роботи',
+          caseDates: '1970',
+          keywords: 'слова'
+        }}
+      />
+    );
+
+    expect(screen.getByDisplayValue('Опис роботи')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Автор роботи')).toBeInTheDocument();
+  });
+
+  it('shows a success toast and closes the modal on save', async () => {
+    render(<ResearchModal isOpen onClose={onClose} />);
+
+    fireEvent.change(screen.getByLabelText(/бібліографічний опис/i), { target: { value: 'Опис' } });
+    fireEvent.change(screen.getByLabelText(/автор/i), { target: { value: 'Автор' } });
+    fireEvent.change(screen.getByLabelText(/дати справи/i), { target: { value: '1970' } });
+    fireEvent.change(screen.getByLabelText(/ключові слова/i), { target: { value: 'слово' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Зберегти' }));
+
+    await screen.findByText('Нова робота'); // await a tick for the async handler
+
+    expect(toast.success).toHaveBeenCalledWith('Роботу успішно додано!');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when Cancel is clicked', () => {
+    render(<ResearchModal isOpen onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Скасувати' }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows an error toast when saving fails', async () => {
+    (toast.success as jest.Mock).mockImplementationOnce(() => {
+      throw new Error('Toast failed');
+    });
+
+    render(<ResearchModal isOpen onClose={onClose} />);
+
+    fireEvent.change(screen.getByLabelText(/бібліографічний опис/i), { target: { value: 'Опис' } });
+    fireEvent.change(screen.getByLabelText(/автор/i), { target: { value: 'Автор' } });
+    fireEvent.change(screen.getByLabelText(/дати справи/i), { target: { value: '1970' } });
+    fireEvent.change(screen.getByLabelText(/ключові слова/i), { target: { value: 'слово' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Зберегти' }));
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('Помилка при збереженні роботи'))
+    );
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('shows the update success toast when saving in edit mode', async () => {
+    render(
+      <ResearchModal
+        isOpen
+        mode="edit"
+        onClose={onClose}
+        initialData={{ author: 'Автор', bibliographicDescription: 'Опис', caseDates: '1970', keywords: 'слово' }}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Зберегти' }));
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith('Роботу успішно оновлено!'));
+  });
+});

--- a/app/shared/components/research-modal/ResearchModal.test.tsx
+++ b/app/shared/components/research-modal/ResearchModal.test.tsx
@@ -51,35 +51,7 @@ describe('ResearchModal', () => {
     expect(screen.getByDisplayValue('Автор роботи')).toBeInTheDocument();
   });
 
-  it('shows a success toast and closes the modal on save', async () => {
-    render(<ResearchModal isOpen onClose={onClose} />);
-
-    fireEvent.change(screen.getByLabelText(/бібліографічний опис/i), { target: { value: 'Опис' } });
-    fireEvent.change(screen.getByLabelText(/автор/i), { target: { value: 'Автор' } });
-    fireEvent.change(screen.getByLabelText(/дати справи/i), { target: { value: '1970' } });
-    fireEvent.change(screen.getByLabelText(/ключові слова/i), { target: { value: 'слово' } });
-
-    fireEvent.click(screen.getByRole('button', { name: 'Зберегти' }));
-
-    await screen.findByText('Нова робота'); // await a tick for the async handler
-
-    expect(toast.success).toHaveBeenCalledWith('Роботу успішно додано!');
-    expect(onClose).toHaveBeenCalledTimes(1);
-  });
-
-  it('calls onClose when Cancel is clicked', () => {
-    render(<ResearchModal isOpen onClose={onClose} />);
-
-    fireEvent.click(screen.getByRole('button', { name: 'Скасувати' }));
-
-    expect(onClose).toHaveBeenCalledTimes(1);
-  });
-
-  it('shows an error toast when saving fails', async () => {
-    (toast.success as jest.Mock).mockImplementationOnce(() => {
-      throw new Error('Toast failed');
-    });
-
+  it('shows a "not implemented" message and keeps the modal open on save', async () => {
     render(<ResearchModal isOpen onClose={onClose} />);
 
     fireEvent.change(screen.getByLabelText(/бібліографічний опис/i), { target: { value: 'Опис' } });
@@ -90,12 +62,20 @@ describe('ResearchModal', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Зберегти' }));
 
     await waitFor(() =>
-      expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('Помилка при збереженні роботи'))
+      expect(toast.error).toHaveBeenCalledWith('Збереження ще не реалізовано. Дані не будуть збережені.')
     );
     expect(onClose).not.toHaveBeenCalled();
   });
 
-  it('shows the update success toast when saving in edit mode', async () => {
+  it('calls onClose when Cancel is clicked', () => {
+    render(<ResearchModal isOpen onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Скасувати' }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the same "not implemented" message in edit mode', async () => {
     render(
       <ResearchModal
         isOpen
@@ -107,6 +87,8 @@ describe('ResearchModal', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Зберегти' }));
 
-    await waitFor(() => expect(toast.success).toHaveBeenCalledWith('Роботу успішно оновлено!'));
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('Збереження ще не реалізовано. Дані не будуть збережені.')
+    );
   });
 });

--- a/app/shared/components/research-modal/ResearchModal.tsx
+++ b/app/shared/components/research-modal/ResearchModal.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import React from 'react';
+import toast from 'react-hot-toast';
+
+import { ResearchModalView, ResearchWorkFormData } from './research-modal-view/ResearchModalView';
+
+interface ResearchModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  mode?: 'create' | 'edit';
+  initialData?: Partial<ResearchWorkFormData>;
+}
+
+const ResearchModal: React.FC<ResearchModalProps> = ({ isOpen, onClose, mode = 'create', initialData }) => {
+  const handleSave = async (data: ResearchWorkFormData) => {
+    try {
+      // eslint-disable-next-line no-console
+      console.log('Saving research work:', data);
+
+      toast.success(mode === 'create' ? 'Роботу успішно додано!' : 'Роботу успішно оновлено!');
+      onClose();
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      toast.error(`Помилка при збереженні роботи: ${errorMessage}`);
+    }
+  };
+
+  return (
+    <ResearchModalView
+      dialogTitle={mode === 'create' ? 'Нова робота' : 'Деталі роботи'}
+      isOpen={isOpen}
+      initialData={initialData}
+      onClose={onClose}
+      onSave={handleSave}
+    />
+  );
+};
+
+export default ResearchModal;

--- a/app/shared/components/research-modal/ResearchModal.tsx
+++ b/app/shared/components/research-modal/ResearchModal.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import React from 'react';
 import toast from 'react-hot-toast';
 
@@ -12,18 +10,12 @@ interface ResearchModalProps {
   initialData?: Partial<ResearchWorkFormData>;
 }
 
-const ResearchModal: React.FC<ResearchModalProps> = ({ isOpen, onClose, mode = 'create', initialData }) => {
+const ResearchModal = ({ isOpen, onClose, mode = 'create', initialData }: ResearchModalProps) => {
   const handleSave = async (data: ResearchWorkFormData) => {
-    try {
-      // eslint-disable-next-line no-console
-      console.log('Saving research work:', data);
+    // eslint-disable-next-line no-console
+    console.log('Research work data (persistence not implemented yet):', data);
 
-      toast.success(mode === 'create' ? 'Роботу успішно додано!' : 'Роботу успішно оновлено!');
-      onClose();
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      toast.error(`Помилка при збереженні роботи: ${errorMessage}`);
-    }
+    toast.error('Збереження ще не реалізовано. Дані не будуть збережені.');
   };
 
   return (

--- a/app/shared/components/research-modal/research-modal-view/ResearchModalView.styles.ts
+++ b/app/shared/components/research-modal/research-modal-view/ResearchModalView.styles.ts
@@ -1,0 +1,83 @@
+import { SxProps, Theme } from '@mui/material';
+
+import { mainHexPalette } from '~/shared/theme/colors';
+
+export const styles: Record<string, SxProps<Theme>> = {
+  dialog: {
+    '& .MuiDialog-paper': {
+      borderRadius: '20px',
+      p: '24px',
+      width: 713
+    },
+    '& .MuiInputLabel-root': {
+      transform: 'translate(14px, 13px) scale(1)'
+    },
+    '& .MuiInputLabel-shrink': {
+      transform: 'translate(14px, -9px) scale(0.75)'
+    }
+  },
+  dialogTitle: {
+    typography: 'h6',
+    lineHeight: 1.2,
+    p: 0
+  },
+  dialogContent: {
+    p: '24px 0 0 0',
+    '&::-webkit-scrollbar': { display: 'none' },
+    msOverflowStyle: 'none',
+    scrollbarWidth: 'none'
+  },
+  contentContainer: {
+    p: '24px 0'
+  },
+  charCounter: {
+    display: 'block',
+    textAlign: 'right',
+    mt: '4px',
+    color: 'text.secondary'
+  },
+  fileSectionTitle: {
+    color: 'text.primary',
+    fontWeight: 600
+  },
+  fileLabel: {
+    color: 'text.secondary'
+  },
+  addFileButton: {
+    textTransform: 'none',
+    borderRadius: '20px',
+    color: mainHexPalette.blue[700],
+    backgroundColor: mainHexPalette.blue[100],
+    border: 'none',
+    '&:hover': {
+      backgroundColor: mainHexPalette.blue[200]
+    },
+    '&.Mui-disabled': {
+      backgroundColor: mainHexPalette.blue[100],
+      color: mainHexPalette.blue[500]
+    }
+  },
+  dialogActions: {
+    width: '100%',
+    p: '16px'
+  },
+  cancelButton: {
+    textTransform: 'none',
+    width: '100%'
+  },
+  saveButton: {
+    width: '100%',
+    borderRadius: '28px'
+  },
+  fileRow: {
+    display: 'flex',
+    alignItems: 'center',
+    width: '100%',
+    gap: '12px'
+  },
+  fileRowDivider: {
+    flex: '1 1 auto',
+    minWidth: '20px',
+    borderBottom: `1px solid ${mainHexPalette.blue[200]}`
+  }
+};

--- a/app/shared/components/research-modal/research-modal-view/ResearchModalView.styles.ts
+++ b/app/shared/components/research-modal/research-modal-view/ResearchModalView.styles.ts
@@ -73,5 +73,23 @@ export const styles: Record<string, SxProps<Theme>> = {
     flex: '1 1 auto',
     minWidth: '20px',
     borderBottom: `1px solid ${mainHexPalette.blue[200]}`
+  },
+  multilineField: {
+    '& .MuiInputBase-root': {
+      '&::-webkit-scrollbar': {
+        width: '0px',
+        display: 'none'
+      },
+      scrollbarWidth: 'none',
+      msOverflowStyle: 'none'
+    },
+    '& textarea': {
+      '&::-webkit-scrollbar': {
+        width: '0px',
+        display: 'none'
+      },
+      scrollbarWidth: 'none',
+      msOverflowStyle: 'none'
+    }
   }
 };

--- a/app/shared/components/research-modal/research-modal-view/ResearchModalView.styles.ts
+++ b/app/shared/components/research-modal/research-modal-view/ResearchModalView.styles.ts
@@ -8,12 +8,6 @@ export const styles: Record<string, SxProps<Theme>> = {
       borderRadius: '20px',
       p: '24px',
       width: 713
-    },
-    '& .MuiInputLabel-root': {
-      transform: 'translate(14px, 13px) scale(1)'
-    },
-    '& .MuiInputLabel-shrink': {
-      transform: 'translate(14px, -9px) scale(0.75)'
     }
   },
   dialogTitle: {

--- a/app/shared/components/research-modal/research-modal-view/ResearchModalView.test.tsx
+++ b/app/shared/components/research-modal/research-modal-view/ResearchModalView.test.tsx
@@ -1,0 +1,205 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { ResearchModalView } from './ResearchModalView';
+
+jest.mock('../../composition-modal/file-item/FileItem', () => ({
+  __esModule: true,
+  default: ({ fileName, onDelete }: { fileName: string; onDelete: () => void }) => (
+    <div data-testid="mock-file-item">
+      {fileName}
+      <button type="button" onClick={onDelete}>
+        delete-file
+      </button>
+    </div>
+  )
+}));
+
+describe('ResearchModalView', () => {
+  const onClose = jest.fn();
+  const onSave = jest.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders all required form fields', () => {
+    render(<ResearchModalView isOpen onClose={onClose} onSave={onSave} />);
+
+    expect(screen.getByLabelText(/бібліографічний опис/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/автор/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/дати справи/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/ключові слова/i)).toBeInTheDocument();
+    expect(screen.getByText('Додайте файл або URL')).toBeInTheDocument();
+    expect(screen.getByLabelText(/показувати на сайті/i)).toBeInTheDocument();
+  });
+
+  it('renders Cancel and Save actions', () => {
+    render(<ResearchModalView isOpen onClose={onClose} onSave={onSave} />);
+
+    expect(screen.getByRole('button', { name: 'Скасувати' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Зберегти' })).toBeInTheDocument();
+  });
+
+  it('disables the Save button when required fields are empty', () => {
+    render(<ResearchModalView isOpen onClose={onClose} onSave={onSave} />);
+
+    expect(screen.getByRole('button', { name: 'Зберегти' })).toBeDisabled();
+  });
+
+  it('enables the Save button once all required fields are filled', () => {
+    render(<ResearchModalView isOpen onClose={onClose} onSave={onSave} />);
+
+    fireEvent.change(screen.getByLabelText(/бібліографічний опис/i), { target: { value: 'Опис' } });
+    fireEvent.change(screen.getByLabelText(/автор/i), { target: { value: 'Автор' } });
+    fireEvent.change(screen.getByLabelText(/дати справи/i), { target: { value: '1970' } });
+    fireEvent.change(screen.getByLabelText(/ключові слова/i), { target: { value: 'слово' } });
+
+    expect(screen.getByRole('button', { name: 'Зберегти' })).toBeEnabled();
+  });
+
+  it('pre-populates fields from initialData', () => {
+    render(
+      <ResearchModalView
+        isOpen
+        onClose={onClose}
+        onSave={onSave}
+        initialData={{
+          bibliographicDescription: 'Існуючий опис',
+          author: 'Існуючий автор',
+          caseDates: '1980',
+          keywords: 'існуючі слова'
+        }}
+      />
+    );
+
+    expect(screen.getByDisplayValue('Існуючий опис')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Існуючий автор')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('1980')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('існуючі слова')).toBeInTheDocument();
+  });
+
+  it('calls onClose when Cancel is clicked', () => {
+    render(<ResearchModalView isOpen onClose={onClose} onSave={onSave} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Скасувати' }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onSave with form data when Save is clicked', async () => {
+    render(<ResearchModalView isOpen onClose={onClose} onSave={onSave} />);
+
+    fireEvent.change(screen.getByLabelText(/бібліографічний опис/i), { target: { value: 'Опис' } });
+    fireEvent.change(screen.getByLabelText(/автор/i), { target: { value: 'Автор' } });
+    fireEvent.change(screen.getByLabelText(/дати справи/i), { target: { value: '1970' } });
+    fireEvent.change(screen.getByLabelText(/ключові слова/i), { target: { value: 'слово' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Зберегти' }));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bibliographicDescription: 'Опис',
+        author: 'Автор',
+        caseDates: '1970',
+        keywords: 'слово'
+      })
+    );
+  });
+
+  it('enforces the keywords character limit', () => {
+    render(<ResearchModalView isOpen onClose={onClose} onSave={onSave} />);
+
+    const longText = 'a'.repeat(300);
+    fireEvent.change(screen.getByLabelText(/ключові слова/i), { target: { value: longText } });
+
+    expect(screen.getByLabelText(/ключові слова/i)).not.toHaveValue(longText);
+  });
+
+  it('does not render the dialog content when isOpen is false', () => {
+    render(<ResearchModalView isOpen={false} onClose={onClose} onSave={onSave} />);
+
+    expect(screen.queryByLabelText(/бібліографічний опис/i)).not.toBeInTheDocument();
+  });
+
+  it('uploads a file via the file input and displays it', () => {
+    render(<ResearchModalView isOpen onClose={onClose} onSave={onSave} />);
+
+    const file = new File(['dummy content'], 'document.pdf', { type: 'application/pdf' });
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    expect(screen.getByTestId('mock-file-item')).toHaveTextContent('document.pdf');
+  });
+
+  it('disables the "Add file" button once a file is uploaded', () => {
+    render(<ResearchModalView isOpen onClose={onClose} onSave={onSave} />);
+
+    const file = new File(['dummy content'], 'document.pdf', { type: 'application/pdf' });
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    expect(screen.getByRole('button', { name: 'Додати файл' })).toBeDisabled();
+  });
+
+  it('disables the URL field once a file is uploaded', () => {
+    render(<ResearchModalView isOpen onClose={onClose} onSave={onSave} />);
+
+    const file = new File(['dummy content'], 'document.pdf', { type: 'application/pdf' });
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    expect(screen.getByLabelText(/url/i)).toBeDisabled();
+  });
+
+  it('removes the uploaded file when delete is triggered', () => {
+    render(<ResearchModalView isOpen onClose={onClose} onSave={onSave} />);
+
+    const file = new File(['dummy content'], 'document.pdf', { type: 'application/pdf' });
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+
+    fireEvent.change(fileInput, { target: { files: [file] } });
+    expect(screen.getByTestId('mock-file-item')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('delete-file'));
+
+    expect(screen.queryByTestId('mock-file-item')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Додати файл' })).toBeEnabled();
+  });
+
+  it('updates the URL field value', () => {
+    render(<ResearchModalView isOpen onClose={onClose} onSave={onSave} />);
+
+    const urlInput = screen.getByLabelText(/url/i);
+    fireEvent.change(urlInput, { target: { value: 'https://example.com/doc.pdf' } });
+
+    expect(urlInput).toHaveValue('https://example.com/doc.pdf');
+  });
+
+  it('resets the form after a successful save', async () => {
+    render(<ResearchModalView isOpen onClose={onClose} onSave={onSave} />);
+
+    fireEvent.change(screen.getByLabelText(/бібліографічний опис/i), { target: { value: 'Опис' } });
+    fireEvent.change(screen.getByLabelText(/автор/i), { target: { value: 'Автор' } });
+    fireEvent.change(screen.getByLabelText(/дати справи/i), { target: { value: '1970' } });
+    fireEvent.change(screen.getByLabelText(/ключові слова/i), { target: { value: 'слово' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Зберегти' }));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+  });
+  it('triggers the hidden file input when "Add file" is clicked', () => {
+    render(<ResearchModalView isOpen onClose={onClose} onSave={onSave} />);
+
+    const fileInput = screen.getByTestId('file-input') as HTMLInputElement;
+    const clickSpy = jest.spyOn(fileInput, 'click');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Додати файл' }));
+
+    expect(clickSpy).toHaveBeenCalled();
+  });
+});

--- a/app/shared/components/research-modal/research-modal-view/ResearchModalView.tsx
+++ b/app/shared/components/research-modal/research-modal-view/ResearchModalView.tsx
@@ -134,7 +134,9 @@ export const ResearchModalView = ({
             required
             fullWidth
             multiline
-            minRows={2}
+            minRows={1}
+            maxRows={2}
+            sx={styles.multilineField}
           />
 
           <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
@@ -156,7 +158,9 @@ export const ResearchModalView = ({
               required
               fullWidth
               multiline
-              minRows={2}
+              minRows={1}
+              maxRows={2}
+              sx={styles.multilineField}
             />
             <Typography variant="caption" sx={styles.charCounter}>
               {keywords.length}/{KEYWORDS_MAX_LENGTH}

--- a/app/shared/components/research-modal/research-modal-view/ResearchModalView.tsx
+++ b/app/shared/components/research-modal/research-modal-view/ResearchModalView.tsx
@@ -1,0 +1,214 @@
+'use client';
+
+import {
+  Box,
+  Button,
+  Checkbox,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  Stack,
+  SxProps,
+  TextField,
+  Theme,
+  Typography
+} from '@mui/material';
+import React, { useRef, useState } from 'react';
+
+import FileItem from '../../composition-modal/file-item/FileItem';
+import { styles } from './ResearchModalView.styles';
+import { sxToArray } from '~/lib/utils/sxToArray';
+
+const KEYWORDS_MAX_LENGTH = 250;
+
+export interface ResearchWorkFormData {
+  bibliographicDescription: string;
+  author: string;
+  caseDates: string;
+  keywords: string;
+  file: File | null;
+  fileName: string | null;
+  url: string;
+  isVisibleOnSite: boolean;
+}
+
+export interface ResearchModalViewProps {
+  dialogTitle?: string;
+  isOpen: boolean;
+  initialData?: Partial<ResearchWorkFormData>;
+  onClose: () => void;
+  onSave: (data: ResearchWorkFormData) => Promise<void>;
+  sx?: SxProps<Theme>;
+}
+
+const DEFAULT_DATA: ResearchWorkFormData = {
+  bibliographicDescription: '',
+  author: '',
+  caseDates: '',
+  keywords: '',
+  file: null,
+  fileName: null,
+  url: '',
+  isVisibleOnSite: true
+};
+
+export const ResearchModalView: React.FC<ResearchModalViewProps> = ({
+  dialogTitle = 'Нова робота',
+  isOpen,
+  initialData,
+  onClose,
+  onSave,
+  sx
+}) => {
+  const [bibliographicDescription, setBibliographicDescription] = useState(
+    initialData?.bibliographicDescription ?? DEFAULT_DATA.bibliographicDescription
+  );
+  const [author, setAuthor] = useState(initialData?.author ?? DEFAULT_DATA.author);
+  const [caseDates, setCaseDates] = useState(initialData?.caseDates ?? DEFAULT_DATA.caseDates);
+  const [keywords, setKeywords] = useState(initialData?.keywords ?? DEFAULT_DATA.keywords);
+  const [file, setFile] = useState<File | null>(initialData?.file ?? DEFAULT_DATA.file);
+  const [fileName, setFileName] = useState<string | null>(initialData?.fileName ?? DEFAULT_DATA.fileName);
+  const [url, setUrl] = useState(initialData?.url ?? DEFAULT_DATA.url);
+  const [isVisibleOnSite, setIsVisibleOnSite] = useState(initialData?.isVisibleOnSite ?? DEFAULT_DATA.isVisibleOnSite);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const resetForm = () => {
+    setBibliographicDescription(DEFAULT_DATA.bibliographicDescription);
+    setAuthor(DEFAULT_DATA.author);
+    setCaseDates(DEFAULT_DATA.caseDates);
+    setKeywords(DEFAULT_DATA.keywords);
+    setFile(DEFAULT_DATA.file);
+    setFileName(DEFAULT_DATA.fileName);
+    setUrl(DEFAULT_DATA.url);
+    setIsVisibleOnSite(DEFAULT_DATA.isVisibleOnSite);
+    setIsSaving(false);
+  };
+
+  const handleCancel = () => {
+    resetForm();
+    onClose();
+  };
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    await onSave({ bibliographicDescription, author, caseDates, keywords, file, fileName, url, isVisibleOnSite });
+    resetForm();
+  };
+
+  const handleFileButtonClick = () => fileInputRef.current?.click();
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = event.target.files?.[0];
+    if (selected) {
+      setFile(selected);
+      setFileName(selected.name);
+    }
+    event.target.value = '';
+  };
+
+  const handleFileDelete = () => {
+    setFile(null);
+    setFileName(null);
+  };
+
+  const isFormValid = Boolean(bibliographicDescription.trim() && author.trim() && caseDates.trim() && keywords.trim());
+
+  return (
+    <Dialog disableScrollLock open={isOpen} sx={{ ...styles.dialog, ...sxToArray(sx) }} onClose={onClose} fullWidth>
+      <DialogTitle sx={styles.dialogTitle}>{dialogTitle}</DialogTitle>
+
+      <DialogContent sx={styles.dialogContent}>
+        <Stack spacing={3} sx={styles.contentContainer}>
+          <TextField
+            label="Бібліографічний опис"
+            value={bibliographicDescription}
+            onChange={(e) => setBibliographicDescription(e.target.value)}
+            required
+            fullWidth
+            multiline
+            minRows={2}
+          />
+
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+            <TextField label="Автор" value={author} onChange={(e) => setAuthor(e.target.value)} required fullWidth />
+            <TextField
+              label="Дати справи"
+              value={caseDates}
+              onChange={(e) => setCaseDates(e.target.value)}
+              required
+              fullWidth
+            />
+          </Stack>
+
+          <Box>
+            <TextField
+              label="Ключові слова"
+              value={keywords}
+              onChange={(e) => e.target.value.length <= KEYWORDS_MAX_LENGTH && setKeywords(e.target.value)}
+              required
+              fullWidth
+              multiline
+              minRows={2}
+            />
+            <Typography variant="caption" sx={styles.charCounter}>
+              {keywords.length}/{KEYWORDS_MAX_LENGTH}
+            </Typography>
+          </Box>
+
+          <Stack spacing={2}>
+            <Typography variant="subtitle2" sx={styles.fileSectionTitle}>
+              Додайте файл або URL
+            </Typography>
+
+            <Stack direction="row" alignItems="center" spacing={0} sx={styles.fileRow}>
+              <Typography variant="body2" sx={styles.fileLabel}>
+                Файл
+              </Typography>
+              <Box sx={styles.fileRowDivider} />
+              <Button variant="text" onClick={handleFileButtonClick} disabled={!!file} sx={styles.addFileButton}>
+                Додати файл
+              </Button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                hidden
+                accept="application/pdf,.pdf"
+                onChange={handleFileChange}
+                data-testid="file-input"
+              />
+            </Stack>
+
+            {fileName && <FileItem fileName={fileName} fileType="pdf" onDelete={handleFileDelete} />}
+
+            <TextField label="URL" value={url} onChange={(e) => setUrl(e.target.value)} fullWidth disabled={!!file} />
+          </Stack>
+
+          <FormControlLabel
+            control={<Checkbox checked={isVisibleOnSite} onChange={(e) => setIsVisibleOnSite(e.target.checked)} />}
+            label="Показувати на сайті"
+          />
+        </Stack>
+      </DialogContent>
+
+      <DialogActions sx={styles.dialogActions}>
+        <Button onClick={handleCancel} disabled={isSaving} variant="outlined" sx={styles.cancelButton}>
+          Скасувати
+        </Button>
+        <Button
+          variant="contained"
+          color="tertiary"
+          onClick={handleSave}
+          disabled={!isFormValid || isSaving}
+          disableElevation
+          sx={styles.saveButton}
+        >
+          {isSaving ? 'Збереження...' : 'Зберегти'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/app/shared/components/research-modal/research-modal-view/ResearchModalView.tsx
+++ b/app/shared/components/research-modal/research-modal-view/ResearchModalView.tsx
@@ -54,14 +54,14 @@ const DEFAULT_DATA: ResearchWorkFormData = {
   isVisibleOnSite: true
 };
 
-export const ResearchModalView: React.FC<ResearchModalViewProps> = ({
+export const ResearchModalView = ({
   dialogTitle = 'Нова робота',
   isOpen,
   initialData,
   onClose,
   onSave,
   sx
-}) => {
+}: ResearchModalViewProps) => {
   const [bibliographicDescription, setBibliographicDescription] = useState(
     initialData?.bibliographicDescription ?? DEFAULT_DATA.bibliographicDescription
   );
@@ -95,8 +95,12 @@ export const ResearchModalView: React.FC<ResearchModalViewProps> = ({
 
   const handleSave = async () => {
     setIsSaving(true);
-    await onSave({ bibliographicDescription, author, caseDates, keywords, file, fileName, url, isVisibleOnSite });
-    resetForm();
+    try {
+      await onSave({ bibliographicDescription, author, caseDates, keywords, file, fileName, url, isVisibleOnSite });
+      resetForm();
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   const handleFileButtonClick = () => fileInputRef.current?.click();

--- a/app/shared/components/table-layout/components/EditAction.tsx
+++ b/app/shared/components/table-layout/components/EditAction.tsx
@@ -10,31 +10,18 @@ type EditActionProps = Readonly<{
 }>;
 
 export function EditAction({ href, label, onClick }: EditActionProps) {
-  if (onClick) {
-    return (
-      <Box sx={styles.editActionWrapper}>
-        <IconButton
-          onClick={(e) => {
-            e.stopPropagation();
-            onClick();
-          }}
-          aria-label={label}
-          sx={styles.editActionButton}
-        >
-          <Pencil size={20} />
-        </IconButton>
-      </Box>
-    );
-  }
+  const clickProps = onClick
+    ? {
+      onClick: (e: React.MouseEvent) => {
+        e.stopPropagation();
+        onClick();
+      }
+    }
+    : { component: Link, href, onClick: (e: React.MouseEvent) => e.stopPropagation() };
+
   return (
     <Box sx={styles.editActionWrapper}>
-      <IconButton
-        component={Link}
-        href={href}
-        onClick={(e) => e.stopPropagation()}
-        aria-label={label}
-        sx={styles.editActionButton}
-      >
+      <IconButton {...clickProps} aria-label={label} sx={styles.editActionButton}>
         <Pencil size={20} />
       </IconButton>
     </Box>

--- a/app/shared/components/table-layout/components/EditAction.tsx
+++ b/app/shared/components/table-layout/components/EditAction.tsx
@@ -3,7 +3,29 @@ import { Pencil } from 'lucide-react';
 
 import { styles } from './EditAction.styles';
 
-export function EditAction({ href, label }: Readonly<{ href: string; label: string }>) {
+type EditActionProps = Readonly<{
+  label: string;
+  href?: string;
+  onClick?: () => void;
+}>;
+
+export function EditAction({ href, label, onClick }: EditActionProps) {
+  if (onClick) {
+    return (
+      <Box sx={styles.editActionWrapper}>
+        <IconButton
+          onClick={(e) => {
+            e.stopPropagation();
+            onClick();
+          }}
+          aria-label={label}
+          sx={styles.editActionButton}
+        >
+          <Pencil size={20} />
+        </IconButton>
+      </Box>
+    );
+  }
   return (
     <Box sx={styles.editActionWrapper}>
       <IconButton

--- a/app/shared/components/table-layout/components/RowActions.tsx
+++ b/app/shared/components/table-layout/components/RowActions.tsx
@@ -7,7 +7,7 @@ import { EditAction } from './EditAction';
 import { styles } from './RowActions.styles';
 
 type RowActionsProps = Readonly<{
-  editAction?: { editHref: string; editLabel: string };
+  editAction?: { editHref?: string; editLabel: string; onEditClick?: () => void };
   menuActions?: { menuItems: ActionMenuGroups; menuTriggerLabel: string };
 }>;
 
@@ -16,7 +16,9 @@ export function RowActions({ editAction, menuActions }: RowActionsProps) {
 
   return (
     <Box sx={styles.rowActionsCell}>
-      {editAction && <EditAction href={editAction.editHref} label={editAction.editLabel} />}
+      {editAction && (
+        <EditAction href={editAction.editHref} label={editAction.editLabel} onClick={editAction.onEditClick} />
+      )}
       {menuActions && <ContextMenu items={menuActions.menuItems} triggerLabel={menuActions.menuTriggerLabel} />}
     </Box>
   );


### PR DESCRIPTION
## Description

Implemented a dedicated modal for creating and editing "Дослідження та наукові праці" (research/scientific works) in the admin panel, reusing the structure and styling patterns of `CompositionModal.tsx`.

- Added `ResearchModal` (`app/shared/components/research-modal/ResearchModal.tsx`) — a thin wrapper handling save/error toasts and passing create/edit mode + initial data to the view
- Added `ResearchModalView` — the actual dialog UI with all required fields: Бібліографічний опис, Автор, Дати справи, Ключові слова, file/URL upload section (reusing `FileItem` from the composition modal), and a "Показувати на сайті" checkbox
- Wired the modal into `ResearchPageContent`:
  - "Додати роботу" button in the header opens the modal in **create** mode
  - The edit (pencil) icon and "Редагувати" menu item in each table row open the modal in **edit** mode, pre-filled with the row's data
- Updated `ResearchTable`/`RowActions`/`EditAction` to support an `onClick`-based edit trigger (in addition to the existing `href`-based one), since there is no dedicated edit route yet
- Save currently only shows a success/error toast and closes the modal (no backend/API call yet) 
- Added unit tests for `ResearchModal`, `ResearchModalView`, and updated tests across `ResearchPageContent`, `ResearchContent`, `ResearchTable`, and `ResearchCreateAction` to cover the new modal wiring

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Navigate to **Каталоги → Дослідження та наукові праці**
2. Click **"Додати роботу"** in the header — the modal should open in create mode with empty fields
3. Fill in all required fields (Бібліографічний опис, Автор, Дати справи, Ключові слова) and click **"Зберегти"** — a success toast should appear and the modal should close
4. Click **"Скасувати"** — the modal should close and reset without saving
5. In the table, click the pencil icon on any row — the modal should open in edit mode, pre-filled with that row's data
6. Try uploading a PDF file via "Додати файл" — it should appear as a file item and disable the URL field 

## Video / Screenshots


https://github.com/user-attachments/assets/c4aa82e1-aa39-442c-87a0-b6670b59ec28


## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---

Close #668 