### PR TITLE
fix: enforce meta title length limits (2-150 chars) on create / update news

### DIFF
--- a/app/constants/errors.ts
+++ b/app/constants/errors.ts
@@ -117,12 +117,14 @@ export const MediaMentionsErrors = {
 export const seoFormErrors = {
   uk: {
     minLength: 'Мінімум 2 символа',
+    maxLength: 'Максимум 150 символів',
     required: 'Обовʼязкове поле',
     invalidUrl: 'Некоректний URL',
     keywords: 'Ключові слова мають бути через кому, без порожніх значень'
   },
   en: {
     minLength: 'Minimum 2 characters',
+    maxLength: 'Maximum 150 characters',
     required: 'Required field',
     invalidUrl: 'Invalid URL',
     keywords: 'Keywords must be comma-separated, without empty values'

--- a/app/constants/publications.ts
+++ b/app/constants/publications.ts
@@ -273,6 +273,8 @@ export const ADMIN_TITLE_LABELS: Record<PublicationsItemType, string> = {
   media: 'Назва публікації в адмінці'
 } as const;
 
+export const META_TITLE_MAX_LENGTH = 150;
+
 export const CROP_RATIOS = {
   HERO_BANNER: 816 / 300,
   FUNDATION_PROFILE_SMALL: 336 / 400,

--- a/app/shared/components/forms/seo-metadata-form/SeoMetadataForm.test.tsx
+++ b/app/shared/components/forms/seo-metadata-form/SeoMetadataForm.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 import { SeoCanonicalUrlField } from './seo-canonicalurl-field/SeoCanonicalUrlField';
 import SeoMetadataForm, { SeoMetadataFormProps } from './SeoMetadataForm';
+import { META_TITLE_MAX_LENGTH } from '~/constants/publications';
 
 jest.mock('~/shared/components/design-system/photo-block/PhotoBlock', () => ({
   ImagePreviewBlock: ({
@@ -88,6 +89,26 @@ describe('SeoMetadataForm', () => {
     await user.click(input);
     await user.tab();
     expect(await screen.findByText(/мінімум 2 символа/i)).toBeInTheDocument();
+  });
+
+  it('rejects title longer than the maximum length on blur, respects input maxLength attribute', async () => {
+    renderWithState();
+    const input = screen.getByLabelText(/meta title/i) as HTMLInputElement;
+
+    expect(input).toHaveAttribute('maxlength', String(META_TITLE_MAX_LENGTH));
+
+    fireEvent.change(input, { target: { value: 'a'.repeat(META_TITLE_MAX_LENGTH + 1) } });
+    fireEvent.blur(input);
+    expect(await screen.findByText(/максимум 150 символів/i)).toBeInTheDocument();
+  });
+
+  it('accepts title within the allowed length range', async () => {
+    renderWithState();
+    const input = screen.getByLabelText(/meta title/i);
+
+    await user.type(input, 'Валідний заголовок');
+    fireEvent.blur(input);
+    expect(screen.queryByText(/мінімум|максимум/i)).not.toBeInTheDocument();
   });
 
   it('calls onIndexingChange', async () => {

--- a/app/shared/components/forms/seo-metadata-form/SeoMetadataForm.tsx
+++ b/app/shared/components/forms/seo-metadata-form/SeoMetadataForm.tsx
@@ -95,8 +95,12 @@ export default function SeoMetadataForm({
 
   const validateField = (field: keyof LocalizedMeta, val: string) => {
     switch (field) {
-    case 'title':
-      return val.trim().length < 2 ? translationErrors.minLength : '';
+    case 'title': {
+      const length = val.trim().length;
+      if (length < 2) return translationErrors.minLength;
+      if (length > 150) return translationErrors.maxLength;
+      return '';
+    }
     case 'description':
       return val.trim() ? '' : translationErrors.required;
     case 'canonicalUrl':

--- a/app/shared/components/forms/seo-metadata-form/seo-base-fields/SeoBaseFields.tsx
+++ b/app/shared/components/forms/seo-metadata-form/seo-base-fields/SeoBaseFields.tsx
@@ -2,6 +2,7 @@ import { Stack, TextField } from '@mui/material';
 
 import type { LocalizedMeta } from '../SeoMetadataForm';
 import { styles } from '../SeoMetadataForm.styles';
+import { META_TITLE_MAX_LENGTH } from '~/constants/publications';
 
 interface SeoBaseFieldsProps {
   readonly value: LocalizedMeta;
@@ -19,7 +20,7 @@ interface SeoBaseFieldsProps {
 
 export function SeoBaseFields({ value, errors, touched, onFieldChange, onBlur, showKeywords = true, labels = {} }: SeoBaseFieldsProps) {
   const fields = [
-    { key: 'title' as const, label: labels.metaTitle || 'Meta title', required: true },
+    { key: 'title' as const, label: labels.metaTitle || 'Meta title', required: true, maxLength: META_TITLE_MAX_LENGTH },
     {
       key: 'description' as const,
       label: labels.metaDescription || 'Meta description',
@@ -33,7 +34,7 @@ export function SeoBaseFields({ value, errors, touched, onFieldChange, onBlur, s
 
   return (
     <Stack direction="column" spacing={2.5} sx={styles.formFieldsContainer}>
-      {fields.map(({ key, label, required, multiline, minRows, maxRows }) => (
+      {fields.map(({ key, label, required, multiline, minRows, maxRows, maxLength }) => (
         <TextField
           key={key}
           label={label}
@@ -48,6 +49,7 @@ export function SeoBaseFields({ value, errors, touched, onFieldChange, onBlur, s
           multiline={multiline}
           minRows={minRows}
           maxRows={maxRows}
+          slotProps={maxLength ? { htmlInput: { maxLength } } : undefined}
         />
       ))}
     </Stack>

--- a/src/constants/errors.ts
+++ b/src/constants/errors.ts
@@ -32,7 +32,8 @@ export const newsServiceErrors = {
   FAILED_TO_HIDE: (id: string) => `Failed to hide news with id "${id}"`,
   FAILED_TO_DELETE: (id: string) => `News with id "${id}" not found or could not be deleted`,
   TITLE_REQUIRED_FOR_SLUG: 'Title is required to generate a slug',
-  TITLE_TOO_SHORT_FOR_SLUG: 'Title must be at least 2 characters long to generate a slug'
+  TITLE_TOO_SHORT_FOR_SLUG: 'Title must be at least 2 characters long to generate a slug',
+  TITLE_TOO_LONG_FOR_SLUG: 'Title must not exceed 150 characters'
 };
 
 export const opusServiceErrors = {

--- a/src/interfaces/graphql/resolvers/news/newsMutation.test.ts
+++ b/src/interfaces/graphql/resolvers/news/newsMutation.test.ts
@@ -138,6 +138,17 @@ describe('NewsMutation Resolvers', () => {
       expect(mockRepo.create).toHaveBeenCalled();
     });
 
+    it('should accept and trim a title with 150 meaningful characters plus a trailing space (review feedback)', async () => {
+      mockAction('findBySlug', null);
+      mockAction('create', createMockNews({ id: 'new-id' }));
+      const validInput = { ...baseInput, title: { uk: `${'a'.repeat(150)} `, en: 'Valid title' } };
+
+      await expect(NewsMutation.createNews({}, { input: validInput }, adminContext)).resolves.toBeDefined();
+
+      const createCallArg = (mockRepo.create as jest.Mock).mock.calls[0][0];
+      expect(createCallArg.title.uk).toBe('a'.repeat(150));
+    });
+
     it('should throw GraphQLError for createNews if user is unauthenticated', async () => {
       await expect(NewsMutation.createNews({}, { input: baseInput }, userContext)).rejects.toThrow();
     });
@@ -226,6 +237,20 @@ describe('NewsMutation Resolvers', () => {
       }
 
       expect(mockRepo.update).not.toHaveBeenCalled();
+    });
+
+    it('should accept and trim an updated title with 150 meaningful characters plus a trailing space (review feedback)', async () => {
+      mockAction('findById', createMockNews({ id }));
+      mockAction('update', createMockNews({ id }));
+
+      await NewsMutation.updateNews(
+        {},
+        { id, input: { title: { uk: `${'a'.repeat(150)} `, en: 'Valid title' } } },
+        adminContext
+      );
+
+      const updateCallArg = (mockRepo.update as jest.Mock).mock.calls[0][1];
+      expect(updateCallArg.title.uk).toBe('a'.repeat(150));
     });
 
     it('should fall back to empty content object structure during processContentFields execution if content property is missing', async () => {

--- a/src/interfaces/graphql/resolvers/news/newsMutation.test.ts
+++ b/src/interfaces/graphql/resolvers/news/newsMutation.test.ts
@@ -101,6 +101,29 @@ describe('NewsMutation Resolvers', () => {
       );
     });
 
+    it('should throw TITLE_TOO_LONG_FOR_SLUG if title.uk exceeds 150 characters (lf-manual-tests#469)', async () => {
+      const invalidInput = { ...baseInput, title: { uk: 'а'.repeat(151), en: 'Valid title' } };
+      await expect(NewsMutation.createNews({}, { input: invalidInput }, adminContext)).rejects.toThrow(
+        newsServiceErrors.TITLE_TOO_LONG_FOR_SLUG
+      );
+    });
+
+    it('should throw TITLE_TOO_LONG_FOR_SLUG if title.en exceeds 150 characters (lf-manual-tests#469)', async () => {
+      const invalidInput = { ...baseInput, title: { uk: 'Валідний заголовок', en: 'a'.repeat(151) } };
+      await expect(NewsMutation.createNews({}, { input: invalidInput }, adminContext)).rejects.toThrow(
+        newsServiceErrors.TITLE_TOO_LONG_FOR_SLUG
+      );
+    });
+
+    it('should accept a title exactly 150 characters long', async () => {
+      mockAction('findBySlug', null);
+      mockAction('create', createMockNews({ id: 'new-id' }));
+      const validInput = { ...baseInput, title: { uk: 'а'.repeat(150), en: 'a'.repeat(150) } };
+
+      await expect(NewsMutation.createNews({}, { input: validInput }, adminContext)).resolves.toBeDefined();
+      expect(mockRepo.create).toHaveBeenCalled();
+    });
+
     it('should throw GraphQLError for createNews if user is unauthenticated', async () => {
       await expect(NewsMutation.createNews({}, { input: baseInput }, userContext)).rejects.toThrow();
     });
@@ -168,6 +191,16 @@ describe('NewsMutation Resolvers', () => {
       await expect(
         NewsMutation.updateNews({}, { id, input: { title: { uk: 'Т', en: 'T' } } }, adminContext)
       ).rejects.toThrow(newsServiceErrors.TITLE_TOO_SHORT_FOR_SLUG);
+
+      expect(mockRepo.update).not.toHaveBeenCalled();
+    });
+
+    it('should throw TITLE_TOO_LONG_FOR_SLUG if updated title.uk exceeds 150 characters (lf-manual-tests#469)', async () => {
+      mockAction('findById', createMockNews({ id }));
+
+      await expect(
+        NewsMutation.updateNews({}, { id, input: { title: { uk: 'а'.repeat(151), en: 'Valid title' } } }, adminContext)
+      ).rejects.toThrow(newsServiceErrors.TITLE_TOO_LONG_FOR_SLUG);
 
       expect(mockRepo.update).not.toHaveBeenCalled();
     });

--- a/src/interfaces/graphql/resolvers/news/newsMutation.test.ts
+++ b/src/interfaces/graphql/resolvers/news/newsMutation.test.ts
@@ -1,3 +1,5 @@
+import { GraphQLError } from 'graphql';
+
 import { CreateNewsGQLInput, NewsMutation, UpdateNewsGQLInput } from './newsMutation';
 import type { News } from '~/domain/entities/News';
 import { createMockContext } from '~/interfaces/graphql/resolvers/testUtils';
@@ -101,18 +103,30 @@ describe('NewsMutation Resolvers', () => {
       );
     });
 
-    it('should throw TITLE_TOO_LONG_FOR_SLUG if title.uk exceeds 150 characters (lf-manual-tests#469)', async () => {
+    it('should throw GraphQLError with BAD_USER_INPUT if title.uk exceeds 150 characters (lf-manual-tests#469)', async () => {
+      expect.assertions(3);
       const invalidInput = { ...baseInput, title: { uk: 'а'.repeat(151), en: 'Valid title' } };
-      await expect(NewsMutation.createNews({}, { input: invalidInput }, adminContext)).rejects.toThrow(
-        newsServiceErrors.TITLE_TOO_LONG_FOR_SLUG
-      );
+
+      try {
+        await NewsMutation.createNews({}, { input: invalidInput }, adminContext);
+      } catch (error) {
+        expect(error).toBeInstanceOf(GraphQLError);
+        expect((error as GraphQLError).message).toBe(newsServiceErrors.TITLE_TOO_LONG_FOR_SLUG);
+        expect((error as GraphQLError).extensions.code).toBe('BAD_USER_INPUT');
+      }
     });
 
-    it('should throw TITLE_TOO_LONG_FOR_SLUG if title.en exceeds 150 characters (lf-manual-tests#469)', async () => {
+    it('should throw GraphQLError with BAD_USER_INPUT if title.en exceeds 150 characters (lf-manual-tests#469)', async () => {
+      expect.assertions(3);
       const invalidInput = { ...baseInput, title: { uk: 'Валідний заголовок', en: 'a'.repeat(151) } };
-      await expect(NewsMutation.createNews({}, { input: invalidInput }, adminContext)).rejects.toThrow(
-        newsServiceErrors.TITLE_TOO_LONG_FOR_SLUG
-      );
+
+      try {
+        await NewsMutation.createNews({}, { input: invalidInput }, adminContext);
+      } catch (error) {
+        expect(error).toBeInstanceOf(GraphQLError);
+        expect((error as GraphQLError).message).toBe(newsServiceErrors.TITLE_TOO_LONG_FOR_SLUG);
+        expect((error as GraphQLError).extensions.code).toBe('BAD_USER_INPUT');
+      }
     });
 
     it('should accept a title exactly 150 characters long', async () => {
@@ -195,12 +209,21 @@ describe('NewsMutation Resolvers', () => {
       expect(mockRepo.update).not.toHaveBeenCalled();
     });
 
-    it('should throw TITLE_TOO_LONG_FOR_SLUG if updated title.uk exceeds 150 characters (lf-manual-tests#469)', async () => {
+    it('should throw GraphQLError with BAD_USER_INPUT if updated title.uk exceeds 150 characters (lf-manual-tests#469)', async () => {
+      expect.assertions(4);
       mockAction('findById', createMockNews({ id }));
 
-      await expect(
-        NewsMutation.updateNews({}, { id, input: { title: { uk: 'а'.repeat(151), en: 'Valid title' } } }, adminContext)
-      ).rejects.toThrow(newsServiceErrors.TITLE_TOO_LONG_FOR_SLUG);
+      try {
+        await NewsMutation.updateNews(
+          {},
+          { id, input: { title: { uk: 'а'.repeat(151), en: 'Valid title' } } },
+          adminContext
+        );
+      } catch (error) {
+        expect(error).toBeInstanceOf(GraphQLError);
+        expect((error as GraphQLError).message).toBe(newsServiceErrors.TITLE_TOO_LONG_FOR_SLUG);
+        expect((error as GraphQLError).extensions.code).toBe('BAD_USER_INPUT');
+      }
 
       expect(mockRepo.update).not.toHaveBeenCalled();
     });

--- a/src/interfaces/graphql/resolvers/news/newsMutation.ts
+++ b/src/interfaces/graphql/resolvers/news/newsMutation.ts
@@ -66,7 +66,9 @@ const validateTitleMaxLength = (title: LocalizedString | undefined): void => {
   (['uk', 'en'] as const).forEach((lang) => {
     const value = title[lang];
     if (typeof value === 'string' && value.trim().length > TITLE_MAX_LENGTH) {
-      throw new Error(newsServiceErrors.TITLE_TOO_LONG_FOR_SLUG);
+      throw new GraphQLError(newsServiceErrors.TITLE_TOO_LONG_FOR_SLUG, {
+        extensions: { code: 'BAD_USER_INPUT' }
+      });
     }
   });
 };

--- a/src/interfaces/graphql/resolvers/news/newsMutation.ts
+++ b/src/interfaces/graphql/resolvers/news/newsMutation.ts
@@ -58,6 +58,19 @@ const processContentFields = async (input: UpdateNewsGQLInput, updateData: Updat
   }
 };
 
+const TITLE_MAX_LENGTH = 150;
+
+const validateTitleMaxLength = (title: LocalizedString | undefined): void => {
+  if (!title) return;
+
+  (['uk', 'en'] as const).forEach((lang) => {
+    const value = title[lang];
+    if (typeof value === 'string' && value.trim().length > TITLE_MAX_LENGTH) {
+      throw new Error(newsServiceErrors.TITLE_TOO_LONG_FOR_SLUG);
+    }
+  });
+};
+
 const endpointHandler = endpointRepositoryHandler('newsRepository');
 
 export const NewsMutation = {
@@ -77,6 +90,8 @@ export const NewsMutation = {
     } else if (titleForSlug.trim().length < 2) {
       throw new Error(newsServiceErrors.TITLE_TOO_SHORT_FOR_SLUG);
     }
+
+    validateTitleMaxLength(input.title);
 
     const slug = await generateUniqueSlug(titleForSlug, {
       checkExists: async (slug: string) => {
@@ -142,6 +157,8 @@ export const NewsMutation = {
       } else if (titleForSlug.trim().length < 2) {
         throw new Error(newsServiceErrors.TITLE_TOO_SHORT_FOR_SLUG);
       }
+
+      validateTitleMaxLength(input.title);
 
       await processSlugUpdate(id, input.title, repo, updateData);
     }

--- a/src/interfaces/graphql/resolvers/news/newsMutation.ts
+++ b/src/interfaces/graphql/resolvers/news/newsMutation.ts
@@ -73,6 +73,24 @@ const validateTitleMaxLength = (title: LocalizedString | undefined): void => {
   });
 };
 
+// Trims uk/en title values so the persisted title always matches what was validated
+// (validation checks trimmed length; without this, a title with trailing/leading
+// whitespace could be stored with a raw length different from its validated length).
+const trimLocalizedTitle = (title: LocalizedString | undefined): LocalizedString | undefined => {
+  if (!title) return title;
+
+  const trimmed: LocalizedString = { ...title };
+
+  (['uk', 'en'] as const).forEach((lang) => {
+    const value = title[lang];
+    if (typeof value === 'string') {
+      trimmed[lang] = value.trim();
+    }
+  });
+
+  return trimmed;
+};
+
 const endpointHandler = endpointRepositoryHandler('newsRepository');
 
 export const NewsMutation = {
@@ -106,6 +124,7 @@ export const NewsMutation = {
 
     const newsData: CreateNewsInput = {
       ...processedInput,
+      title: trimLocalizedTitle(input.title) ?? input.title,
       slug,
       newsDate: input.newsDate,
       status: input.status || NewsStatus.Draft,
@@ -163,6 +182,7 @@ export const NewsMutation = {
       validateTitleMaxLength(input.title);
 
       await processSlugUpdate(id, input.title, repo, updateData);
+      updateData.title = trimLocalizedTitle(input.title) ?? input.title;
     }
 
     const res = await repo.update(id, updateData);

--- a/src/interfaces/graphql/resolvers/news/newsMutation.ts
+++ b/src/interfaces/graphql/resolvers/news/newsMutation.ts
@@ -73,9 +73,6 @@ const validateTitleMaxLength = (title: LocalizedString | undefined): void => {
   });
 };
 
-// Trims uk/en title values so the persisted title always matches what was validated
-// (validation checks trimmed length; without this, a title with trailing/leading
-// whitespace could be stored with a raw length different from its validated length).
 const trimLocalizedTitle = (title: LocalizedString | undefined): LocalizedString | undefined => {
   if (!title) return title;
 


### PR DESCRIPTION
## Description

Closes https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/469

Fixes lf-manual-tests#469: the GraphQL API (`createNews`/`updateNews`)
accepted a meta `title` (uk/en) longer than the documented 150-character
limit, silently saving it as the public H1.

This PR adds server-side and client-side max-length validation (150
characters) for the news title, additive to the min-length validation
already merged in #695 — no duplication of that logic.

## Changes

- `src/interfaces/graphql/resolvers/news/newsMutation.ts`: add
  `validateTitleMaxLength()`, called in both `createNews` and
  `updateNews`, checking `title.uk` and `title.en` independently.
  Throws `GraphQLError` with `extensions.code: 'BAD_USER_INPUT'`
  (matches the convention used elsewhere, e.g. `opusMutation.ts`).
- `src/interfaces/graphql/resolvers/news/newsMutation.ts`: add
  `trimLocalizedTitle()` — the title is trimmed before being persisted,
  so the stored value always matches what was validated (avoids a
  151-raw-character title with a trailing space being accepted as
  "150 characters" without normalizing storage).
- `src/constants/errors.ts`: add `TITLE_TOO_LONG_FOR_SLUG` message.
- `app/constants/publications.ts`: add `META_TITLE_MAX_LENGTH = 150`.
- `app/constants/errors.ts`: add `maxLength` message to `seoFormErrors`
  (uk/en).
- `SeoMetadataForm.tsx`: validate title length against the max on blur.
- `SeoBaseFields.tsx`: enforce `maxLength` on the meta title `TextField`
  via `slotProps.htmlInput`.
- Tests added/extended in `newsMutation.test.ts` and
  `SeoMetadataForm.test.tsx` covering: exactly 150 chars (valid), 151
  chars (rejected, both uk/en), and 150 chars + trailing whitespace
  (accepted and trimmed on store).

## Manual test steps

1. `createNews`/`updateNews` with `title.uk` or `title.en` at 151
   characters → expect `errors[0].extensions.code === "BAD_USER_INPUT"`.
2. Same with exactly 150 characters → expect success.
3. Same with 150 characters + trailing space → expect success, and the
   stored title has no trailing space.

## Related

- #602, #680 — drag-and-drop reordering (unrelated, referenced for
  context only)
- #695 — min-length validation this PR builds on top of (not duplicated)

## Video / Screenshots

<img width="828" height="701" alt="image" src="https://github.com/user-attachments/assets/a884e185-ee5f-48a3-a26a-9ee68c3b15e8" />
<img width="815" height="707" alt="image" src="https://github.com/user-attachments/assets/f3d6e257-4fe1-45d6-a4a5-4f14696a6337" />
