### PR TITLE
Fix: Store uploaded files by name and support R2 rename

### DIFF
--- a/app/(logged_in)/files/FilesPageContent.test.tsx
+++ b/app/(logged_in)/files/FilesPageContent.test.tsx
@@ -729,6 +729,62 @@ describe('FilesPageContent', () => {
     });
   });
 
+  it('deletes an orphan root R2 file through the root uploads endpoint', async () => {
+    const rootR2File = {
+      ...orphanR2File,
+      filename: 'root-file.pdf',
+      originalName: 'root-file.pdf',
+      mimeType: 'application/pdf',
+      url: 'https://r2.example.com/root-file.pdf'
+    };
+    mockR2Files = [rootR2File];
+    const createAsset = jest.fn();
+    const deleteAsset = jest.fn();
+
+    setupHooks({ assets: [], createAsset, deleteAsset });
+    render(<FilesPageContent activeTab="all" />);
+
+    expect(await screen.findByTestId('files-cards-layout')).toBeInTheDocument();
+    const orphanItem = capturedCardsProps?.items[0];
+    expect(orphanItem).toBeDefined();
+
+    if (!orphanItem) return;
+
+    fireEvent.click(screen.getByText(`delete-${orphanItem.id}`));
+    fireEvent.click(await screen.findByText('confirm-delete'));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith('/api/uploads/root-file.pdf', { method: 'DELETE' });
+      expect(createAsset).not.toHaveBeenCalled();
+      expect(deleteAsset).not.toHaveBeenCalled();
+    });
+  });
+
+  it('shows an error toast when orphan R2 delete cannot resolve a filename', async () => {
+    const rootUrlWithoutFilename = {
+      ...orphanR2File,
+      url: 'https://r2.example.com'
+    };
+    mockR2Files = [rootUrlWithoutFilename];
+
+    setupHooks({ assets: [] });
+    render(<FilesPageContent activeTab="all" />);
+
+    expect(await screen.findByTestId('files-cards-layout')).toBeInTheDocument();
+    const orphanItem = capturedCardsProps?.items[0];
+    expect(orphanItem).toBeDefined();
+
+    if (!orphanItem) return;
+
+    fireEvent.click(screen.getByText(`delete-${orphanItem.id}`));
+    fireEvent.click(await screen.findByText('confirm-delete'));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Не вдалося визначити файл.');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
   it('keeps an orphan R2 file visible when cloud delete fails', async () => {
     mockR2Files = [orphanR2File];
     mockFetch.mockResolvedValue({
@@ -804,7 +860,7 @@ describe('FilesPageContent', () => {
     fireEvent.click(screen.getByText('download-1'));
 
     await waitFor(() => {
-      expect(downloadFile).toHaveBeenCalledWith(baseAsset.url, baseAsset.originalname);
+      expect(downloadFile).toHaveBeenCalledWith(baseAsset.url, baseAsset.filename);
     });
   });
 
@@ -826,6 +882,24 @@ describe('FilesPageContent', () => {
         '/api/uploads/Test_image_1.jpeg?folder=photos',
         'Test_image_1.jpeg'
       );
+    });
+  });
+
+  it('downloads a root R2 file directly when no folder is present', async () => {
+    const rootR2Asset = {
+      ...baseAsset,
+      url: 'https://pub-2b50c59c64954ab89b7837f9f4607e12.r2.dev/root-file.pdf',
+      filename: 'root-file.pdf',
+      originalname: 'root-file.pdf'
+    };
+
+    setupHooks({ assets: [rootR2Asset] });
+    render(<FilesPageContent activeTab="all" />);
+
+    fireEvent.click(screen.getByText('download-1'));
+
+    await waitFor(() => {
+      expect(downloadFile).toHaveBeenCalledWith(rootR2Asset.url, 'root-file.pdf');
     });
   });
 
@@ -897,12 +971,14 @@ describe('FilesPageContent', () => {
     const orphanItem = capturedCardsProps?.items[0];
     expect(orphanItem).toBeDefined();
 
-    if (!orphanItem || !capturedCardsProps) return;
+    const cardsProps = capturedCardsProps;
+
+    if (!orphanItem || !cardsProps) return;
 
     fireEvent.click(screen.getByText(`select-${orphanItem.id}`));
 
     await act(async () => {
-      await capturedCardsProps.onItemToggleStar(orphanItem, true);
+      await cardsProps.onItemToggleStar(orphanItem, true);
     });
 
     expect(updateAsset).toHaveBeenCalledWith({

--- a/app/(logged_in)/files/FilesPageContent.test.tsx
+++ b/app/(logged_in)/files/FilesPageContent.test.tsx
@@ -885,7 +885,7 @@ describe('FilesPageContent', () => {
     });
   });
 
-  it('downloads a root R2 file directly when no folder is present', async () => {
+  it('downloads a root R2 file through the same-origin uploads endpoint', async () => {
     const rootR2Asset = {
       ...baseAsset,
       url: 'https://pub-2b50c59c64954ab89b7837f9f4607e12.r2.dev/root-file.pdf',
@@ -899,7 +899,7 @@ describe('FilesPageContent', () => {
     fireEvent.click(screen.getByText('download-1'));
 
     await waitFor(() => {
-      expect(downloadFile).toHaveBeenCalledWith(rootR2Asset.url, 'root-file.pdf');
+      expect(downloadFile).toHaveBeenCalledWith('/api/uploads/root-file.pdf', 'root-file.pdf');
     });
   });
 

--- a/app/(logged_in)/files/FilesPageContent.test.tsx
+++ b/app/(logged_in)/files/FilesPageContent.test.tsx
@@ -311,8 +311,8 @@ let mockMediaModalOnApply:
     }) => Promise<void>)
   | null = null;
 
- 
 let deleteModalOnConfirm: ((id: string) => Promise<unknown>) | null = null;
+let capturedDeleteModalFile: DeleteFileModalProps['file'] | null = null;
 
 jest.mock('~/shared/components/media-modal/MediaModal', () => ({
   MediaModal: ({ open, onApply, onClose, renderers }: MediaModalProps) => {
@@ -361,10 +361,12 @@ jest.mock('~/shared/components/delete-file-modal/DeleteFileModal', () => ({
   __esModule: true,
   default: ({ open, onConfirm, file, onClose }: DeleteFileModalProps) => {
     deleteModalOnConfirm = onConfirm;
+    capturedDeleteModalFile = file;
     if (!open) return null;
     return (
       <div data-testid="delete-modal">
         <span>{file?.filename}</span>
+        <span data-testid="delete-modal-usage-count">{file?.usageRefs.length ?? 0}</span>
         <button onClick={() => onConfirm(file?.id ?? '')}>confirm-delete</button>
         <button onClick={onClose}>close-delete</button>
       </div>
@@ -418,6 +420,7 @@ beforeEach(() => {
   capturedCardsProps = null;
   mockMediaModalOnApply = null;
   deleteModalOnConfirm = null;
+  capturedDeleteModalFile = null;
   capturedUploadViewProps = null;
   mockFetch.mockResolvedValue({
     ok: true,
@@ -483,11 +486,33 @@ describe('FilesPageContent', () => {
     render(<FilesPageContent activeTab="all" />);
 
     fireEvent.click(screen.getByText('delete-1'));
-    fireEvent.click(screen.getByText('confirm-delete'));
+    fireEvent.click(await screen.findByText('confirm-delete'));
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Network error');
     });
+  });
+
+  it('refreshes asset usage before opening delete modal', async () => {
+    const staleAsset = { ...baseAsset, usageRefs: [] };
+    const refreshedAsset = {
+      ...baseAsset,
+      usageRefs: [{ __typename: 'AssetUsageRef' as const, pageId: 'about-us', blockId: 'hero', locale: 'uk' }]
+    };
+    const refetch = jest.fn().mockResolvedValue({ data: { allAssets: [refreshedAsset] } });
+
+    setupHooks({ assets: [staleAsset], refetch });
+    render(<FilesPageContent activeTab="all" />);
+
+    fireEvent.click(screen.getByText('delete-1'));
+
+    await waitFor(() => {
+      expect(refetch).toHaveBeenCalled();
+      expect(screen.getByTestId('delete-modal')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('delete-modal-usage-count')).toHaveTextContent('1');
+    expect(capturedDeleteModalFile?.usageRefs).toEqual([{ pageId: 'about-us', blockId: 'hero' }]);
   });
 
   it('renders correct empty state scenarios (coverage for 447-476)', () => {

--- a/app/(logged_in)/files/FilesPageContent.test.tsx
+++ b/app/(logged_in)/files/FilesPageContent.test.tsx
@@ -9,7 +9,9 @@ import {
   FILES_FAVORITES_EMPTY_STATE_TITLE,
   FILES_LOADING_STATE_TITLE,
   FILES_UNKNOWN_SECTION_LABEL,
-  FILES_UPLOAD_BUTTON_LABEL} from '~/constants/files';
+  FILES_UPLOAD_BUTTON_LABEL,
+  FILES_UPLOAD_FAILED_ERROR
+} from '~/constants/files';
 import { downloadFile } from '~/lib/utils/downloadFile';
 import { useAllAssets } from '~/shared/hooks/use-assets/useAssets';
 import { useFilesFiltering } from '~/shared/hooks/use-files';
@@ -309,7 +311,7 @@ let mockMediaModalOnApply:
     }) => Promise<void>)
   | null = null;
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+ 
 let deleteModalOnConfirm: ((id: string) => Promise<unknown>) | null = null;
 
 jest.mock('~/shared/components/media-modal/MediaModal', () => ({
@@ -782,6 +784,19 @@ describe('FilesPageContent', () => {
     });
   });
 
+  it('shows file not found toast when delete target no longer exists', async () => {
+    setupHooks({ assets: [baseAsset] });
+    render(<FilesPageContent activeTab="all" />);
+
+    expect(deleteModalOnConfirm).toBeDefined();
+
+    await act(async () => {
+      await deleteModalOnConfirm?.('missing-file');
+    });
+
+    expect(toast.error).toHaveBeenCalledWith('Файл не знайдено');
+  });
+
   it('downloads a file when download action is triggered and url exists', async () => {
     setupHooks({ assets: [baseAsset] });
     render(<FilesPageContent activeTab="all" />);
@@ -790,6 +805,27 @@ describe('FilesPageContent', () => {
 
     await waitFor(() => {
       expect(downloadFile).toHaveBeenCalledWith(baseAsset.url, baseAsset.originalname);
+    });
+  });
+
+  it('downloads an R2 file through the same-origin uploads endpoint', async () => {
+    const r2Asset = {
+      ...baseAsset,
+      url: 'https://pub-2b50c59c64954ab89b7837f9f4607e12.r2.dev/photos/Test_image_1.jpeg',
+      filename: 'Test_image_1.jpeg',
+      originalname: 'Test_image_1.jpeg'
+    };
+
+    setupHooks({ assets: [r2Asset] });
+    render(<FilesPageContent activeTab="all" />);
+
+    fireEvent.click(screen.getByText('download-1'));
+
+    await waitFor(() => {
+      expect(downloadFile).toHaveBeenCalledWith(
+        '/api/uploads/Test_image_1.jpeg?folder=photos',
+        'Test_image_1.jpeg'
+      );
     });
   });
 
@@ -807,6 +843,73 @@ describe('FilesPageContent', () => {
         }
       });
       expect(refetch).toHaveBeenCalled();
+    });
+  });
+
+  it('rejects file updates when the target file no longer exists', async () => {
+    setupHooks({ assets: [baseAsset] });
+    render(<FilesPageContent activeTab="all" />);
+
+    expect(await screen.findByTestId('files-cards-layout')).toBeInTheDocument();
+    expect(capturedCardsProps).toBeDefined();
+
+    await expect(
+      capturedCardsProps?.onItemToggleStar(
+        {
+          id: 'missing-file',
+          type: 'image',
+          name: 'missing.png',
+          dateAdded: '23.07.2026',
+          isStarred: false,
+          usageLinks: 0,
+          usage: []
+        },
+        true
+      )
+    ).rejects.toThrow('Файл не знайдено');
+  });
+
+  it('throws upload error when lazy orphan asset creation returns no asset', async () => {
+    mockR2Files = [orphanR2File];
+    const createAsset = jest.fn().mockResolvedValue({ data: null });
+
+    setupHooks({ assets: [], createAsset });
+    render(<FilesPageContent activeTab="all" />);
+
+    expect(await screen.findByTestId('files-cards-layout')).toBeInTheDocument();
+    const orphanItem = capturedCardsProps?.items[0];
+    expect(orphanItem).toBeDefined();
+
+    if (!orphanItem || !capturedCardsProps) return;
+
+    await expect(capturedCardsProps.onItemToggleStar(orphanItem, true)).rejects.toThrow(FILES_UPLOAD_FAILED_ERROR);
+  });
+
+  it('updates selected orphan file id after lazy asset creation', async () => {
+    mockR2Files = [orphanR2File];
+    const createAsset = jest.fn().mockResolvedValue({ data: { createAsset: { id: 'created-orphan-id' } } });
+    const updateAsset = jest.fn().mockResolvedValue({ data: { updateAsset: { id: 'created-orphan-id' } } });
+
+    setupHooks({ assets: [], createAsset, updateAsset });
+    render(<FilesPageContent activeTab="all" />);
+
+    expect(await screen.findByTestId('files-cards-layout')).toBeInTheDocument();
+    const orphanItem = capturedCardsProps?.items[0];
+    expect(orphanItem).toBeDefined();
+
+    if (!orphanItem || !capturedCardsProps) return;
+
+    fireEvent.click(screen.getByText(`select-${orphanItem.id}`));
+
+    await act(async () => {
+      await capturedCardsProps.onItemToggleStar(orphanItem, true);
+    });
+
+    expect(updateAsset).toHaveBeenCalledWith({
+      variables: {
+        id: 'created-orphan-id',
+        input: { isStarred: true }
+      }
     });
   });
 

--- a/app/(logged_in)/files/FilesPageContent.tsx
+++ b/app/(logged_in)/files/FilesPageContent.tsx
@@ -79,8 +79,17 @@ const isFilesSupportedFile = (file: File): boolean => {
   return Boolean(extension && supportedUploadExtensions.has(extension));
 };
 
+const isR2Url = (url: URL): boolean => {
+  return url.hostname.endsWith('.r2.dev') || url.hostname.startsWith('r2.');
+};
+
 const getR2FileEndpoint = (fileUrl: string): string => {
   const parsedUrl = new URL(fileUrl, 'http://localhost');
+
+  if (!isR2Url(parsedUrl)) {
+    return fileUrl;
+  }
+
   const pathParts = parsedUrl.pathname.split('/').filter(Boolean).map(decodeURIComponent);
   const filename = pathParts.pop();
 
@@ -92,7 +101,7 @@ const getR2FileEndpoint = (fileUrl: string): string => {
   const encodedFilename = encodeURIComponent(filename);
 
   if (!folder) {
-    return fileUrl;
+    return `/api/uploads/${encodedFilename}`;
   }
 
   return `/api/uploads/${encodedFilename}?folder=${encodeURIComponent(folder)}`;
@@ -103,7 +112,7 @@ const getR2DeleteEndpoint = (fileUrl: string): string => {
 
   if (endpoint === fileUrl) {
     const parsedUrl = new URL(fileUrl, 'http://localhost');
-    const filename = parsedUrl.pathname.split('/').filter(Boolean).pop();
+    const filename = parsedUrl.pathname.split('/').findLast(Boolean);
 
     if (!filename) {
       throw new Error('Не вдалося визначити файл для видалення.');

--- a/app/(logged_in)/files/FilesPageContent.tsx
+++ b/app/(logged_in)/files/FilesPageContent.tsx
@@ -79,23 +79,40 @@ const isFilesSupportedFile = (file: File): boolean => {
   return Boolean(extension && supportedUploadExtensions.has(extension));
 };
 
-const getR2DeleteEndpoint = (fileUrl: string): string => {
+const getR2FileEndpoint = (fileUrl: string): string => {
   const parsedUrl = new URL(fileUrl, 'http://localhost');
   const pathParts = parsedUrl.pathname.split('/').filter(Boolean).map(decodeURIComponent);
   const filename = pathParts.pop();
 
   if (!filename) {
-    throw new Error('Не вдалося визначити файл для видалення.');
+    throw new Error('Не вдалося визначити файл.');
   }
 
   const folder = pathParts.join('/');
   const encodedFilename = encodeURIComponent(filename);
 
   if (!folder) {
-    return `/api/uploads/${encodedFilename}`;
+    return fileUrl;
   }
 
   return `/api/uploads/${encodedFilename}?folder=${encodeURIComponent(folder)}`;
+};
+
+const getR2DeleteEndpoint = (fileUrl: string): string => {
+  const endpoint = getR2FileEndpoint(fileUrl);
+
+  if (endpoint === fileUrl) {
+    const parsedUrl = new URL(fileUrl, 'http://localhost');
+    const filename = parsedUrl.pathname.split('/').filter(Boolean).pop();
+
+    if (!filename) {
+      throw new Error('Не вдалося визначити файл для видалення.');
+    }
+
+    return `/api/uploads/${encodeURIComponent(decodeURIComponent(filename))}`;
+  }
+
+  return endpoint;
 };
 
 const deleteR2FileByUrl = async (fileUrl: string): Promise<void> => {
@@ -267,7 +284,7 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
   };
 
   const handleDownload = async (fileUrl: string, filename: string) => {
-    await downloadFile(fileUrl, filename);
+    await downloadFile(getR2FileEndpoint(fileUrl), filename);
   };
 
   const handleItemAction = (action: 'rename' | 'delete' | 'download', item: FilesCardsLayoutItem) => {

--- a/app/(logged_in)/files/FilesPageContent.tsx
+++ b/app/(logged_in)/files/FilesPageContent.tsx
@@ -54,6 +54,7 @@ import { useAllAssets } from '~/shared/hooks/use-assets/useAssets';
 import { useFilesFiltering } from '~/shared/hooks/use-files';
 import { toCreateAssetInput, useHybridFiles, useR2Files } from '~/shared/hooks/use-files/useHybridFiles';
 import {
+  type AllAssetsQuery,
   AssetType,
   useCreateAssetMutation,
   useDeleteAssetMutation,
@@ -153,6 +154,7 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
     open: false,
     fileId: null
   });
+  const [latestAssetsForDelete, setLatestAssetsForDelete] = useState<AllAssetsQuery['allAssets'] | null>(null);
   const [uploadModalInitial, setUploadModalInitial] = useState<MediaModalOpenState | undefined>(undefined);
   const [renameModalState, setRenameModalState] = useState<{ open: boolean; fileId: string; currentFilename: string }>({
     open: false,
@@ -296,10 +298,28 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
     await downloadFile(getR2FileEndpoint(fileUrl), filename);
   };
 
-  const handleItemAction = (action: 'rename' | 'delete' | 'download', item: FilesCardsLayoutItem) => {
+  const handleCloseDeleteModal = () => {
+    setDeleteModalState({ open: false, fileId: null });
+    setLatestAssetsForDelete(null);
+  };
+
+  const handleItemAction = async (action: 'rename' | 'delete' | 'download', item: FilesCardsLayoutItem) => {
     if (action === 'rename') {
       setRenameModalState({ open: true, fileId: item.id, currentFilename: item.name });
     } else if (action === 'delete') {
+      const file = allFiles.find((f) => f.id === item.id);
+
+      if (file && !file.isOrphan) {
+        try {
+          const latestAssets = await refetch();
+          setLatestAssetsForDelete(latestAssets?.data?.allAssets ?? data?.allAssets ?? null);
+        } catch {
+          setLatestAssetsForDelete(data?.allAssets ?? null);
+        }
+      } else {
+        setLatestAssetsForDelete(null);
+      }
+
       setDeleteModalState({ open: true, fileId: item.id });
     } else if (action === 'download') {
       const file = allFiles.find((f) => f.id === item.id);
@@ -324,7 +344,7 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
       if (fileToDelete.isOrphan) {
         await deleteR2FileByUrl(fileUrlToDelete);
         toast.success('Файл успішно видалено');
-        setDeleteModalState({ open: false, fileId: null });
+        handleCloseDeleteModal();
         if (selectedFileId === id) setSelectedFileId(null);
         removeR2FileByUrl(fileUrlToDelete);
         return;
@@ -340,7 +360,7 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
         }
       });
       toast.success('Файл успішно видалено');
-      setDeleteModalState({ open: false, fileId: null });
+      handleCloseDeleteModal();
       if (selectedFileId === id || selectedFileId === persistedId) setSelectedFileId(null);
       removeR2FileByUrl(fileUrlToDelete);
       await refetch();
@@ -354,12 +374,20 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
     if (!deleteModalState.fileId) return null;
     const file = allFiles.find((f) => f.id === deleteModalState.fileId);
     if (!file) return null;
+    const latestAsset =
+      latestAssetsForDelete?.find((asset) => asset.id === file.id) ?? data?.allAssets?.find((asset) => asset.id === file.id);
+    const usageRefs =
+      latestAsset?.usageRefs.map((usageRef) => ({
+        pageId: usageRef.pageId ?? undefined,
+        blockId: usageRef.blockId ?? undefined
+      })) ?? file.usage.map((u) => ({ pageId: u.label, blockId: '' }));
+
     return {
       id: file.id,
       filename: file.name,
-      usageRefs: file.usage.map((u) => ({ pageId: u.label, blockId: '' }))
+      usageRefs
     };
-  }, [deleteModalState.fileId, allFiles]);
+  }, [deleteModalState.fileId, allFiles, latestAssetsForDelete, data?.allAssets]);
 
   const { filteredFiles, toolbarProps, sortProps } = useFilesFiltering(allFiles, activeTab);
 
@@ -535,7 +563,7 @@ export function FilesPageContent({ activeTab }: FilesPageContentProps) {
       <DeleteFileModal
         disableScrollLock
         open={deleteModalState.open}
-        onClose={() => setDeleteModalState({ open: false, fileId: null })}
+        onClose={handleCloseDeleteModal}
         onConfirm={handleDeleteConfirm}
         file={fileForDeleteModal}
         isDeleting={isDeleting}

--- a/app/(logged_in)/files/page.test.tsx
+++ b/app/(logged_in)/files/page.test.tsx
@@ -260,7 +260,7 @@ describe('Files page', () => {
     await renderPageAndWaitForFiles();
 
     expect(screen.getByText('Файли')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Завантажити файл/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Додати файл/i })).toBeInTheDocument();
   });
 
   it('renders main files controls', async () => {
@@ -313,7 +313,7 @@ describe('Files page', () => {
   it('opens media modal when upload button is clicked', async () => {
     await renderPageAndWaitForFiles();
 
-    fireEvent.click(screen.getByRole('button', { name: /Завантажити файл/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Додати файл/i }));
 
     expect(screen.getByTestId('media-modal')).toBeInTheDocument();
   });

--- a/app/api/uploads/__tests__/single.route.test.ts
+++ b/app/api/uploads/__tests__/single.route.test.ts
@@ -95,4 +95,71 @@ describe('POST /api/uploads/single', () => {
     expect(res.status).toBe(400);
     expect(data.error).toBe('No file uploaded');
   });
+
+  it('should return service status code when upload fails', async () => {
+    const formData = new FormData();
+    const content = Buffer.from('test content');
+    const blob = new Blob([content], { type: 'image/png' });
+
+    formData.append('file', blob, 'test.png');
+
+    mockUploadFile.mockResolvedValue({
+      success: false,
+      errors: ['Файл test.png вже існує'],
+      statusCode: 409
+    });
+
+    const req = new NextRequest('https://localhost/api/uploads/single', {
+      method: 'POST',
+      body: formData as unknown as ReadableStream
+    });
+
+    const res = await POST(req);
+    const data = (await res.json()) as { success: boolean; errors: string[] };
+
+    expect(res.status).toBe(409);
+    expect(data).toEqual({
+      success: false,
+      errors: ['Файл test.png вже існує']
+    });
+  });
+
+  it('should return 400 when upload fails without a service status code', async () => {
+    const formData = new FormData();
+    const content = Buffer.from('test content');
+    const blob = new Blob([content], { type: 'image/png' });
+
+    formData.append('file', blob, 'test.png');
+
+    mockUploadFile.mockResolvedValue({
+      success: false,
+      errors: ['Invalid image']
+    });
+
+    const req = new NextRequest('https://localhost/api/uploads/single', {
+      method: 'POST',
+      body: formData as unknown as ReadableStream
+    });
+
+    const res = await POST(req);
+    const data = (await res.json()) as { success: boolean; errors: string[] };
+
+    expect(res.status).toBe(400);
+    expect(data).toEqual({
+      success: false,
+      errors: ['Invalid image']
+    });
+  });
+
+  it('should return 500 when request parsing fails', async () => {
+    const req = {
+      formData: jest.fn().mockRejectedValue(new Error('form data failed'))
+    } as unknown as NextRequest;
+
+    const res = await POST(req);
+    const data = (await res.json()) as { success: boolean; error: string };
+
+    expect(res.status).toBe(500);
+    expect(data).toEqual({ success: false, error: 'Internal server error' });
+  });
 });

--- a/app/api/uploads/single/route.ts
+++ b/app/api/uploads/single/route.ts
@@ -26,7 +26,7 @@ export async function POST(req: NextRequest) {
     const result = await getUploadModule().uploadService.uploadFile(uploadedFile, options);
 
     if (!result.success) {
-      return NextResponse.json({ success: false, errors: result.errors }, { status: 400 });
+      return NextResponse.json({ success: false, errors: result.errors }, { status: result.statusCode ?? 400 });
     }
 
     return NextResponse.json({

--- a/app/constants/files.ts
+++ b/app/constants/files.ts
@@ -59,7 +59,7 @@ export const FILES_UPLOAD_ACCEPT = [
   ...FILES_UPLOAD_ALLOWED_EXTENSIONS.map((ext) => `.${ext}`)
 ].join(',');
 export const FILES_PAGE_TITLE = 'Файли';
-export const FILES_UPLOAD_BUTTON_LABEL = 'Завантажити файл';
+export const FILES_UPLOAD_BUTTON_LABEL = 'Додати файл';
 export const FILES_UPLOAD_ERROR = 'Підтримуються зображення, PDF, аудіо, документи (Docx, Xlsx) та архіви (Zip, Rar)';
 export const FILES_UPLOAD_READ_ERROR = 'Не вдалося прочитати файл для завантаження.';
 export const FILES_UPLOAD_FAILED_ERROR = 'Не вдалося завантажити файл. Спробуйте ще раз.';
@@ -88,4 +88,3 @@ export const USAGE_FILTER_OPTIONS: ReadonlyArray<{ value: string; label: string 
   { value: 'research', label: 'Наукові праці' },
   { value: 'unused', label: 'Не використані' }
 ];
-

--- a/app/shared/components/file-info-sidebar/useAutosavedDescription.test.ts
+++ b/app/shared/components/file-info-sidebar/useAutosavedDescription.test.ts
@@ -12,7 +12,7 @@ describe('useAutosavedDescription', () => {
     jest.useFakeTimers();
   });
   afterEach(() => {
-    jest.runOnlyPendingTimers();
+    jest.clearAllTimers();
     jest.useRealTimers();
   });
 
@@ -92,6 +92,7 @@ describe('useAutosavedDescription', () => {
 
     await act(async () => {
       jest.advanceTimersByTime(2);
+      await Promise.resolve();
       await Promise.resolve();
     });
 

--- a/app/shared/components/rename-file-modal/RenameFileModal.test.tsx
+++ b/app/shared/components/rename-file-modal/RenameFileModal.test.tsx
@@ -99,7 +99,7 @@ describe('RenameFileModal', () => {
     await user.clear(input);
     await user.type(input, 'bad/name');
 
-    expect(screen.getByText(String.raw`Ім'я файлу містить заборонені символи: \ / : * ? " < > |`)).toBeInTheDocument();
+    expect(screen.getByText('Введіть назву файлу без крапки та розширення')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /зберегти/i })).toHaveAttribute('aria-disabled', 'true');
     expect(mockUpdateAsset).not.toHaveBeenCalled();
   });
@@ -114,7 +114,7 @@ describe('RenameFileModal', () => {
 
     await user.click(screen.getByRole('button', { name: /зберегти/i }));
 
-    expect(toast.error).toHaveBeenCalledWith('Ім\'я файлу містить заборонені символи');
+    expect(toast.error).toHaveBeenCalledWith('Введіть назву файлу без крапки та розширення');
     expect(mockUpdateAsset).not.toHaveBeenCalled();
     expect(mockOnClose).not.toHaveBeenCalled();
   });
@@ -155,6 +155,40 @@ describe('RenameFileModal', () => {
     });
   });
 
+  it('rejects typing a different file extension during rename', async () => {
+    const user = userEvent.setup();
+
+    render(<RenameFileModal {...defaultProps} currentFilename="old_name.jpeg" />);
+
+    const input = screen.getByDisplayValue('old_name');
+    await user.clear(input);
+    await user.type(input, 'new_name.png');
+
+    const saveButton = screen.getByRole('button', { name: /зберегти/i });
+    await user.click(saveButton);
+
+    expect(toast.error).toHaveBeenCalledWith('Введіть назву файлу без крапки та розширення');
+    expect(mockUpdateAsset).not.toHaveBeenCalled();
+    expect(mockOnClose).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown typed extensions instead of appending the current extension', async () => {
+    const user = userEvent.setup();
+
+    render(<RenameFileModal {...defaultProps} currentFilename="old_name.jpeg" />);
+
+    const input = screen.getByDisplayValue('old_name');
+    await user.clear(input);
+    await user.type(input, 'new_name.ppdf');
+
+    const saveButton = screen.getByRole('button', { name: /зберегти/i });
+    await user.click(saveButton);
+
+    expect(toast.error).toHaveBeenCalledWith('Введіть назву файлу без крапки та розширення');
+    expect(mockUpdateAsset).not.toHaveBeenCalled();
+    expect(mockOnClose).not.toHaveBeenCalled();
+  });
+
   it('calls onRename when custom rename handler is provided', async () => {
     const user = userEvent.setup();
     const onRename = jest.fn().mockResolvedValue(undefined);
@@ -179,7 +213,7 @@ describe('RenameFileModal', () => {
 
   it('shows error toast when custom rename handler fails', async () => {
     const user = userEvent.setup();
-    const onRename = jest.fn().mockRejectedValue(new Error('Rename failed'));
+    const onRename = jest.fn().mockRejectedValue(new Error('Файл custom_name.jpg вже існує'));
 
     render(<RenameFileModal {...defaultProps} onRename={onRename} />);
 
@@ -192,7 +226,7 @@ describe('RenameFileModal', () => {
 
     await waitFor(() => {
       expect(onRename).toHaveBeenCalledWith('file-123', 'custom_name.jpg');
-      expect(toast.error).toHaveBeenCalledWith('Помилка при перейменуванні файлу');
+      expect(toast.error).toHaveBeenCalledWith('Файл custom_name.jpg вже існує');
       expect(mockOnClose).not.toHaveBeenCalled();
     });
   });
@@ -232,7 +266,7 @@ describe('RenameFileModal', () => {
     await user.click(saveButton);
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith('Помилка при перейменуванні файлу');
+      expect(toast.error).toHaveBeenCalledWith('API Error');
       expect(mockOnClose).not.toHaveBeenCalled();
     });
   });

--- a/app/shared/components/rename-file-modal/RenameFileModal.test.tsx
+++ b/app/shared/components/rename-file-modal/RenameFileModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import toast from 'react-hot-toast';
@@ -101,6 +101,24 @@ describe('RenameFileModal', () => {
 
     expect(screen.getByText('Введіть назву файлу без крапки та розширення')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /зберегти/i })).toHaveAttribute('aria-disabled', 'true');
+    expect(mockUpdateAsset).not.toHaveBeenCalled();
+  });
+
+  it('rejects every reserved filename character including null byte', () => {
+    const invalidCharacters = ['\\', '/', ':', '*', '?', '"', '\'', '`', '<', '>', '|', '\0', '\u02bc', '\u2018', '\u2019', '\u201c', '\u201d'];
+
+    for (const invalidCharacter of invalidCharacters) {
+      const { unmount } = render(<RenameFileModal {...defaultProps} />);
+      const input = screen.getByDisplayValue('old_name');
+
+      fireEvent.change(input, { target: { value: `bad${invalidCharacter}name` } });
+
+      expect(screen.getByText('Введіть назву файлу без крапки та розширення')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /зберегти/i })).toHaveAttribute('aria-disabled', 'true');
+
+      unmount();
+    }
+
     expect(mockUpdateAsset).not.toHaveBeenCalled();
   });
 

--- a/app/shared/components/rename-file-modal/RenameFileModal.tsx
+++ b/app/shared/components/rename-file-modal/RenameFileModal.tsx
@@ -15,6 +15,8 @@ export type RenameFileModalProps = {
   onRename?: (fileId: string, filename: string) => Promise<void> | void;
 };
 
+const INVALID_FILENAME_MESSAGE = 'Введіть назву файлу без крапки та розширення';
+
 export function RenameFileModal({ open, onClose, fileId, currentFilename, onRename }: Readonly<RenameFileModalProps>) {
   const { initialBaseName, extension } = useMemo(() => {
     const lastDotIndex = currentFilename.lastIndexOf('.');
@@ -28,7 +30,7 @@ export function RenameFileModal({ open, onClose, fileId, currentFilename, onRena
 
   const [baseName, setBaseName] = useState(initialBaseName);
   const [updateAsset, { loading }] = useUpdateAssetMutation();
-  const hasInvalidChars = /[\\/:*?"<>|]/.test(baseName);
+  const hasInvalidChars = /[\\/:*?"<>|.]/.test(baseName);
 
   useEffect(() => {
     if (open) {
@@ -38,7 +40,7 @@ export function RenameFileModal({ open, onClose, fileId, currentFilename, onRena
 
   const handleSave = async () => {
     if (hasInvalidChars) {
-      toast.error('Ім\'я файлу містить заборонені символи');
+      toast.error(INVALID_FILENAME_MESSAGE);
       return;
     }
 
@@ -66,8 +68,8 @@ export function RenameFileModal({ open, onClose, fileId, currentFilename, onRena
       });
       onClose();
       toast.success('Файл успішно перейменовано');
-    } catch {
-      toast.error('Помилка при перейменуванні файлу');
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Помилка при перейменуванні файлу');
     }
   };
 
@@ -101,7 +103,7 @@ export function RenameFileModal({ open, onClose, fileId, currentFilename, onRena
           onChange={(e) => setBaseName(e.target.value)}
           disabled={loading}
           error={hasInvalidChars}
-          helperText={hasInvalidChars ? String.raw`Ім'я файлу містить заборонені символи: \ / : * ? " < > |` : ''}
+          helperText={hasInvalidChars ? INVALID_FILENAME_MESSAGE : ''}
         />
       </Box>
 

--- a/app/shared/components/rename-file-modal/RenameFileModal.tsx
+++ b/app/shared/components/rename-file-modal/RenameFileModal.tsx
@@ -30,7 +30,7 @@ export function RenameFileModal({ open, onClose, fileId, currentFilename, onRena
 
   const [baseName, setBaseName] = useState(initialBaseName);
   const [updateAsset, { loading }] = useUpdateAssetMutation();
-  const hasInvalidChars = /[\\/:*?"<>|.]/.test(baseName);
+  const hasInvalidChars = /[\\/:*?"'`<>|.\0\u02bc\u2018\u2019\u201c\u201d]/.test(baseName);
 
   useEffect(() => {
     if (open) {

--- a/app/shared/hooks/use-debounce/useDebounce.test.ts
+++ b/app/shared/hooks/use-debounce/useDebounce.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, jest } from '@jest/globals';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 
 import { useDebounce } from './useDebounce';
 
@@ -28,7 +28,9 @@ describe('useDebounce', () => {
     rerender({ value: 'updated', delay: 300 });
     expect(result.current).toBe('initial');
 
-    jest.advanceTimersByTime(300);
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
 
     await waitFor(() => {
       expect(result.current).toBe('updated');
@@ -41,13 +43,19 @@ describe('useDebounce', () => {
     });
 
     rerender({ value: 'first' });
-    jest.advanceTimersByTime(100);
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
 
     rerender({ value: 'second' });
-    jest.advanceTimersByTime(100);
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
 
     rerender({ value: 'final' });
-    jest.advanceTimersByTime(300);
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
 
     await waitFor(() => {
       expect(result.current).toBe('final');
@@ -60,7 +68,9 @@ describe('useDebounce', () => {
     });
 
     rerender({ value: 'updated', delay: 500 });
-    jest.advanceTimersByTime(500);
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
 
     await waitFor(() => {
       expect(result.current).toBe('updated');
@@ -73,7 +83,9 @@ describe('useDebounce', () => {
     expect(result.current).toBe(0);
 
     rerender({ value: 42 });
-    jest.advanceTimersByTime(300);
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
 
     await waitFor(() => {
       expect(result.current).toBe(42);
@@ -84,7 +96,9 @@ describe('useDebounce', () => {
     const { result, rerender } = renderHook(({ value }) => useDebounce(value), { initialProps: { value: 'initial' } });
 
     rerender({ value: 'updated' });
-    jest.advanceTimersByTime(200);
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
 
     await waitFor(() => {
       expect(result.current).toBe('updated');

--- a/app/shared/hooks/use-files/useHybridFiles.test.ts
+++ b/app/shared/hooks/use-files/useHybridFiles.test.ts
@@ -50,7 +50,8 @@ describe('useHybridFiles', () => {
     expect(result.current).toHaveLength(1);
     expect(result.current[0]).toMatchObject({
       id: 'asset-1',
-      name: 'original-photo.jpg',
+      name: 'generated-photo.jpg',
+      originalname: 'original-photo.jpg',
       description: 'Mongo description',
       isStarred: true,
       usageLinks: 1,

--- a/app/shared/hooks/use-files/useHybridFiles.ts
+++ b/app/shared/hooks/use-files/useHybridFiles.ts
@@ -106,7 +106,7 @@ const getAssetTypeFromFile = (mimeType: string, filename: string): AssetType => 
 const toFileItemFromAsset = (asset: AssetItem): FilesPageFileItem => ({
   id: asset.id,
   type: assetCardTypeMap[asset.type],
-  name: asset.originalname || asset.filename,
+  name: asset.filename,
   dateAdded: formatDateAdded(asset.createdAt),
   createdAtRaw: asset.createdAt,
   isStarred: asset.isStarred,

--- a/src/infrastructure/repositories/assetRepository/assetRepository.test.ts
+++ b/src/infrastructure/repositories/assetRepository/assetRepository.test.ts
@@ -18,7 +18,10 @@ jest.mock('../../../config', () => ({
 
 jest.mock('../../../uploads/storage', () => ({
   createStorageAdapter: jest.fn(() => ({
-    delete: jest.fn().mockResolvedValue({ success: true })
+    delete: jest.fn().mockResolvedValue({ success: true }),
+    exists: jest.fn().mockResolvedValue(false),
+    move: jest.fn().mockResolvedValue({ success: true }),
+    getUrl: jest.fn((filename: string) => `https://example.com/${filename}`)
   }))
 }));
 
@@ -162,14 +165,24 @@ describe('AssetRepository', () => {
     const repository = AssetRepository({ AssetModel: mockAssetModel as never });
 
     let mockStorageDelete: jest.Mock;
+    let mockStorageExists: jest.Mock;
+    let mockStorageMove: jest.Mock;
+    let mockStorageGetUrl: jest.Mock;
 
     beforeAll(() => {
-      mockStorageDelete = (createStorageAdapter as jest.Mock).mock.results[0].value.delete;
+      const mockStorage = (createStorageAdapter as jest.Mock).mock.results[0].value;
+      mockStorageDelete = mockStorage.delete;
+      mockStorageExists = mockStorage.exists;
+      mockStorageMove = mockStorage.move;
+      mockStorageGetUrl = mockStorage.getUrl;
     });
 
     beforeEach(() => {
       jest.clearAllMocks();
       mockStorageDelete.mockResolvedValue({ success: true });
+      mockStorageExists.mockResolvedValue(false);
+      mockStorageMove.mockResolvedValue({ success: true });
+      mockStorageGetUrl.mockImplementation((filename: string) => `https://example.com/${filename}`);
     });
 
     describe('deleteAsset', () => {
@@ -287,30 +300,132 @@ describe('AssetRepository', () => {
         updatedAt: new Date('2026-01-01T00:00:00.000Z')
       };
 
-      it('should preserve the original file extension when renaming', async () => {
-        mockAssetModel.findById.mockResolvedValueOnce({ filename: 'original.jpg' });
+      it('should rename the R2 object and keep the current filename extension', async () => {
+        mockAssetModel.findById.mockResolvedValueOnce({
+          filename: 'old name.jpeg',
+          originalname: 'old name.jpeg',
+          mimeType: 'image/jpeg',
+          type: 'image',
+          url: 'https://example.com/photos/old%20name.jpeg',
+          usageRefs: []
+        });
         mockAssetModel.findByIdAndUpdate.mockResolvedValueOnce(updatedDoc);
 
-        await repository.updateAsset('asset-id', { filename: 'new-name' });
+        await repository.updateAsset('asset-id', { filename: 'new-name.jpeg' });
 
+        expect(mockStorageExists).toHaveBeenCalledWith('new-name.jpeg', 'photos');
+        expect(mockStorageMove).toHaveBeenCalledWith('old name.jpeg', 'new-name.jpeg', 'photos');
+        expect(mockStorageGetUrl).toHaveBeenCalledWith('photos/new-name.jpeg');
         expect(mockAssetModel.findByIdAndUpdate).toHaveBeenCalledWith(
           'asset-id',
-          { $set: { filename: 'new-name.jpg' } },
+          {
+            $set: {
+              filename: 'new-name.jpeg',
+              url: 'https://example.com/photos/new-name.jpeg'
+            }
+          },
           { new: true }
         );
       });
 
-      it('should keep the provided filename unchanged when existing doc is not found', async () => {
-        mockAssetModel.findById.mockResolvedValueOnce(null);
-        mockAssetModel.findByIdAndUpdate.mockResolvedValueOnce(updatedDoc);
+      it('should reject rename filenames with extra dots before checking R2', async () => {
+        mockAssetModel.findById.mockResolvedValueOnce({
+          filename: 'original.jpeg',
+          mimeType: 'image/jpeg',
+          type: 'image',
+          url: 'https://example.com/photos/original.jpeg',
+          usageRefs: []
+        });
 
-        await repository.updateAsset('asset-id', { filename: 'new-name.png' });
-
-        expect(mockAssetModel.findByIdAndUpdate).toHaveBeenCalledWith(
-          'asset-id',
-          { $set: { filename: 'new-name.png' } },
-          { new: true }
+        await expect(repository.updateAsset('asset-id', { filename: 'new-name.ppdf.jpeg' })).rejects.toThrow(
+          'Введіть назву файлу без крапки та розширення'
         );
+
+        expect(mockStorageExists).not.toHaveBeenCalled();
+        expect(mockStorageMove).not.toHaveBeenCalled();
+        expect(mockAssetModel.findByIdAndUpdate).not.toHaveBeenCalled();
+      });
+
+      it('should reject changing the current filename extension before checking R2', async () => {
+        mockAssetModel.findById.mockResolvedValueOnce({
+          filename: 'original.jpeg',
+          mimeType: 'image/jpeg',
+          type: 'image',
+          url: 'https://example.com/photos/original.jpeg',
+          usageRefs: []
+        });
+
+        await expect(repository.updateAsset('asset-id', { filename: 'new-name.png' })).rejects.toThrow(
+          'Розширення файлу має залишатися .jpeg'
+        );
+
+        expect(mockStorageExists).not.toHaveBeenCalled();
+        expect(mockStorageMove).not.toHaveBeenCalled();
+        expect(mockAssetModel.findByIdAndUpdate).not.toHaveBeenCalled();
+      });
+
+      it('should return null when renaming a missing document', async () => {
+        mockAssetModel.findById.mockResolvedValueOnce(null);
+
+        const result = await repository.updateAsset('asset-id', { filename: 'new-name.png' });
+
+        expect(result).toBeNull();
+        expect(mockStorageMove).not.toHaveBeenCalled();
+        expect(mockAssetModel.findByIdAndUpdate).not.toHaveBeenCalled();
+      });
+
+      it('should reject duplicate filenames before moving the R2 object', async () => {
+        mockAssetModel.findById.mockResolvedValueOnce({
+          filename: 'original.png',
+          mimeType: 'image/png',
+          type: 'image',
+          url: 'https://example.com/photos/original.png',
+          usageRefs: []
+        });
+        mockStorageExists.mockResolvedValueOnce(true);
+
+        await expect(repository.updateAsset('asset-id', { filename: 'duplicate.png' })).rejects.toThrow(
+          'Файл duplicate.png вже існує'
+        );
+
+        expect(mockStorageMove).not.toHaveBeenCalled();
+        expect(mockAssetModel.findByIdAndUpdate).not.toHaveBeenCalled();
+      });
+
+      it('should not update MongoDB when the R2 rename fails', async () => {
+        mockAssetModel.findById.mockResolvedValueOnce({
+          filename: 'original.png',
+          mimeType: 'image/png',
+          type: 'image',
+          url: 'https://example.com/photos/original.png',
+          usageRefs: []
+        });
+        mockStorageMove.mockResolvedValueOnce({ success: false, error: 'R2 copy failed' });
+
+        await expect(repository.updateAsset('asset-id', { filename: 'new-name.png' })).rejects.toThrow(
+          'The file was not renamed in cloud storage. Please try again later.'
+        );
+
+        expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('R2 copy failed'));
+        expect(mockAssetModel.findByIdAndUpdate).not.toHaveBeenCalled();
+      });
+
+      it('should block renaming files that are already in use', async () => {
+        mockAssetModel.findById.mockResolvedValueOnce({
+          filename: 'used.png',
+          mimeType: 'image/png',
+          type: 'image',
+          url: 'https://example.com/photos/used.png',
+          usageRefs: [{ pageId: 'about' }]
+        });
+
+        await expect(repository.updateAsset('asset-id', { filename: 'new-name.png' })).rejects.toThrow(
+          'Cannot rename: file is in use on the site.'
+        );
+
+        expect(mockStorageExists).not.toHaveBeenCalled();
+        expect(mockStorageMove).not.toHaveBeenCalled();
+        expect(mockAssetModel.findByIdAndUpdate).not.toHaveBeenCalled();
       });
 
       it('should not call findById when filename is not in the update data', async () => {

--- a/src/infrastructure/repositories/assetRepository/assetRepository.test.ts
+++ b/src/infrastructure/repositories/assetRepository/assetRepository.test.ts
@@ -323,6 +323,7 @@ describe('AssetRepository', () => {
           {
             $set: {
               filename: 'new-name.jpeg',
+              originalname: 'new-name.jpeg',
               url: 'https://example.com/photos/new-name.jpeg'
             }
           },

--- a/src/infrastructure/repositories/assetRepository/assetRepository.test.ts
+++ b/src/infrastructure/repositories/assetRepository/assetRepository.test.ts
@@ -158,6 +158,7 @@ describe('AssetRepository', () => {
       findById: jest.fn(),
       findByIdAndDelete: jest.fn(),
       findByIdAndUpdate: jest.fn(),
+      find: jest.fn(),
       findOneAndUpdate: jest.fn(),
       create: jest.fn()
     };
@@ -183,6 +184,7 @@ describe('AssetRepository', () => {
       mockStorageExists.mockResolvedValue(false);
       mockStorageMove.mockResolvedValue({ success: true });
       mockStorageGetUrl.mockImplementation((filename: string) => `https://example.com/${filename}`);
+      mockAssetModel.find.mockResolvedValue([]);
     });
 
     describe('deleteAsset', () => {
@@ -483,6 +485,69 @@ describe('AssetRepository', () => {
         );
         expect(result.id).toBe('new-asset-id');
         expect(result.isStarred).toBe(false);
+      });
+
+      it('should reject assets that duplicate a legacy original name in the same folder', async () => {
+        mockAssetModel.find.mockResolvedValueOnce([
+          {
+            filename: '1784204080559-15cd928d217815eb.png',
+            originalname: 'kitten.png',
+            type: 'image',
+            url: 'https://example.com/photos/1784204080559-15cd928d217815eb.png'
+          }
+        ]);
+
+        await expect(
+          repository.createAsset({
+            filename: 'kitten.png',
+            originalname: 'kitten.png',
+            mimeType: 'image/png',
+            sizeBytes: 1024,
+            url: 'https://example.com/photos/kitten.png',
+            type: 'image'
+          })
+        ).rejects.toThrow('Файл kitten.png вже існує');
+
+        expect(mockAssetModel.create).not.toHaveBeenCalled();
+      });
+
+      it('should allow the same original name in a different folder', async () => {
+        const newDoc = {
+          _id: { toString: () => 'new-doc-id' },
+          type: 'pdf' as const,
+          tags: [],
+          usageRefs: [],
+          filename: 'kitten.png',
+          originalname: 'kitten.png',
+          mimeType: 'application/pdf',
+          sizeBytes: 1024,
+          url: 'https://example.com/documents/kitten.png',
+          isStarred: false,
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+          updatedAt: new Date('2026-01-01T00:00:00.000Z')
+        };
+
+        mockAssetModel.find.mockResolvedValueOnce([
+          {
+            filename: '1784204080559-15cd928d217815eb.png',
+            originalname: 'kitten.png',
+            type: 'image',
+            url: 'https://example.com/photos/1784204080559-15cd928d217815eb.png'
+          }
+        ]);
+        mockAssetModel.create.mockResolvedValueOnce(newDoc);
+
+        const result = await repository.createAsset({
+          filename: 'kitten.png',
+          originalname: 'kitten.png',
+          mimeType: 'application/pdf',
+          sizeBytes: 1024,
+          url: 'https://example.com/documents/kitten.png',
+          type: 'pdf'
+        });
+
+        expect(result.id).toBe('new-doc-id');
+        expect(mockAssetModel.create).toHaveBeenCalled();
       });
     });
 

--- a/src/infrastructure/repositories/assetRepository/assetRepository.ts
+++ b/src/infrastructure/repositories/assetRepository/assetRepository.ts
@@ -1,8 +1,9 @@
 import { FilterQuery, Model, Types } from 'mongoose';
-import * as path from 'node:path';
 
 import { config } from '../../../config';
+import { UPLOAD_ERRORS } from '../../../uploads/errors';
 import { createStorageAdapter } from '../../../uploads/storage';
+import { preserveOriginalFilenameSafely } from '../../../uploads/utils';
 import { createBaseRepository } from '../baseRepository/baseRepository';
 import logger from '~/src/middleware/logger/logger';
 
@@ -91,6 +92,14 @@ const toEntity = (doc: DbAsset): AssetEntity => ({
   updatedAt: dateToIso(doc.updatedAt)
 });
 
+const decodeUrlPathSegment = (segment: string): string => {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+};
+
 const buildAssetQuery = (
   filters?: Omit<AssetFilters, 'limit' | 'skip' | 'sortBy' | 'sortOrder'>
 ): FilterQuery<DbAsset> => {
@@ -144,6 +153,36 @@ export type CreateAssetData = {
   description?: string;
 };
 
+type AssetUpdateFields = Partial<
+  Pick<AssetEntity, 'isStarred' | 'filename' | 'description' | 'url'>
+>;
+
+const INVALID_RENAME_FILENAME_MESSAGE = 'Введіть назву файлу без крапки та розширення';
+
+const joinStoragePath = (folder: string, filename: string): string => {
+  return folder ? `${folder}/${filename}` : filename;
+};
+
+const getFilenameExtension = (filename: string): string => {
+  const lastDotIndex = filename.lastIndexOf('.');
+
+  return lastDotIndex > 0 ? filename.substring(lastDotIndex) : '';
+};
+
+const validateRenameFilename = (nextFilename: string, currentFilename: string): void => {
+  const currentExtension = getFilenameExtension(currentFilename);
+  const nextExtension = getFilenameExtension(nextFilename);
+  const nextBaseName = nextExtension ? nextFilename.slice(0, -nextExtension.length) : nextFilename;
+
+  if (nextBaseName.includes('.') || nextFilename.startsWith('.') || nextFilename.endsWith('.')) {
+    throw new Error(INVALID_RENAME_FILENAME_MESSAGE);
+  }
+
+  if (nextExtension !== currentExtension) {
+    throw new Error(`Розширення файлу має залишатися ${currentExtension || 'порожнім'}`);
+  }
+};
+
 export const AssetRepository = ({ AssetModel }: AssetRepoDeps) => {
   const baseRepo = createBaseRepository<AssetEntity, DbAsset, AssetFilters>({
     model: AssetModel,
@@ -153,19 +192,46 @@ export const AssetRepository = ({ AssetModel }: AssetRepoDeps) => {
   });
 
   const updateAsset = async (id: string, data: UpdateAssetData): Promise<AssetEntity | null> => {
-    if (data.filename) {
+    let updateData: AssetUpdateFields = { ...data };
+
+    if (typeof data.filename === 'string') {
       const existingDoc = await AssetModel.findById(id);
 
-      if (existingDoc) {
-        const originalExt = path.extname(existingDoc.filename);
-
-        const safeBaseName = path.parse(data.filename).name;
-
-        data.filename = `${safeBaseName}${originalExt}`;
+      if (!existingDoc) {
+        return null;
       }
+
+      if (existingDoc.usageRefs && existingDoc.usageRefs.length > 0) {
+        throw new Error('Cannot rename: file is in use on the site.');
+      }
+
+      const nextFilename = preserveOriginalFilenameSafely(data.filename, existingDoc.mimeType);
+      const { filename: currentStorageFilename, folder } = getCloudStoragePath(existingDoc);
+      validateRenameFilename(nextFilename, currentStorageFilename);
+
+      if (nextFilename !== currentStorageFilename) {
+        const fileAlreadyExists = await storage.exists(nextFilename, folder);
+
+        if (fileAlreadyExists) {
+          throw new Error(UPLOAD_ERRORS.FILE_ALREADY_EXISTS(nextFilename));
+        }
+
+        const storageResult = await storage.move(currentStorageFilename, nextFilename, folder);
+
+        if (!storageResult.success) {
+          logger.warn(`Failed to rename file in Cloudflare: ${storageResult.error}`);
+          throw new Error('The file was not renamed in cloud storage. Please try again later.');
+        }
+      }
+
+      updateData = {
+        ...updateData,
+        filename: nextFilename,
+        url: storage.getUrl(joinStoragePath(folder, nextFilename)) ?? existingDoc.url
+      };
     }
 
-    const updatedDoc = await AssetModel.findByIdAndUpdate(id, { $set: data }, { new: true });
+    const updatedDoc = await AssetModel.findByIdAndUpdate(id, { $set: updateData }, { new: true });
 
     return updatedDoc ? toEntity(updatedDoc) : null;
   };
@@ -193,8 +259,8 @@ export const AssetRepository = ({ AssetModel }: AssetRepoDeps) => {
         const pathParts = urlObj.pathname.split('/').filter(Boolean);
 
         if (pathParts.length > 0) {
-          filename = pathParts.pop() || asset.filename;
-          folder = pathParts.length > 0 ? pathParts.join('/') : '';
+          filename = decodeUrlPathSegment(pathParts.pop() || asset.filename);
+          folder = pathParts.length > 0 ? pathParts.map(decodeUrlPathSegment).join('/') : '';
         }
       }
     } catch {

--- a/src/infrastructure/repositories/assetRepository/assetRepository.ts
+++ b/src/infrastructure/repositories/assetRepository/assetRepository.ts
@@ -154,7 +154,7 @@ export type CreateAssetData = {
 };
 
 type AssetUpdateFields = Partial<
-  Pick<AssetEntity, 'isStarred' | 'filename' | 'description' | 'url'>
+  Pick<AssetEntity, 'isStarred' | 'filename' | 'originalname' | 'description' | 'url'>
 >;
 
 const INVALID_RENAME_FILENAME_MESSAGE = 'Введіть назву файлу без крапки та розширення';
@@ -231,6 +231,7 @@ export const AssetRepository = ({ AssetModel }: AssetRepoDeps) => {
       updateData = {
         ...updateData,
         filename: nextFilename,
+        originalname: nextFilename,
         url: storage.getUrl(joinStoragePath(folder, nextFilename)) ?? existingDoc.url
       };
     }
@@ -250,9 +251,9 @@ export const AssetRepository = ({ AssetModel }: AssetRepoDeps) => {
     const existingAssets = await AssetModel.find({
       $or: [{ filename: { $in: checkedNames } }, { originalname: { $in: checkedNames } }]
     });
-    const duplicateAsset = existingAssets.find((asset) => getCloudStoragePath(asset).folder === targetFolder);
+    const hasDuplicateAsset = existingAssets.some((asset) => getCloudStoragePath(asset).folder === targetFolder);
 
-    if (duplicateAsset) {
+    if (hasDuplicateAsset) {
       throw new Error(UPLOAD_ERRORS.FILE_ALREADY_EXISTS(data.originalname ?? data.filename));
     }
 

--- a/src/infrastructure/repositories/assetRepository/assetRepository.ts
+++ b/src/infrastructure/repositories/assetRepository/assetRepository.ts
@@ -183,6 +183,10 @@ const validateRenameFilename = (nextFilename: string, currentFilename: string): 
   }
 };
 
+const getUniqueNames = (...names: Array<string | undefined>): string[] => {
+  return Array.from(new Set(names.filter((name): name is string => Boolean(name?.trim()))));
+};
+
 export const AssetRepository = ({ AssetModel }: AssetRepoDeps) => {
   const baseRepo = createBaseRepository<AssetEntity, DbAsset, AssetFilters>({
     model: AssetModel,
@@ -237,6 +241,21 @@ export const AssetRepository = ({ AssetModel }: AssetRepoDeps) => {
   };
 
   const createAsset = async (data: CreateAssetData): Promise<AssetEntity> => {
+    const checkedNames = getUniqueNames(data.filename, data.originalname);
+    const targetFolder = getCloudStoragePath({
+      filename: data.filename,
+      url: data.url,
+      type: data.type
+    } as DbAsset).folder;
+    const existingAssets = await AssetModel.find({
+      $or: [{ filename: { $in: checkedNames } }, { originalname: { $in: checkedNames } }]
+    });
+    const duplicateAsset = existingAssets.find((asset) => getCloudStoragePath(asset).folder === targetFolder);
+
+    if (duplicateAsset) {
+      throw new Error(UPLOAD_ERRORS.FILE_ALREADY_EXISTS(data.originalname ?? data.filename));
+    }
+
     const newDoc = await AssetModel.create({
       ...data,
       isStarred: false,

--- a/src/uploads/__tests__/uploadController.test.ts
+++ b/src/uploads/__tests__/uploadController.test.ts
@@ -72,6 +72,32 @@ describe('UploadController', () => {
       }));
     });
 
+    it('should return service status code when upload fails with a conflict', async () => {
+      const req = {
+        file: {
+          originalname: 'test.jpg',
+          buffer: Buffer.from('abc'),
+          mimetype: 'image/jpeg',
+          size: 3
+        },
+        body: {}
+      } as unknown as Request;
+
+      mockService.uploadFile.mockResolvedValue({
+        success: false,
+        errors: [UPLOAD_ERRORS.FILE_ALREADY_EXISTS('test.jpg')],
+        statusCode: 409
+      });
+
+      await controller.uploadSingleFile(req, getMockRes(), next);
+
+      expect(mockRes.status).toHaveBeenCalledWith(409);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        success: false,
+        errors: [UPLOAD_ERRORS.FILE_ALREADY_EXISTS('test.jpg')]
+      });
+    });
+
     it('should propagate errors to next() middleware', async () => {
       const req = { file: { originalname: 'test.jpg' }, body: {} } as unknown as Request;
       const error = new Error('Database down');

--- a/src/uploads/__tests__/uploadService.test.ts
+++ b/src/uploads/__tests__/uploadService.test.ts
@@ -65,7 +65,42 @@ describe('UploadService', () => {
 
       expect(result.success).toBe(true);
       expect(result.filename).toBe('unique-test.jpg');
-      expect(mockStorage.store).toHaveBeenCalled();
+      expect(mockStorage.store).toHaveBeenCalledWith(
+        testFile.buffer,
+        'test.jpg',
+        'image/jpeg',
+        expect.objectContaining({ originalName: 'test.jpg' })
+      );
+    });
+
+    it('should preserve the uploaded file name and extension when storing the file', async () => {
+      const jpegFile: UploadedFile = {
+        ...testFile,
+        originalname: ' Test_image_1.jpeg ',
+        mimetype: 'image/jpeg'
+      };
+
+      mockValidator.validate.mockResolvedValue({ valid: true, errors: [] });
+      mockStorage.store.mockResolvedValue({
+        success: true,
+        metadata: {
+          filename: 'Test_image_1.jpeg',
+          size: 12,
+          mimeType: 'image/jpeg',
+          uploadedAt: new Date(),
+          originalName: ' Test_image_1.jpeg ',
+          url: 'https://example.com/photos/Test_image_1.jpeg'
+        } as StorageMetadata
+      });
+
+      await service.uploadFile(jpegFile);
+
+      expect(mockStorage.store).toHaveBeenCalledWith(
+        jpegFile.buffer,
+        'Test_image_1.jpeg',
+        'image/jpeg',
+        expect.objectContaining({ originalName: ' Test_image_1.jpeg ' })
+      );
     });
 
     it('should return error and not call storage if validation fails', async () => {
@@ -90,6 +125,19 @@ describe('UploadService', () => {
 
       expect(result.success).toBe(false);
       expect(result.errors).toContain('S3 Connection Error');
+    });
+
+    it('should return default storage error if storage fails without a message', async () => {
+      mockValidator.validate.mockResolvedValue({ valid: true, errors: [] });
+      mockStorage.store.mockResolvedValue({
+        success: false,
+        metadata: {} as StorageMetadata
+      });
+
+      const result = await service.uploadFile(testFile);
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toContain(UPLOAD_ERRORS.STORAGE_FAILED);
     });
 
     it('should catch and wrap unexpected exceptions', async () => {
@@ -195,6 +243,59 @@ describe('UploadService', () => {
   });
 
   describe('UploadService Edge Cases', () => {
+    it('should use default image file type when config does not provide it', async () => {
+      service = createUploadService({ storage: mockStorage });
+      mockValidator.validate.mockResolvedValue({ valid: true, errors: [] });
+      mockStorage.store.mockResolvedValue({
+        success: true,
+        metadata: { filename: 'test.jpg' } as StorageMetadata
+      });
+
+      await service.uploadFile(testFile);
+
+      expect(mockedCreateValidator).toHaveBeenCalledWith({
+        fileType: 'image',
+        rules: {}
+      });
+    });
+
+    it('should prefer file type and validation rules from upload options', async () => {
+      mockValidator.validate.mockResolvedValue({ valid: true, errors: [] });
+      mockStorage.store.mockResolvedValue({
+        success: true,
+        metadata: { filename: 'audio.mp3' } as StorageMetadata
+      });
+
+      await service.uploadFile(
+        { ...testFile, originalname: 'audio.mp3', mimetype: 'audio/mpeg' },
+        { fileType: 'audio', validationRules: { maxSize: 1024 } }
+      );
+
+      expect(mockedCreateValidator).toHaveBeenCalledWith({
+        fileType: 'audio',
+        rules: { maxSize: 1024 }
+      });
+    });
+
+    it('should use a custom filename generator when provided', async () => {
+      mockValidator.validate.mockResolvedValue({ valid: true, errors: [] });
+      mockStorage.store.mockResolvedValue({
+        success: true,
+        metadata: { filename: 'custom-name.jpg' } as StorageMetadata
+      });
+
+      await service.uploadFile(testFile, {
+        generateFilename: () => 'custom-name.jpg'
+      });
+
+      expect(mockStorage.store).toHaveBeenCalledWith(
+        expect.any(Buffer),
+        'custom-name.jpg',
+        'image/jpeg',
+        expect.objectContaining({ originalName: 'test.jpg' })
+      );
+    });
+
     it('should apply custom directory from options to storage metadata', async () => {
       mockValidator.validate.mockResolvedValue({ valid: true, errors: [] });
       mockStorage.store.mockResolvedValue({
@@ -221,7 +322,7 @@ describe('UploadService', () => {
 
     it('should return UPLOAD_ERRORS.UNKNOWN_ERROR if a non-Error is thrown', async () => {
       mockValidator.validate.mockImplementation(() => {
-        throw new Error(UPLOAD_ERRORS.UNKNOWN_ERROR);
+        throw 'string-error';
       });
 
       const result = await service.uploadFile(testFile);

--- a/src/uploads/__tests__/uploadService.test.ts
+++ b/src/uploads/__tests__/uploadService.test.ts
@@ -13,6 +13,7 @@ describe('UploadService', () => {
     store: jest.fn(),
     retrieve: jest.fn(),
     delete: jest.fn(),
+    move: jest.fn(),
     exists: jest.fn(),
     getMetadata: jest.fn(),
     getUrl: jest.fn(),

--- a/src/uploads/__tests__/uploadService.test.ts
+++ b/src/uploads/__tests__/uploadService.test.ts
@@ -37,6 +37,7 @@ describe('UploadService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockedCreateValidator.mockReturnValue(mockValidator);
+    mockStorage.exists.mockResolvedValue(false);
     service = createUploadService({
       storage: mockStorage,
       defaultFileType: 'image',
@@ -101,6 +102,19 @@ describe('UploadService', () => {
         'image/jpeg',
         expect.objectContaining({ originalName: ' Test_image_1.jpeg ' })
       );
+    });
+
+    it('should return conflict and skip storage when file already exists', async () => {
+      mockValidator.validate.mockResolvedValue({ valid: true, errors: [] });
+      mockStorage.exists.mockResolvedValue(true);
+
+      const result = await service.uploadFile(testFile, { directory: 'photos' });
+
+      expect(result.success).toBe(false);
+      expect(result.statusCode).toBe(409);
+      expect(result.errors).toContain(UPLOAD_ERRORS.FILE_ALREADY_EXISTS('test.jpg'));
+      expect(mockStorage.exists).toHaveBeenCalledWith('test.jpg', 'photos');
+      expect(mockStorage.store).not.toHaveBeenCalled();
     });
 
     it('should return error and not call storage if validation fails', async () => {

--- a/src/uploads/__tests__/utils.test.ts
+++ b/src/uploads/__tests__/utils.test.ts
@@ -1,9 +1,12 @@
 import {
   formatBytes,
   formatMultipleUploadResults,
+  generateFilenameWithOriginal,
   generateUniqueFilename,
+  getExtensionFromFilename,
   getExtensionFromMimeType,
   parseUploadOptions,
+  preserveOriginalFilenameSafely,
   sanitizeFilename,
 } from '../utils';
 
@@ -34,11 +37,27 @@ describe('Upload Utils', () => {
     });
   });
 
+  describe('getExtensionFromFilename', () => {
+    it('should return lowercase extension from filename', () => {
+      expect(getExtensionFromFilename('Photo.JPEG')).toBe('jpeg');
+    });
+
+    it('should return empty string when filename has no extension', () => {
+      expect(getExtensionFromFilename('README')).toBe('');
+    });
+  });
+
   describe('formatBytes', () => {
     it('should format bytes into human-readable strings', () => {
       expect(formatBytes(0)).toBe('0 Bytes');
+      expect(formatBytes(512)).toBe('512 Bytes');
       expect(formatBytes(1024)).toBe('1 KB');
       expect(formatBytes(1048576)).toBe('1 MB');
+      expect(formatBytes(1073741824)).toBe('1 GB');
+    });
+
+    it('should respect custom decimal precision', () => {
+      expect(formatBytes(1536, 1)).toBe('1.5 KB');
     });
   });
 
@@ -51,6 +70,43 @@ describe('Upload Utils', () => {
     it('should fallback to extension from filename if mime type is unknown', () => {
       const filename = generateUniqueFilename('manual.pdf', 'unknown/type');
       expect(filename).toContain('.pdf');
+    });
+
+    it('should generate a filename without extension if none can be resolved', () => {
+      const filename = generateUniqueFilename('README', 'unknown/type');
+      expect(filename).toMatch(/^\d+-[a-f0-9]+$/);
+    });
+  });
+
+  describe('generateFilenameWithOriginal', () => {
+    it('should include timestamp, hash, sanitized original name and original extension', () => {
+      const filename = generateFilenameWithOriginal('My File.JPEG', 'image/jpeg');
+
+      expect(filename).toMatch(/^\d+-[a-f0-9]{8}-my_file\.jpeg$/);
+    });
+
+    it('should omit extension when original name has no extension', () => {
+      const filename = generateFilenameWithOriginal('README', 'text/plain');
+
+      expect(filename).toMatch(/^\d+-[a-f0-9]{8}-readme$/);
+    });
+  });
+
+  describe('preserveOriginalFilenameSafely', () => {
+    it('should keep user-facing filename and original extension', () => {
+      expect(preserveOriginalFilenameSafely(' Test_image_1.jpeg ', 'image/jpeg')).toBe('Test_image_1.jpeg');
+      expect(preserveOriginalFilenameSafely('kitten.png', 'image/png')).toBe('kitten.png');
+    });
+
+    it('should replace path separators without lowercasing or changing extension', () => {
+      expect(preserveOriginalFilenameSafely('folder\\Nested/File Name.JPEG', 'image/jpeg')).toBe(
+        'folder_Nested_File Name.JPEG'
+      );
+    });
+
+    it('should reject empty or separator-only names', () => {
+      expect(() => preserveOriginalFilenameSafely('   ', 'image/png')).toThrow('Filename is required');
+      expect(() => preserveOriginalFilenameSafely('///', 'image/png')).toThrow('Filename is required');
     });
   });
 
@@ -65,6 +121,16 @@ describe('Upload Utils', () => {
       expect(result.success).toBe(false);
       expect(result.data.uploaded).toBe(1);
       expect(result.data.failed).toBe(1);
+    });
+
+    it('should fallback to empty errors array for failed results without errors', () => {
+      const result = formatMultipleUploadResults([
+        { success: false, originalName: 'broken.jpg' }
+      ]);
+
+      expect(result.data.errors).toEqual([
+        { originalName: 'broken.jpg', errors: [] }
+      ]);
     });
   });
 

--- a/src/uploads/__tests__/utils.test.ts
+++ b/src/uploads/__tests__/utils.test.ts
@@ -98,15 +98,19 @@ describe('Upload Utils', () => {
       expect(preserveOriginalFilenameSafely('kitten.png', 'image/png')).toBe('kitten.png');
     });
 
-    it('should replace path separators without lowercasing or changing extension', () => {
-      expect(preserveOriginalFilenameSafely('folder\\Nested/File Name.JPEG', 'image/jpeg')).toBe(
-        'folder_Nested_File Name.JPEG'
-      );
+    it('should reject reserved filename characters and null byte', () => {
+      const invalidCharacters = ['\\', '/', ':', '*', '?', '"', '\'', '`', '<', '>', '|', '\0', '\u02bc', '\u2018', '\u2019', '\u201c', '\u201d'];
+
+      for (const invalidCharacter of invalidCharacters) {
+        expect(() => preserveOriginalFilenameSafely(`bad${invalidCharacter}name.jpeg`, 'image/jpeg')).toThrow(
+          'Filename contains invalid characters'
+        );
+      }
     });
 
     it('should reject empty or separator-only names', () => {
       expect(() => preserveOriginalFilenameSafely('   ', 'image/png')).toThrow('Filename is required');
-      expect(() => preserveOriginalFilenameSafely('///', 'image/png')).toThrow('Filename is required');
+      expect(() => preserveOriginalFilenameSafely('___', 'image/png')).toThrow('Filename is required');
     });
   });
 

--- a/src/uploads/errors.ts
+++ b/src/uploads/errors.ts
@@ -3,6 +3,7 @@ export const UPLOAD_ERRORS = {
   NO_FILE_UPLOADED: 'No file uploaded',
   NO_FILES_UPLOADED: 'No files uploaded',
   FILENAME_REQUIRED: 'Filename is required',
+  FILENAME_CONTAINS_INVALID_CHARACTERS: 'Filename contains invalid characters',
   FILE_NOT_FOUND: 'File not found',
   FILE_NOT_FOUND_OR_DELETE_FAILED: 'File not found or could not be deleted',
 

--- a/src/uploads/errors.ts
+++ b/src/uploads/errors.ts
@@ -9,6 +9,7 @@ export const UPLOAD_ERRORS = {
   // Service errors
   STORAGE_FAILED: 'Storage failed',
   UNKNOWN_ERROR: 'Unknown error',
+  FILE_ALREADY_EXISTS: (filename: string) => `Файл ${filename} вже існує`,
 
   // Validator errors
   DOCUMENT_VALIDATOR_NOT_IMPLEMENTED: 'Document validator not yet implemented',

--- a/src/uploads/storage/__tests__/cloudStorage.test.ts
+++ b/src/uploads/storage/__tests__/cloudStorage.test.ts
@@ -1,4 +1,5 @@
 import {
+  CopyObjectCommand,
   DeleteObjectCommand,
   GetObjectCommand,
   HeadObjectCommand,
@@ -19,6 +20,7 @@ jest.mock('~/src/middleware/logger/logger', () => ({
 }));
 
 const MockS3Client = S3Client as jest.MockedClass<typeof S3Client>;
+const MockCopyObjectCommand = CopyObjectCommand as jest.MockedClass<typeof CopyObjectCommand>;
 const MockPutObjectCommand = PutObjectCommand as jest.MockedClass<typeof PutObjectCommand>;
 const MockGetObjectCommand = GetObjectCommand as jest.MockedClass<typeof GetObjectCommand>;
 const MockDeleteObjectCommand = DeleteObjectCommand as jest.MockedClass<typeof DeleteObjectCommand>;
@@ -354,6 +356,21 @@ describe('createCloudStorage', () => {
       });
     });
 
+    it('should delete files from the root when folder is an empty string', async () => {
+      const options = createAwsOptions();
+      const storage = createCloudStorage(options);
+
+      mockSend.mockResolvedValue({});
+
+      const result = await storage.delete('root-file.txt', '');
+
+      expect(result.success).toBe(true);
+      expect(MockDeleteObjectCommand).toHaveBeenCalledWith({
+        Bucket: 'test-bucket',
+        Key: 'root-file.txt'
+      });
+    });
+
     it('should handle delete errors', async () => {
       const options = createAwsOptions();
       const storage = createCloudStorage(options);
@@ -364,6 +381,18 @@ describe('createCloudStorage', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe('Access denied');
+    });
+
+    it('should use the fallback error message when delete fails with a non-Error value', async () => {
+      const options = createAwsOptions();
+      const storage = createCloudStorage(options);
+
+      mockSend.mockRejectedValue('Access denied');
+
+      const result = await storage.delete('test.txt');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Unknown error occurred');
     });
 
     it('should throw error for unsupported providers', async () => {
@@ -379,6 +408,160 @@ describe('createCloudStorage', () => {
       const storage = createCloudStorage(options);
 
       const result = await storage.delete('test.txt');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Cloud storage for gcp not yet implemented');
+    });
+  });
+
+  describe('move', () => {
+    it('should copy the source object to the target key and delete the source object', async () => {
+      const options = createCloudflareOptions();
+      const storage = createCloudStorage(options);
+
+      mockSend.mockResolvedValue({});
+
+      const result = await storage.move('old name.jpeg', 'new-name.jpeg', 'photos');
+
+      expect(result.success).toBe(true);
+      expect(MockCopyObjectCommand).toHaveBeenCalledWith({
+        Bucket: 'test-bucket',
+        CopySource: 'test-bucket/photos/old%20name.jpeg',
+        Key: 'photos/new-name.jpeg'
+      });
+      expect(MockDeleteObjectCommand).toHaveBeenCalledWith({
+        Bucket: 'test-bucket',
+        Key: 'photos/old name.jpeg'
+      });
+    });
+
+    it('should move files at the storage root when folder is an empty string', async () => {
+      const options = createAwsOptions();
+      const storage = createCloudStorage(options);
+
+      mockSend.mockResolvedValue({});
+
+      const result = await storage.move('old.txt', 'new.txt', '');
+
+      expect(result.success).toBe(true);
+      expect(MockCopyObjectCommand).toHaveBeenCalledWith({
+        Bucket: 'test-bucket',
+        CopySource: 'test-bucket/old.txt',
+        Key: 'new.txt'
+      });
+      expect(MockDeleteObjectCommand).toHaveBeenCalledWith({
+        Bucket: 'test-bucket',
+        Key: 'old.txt'
+      });
+    });
+
+    it('should return an error when moving fails', async () => {
+      const options = createAwsOptions();
+      const storage = createCloudStorage(options);
+
+      mockSend.mockRejectedValue(new Error('Copy failed'));
+
+      const result = await storage.move('old.txt', 'new.txt');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Copy failed');
+    });
+
+    it('should fallback to retrieve, store and delete when object copy fails', async () => {
+      const options = createCloudflareOptions();
+      const storage = createCloudStorage(options);
+      const fileBuffer = Buffer.from('file content');
+
+      mockSend
+        .mockRejectedValueOnce(new Error('Copy failed'))
+        .mockResolvedValueOnce({
+          ContentType: 'image/jpeg',
+          ContentLength: fileBuffer.length,
+          LastModified: new Date('2026-07-24T00:00:00.000Z'),
+          Metadata: { originalName: 'old.jpeg' }
+        })
+        .mockResolvedValueOnce({ Body: Readable.from([fileBuffer]) })
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({});
+
+      const result = await storage.move('old.jpeg', 'new.jpeg', 'photos');
+
+      expect(result.success).toBe(true);
+      expect(MockCopyObjectCommand).toHaveBeenCalledWith({
+        Bucket: 'test-bucket',
+        CopySource: 'test-bucket/photos/old.jpeg',
+        Key: 'photos/new.jpeg'
+      });
+      expect(MockGetObjectCommand).toHaveBeenCalledWith({
+        Bucket: 'test-bucket',
+        Key: 'photos/old.jpeg'
+      });
+      expect(MockPutObjectCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          Bucket: 'test-bucket',
+          Key: 'photos/new.jpeg',
+          Body: fileBuffer,
+          ContentType: 'image/jpeg'
+        })
+      );
+      expect(MockDeleteObjectCommand).toHaveBeenCalledWith({
+        Bucket: 'test-bucket',
+        Key: 'photos/old.jpeg'
+      });
+    });
+
+    it('should return fallback store error when copy fallback cannot store the target object', async () => {
+      const options = createCloudflareOptions();
+      const storage = createCloudStorage(options);
+      const fileBuffer = Buffer.from('file content');
+
+      mockSend
+        .mockRejectedValueOnce(new Error('Copy failed'))
+        .mockResolvedValueOnce({ ContentType: 'application/pdf' })
+        .mockResolvedValueOnce({ Body: Readable.from([fileBuffer]) })
+        .mockRejectedValueOnce(new Error('Store failed'));
+
+      const result = await storage.move('old.pdf', 'new.pdf', 'uploads');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Store failed');
+    });
+
+    it('should return fallback delete error when copy fallback cannot delete the source object', async () => {
+      const options = createCloudflareOptions();
+      const storage = createCloudStorage(options);
+      const fileBuffer = Buffer.from('file content');
+
+      mockSend
+        .mockRejectedValueOnce(new Error('Copy failed'))
+        .mockResolvedValueOnce({ ContentType: 'application/pdf' })
+        .mockResolvedValueOnce({ Body: Readable.from([fileBuffer]) })
+        .mockResolvedValueOnce({})
+        .mockRejectedValueOnce(new Error('Delete failed'));
+
+      const result = await storage.move('old.pdf', 'new.pdf', 'uploads');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Delete failed');
+    });
+
+    it('should use the fallback error message when moving fails with a non-Error value', async () => {
+      const options = createAwsOptions();
+      const storage = createCloudStorage(options);
+
+      mockSend.mockRejectedValue('Copy failed');
+
+      const result = await storage.move('old.txt', 'new.txt');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Unknown error occurred');
+    });
+
+    it('should return an error for unsupported providers', async () => {
+      const options = createAwsOptions({ provider: 'gcp' as unknown as CloudStorageOptions['provider'] });
+      const storage = createCloudStorage(options);
+
+      const result = await storage.move('old.txt', 'new.txt');
 
       expect(result.success).toBe(false);
       expect(result.error).toBe('Cloud storage for gcp not yet implemented');
@@ -502,6 +685,14 @@ describe('createCloudStorage', () => {
       const url = storage.getUrl('test.txt');
 
       expect(url).toBe('https://cdn.example.com/test.txt');
+    });
+
+    it('should remove a leading slash before generating a URL', () => {
+      const options = createAwsOptions({ baseUrl: 'https://cdn.example.com' });
+      const storage = createCloudStorage(options);
+      const url = storage.getUrl('/photos/test.txt');
+
+      expect(url).toBe('https://cdn.example.com/photos/test.txt');
     });
 
     it('should generate default AWS S3 URL', () => {

--- a/src/uploads/storage/cloudStorage.ts
+++ b/src/uploads/storage/cloudStorage.ts
@@ -1,4 +1,5 @@
 import {
+  CopyObjectCommand,
   DeleteObjectCommand,
   GetObjectCommand,
   HeadObjectCommand,
@@ -61,8 +62,13 @@ export const createCloudStorage = (options: CloudStorageOptions): StorageAdapter
 
 
   const getTargetKey = (filename: string, folder?: string, metadataDir?: unknown): string => {
-    const targetFolder = folder || (typeof metadataDir === 'string' ? metadataDir : folderPrefix);
-    return `${targetFolder}/${filename}`;
+    const targetFolder = folder ?? (typeof metadataDir === 'string' ? metadataDir : folderPrefix);
+    return targetFolder ? `${targetFolder}/${filename}` : filename;
+  };
+
+  const getCopySource = (key: string): string => {
+    const encodedKey = key.split('/').map(encodeURIComponent).join('/');
+    return `${bucket}/${encodedKey}`;
   };
 
   const store = async (
@@ -165,6 +171,60 @@ export const createCloudStorage = (options: CloudStorageOptions): StorageAdapter
     }
   };
 
+  const move = async (sourceFilename: string, targetFilename: string, folder?: string): Promise<DeleteResult> => {
+    try {
+      if (provider !== 'aws' && provider !== 'cloudflare') {
+        throw new Error(UPLOAD_ERRORS.CLOUD_STORAGE_NOT_IMPLEMENTED(provider));
+      }
+
+      const client = getS3Client();
+      const sourceKey = getTargetKey(sourceFilename, folder);
+      const targetKey = getTargetKey(targetFilename, folder);
+
+      await client.send(
+        new CopyObjectCommand({
+          Bucket: bucket,
+          CopySource: getCopySource(sourceKey),
+          Key: targetKey
+        })
+      );
+      await client.send(new DeleteObjectCommand({ Bucket: bucket, Key: sourceKey }));
+
+      return { success: true };
+    } catch (copyError) {
+      try {
+        const sourceMetadata = await getMetadata(sourceFilename, folder);
+        const sourceBuffer = await retrieve(sourceFilename, folder);
+
+        if (!sourceBuffer) {
+          throw copyError;
+        }
+
+        const storeResult = await store(sourceBuffer, targetFilename, sourceMetadata?.mimeType ?? 'application/octet-stream', {
+          directory: folder ?? folderPrefix,
+          originalName: targetFilename
+        });
+
+        if (!storeResult.success) {
+          throw new Error(storeResult.error ?? UPLOAD_ERRORS.STORAGE_FAILED);
+        }
+
+        const deleteResult = await deleteFile(sourceFilename, folder);
+
+        if (!deleteResult.success) {
+          throw new Error(deleteResult.error ?? UPLOAD_ERRORS.FILE_NOT_FOUND_OR_DELETE_FAILED);
+        }
+
+        return { success: true };
+      } catch (fallbackError) {
+        return {
+          success: false,
+          error: fallbackError instanceof Error ? fallbackError.message : UPLOAD_ERRORS.UNKNOWN_ERROR_OCCURRED
+        };
+      }
+    }
+  };
+
   const exists = async (filename: string, folder?: string): Promise<boolean> => {
     try {
       if (provider !== 'aws' && provider !== 'cloudflare') return false;
@@ -255,5 +315,5 @@ export const createCloudStorage = (options: CloudStorageOptions): StorageAdapter
     }
   };
 
-  return { store, retrieve, delete: deleteFile, exists, getMetadata, getUrl, list };
+  return { store, retrieve, delete: deleteFile, move, exists, getMetadata, getUrl, list };
 };

--- a/src/uploads/storage/types.ts
+++ b/src/uploads/storage/types.ts
@@ -30,6 +30,8 @@ export interface StorageAdapter {
 
   delete: (filename: string, folder?: string) => Promise<DeleteResult>;
 
+  move: (sourceFilename: string, targetFilename: string, folder?: string) => Promise<DeleteResult>;
+
   exists: (filename: string, folder?: string) => Promise<boolean>;
 
   getMetadata: (filename: string, folder?: string) => Promise<StorageMetadata | null>;

--- a/src/uploads/types.ts
+++ b/src/uploads/types.ts
@@ -16,6 +16,7 @@ export interface UploadResult {
   mimeType?: string;
   metadata?: Record<string, unknown>;
   errors?: string[];
+  statusCode?: number;
 }
 
 export interface UploadOptions {

--- a/src/uploads/uploadController.ts
+++ b/src/uploads/uploadController.ts
@@ -30,7 +30,7 @@ export const createUploadController = (config: UploadControllerConfig) => {
       const result = await uploadService.uploadFile(uploadedFile, options);
 
       if (!result.success) {
-        res.status(400).json({ success: false, errors: result.errors });
+        res.status(result.statusCode ?? 400).json({ success: false, errors: result.errors });
         return;
       }
 

--- a/src/uploads/uploadService.ts
+++ b/src/uploads/uploadService.ts
@@ -1,7 +1,7 @@
 import { UPLOAD_ERRORS } from './errors';
 import { StorageAdapter } from './storage';
 import { UploadedFile, UploadOptions, UploadResult } from './types';
-import { generateUniqueFilename } from './utils';
+import { preserveOriginalFilenameSafely } from './utils';
 import { createValidator, FileValidator } from './validators';
 
 export interface UploadServiceConfig {
@@ -35,7 +35,7 @@ export const createUploadService = (config: UploadServiceConfig) => {
         };
       }
 
-      const generateFilename = options.generateFilename || generateUniqueFilename;
+      const generateFilename = options.generateFilename || preserveOriginalFilenameSafely;
       const filename = generateFilename(file.originalname, file.mimetype);
 
       const storageMetadata: Record<string, unknown> = {

--- a/src/uploads/uploadService.ts
+++ b/src/uploads/uploadService.ts
@@ -38,6 +38,15 @@ export const createUploadService = (config: UploadServiceConfig) => {
       const generateFilename = options.generateFilename || preserveOriginalFilenameSafely;
       const filename = generateFilename(file.originalname, file.mimetype);
 
+      const fileAlreadyExists = await storage.exists(filename, options.directory);
+      if (fileAlreadyExists) {
+        return {
+          success: false,
+          errors: [UPLOAD_ERRORS.FILE_ALREADY_EXISTS(filename)],
+          statusCode: 409
+        };
+      }
+
       const storageMetadata: Record<string, unknown> = {
         originalName: file.originalname,
         ...(options.metadata as Record<string, unknown>)

--- a/src/uploads/utils.ts
+++ b/src/uploads/utils.ts
@@ -1,6 +1,7 @@
 import * as crypto from 'node:crypto';
 import * as path from 'node:path';
 
+import { UPLOAD_ERRORS } from './errors';
 import { UploadResult } from '~/uploads/types';
 
 export const getExtensionFromFilename = (filename: string): string => {
@@ -42,6 +43,17 @@ export const sanitizeFilename = (filename: string): string => {
     .replaceAll(/[^a-zA-Z0-9._-]/g, '_')
     .replaceAll(/_{2,}/g, '_')
     .toLowerCase();
+};
+
+export const preserveOriginalFilenameSafely = (originalName: string, _mimeType?: string): string => {
+  const filename = originalName.trim().replaceAll(/[\\/]/g, '_');
+  const meaningfulName = filename.replaceAll(/[._-]/g, '').trim();
+
+  if (!meaningfulName) {
+    throw new Error(UPLOAD_ERRORS.FILENAME_REQUIRED);
+  }
+
+  return filename;
 };
 
 export const generateUniqueFilename = (originalName: string, mimeType: string): string => {

--- a/src/uploads/utils.ts
+++ b/src/uploads/utils.ts
@@ -46,11 +46,15 @@ export const sanitizeFilename = (filename: string): string => {
 };
 
 export const preserveOriginalFilenameSafely = (originalName: string, _mimeType?: string): string => {
-  const filename = originalName.trim().replaceAll(/[\\/]/g, '_');
+  const filename = originalName.trim();
   const meaningfulName = filename.replaceAll(/[._-]/g, '').trim();
 
   if (!meaningfulName) {
     throw new Error(UPLOAD_ERRORS.FILENAME_REQUIRED);
+  }
+
+  if (/[\\/:*?"'`<>|\0\u02bc\u2018\u2019\u201c\u201d]/.test(filename)) {
+    throw new Error(UPLOAD_ERRORS.FILENAME_CONTAINS_INVALID_CHARACTERS);
   }
 
   return filename;

--- a/src/uploads/validators/__tests__/uploadController.test.ts
+++ b/src/uploads/validators/__tests__/uploadController.test.ts
@@ -55,6 +55,22 @@ describe('UploadController', () => {
       expect(res.json).toHaveBeenCalledWith({ success: false, errors: ['Invalid image'] });
     });
 
+    it('returns conflict status when service rejects duplicate filenames', async () => {
+      req.file = { originalname: 'test.jpg', buffer: Buffer.from('') } as unknown as never;
+      mockUploadService.uploadFile.mockResolvedValueOnce({
+        success: false,
+        errors: [UPLOAD_ERRORS.FILE_ALREADY_EXISTS('test.jpg')],
+        statusCode: 409
+      });
+
+      await controller.uploadSingleFile(req as Request, res as Response, next);
+      expect(res.status).toHaveBeenCalledWith(409);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        errors: [UPLOAD_ERRORS.FILE_ALREADY_EXISTS('test.jpg')]
+      });
+    });
+
     it('returns 201 on successful upload format mapping', async () => {
       req.file = { originalname: 'test.jpg', buffer: Buffer.from('') } as unknown as never;
       mockUploadService.uploadFile.mockResolvedValueOnce({ success: true, url: 'http://test.url' });


### PR DESCRIPTION
## Description

Updates the file upload, rename, and download flows for Cloudflare R2.
Closes #721 
### File upload

Previously, new files were stored in R2 using a generated technical key:

```text
photos/1784714732168-47ad535ba7b64a85.jpg
```

The `preserve original filename safely` strategy is now used, meaning that the R2 object key is based on the user-facing filename.

Examples:

```text
photos/Test_image_1.jpeg
documents/file.pdf
compositions/audio.mp3
```

Filename processing rules:

- A timestamp/hash is no longer added.
- Leading and trailing spaces are removed.
- Empty filenames are not allowed.
- Only the following system-specific characters remain forbidden: `\`, `/`, `:`, `*`, `?`, `"`, `<`, `>`, `|`, `ʼ`.
- If a filename contains a forbidden character, the upload or rename operation is rejected and an appropriate validation message is shown.
- File extensions are preserved without aggressive normalization.
- `.jpeg` remains `.jpeg`, while `.jpg` remains `.jpg`.
- The UI may group `.jpeg` files as `.jpg` when needed, but this does not change the physical R2 object name.
- `filename`, `originalname`, and `url` remain synchronized.

Expected record after upload:

```json
{
  "filename": "Test_image_1.jpeg",
  "originalname": "Test_image_1.jpeg",
  "url": "https://pub-...r2.dev/photos/Test_image_1.jpeg"
}
```

### Duplicate validation

Before uploading or renaming a file, the backend checks whether a file with the same name already exists in the target R2 directory.

The check uses the target directory and filename combination:

```text
photos/Test_image_1.jpeg
documents/Test_image_1.jpeg
compositions/Test_image_1.jpeg
```

Files with the same name may exist in different directories.

If an object with the same key already exists:

- The backend returns `409 Conflict`.
- The existing file is not overwritten.
- The UI does not display the operation as successful.
- The upload or rename modal remains open.
- The user sees a message indicating that a file with the same name already exists.
- The user can immediately enter another filename.

### File rename

Previously, renaming updated only `filename` in MongoDB, while:

- `originalname` remained unchanged.
- The URL continued to contain the old technical key.
- The actual Cloudflare R2 object was not renamed.
- A duplicated extension could be produced, for example `Test_image_007.jpeg.jpg`.

Cloudflare R2 does not support a native object rename operation. Therefore, a physical rename uses the following flow:

1. Find the asset in MongoDB.
2. Validate and sanitize the new filename.
3. Verify that the filename does not contain forbidden system characters.
4. Generate the new R2 key.
5. Check for a duplicate in the target directory.
6. Copy the old R2 object to the new key.
7. Delete the object stored under the old key.
8. Update the following fields in MongoDB:
   - `filename`;
   - `originalname`;
   - `url`.
9. Return the updated data to the UI.

Expected record after rename:

```json
{
  "filename": "Test_image_007.jpeg",
  "originalname": "Test_image_007.jpeg",
  "url": "https://pub-...r2.dev/photos/Test_image_007.jpeg"
}
```

MongoDB must not be left in an inconsistent state if copying or deleting the R2 object fails.

### File download

Previously, files were downloaded using a direct `fetch()` request to the public Cloudflare R2 URL, which could cause a CORS error.

R2 files are now downloaded through a same-origin API endpoint.

For example, the following R2 URL:

```text
https://pub-...r2.dev/photos/Test_image_1.jpeg
```

is converted to:

```text
/api/uploads/Test_image_1.jpeg?folder=photos
```

The following helper was added:

```text
getR2FileEndpoint(fileUrl)
```

The download flow was changed from:

```text
downloadFile(fileUrl, filename)
```

to:

```text
downloadFile(getR2FileEndpoint(fileUrl), filename)
```

The delete flow continues to use the internal endpoint through `getR2DeleteEndpoint`.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [x] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other:

## How to test

1. Open the admin panel and navigate to the Files page.
2. Upload `Test_image_1.jpeg`.
3. Verify that the file is created in R2 at:

   ```text
   photos/Test_image_1.jpeg
   ```

4. Verify in MongoDB that `filename`, `originalname`, and `url` contain the current filename.
5. Rename the file to `Test_image_007.jpeg`.
6. Verify that:
   - an object with the new key is created in R2;
   - the object stored under the old key is deleted;
   - `filename`, `originalname`, and `url` are updated;
   - the file extension is not duplicated.
7. Try uploading a file with a name that already exists in the target directory.
8. Verify that the backend returns `409 Conflict`, the UI displays a conflict message, and the modal remains open.
9. Repeat the duplicate-name check during rename.
10. Test upload and rename using each forbidden character:

    ```text
    \ / : * ? " < > | ʼ
    ```

11. Verify that the operation is rejected and the UI displays an invalid filename message.
12. Verify that allowed characters are not removed or changed.
13. Download an R2 file and verify that the request goes through `/api/uploads/...` without a CORS error.
14. Test `.jpeg`, `.jpg`, `.png`, `.mp3`, `.pdf`, `.docx`, and `.xlsx` files separately.

Run the main targeted test suite:

```bash
npm test -- --runInBand --coverage --runTestsByPath 'app/(logged_in)/files/FilesPageContent.test.tsx' app/api/uploads/**tests**/single.route.test.ts src/uploads/**tests**/uploadService.test.ts src/uploads/**tests**/uploadController.test.ts src/uploads/validators/**tests**/uploadController.test.ts src/uploads/**tests**/utils.test.ts src/infrastructure/repositories/assetRepository/assetRepository.test.ts src/uploads/storage/**tests**/cloudStorage.test.ts app/shared/components/rename-file-modal/RenameFileModal.test.tsx --collectCoverageFrom='app/(logged_in)/files/FilesPageContent.tsx' --collectCoverageFrom='app/api/uploads/single/route.ts' --collectCoverageFrom='src/uploads/uploadService.ts' --collectCoverageFrom='src/uploads/uploadController.ts' --collectCoverageFrom='src/uploads/utils.ts' --collectCoverageFrom='src/infrastructure/repositories/assetRepository/assetRepository.ts' --collectCoverageFrom='src/uploads/storage/cloudStorage.ts' --collectCoverageFrom='app/shared/components/rename-file-modal/RenameFileModal.tsx' --detectOpenHandles
```

Run the Files page test:

```bash
npm test -- --runInBand --coverage --runTestsByPath 'app/(logged_in)/files/page.test.tsx' --collectCoverageFrom='app/(logged_in)/files/page.tsx' --collectCoverageFrom='app/(logged_in)/files/FilesPageContent.tsx'
```

## Video / Screenshots

<!-- Attach a video or screenshots demonstrating file upload, rename, duplicate handling, filename validation, and download. -->
## Before
<img width="1466" height="146" alt="Screenshot 2026-07-25 at 10 56 44" src="https://github.com/user-attachments/assets/abb9f300-835c-4683-b692-26847cc603b1" />

## After
<img width="1469" height="143" alt="Screenshot 2026-07-25 at 10 57 01" src="https://github.com/user-attachments/assets/cdb2f576-8dde-460f-a661-8eb5f9b2e4cd" />


https://github.com/user-attachments/assets/b3292090-c3be-4947-b4e9-710ef529da48

## Before in MongoDB
<img width="760" height="282" alt="Screenshot 2026-07-25 at 11 08 46" src="https://github.com/user-attachments/assets/d2e82f67-c2d6-41f3-914f-ac57a676d9dd" />

## After in MongoDB
<img width="714" height="283" alt="Screenshot 2026-07-25 at 11 07 53" src="https://github.com/user-attachments/assets/d1162188-e5bc-434f-bf4f-9f0c31c81dcb" />

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
