### PR TITLE
feat(ui): implement archive fonds table

### DIFF
--- a/app/(logged_in)/archive/(components)/ArchivePageContent.test.tsx
+++ b/app/(logged_in)/archive/(components)/ArchivePageContent.test.tsx
@@ -1,7 +1,60 @@
 import { render, screen, within } from '@testing-library/react';
 
+import type { FondsTableProps } from './archive-fonds-table/ArchiveFondsTable';
 import { ArchivePageContent } from './ArchivePageContent';
-import { ARCHIVE_TABS } from '~/constants/archive';
+import { ARCHIVE_STATUS_FILTER_OPTIONS, ARCHIVE_TABS } from '~/constants/archive';
+
+jest.mock('../(temp)/archive.mock', () => ({
+  __esModule: true,
+  ARCHIVE_FONDS_MOCK_DATA: [
+    {
+      id: '3',
+      fondNumber: 3,
+      name: 'C Fond same part',
+      descriptions: 1,
+      cases: 1,
+      dates: '1900-2000',
+      status: 'published',
+      updatedAt: '2023-01-01',
+    },
+    {
+      id: '1',
+      fondNumber: 1,
+      name: 'A Fond same part',
+      descriptions: 1,
+      cases: 1,
+      dates: '1900-2000',
+      status: 'hidden',
+      updatedAt: '2023-01-01',
+    },
+    {
+      id: '2',
+      fondNumber: 2,
+      name: 'B Fond same part',
+      descriptions: 1,
+      cases: 1,
+      dates: '1900-2000',
+      status: 'published',
+      updatedAt: '2023-01-01',
+    },
+  ],
+}));
+
+jest.mock('./archive-fonds-table/ArchiveFondsTable', () => ({
+  __esModule: true,
+  FondsTable: ({ fonds, hasActiveCriteria }: FondsTableProps) => (
+    <div data-testid="fonds-table">
+      <div data-testid="fonds-table-has-active-criteria">{JSON.stringify(hasActiveCriteria)}</div>
+      <div data-testid="fonds-table-fonds">
+        {fonds.map((fond) => (
+          <div key={fond.id} data-testid={`fonds-table-item-${fond.id}`}>
+            {fond.name}
+          </div>
+        ))}
+      </div>
+    </div>
+  ),
+}));
 
 jest.mock('~/shared/components/page-header/PageHeader', () => ({
   __esModule: true,
@@ -20,20 +73,29 @@ jest.mock('~/shared/components/page-header/PageHeader', () => ({
   )
 }));
 
+const mockSearchProps = {
+  search: 'C Fond',
+  setSearch: jest.fn(),
+  options: [],
+};
+
+const mockStatusFilterProps = {
+  label: 'Status Label',
+  options: [],
+  onChange: jest.fn(),
+  value: ['all'],
+};
+
+const defaultMockReturnValue = {
+  searchProps: mockSearchProps,
+  statusFilterProps: mockStatusFilterProps,
+};
+
+const mockUseArchiveFiltering = jest.fn();
+
 jest.mock('../(hooks)/useArchiveFiltering', () => ({
   __esModule: true,
-  useArchiveFiltering: () => ({
-    searchProps: {
-      search: 'mock-search-query',
-      setSearch: jest.fn(),
-      options: [],
-    },
-    statusFilterProps: {
-      label: 'Status Label',
-      options: [],
-      onChange: jest.fn(),
-    }
-  })
+  useArchiveFiltering: () => mockUseArchiveFiltering()
 }));
 
 jest.mock('./ArchiveCreateAction', () => ({
@@ -52,6 +114,11 @@ jest.mock('~/shared/components/search-status-toolbar/SearchStatusToolbar', () =>
 }));
 
 describe('ArchivePageContent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseArchiveFiltering.mockReturnValue(defaultMockReturnValue);
+  });
+
   it('should render the header, tabs & the search & the status dropdown correctly', () => {
     render(<ArchivePageContent activeTab="all" />);
 
@@ -76,10 +143,113 @@ describe('ArchivePageContent', () => {
 
     const searchInput = within(toolbar).getByTestId('search');
     expect(searchInput).toBeInTheDocument();
-    expect(searchInput).toHaveValue('mock-search-query');
+    expect(searchInput).toHaveValue('C Fond');
 
     const statusDropdown = within(toolbar).getByTestId('status-dropdown');
     expect(statusDropdown).toBeInTheDocument();
     expect(statusDropdown).toHaveTextContent('Status Label');
+
+    expect(screen.getByTestId('fonds-table')).toBeInTheDocument();
+  });
+
+  describe('hasActiveCriteria prop', () => {
+    it('should be false when search is an empty string', () => {
+      mockUseArchiveFiltering.mockReturnValue({
+        ...defaultMockReturnValue,
+        searchProps: {
+          ...defaultMockReturnValue.searchProps,
+          search: '',
+        },
+      });
+
+      render(<ArchivePageContent activeTab="all" />);
+
+      expect(screen.getByTestId('fonds-table-has-active-criteria')).toHaveTextContent('false');
+    });
+
+    it('should be true when search has a value & filterValues too', () => {
+      mockUseArchiveFiltering.mockReturnValue({
+        ...defaultMockReturnValue,
+        statusFilterProps: {
+          ...defaultMockReturnValue.statusFilterProps,
+          value: ['other value from all'],
+        },
+      });
+      render(<ArchivePageContent activeTab="all" />);
+
+      expect(screen.getByTestId('fonds-table-has-active-criteria')).toHaveTextContent('true');
+    });
+    it(`should be false when filterValues are ['${ARCHIVE_STATUS_FILTER_OPTIONS[0].value}'] and search is an empty string`, () => {
+      mockUseArchiveFiltering.mockReturnValue({
+        ...defaultMockReturnValue,
+        searchProps: {
+          ...defaultMockReturnValue.searchProps,
+          search: '',
+        },
+      });
+
+      render(<ArchivePageContent activeTab="all" />);
+
+      expect(screen.getByTestId('fonds-table-has-active-criteria')).toHaveTextContent('false');
+    });
+  });
+
+  describe('fonds prop', () => {
+    it('should pass full asc sorted array when search query matches all and filter is all', () => {
+      mockUseArchiveFiltering.mockReturnValue({
+        ...defaultMockReturnValue,
+        searchProps: {
+          ...defaultMockReturnValue.searchProps,
+          search: 'same part',
+        },
+      });
+      render(<ArchivePageContent activeTab="all" />);
+
+      const items = screen.getAllByTestId(/^fonds-table-item-/);
+      expect(items).toHaveLength(3);
+
+      expect(items[0]).toHaveTextContent('A Fond');
+      expect(items[1]).toHaveTextContent('B Fond');
+      expect(items[2]).toHaveTextContent('C Fond');
+    });
+
+    it('should pass empty array when search query does not match any variants', () => {
+      mockUseArchiveFiltering.mockReturnValue({
+        ...defaultMockReturnValue,
+        searchProps: {
+          ...defaultMockReturnValue.searchProps,
+          search: 'Non-matching-query',
+        },
+      });
+
+      render(<ArchivePageContent activeTab="all" />);
+
+      const fondsContainer = screen.getByTestId('fonds-table-fonds');
+      expect(fondsContainer.children).toHaveLength(0);
+    });
+
+    it('should pass empty array when filter status does not match any variant', () => {
+      mockUseArchiveFiltering.mockReturnValue({
+        ...defaultMockReturnValue,
+        statusFilterProps: {
+          ...defaultMockReturnValue.statusFilterProps,
+          value: ['other'],
+        },
+      });
+
+      render(<ArchivePageContent activeTab="all" />);
+
+      const fondsContainer = screen.getByTestId('fonds-table-fonds');
+      expect(fondsContainer.children).toHaveLength(0);
+    });
+
+    it('should pass an array with matched values when search query matches any variants', () => {
+      render(<ArchivePageContent activeTab="all" />);
+
+      const items = screen.getAllByTestId(/^fonds-table-item-/);
+      expect(items).toHaveLength(1);
+
+      expect(items[0]).toHaveTextContent('C Fond same part');
+    });
   });
 });

--- a/app/(logged_in)/archive/(components)/ArchivePageContent.tsx
+++ b/app/(logged_in)/archive/(components)/ArchivePageContent.tsx
@@ -2,9 +2,12 @@
 import { Box } from '@mui/material';
 
 import { useArchiveFiltering } from '../(hooks)/useArchiveFiltering';
+import { ARCHIVE_FONDS_MOCK_DATA } from '../(temp)/archive.mock';
+import { FondsTable } from './archive-fonds-table/ArchiveFondsTable';
 import { ArchiveCreateAction } from './ArchiveCreateAction';
 import { styles } from './ArchivePageContent.styles';
 import { ARCHIVE_PAGE_TITLE, ARCHIVE_TABS, type ArchiveTabValue } from '~/constants/archive';
+import { normalizeSearch } from '~/lib/utils/normalizeSearch';
 import { PageHeader } from '~/shared/components/page-header/PageHeader';
 import { SearchStatusToolbar } from '~/shared/components/search-status-toolbar/SearchStatusToolbar';
 
@@ -12,6 +15,25 @@ interface ArchivePageContentProps { activeTab: ArchiveTabValue }
 
 export const ArchivePageContent = ({ activeTab }: ArchivePageContentProps) => {
   const { searchProps, statusFilterProps } = useArchiveFiltering();
+
+  const searchValue = searchProps.search;
+  const normalizedSearch = normalizeSearch(searchValue);
+
+  const visibleFounds = ARCHIVE_FONDS_MOCK_DATA.filter((found) => {
+    const isStatusSame = statusFilterProps.value?.includes('all') ? true : statusFilterProps.value?.includes(found.status);
+
+    const normalizedFondName = normalizeSearch(found.name);
+    const isNameSame = normalizedFondName.includes(normalizedSearch);
+
+    if (isStatusSame && isNameSame) {
+      return found;
+    }
+    return false;
+  });
+
+  const ascSortedVisibleFounds = visibleFounds.toSorted((a, b) => Number(a.id) - Number(b.id));
+
+  const hasActiveCriteria = Boolean(searchProps.search) || Boolean(statusFilterProps.value);
 
   return (
     <Box sx={styles.pageContainer}>
@@ -22,6 +44,8 @@ export const ArchivePageContent = ({ activeTab }: ArchivePageContentProps) => {
         action={<ArchiveCreateAction />}
       />
       <SearchStatusToolbar dataTestId='archive-control-panel' searchProps={searchProps} statusFilterProps={statusFilterProps} />
+
+      <FondsTable founds={ascSortedVisibleFounds} hasActiveCriteria={hasActiveCriteria} />
     </Box >
   );
 };

--- a/app/(logged_in)/archive/(components)/ArchivePageContent.tsx
+++ b/app/(logged_in)/archive/(components)/ArchivePageContent.tsx
@@ -6,7 +6,7 @@ import { ARCHIVE_FONDS_MOCK_DATA } from '../(temp)/archive.mock';
 import { FondsTable } from './archive-fonds-table/ArchiveFondsTable';
 import { ArchiveCreateAction } from './ArchiveCreateAction';
 import { styles } from './ArchivePageContent.styles';
-import { ARCHIVE_PAGE_TITLE, ARCHIVE_TABS, type ArchiveTabValue } from '~/constants/archive';
+import { ARCHIVE_PAGE_TITLE, ARCHIVE_STATUS_FILTER_OPTIONS, ARCHIVE_TABS, type ArchiveTabValue } from '~/constants/archive';
 import { normalizeSearch } from '~/lib/utils/normalizeSearch';
 import { PageHeader } from '~/shared/components/page-header/PageHeader';
 import { SearchStatusToolbar } from '~/shared/components/search-status-toolbar/SearchStatusToolbar';
@@ -18,10 +18,10 @@ export const ArchivePageContent = ({ activeTab }: ArchivePageContentProps) => {
 
   const searchValue = searchProps.search;
   const normalizedSearch = normalizeSearch(searchValue);
+  const filterValues = statusFilterProps.value || [];
 
   const visibleFonds = ARCHIVE_FONDS_MOCK_DATA.filter((fond) => {
-    const filterValues = statusFilterProps.value || [];
-    const matchesStatus = filterValues.includes('all') ? true : filterValues.includes(fond.status);
+    const matchesStatus = filterValues.includes(ARCHIVE_STATUS_FILTER_OPTIONS[0].value) ? true : filterValues.includes(fond.status);
 
     const normalizedFondName = normalizeSearch(fond.name);
     const matchesName = normalizedFondName.includes(normalizedSearch);
@@ -29,9 +29,9 @@ export const ArchivePageContent = ({ activeTab }: ArchivePageContentProps) => {
     return matchesStatus && matchesName;
   });
 
-  const ascSortedVisibleFonds = visibleFonds.toSorted((a, b) => Number(a.id) - Number(b.id));
+  const ascSortedVisibleFonds = visibleFonds.toSorted((a, b) => Number(a.fondNumber) - Number(b.fondNumber));
 
-  const hasActiveCriteria = Boolean(searchProps.search) || Boolean(statusFilterProps.value);
+  const hasActiveCriteria = Boolean(searchProps.search) || !filterValues.includes(ARCHIVE_STATUS_FILTER_OPTIONS[0].value);
 
   return (
     <Box sx={styles.pageContainer}>

--- a/app/(logged_in)/archive/(components)/ArchivePageContent.tsx
+++ b/app/(logged_in)/archive/(components)/ArchivePageContent.tsx
@@ -20,15 +20,13 @@ export const ArchivePageContent = ({ activeTab }: ArchivePageContentProps) => {
   const normalizedSearch = normalizeSearch(searchValue);
 
   const visibleFonds = ARCHIVE_FONDS_MOCK_DATA.filter((fond) => {
-    const isStatusSame = statusFilterProps.value?.includes('all') ? true : statusFilterProps.value?.includes(fond.status);
+    const filterValues = statusFilterProps.value || [];
+    const matchesStatus = filterValues.includes('all') ? true : filterValues.includes(fond.status);
 
     const normalizedFondName = normalizeSearch(fond.name);
-    const isNameSame = normalizedFondName.includes(normalizedSearch);
+    const matchesName = normalizedFondName.includes(normalizedSearch);
 
-    if (isStatusSame && isNameSame) {
-      return fond;
-    }
-    return false;
+    return matchesStatus && matchesName;
   });
 
   const ascSortedVisibleFonds = visibleFonds.toSorted((a, b) => Number(a.id) - Number(b.id));

--- a/app/(logged_in)/archive/(components)/ArchivePageContent.tsx
+++ b/app/(logged_in)/archive/(components)/ArchivePageContent.tsx
@@ -19,19 +19,19 @@ export const ArchivePageContent = ({ activeTab }: ArchivePageContentProps) => {
   const searchValue = searchProps.search;
   const normalizedSearch = normalizeSearch(searchValue);
 
-  const visibleFounds = ARCHIVE_FONDS_MOCK_DATA.filter((found) => {
-    const isStatusSame = statusFilterProps.value?.includes('all') ? true : statusFilterProps.value?.includes(found.status);
+  const visibleFonds = ARCHIVE_FONDS_MOCK_DATA.filter((fond) => {
+    const isStatusSame = statusFilterProps.value?.includes('all') ? true : statusFilterProps.value?.includes(fond.status);
 
-    const normalizedFondName = normalizeSearch(found.name);
+    const normalizedFondName = normalizeSearch(fond.name);
     const isNameSame = normalizedFondName.includes(normalizedSearch);
 
     if (isStatusSame && isNameSame) {
-      return found;
+      return fond;
     }
     return false;
   });
 
-  const ascSortedVisibleFounds = visibleFounds.toSorted((a, b) => Number(a.id) - Number(b.id));
+  const ascSortedVisibleFonds = visibleFonds.toSorted((a, b) => Number(a.id) - Number(b.id));
 
   const hasActiveCriteria = Boolean(searchProps.search) || Boolean(statusFilterProps.value);
 
@@ -45,7 +45,7 @@ export const ArchivePageContent = ({ activeTab }: ArchivePageContentProps) => {
       />
       <SearchStatusToolbar dataTestId='archive-control-panel' searchProps={searchProps} statusFilterProps={statusFilterProps} />
 
-      <FondsTable founds={ascSortedVisibleFounds} hasActiveCriteria={hasActiveCriteria} />
+      <FondsTable fonds={ascSortedVisibleFonds} hasActiveCriteria={hasActiveCriteria} />
     </Box >
   );
 };

--- a/app/(logged_in)/archive/(components)/ArchivePageContent.tsx
+++ b/app/(logged_in)/archive/(components)/ArchivePageContent.tsx
@@ -18,7 +18,7 @@ export const ArchivePageContent = ({ activeTab }: ArchivePageContentProps) => {
 
   const searchValue = searchProps.search;
   const normalizedSearch = normalizeSearch(searchValue);
-  const filterValues = statusFilterProps.value || [];
+  const filterValues = statusFilterProps.value;
 
   const visibleFonds = ARCHIVE_FONDS_MOCK_DATA.filter((fond) => {
     const matchesStatus = filterValues.includes(ARCHIVE_STATUS_FILTER_OPTIONS[0].value) ? true : filterValues.includes(fond.status);

--- a/app/(logged_in)/archive/(components)/archive-fonds-table/ArchiveFondsTable.test.tsx
+++ b/app/(logged_in)/archive/(components)/archive-fonds-table/ArchiveFondsTable.test.tsx
@@ -81,44 +81,55 @@ const renderComponent = (overrides?: Partial<FondsTableProps>) => {
   return render(<FondsTable {...defaultProps} {...overrides} />);
 };
 
+const fond = defaultProps.fonds[0];
+const rowWithActions = {
+  type: 'individual', id: fond.id, plainData: {
+    ...defaultProps.fonds[0], editAction: {
+      editHref: `/archive/fond/${fond.id}/edit`, editLabel: `Редагувати фонд Фонд ${fond.id}`
+    },
+
+    menuActions: {
+      menuItems: [{ items: [{ id: 'edit', text: { name: 'Редагувати' }, href: `/archive/fond/${fond.id}/edit` }, { id: 'share', text: { name: 'Поширити' }, href: `/archive/fond/${fond.id}/share` }] }, { items: [{ id: 'delete', text: { name: 'Видалити' } }] }], menuTriggerLabel: `Дії для фонду Фонд ${fond.id}`
+    }
+  },
+};
+
 describe('ArchiveFondsTable', () => {
   it('should render all columns and rows with fonds data', () => {
     renderComponent();
-    const fond = defaultProps.fonds[0];
-    const rowWithActions = {
-      type: 'individual', id: fond.id, plainData: {
-        ...defaultProps.fonds[0], editAction: {
-          editHref: `/archive/fond/${fond.id}/edit`, editLabel: `Редагувати фонд Фонд ${fond.id}`
-        },
-
-        menuActions: {
-          menuItems: [{ items: [{ id: 'edit', text: { name: 'Редагувати' }, href: `/archive/fond/${fond.id}/edit` }, { id: 'share', text: { name: 'Поширити' }, href: `/archive/fond/${fond.id}/share` }] }, { items: [{ id: 'delete', text: { name: 'Видалити' } }] }], menuTriggerLabel: `Дії для фонду Фонд ${fond.id}`
-        }
-      },
-    };
-
 
     expect(screen.getByTestId('mock-table-layout')).toBeInTheDocument();
-
     expect(screen.getByTestId('mock-table-layout-columns')).toBeInTheDocument();
-    expect(screen.getByTestId('mock-table-layout-column-fondId')).toHaveTextContent(ARCHIVE_FONDS_TABLE_HEADERS.fond);
-    expect(screen.getByTestId('mock-table-layout-column-name')).toHaveTextContent(ARCHIVE_FONDS_TABLE_HEADERS.name);
-    expect(screen.getByTestId('mock-table-layout-column-descriptionsCount')).toHaveTextContent(ARCHIVE_FONDS_TABLE_HEADERS.descr);
-    expect(screen.getByTestId('mock-table-layout-column-casesCount')).toHaveTextContent(ARCHIVE_FONDS_TABLE_HEADERS.cases);
-    expect(screen.getByTestId('mock-table-layout-column-dates')).toHaveTextContent(ARCHIVE_FONDS_TABLE_HEADERS.dates);
-    expect(screen.getByTestId('mock-table-layout-column-status')).toBeInTheDocument();
-    expect(screen.getByTestId('mock-table-layout-column-actions')).toBeInTheDocument();
-
     expect(screen.getByTestId('mock-table-layout-data')).toBeInTheDocument();
     expect(screen.getByTestId('mock-table-layout-row-1')).toHaveTextContent(JSON.stringify(rowWithActions));
+  });
 
-    expect(screen.getByTestId('mock-cell-fondId')).toHaveTextContent(fond.id);
-    expect(screen.getByTestId('mock-cell-name')).toHaveTextContent(fond.name);
-    expect(screen.getByTestId('mock-cell-descriptionsCount')).toHaveTextContent(String(fond.descriptions));
-    expect(screen.getByTestId('mock-cell-casesCount')).toHaveTextContent(String(fond.cases));
-    expect(screen.getByTestId('mock-cell-dates')).toHaveTextContent(fond.dates);
-    expect(screen.getByTestId('mock-cell-status')).toBeInTheDocument();
-    expect(screen.getByTestId('mock-cell-actions')).toBeInTheDocument();
+  it.each([
+    { column: 'fondId', value: ARCHIVE_FONDS_TABLE_HEADERS.fond },
+    { column: 'name', value: ARCHIVE_FONDS_TABLE_HEADERS.name },
+    { column: 'descriptionsCount', value: ARCHIVE_FONDS_TABLE_HEADERS.descr },
+    { column: 'casesCount', value: ARCHIVE_FONDS_TABLE_HEADERS.cases },
+    { column: 'dates', value: ARCHIVE_FONDS_TABLE_HEADERS.dates },
+  ])('should render the $column column with value $value', ({ column, value }) => {
+    renderComponent();
+    expect(screen.getByTestId(`mock-table-layout-column-${column}`)).toHaveTextContent(value);
+  });
+
+  it.each([
+    { cell: 'fondId', value: fond.id },
+    { cell: 'name', value: fond.name },
+    { cell: 'descriptionsCount', value: String(fond.descriptions) },
+    { cell: 'casesCount', value: String(fond.cases) },
+    { cell: 'dates', value: fond.dates },
+    { cell: 'status', value: undefined },
+    { cell: 'actions', value: undefined },
+  ])('should render the $cell cell with value $value', ({ cell, value }) => {
+    renderComponent();
+    if (value) {
+      expect(screen.getByTestId(`mock-cell-${cell}`)).toHaveTextContent(value);
+    } else {
+      expect(screen.getByTestId(`mock-cell-${cell}`)).toBeInTheDocument();
+    }
   });
   describe('should render state UIs', () => {
     it('should render the no search results fallback if rows.length is 0 and hasActiveCriteria is true', () => {

--- a/app/(logged_in)/archive/(components)/archive-fonds-table/ArchiveFondsTable.test.tsx
+++ b/app/(logged_in)/archive/(components)/archive-fonds-table/ArchiveFondsTable.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen } from '@testing-library/react';
+
+import { FondsTable, FondsTableProps } from './ArchiveFondsTable';
+import { ARCHIVE_EMPTY_STATE_DESCRIPTION, ARCHIVE_EMPTY_STATE_NO_RESULTS_DESCRIPTION, ARCHIVE_EMPTY_STATE_NO_RESULTS_TITLE, ARCHIVE_EMPTY_STATE_TITLE } from '~/constants/archive';
+import { BaseRowData, ColumnDef } from '~/shared/components/table-layout/row-variants/Row.types';
+import { BaseContentStatuses } from '~/types/enums/common.enums';
+
+type EmptyStateProps = {
+  title: string;
+  description: string;
+};
+
+type TableLayoutProps<TGroup, TSub, TPlain> = {
+  data: readonly BaseRowData<TGroup, TSub, TPlain>[];
+  columns: readonly ColumnDef<TGroup, TSub, TPlain>[];
+};
+
+jest.mock('~/shared/components/empty-state', () => ({
+  EmptyState: ({ title, description }: EmptyStateProps) => (
+    <div data-testid="mock-empty-state">
+      <div data-testid="mock-empty-state-title">{title}</div>
+      <div data-testid="mock-empty-state-description">{description}</div>
+    </div>
+  ),
+}));
+
+jest.mock('~/shared/components/table-layout/components/RowActions');
+jest.mock('~/shared/components/table-layout/components/StatusBadge');
+
+jest.mock('~/shared/components/table-layout/TableLayout', () => ({
+  TableLayout: <TGroup, TSub, TPlain>({ data, columns }: TableLayoutProps<TGroup, TSub, TPlain>) => (
+    <div data-testid="mock-table-layout">
+      <div data-testid="mock-table-layout-columns">
+        {columns.map((col) => (
+          <span key={col.id} data-testid={`mock-table-layout-column-${col.id}`}>
+            {col.headerLabel}
+          </span>
+        ))}
+      </div>
+      <div data-testid="mock-table-layout-data">
+        {data
+          .filter((item) => item.type === 'individual')
+          .map((item) => (
+            <div key={item.id} data-testid={`mock-table-layout-row-${item.id}`}>
+              {JSON.stringify(item)}
+              {columns.map((col) => (
+                <span key={col.id} data-testid={`mock-cell-${col.id}`}>
+                  {col.renderPlain ? col.renderPlain(item.plainData) : null}
+                </span>
+              ))}
+            </div>
+          ))}
+      </div>
+    </div>
+  ),
+}));
+
+const defaultProps: FondsTableProps = {
+  founds: [
+    {
+      id: '1',
+      fondNumber: 1,
+      name: 'Фонд 1',
+      descriptions: 10,
+      cases: 20,
+      dates: '1990 - 2000',
+      status: BaseContentStatuses.Published,
+      updatedAt: '2023-01-01',
+    },
+  ],
+  hasActiveCriteria: false,
+};
+
+const renderComponent = (overrides?: Partial<FondsTableProps>) => {
+  return render(<FondsTable {...defaultProps} {...overrides} />);
+};
+
+describe('ArchiveFondsTable', () => {
+  it('should render all columns and rows with founds data', () => {
+    renderComponent();
+    const found = defaultProps.founds[0];
+    const rowWithActions = {
+      type: 'individual', id: found.id, plainData: {
+        ...defaultProps.founds[0], editAction: {
+          editHref: `/archive/found/${found.id}/edit`, editLabel: `Редагувати фонд Фонд ${found.id}`
+        },
+
+        menuActions: {
+          menuItems: [{ items: [{ id: 'edit', text: { name: 'Редагувати' }, href: `/archive/found/${found.id}/edit` }, { id: 'share', text: { name: 'Поширити' }, href: `/archive/found/${found.id}/share` }] }, { items: [{ id: 'delete', text: { name: 'Видалити' } }] }], menuTriggerLabel: `Дії для фонду Фонд ${found.id}`
+        }
+      },
+    };
+
+
+    expect(screen.getByTestId('mock-table-layout')).toBeInTheDocument();
+
+    expect(screen.getByTestId('mock-table-layout-columns')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-table-layout-column-fondId')).toHaveTextContent('Фонд');
+    expect(screen.getByTestId('mock-table-layout-column-name')).toHaveTextContent('Назва фонду');
+    expect(screen.getByTestId('mock-table-layout-column-descriptionsCount')).toHaveTextContent('Описи');
+    expect(screen.getByTestId('mock-table-layout-column-casesCount')).toHaveTextContent('Справи');
+    expect(screen.getByTestId('mock-table-layout-column-dates')).toHaveTextContent('Дати утворення');
+    expect(screen.getByTestId('mock-table-layout-column-status')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-table-layout-column-actions')).toBeInTheDocument();
+
+    expect(screen.getByTestId('mock-table-layout-data')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-table-layout-row-1')).toHaveTextContent(JSON.stringify(rowWithActions));
+
+    expect(screen.getByTestId('mock-cell-fondId')).toHaveTextContent(found.id);
+    expect(screen.getByTestId('mock-cell-name')).toHaveTextContent(found.name);
+    expect(screen.getByTestId('mock-cell-descriptionsCount')).toHaveTextContent(String(found.descriptions));
+    expect(screen.getByTestId('mock-cell-casesCount')).toHaveTextContent(String(found.cases));
+    expect(screen.getByTestId('mock-cell-dates')).toHaveTextContent(found.dates);
+    expect(screen.getByTestId('mock-cell-status')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-cell-actions')).toBeInTheDocument();
+  });
+  describe('should render state UIs', () => {
+    it('should render the no search results fallback if rows.length is 0 and hasActiveCriteria is true', () => {
+      renderComponent({ hasActiveCriteria: true, founds: [] });
+
+      expect(screen.getByTestId('mock-empty-state')).toBeInTheDocument();
+      expect(screen.getByTestId('mock-empty-state-title')).toHaveTextContent(ARCHIVE_EMPTY_STATE_NO_RESULTS_TITLE);
+      expect(screen.getByTestId('mock-empty-state-description')).toHaveTextContent(ARCHIVE_EMPTY_STATE_NO_RESULTS_DESCRIPTION);
+    });
+    it('should render the not found fallback if rows.length is 0 and hasActiveCriteria is false', () => {
+      renderComponent({ founds: [] });
+
+      expect(screen.getByTestId('mock-empty-state')).toBeInTheDocument();
+      expect(screen.getByTestId('mock-empty-state-title')).toHaveTextContent(ARCHIVE_EMPTY_STATE_TITLE);
+      expect(screen.getByTestId('mock-empty-state-description')).toHaveTextContent(ARCHIVE_EMPTY_STATE_DESCRIPTION);
+    });
+  });
+});

--- a/app/(logged_in)/archive/(components)/archive-fonds-table/ArchiveFondsTable.test.tsx
+++ b/app/(logged_in)/archive/(components)/archive-fonds-table/ArchiveFondsTable.test.tsx
@@ -56,7 +56,7 @@ jest.mock('~/shared/components/table-layout/TableLayout', () => ({
 }));
 
 const defaultProps: FondsTableProps = {
-  founds: [
+  fonds: [
     {
       id: '1',
       fondNumber: 1,
@@ -76,17 +76,17 @@ const renderComponent = (overrides?: Partial<FondsTableProps>) => {
 };
 
 describe('ArchiveFondsTable', () => {
-  it('should render all columns and rows with founds data', () => {
+  it('should render all columns and rows with fonds data', () => {
     renderComponent();
-    const found = defaultProps.founds[0];
+    const fond = defaultProps.fonds[0];
     const rowWithActions = {
-      type: 'individual', id: found.id, plainData: {
-        ...defaultProps.founds[0], editAction: {
-          editHref: `/archive/found/${found.id}/edit`, editLabel: `Редагувати фонд Фонд ${found.id}`
+      type: 'individual', id: fond.id, plainData: {
+        ...defaultProps.fonds[0], editAction: {
+          editHref: `/archive/fond/${fond.id}/edit`, editLabel: `Редагувати фонд Фонд ${fond.id}`
         },
 
         menuActions: {
-          menuItems: [{ items: [{ id: 'edit', text: { name: 'Редагувати' }, href: `/archive/found/${found.id}/edit` }, { id: 'share', text: { name: 'Поширити' }, href: `/archive/found/${found.id}/share` }] }, { items: [{ id: 'delete', text: { name: 'Видалити' } }] }], menuTriggerLabel: `Дії для фонду Фонд ${found.id}`
+          menuItems: [{ items: [{ id: 'edit', text: { name: 'Редагувати' }, href: `/archive/fond/${fond.id}/edit` }, { id: 'share', text: { name: 'Поширити' }, href: `/archive/fond/${fond.id}/share` }] }, { items: [{ id: 'delete', text: { name: 'Видалити' } }] }], menuTriggerLabel: `Дії для фонду Фонд ${fond.id}`
         }
       },
     };
@@ -106,24 +106,24 @@ describe('ArchiveFondsTable', () => {
     expect(screen.getByTestId('mock-table-layout-data')).toBeInTheDocument();
     expect(screen.getByTestId('mock-table-layout-row-1')).toHaveTextContent(JSON.stringify(rowWithActions));
 
-    expect(screen.getByTestId('mock-cell-fondId')).toHaveTextContent(found.id);
-    expect(screen.getByTestId('mock-cell-name')).toHaveTextContent(found.name);
-    expect(screen.getByTestId('mock-cell-descriptionsCount')).toHaveTextContent(String(found.descriptions));
-    expect(screen.getByTestId('mock-cell-casesCount')).toHaveTextContent(String(found.cases));
-    expect(screen.getByTestId('mock-cell-dates')).toHaveTextContent(found.dates);
+    expect(screen.getByTestId('mock-cell-fondId')).toHaveTextContent(fond.id);
+    expect(screen.getByTestId('mock-cell-name')).toHaveTextContent(fond.name);
+    expect(screen.getByTestId('mock-cell-descriptionsCount')).toHaveTextContent(String(fond.descriptions));
+    expect(screen.getByTestId('mock-cell-casesCount')).toHaveTextContent(String(fond.cases));
+    expect(screen.getByTestId('mock-cell-dates')).toHaveTextContent(fond.dates);
     expect(screen.getByTestId('mock-cell-status')).toBeInTheDocument();
     expect(screen.getByTestId('mock-cell-actions')).toBeInTheDocument();
   });
   describe('should render state UIs', () => {
     it('should render the no search results fallback if rows.length is 0 and hasActiveCriteria is true', () => {
-      renderComponent({ hasActiveCriteria: true, founds: [] });
+      renderComponent({ hasActiveCriteria: true, fonds: [] });
 
       expect(screen.getByTestId('mock-empty-state')).toBeInTheDocument();
       expect(screen.getByTestId('mock-empty-state-title')).toHaveTextContent(ARCHIVE_EMPTY_STATE_NO_RESULTS_TITLE);
       expect(screen.getByTestId('mock-empty-state-description')).toHaveTextContent(ARCHIVE_EMPTY_STATE_NO_RESULTS_DESCRIPTION);
     });
-    it('should render the not found fallback if rows.length is 0 and hasActiveCriteria is false', () => {
-      renderComponent({ founds: [] });
+    it('should render the not fond fallback if rows.length is 0 and hasActiveCriteria is false', () => {
+      renderComponent({ fonds: [] });
 
       expect(screen.getByTestId('mock-empty-state')).toBeInTheDocument();
       expect(screen.getByTestId('mock-empty-state-title')).toHaveTextContent(ARCHIVE_EMPTY_STATE_TITLE);

--- a/app/(logged_in)/archive/(components)/archive-fonds-table/ArchiveFondsTable.test.tsx
+++ b/app/(logged_in)/archive/(components)/archive-fonds-table/ArchiveFondsTable.test.tsx
@@ -1,7 +1,13 @@
 import { render, screen } from '@testing-library/react';
 
 import { FondsTable, FondsTableProps } from './ArchiveFondsTable';
-import { ARCHIVE_EMPTY_STATE_DESCRIPTION, ARCHIVE_EMPTY_STATE_NO_RESULTS_DESCRIPTION, ARCHIVE_EMPTY_STATE_NO_RESULTS_TITLE, ARCHIVE_EMPTY_STATE_TITLE } from '~/constants/archive';
+import {
+  ARCHIVE_EMPTY_STATE_DESCRIPTION,
+  ARCHIVE_EMPTY_STATE_NO_RESULTS_DESCRIPTION,
+  ARCHIVE_EMPTY_STATE_NO_RESULTS_TITLE,
+  ARCHIVE_EMPTY_STATE_TITLE,
+  ARCHIVE_FONDS_TABLE_HEADERS,
+} from '~/constants/archive';
 import { BaseRowData, ColumnDef } from '~/shared/components/table-layout/row-variants/Row.types';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
 
@@ -95,11 +101,11 @@ describe('ArchiveFondsTable', () => {
     expect(screen.getByTestId('mock-table-layout')).toBeInTheDocument();
 
     expect(screen.getByTestId('mock-table-layout-columns')).toBeInTheDocument();
-    expect(screen.getByTestId('mock-table-layout-column-fondId')).toHaveTextContent('Фонд');
-    expect(screen.getByTestId('mock-table-layout-column-name')).toHaveTextContent('Назва фонду');
-    expect(screen.getByTestId('mock-table-layout-column-descriptionsCount')).toHaveTextContent('Описи');
-    expect(screen.getByTestId('mock-table-layout-column-casesCount')).toHaveTextContent('Справи');
-    expect(screen.getByTestId('mock-table-layout-column-dates')).toHaveTextContent('Дати утворення');
+    expect(screen.getByTestId('mock-table-layout-column-fondId')).toHaveTextContent(ARCHIVE_FONDS_TABLE_HEADERS.fond);
+    expect(screen.getByTestId('mock-table-layout-column-name')).toHaveTextContent(ARCHIVE_FONDS_TABLE_HEADERS.name);
+    expect(screen.getByTestId('mock-table-layout-column-descriptionsCount')).toHaveTextContent(ARCHIVE_FONDS_TABLE_HEADERS.descr);
+    expect(screen.getByTestId('mock-table-layout-column-casesCount')).toHaveTextContent(ARCHIVE_FONDS_TABLE_HEADERS.cases);
+    expect(screen.getByTestId('mock-table-layout-column-dates')).toHaveTextContent(ARCHIVE_FONDS_TABLE_HEADERS.dates);
     expect(screen.getByTestId('mock-table-layout-column-status')).toBeInTheDocument();
     expect(screen.getByTestId('mock-table-layout-column-actions')).toBeInTheDocument();
 

--- a/app/(logged_in)/archive/(components)/archive-fonds-table/ArchiveFondsTable.test.tsx
+++ b/app/(logged_in)/archive/(components)/archive-fonds-table/ArchiveFondsTable.test.tsx
@@ -105,7 +105,7 @@ describe('ArchiveFondsTable', () => {
   });
 
   it.each([
-    { column: 'fondId', value: ARCHIVE_FONDS_TABLE_HEADERS.fond },
+    { column: 'fondNumber', value: ARCHIVE_FONDS_TABLE_HEADERS.fond },
     { column: 'name', value: ARCHIVE_FONDS_TABLE_HEADERS.name },
     { column: 'descriptionsCount', value: ARCHIVE_FONDS_TABLE_HEADERS.descr },
     { column: 'casesCount', value: ARCHIVE_FONDS_TABLE_HEADERS.cases },
@@ -116,7 +116,7 @@ describe('ArchiveFondsTable', () => {
   });
 
   it.each([
-    { cell: 'fondId', value: fond.id },
+    { cell: 'fondNumber', value: String(fond.fondNumber) },
     { cell: 'name', value: fond.name },
     { cell: 'descriptionsCount', value: String(fond.descriptions) },
     { cell: 'casesCount', value: String(fond.cases) },

--- a/app/(logged_in)/archive/(components)/archive-fonds-table/ArchiveFondsTable.test.tsx
+++ b/app/(logged_in)/archive/(components)/archive-fonds-table/ArchiveFondsTable.test.tsx
@@ -116,7 +116,7 @@ describe('ArchiveFondsTable', () => {
   });
 
   it.each([
-    { cell: 'fondId', value: fond.id },
+    { cell: 'fondNumber', value: String(fond.fondNumber) },
     { cell: 'name', value: fond.name },
     { cell: 'descriptionsCount', value: String(fond.descriptions) },
     { cell: 'casesCount', value: String(fond.cases) },

--- a/app/(logged_in)/archive/(components)/archive-fonds-table/ArchiveFondsTable.tsx
+++ b/app/(logged_in)/archive/(components)/archive-fonds-table/ArchiveFondsTable.tsx
@@ -26,8 +26,6 @@ export interface FondsTableProps {
   hasActiveCriteria: boolean;
 }
 
-
-
 export const FondsTable = ({ fonds, hasActiveCriteria }: FondsTableProps) => {
   const rows = fonds.map((fond) => ({
     type: 'individual' as const,
@@ -57,12 +55,12 @@ export const FondsTable = ({ fonds, hasActiveCriteria }: FondsTableProps) => {
 
   const columns: readonly ColumnDef<never, never, FondRow>[] = [
     {
-      id: 'fondId',
+      id: 'fondNumber',
       headerLabel: ARCHIVE_FONDS_TABLE_HEADERS.fond,
       align: 'center',
       width: '46px',
       hasRightDivider: true,
-      renderPlain: (fond) => fond.id,
+      renderPlain: (fond) => fond.fondNumber,
     },
     {
       id: 'name',

--- a/app/(logged_in)/archive/(components)/archive-fonds-table/ArchiveFondsTable.tsx
+++ b/app/(logged_in)/archive/(components)/archive-fonds-table/ArchiveFondsTable.tsx
@@ -10,7 +10,7 @@ import { ColumnDef } from '~/shared/components/table-layout/row-variants/Row.typ
 import { TableLayout } from '~/shared/components/table-layout/TableLayout';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
 
-export type Found = {
+export type Fond = {
   id: string;
   fondNumber: number;
   name: string;
@@ -21,32 +21,32 @@ export type Found = {
   updatedAt: string;
 }
 
-export type FoundRow = Found & {
+export type FondRow = Fond & {
   editAction: { editHref: string; editLabel: string };
   menuActions: { menuItems: ActionMenuGroups; menuTriggerLabel: string };
 };
 
 export interface FondsTableProps {
-  founds: Found[];
+  fonds: Fond[];
   hasActiveCriteria: boolean;
 }
 
-export const FondsTable = ({ founds, hasActiveCriteria }: FondsTableProps) => {
-  const rows = founds.map((fond) => ({
+export const FondsTable = ({ fonds, hasActiveCriteria }: FondsTableProps) => {
+  const rows = fonds.map((fond) => ({
     type: 'individual' as const,
     id: fond.id,
     plainData: {
       ...fond,
       editAction: {
-        editHref: `${ARCHIVE_BASE_PATH}/found/${fond.id}/edit`,
+        editHref: `${ARCHIVE_BASE_PATH}/fond/${fond.id}/edit`,
         editLabel: `Редагувати фонд ${fond.name}`
       },
       menuActions: {
         menuItems: [
           {
             items: [
-              { id: 'edit', text: { name: 'Редагувати' }, href: `${ARCHIVE_BASE_PATH}/found/${fond.id}/edit` },
-              { id: 'share', text: { name: 'Поширити' }, href: `${ARCHIVE_BASE_PATH}/found/${fond.id}/share` }
+              { id: 'edit', text: { name: 'Редагувати' }, href: `${ARCHIVE_BASE_PATH}/fond/${fond.id}/edit` },
+              { id: 'share', text: { name: 'Поширити' }, href: `${ARCHIVE_BASE_PATH}/fond/${fond.id}/share` }
             ]
           },
           {
@@ -58,7 +58,7 @@ export const FondsTable = ({ founds, hasActiveCriteria }: FondsTableProps) => {
     },
   }));
 
-  const columns = useMemo<readonly ColumnDef<never, never, FoundRow>[]>(() => {
+  const columns = useMemo<readonly ColumnDef<never, never, FondRow>[]>(() => {
     return [
       {
         id: 'fondId',

--- a/app/(logged_in)/archive/(components)/archive-fonds-table/ArchiveFondsTable.tsx
+++ b/app/(logged_in)/archive/(components)/archive-fonds-table/ArchiveFondsTable.tsx
@@ -1,0 +1,128 @@
+'use client';
+import { useMemo } from 'react';
+
+import { ARCHIVE_BASE_PATH, ARCHIVE_EMPTY_STATE_DESCRIPTION, ARCHIVE_EMPTY_STATE_NO_RESULTS_DESCRIPTION, ARCHIVE_EMPTY_STATE_NO_RESULTS_TITLE, ARCHIVE_EMPTY_STATE_TITLE } from '~/constants/archive';
+import { ActionMenuGroups } from '~/shared/components/dropdown-menu/ActionMenu';
+import { EmptyState } from '~/shared/components/empty-state';
+import { RowActions } from '~/shared/components/table-layout/components/RowActions';
+import { StatusBadge } from '~/shared/components/table-layout/components/StatusBadge';
+import { ColumnDef } from '~/shared/components/table-layout/row-variants/Row.types';
+import { TableLayout } from '~/shared/components/table-layout/TableLayout';
+import { BaseContentStatuses } from '~/types/enums/common.enums';
+
+export type Found = {
+  id: string;
+  fondNumber: number;
+  name: string;
+  descriptions: number;
+  cases: number;
+  dates: string;
+  status: BaseContentStatuses;
+  updatedAt: string;
+}
+
+export type FoundRow = Found & {
+  editAction: { editHref: string; editLabel: string };
+  menuActions: { menuItems: ActionMenuGroups; menuTriggerLabel: string };
+};
+
+interface FondsTableProps {
+  founds: Found[];
+  hasActiveCriteria: boolean;
+}
+
+export const FondsTable = ({ founds, hasActiveCriteria }: FondsTableProps) => {
+  const rows = founds.map((fond) => ({
+    type: 'individual' as const,
+    id: fond.id,
+    plainData: {
+      ...fond,
+      editAction: {
+        editHref: `${ARCHIVE_BASE_PATH}/found/${fond.id}/edit`,
+        editLabel: `Редагувати фонд ${fond.name}`
+      },
+      menuActions: {
+        menuItems: [
+          {
+            items: [
+              { id: 'edit', text: { name: 'Редагувати' }, href: `${ARCHIVE_BASE_PATH}/found/${fond.id}/edit` },
+              { id: 'share', text: { name: 'Поширити' }, href: `${ARCHIVE_BASE_PATH}/found/${fond.id}/share` }
+            ]
+          },
+          {
+            items: [{ id: 'delete', text: { name: 'Видалити' }, onClick: () => { } }]
+          }
+        ],
+        menuTriggerLabel: `Дії для фонду ${fond.name}`
+      }
+    },
+  }));
+
+  const columns = useMemo<readonly ColumnDef<never, never, FoundRow>[]>(() => {
+    return [
+      {
+        id: 'fondId',
+        headerLabel: 'Фонд',
+        align: 'center',
+        width: '46px',
+        hasRightDivider: true,
+        renderPlain: (fond) => fond.id,
+      },
+      {
+        id: 'name',
+        headerLabel: 'Назва фонду',
+        width: 'minmax(300px, 1fr)',
+        renderPlain: (fond) => fond.name,
+      },
+      {
+        id: 'descriptionsCount',
+        headerLabel: 'Описи',
+        width: '96px',
+        renderPlain: (fond) => String(fond.descriptions),
+      },
+      {
+        id: 'casesCount',
+        headerLabel: 'Справи',
+        width: '96px',
+        renderPlain: (fond) => String(fond.cases),
+      },
+      {
+        id: 'dates',
+        headerLabel: 'Дати утворення',
+        width: '160px',
+        renderPlain: (fond) => fond.dates,
+      },
+      {
+        id: 'status',
+        headerLabel: 'Статус',
+        width: '60px',
+        align: 'center',
+        hasLeftDivider: true,
+        hasRightDivider: true,
+        renderPlain: (fond) => <StatusBadge status={fond.status} updatedAt={fond.updatedAt} />,
+      },
+      {
+        id: 'actions',
+        width: '96px',
+        align: 'right',
+        renderPlain: (fond) => <RowActions editAction={{
+          editLabel: fond.editAction.editLabel,
+          editHref: fond.editAction.editHref
+        }} menuActions={fond.menuActions} />
+      }
+    ];
+  }, []);
+
+  if (rows.length === 0) {
+    return (
+      <EmptyState
+        title={hasActiveCriteria ? ARCHIVE_EMPTY_STATE_NO_RESULTS_TITLE : ARCHIVE_EMPTY_STATE_TITLE}
+        description={hasActiveCriteria ? ARCHIVE_EMPTY_STATE_NO_RESULTS_DESCRIPTION : ARCHIVE_EMPTY_STATE_DESCRIPTION}
+      />
+    );
+  }
+
+  return (
+    <TableLayout data={rows} columns={columns} />
+  );
+};

--- a/app/(logged_in)/archive/(components)/archive-fonds-table/ArchiveFondsTable.tsx
+++ b/app/(logged_in)/archive/(components)/archive-fonds-table/ArchiveFondsTable.tsx
@@ -26,7 +26,7 @@ export type FoundRow = Found & {
   menuActions: { menuItems: ActionMenuGroups; menuTriggerLabel: string };
 };
 
-interface FondsTableProps {
+export interface FondsTableProps {
   founds: Found[];
   hasActiveCriteria: boolean;
 }
@@ -50,7 +50,7 @@ export const FondsTable = ({ founds, hasActiveCriteria }: FondsTableProps) => {
             ]
           },
           {
-            items: [{ id: 'delete', text: { name: 'Видалити' }, onClick: () => { } }]
+            items: [{ id: 'delete', text: { name: 'Видалити' } }]
           }
         ],
         menuTriggerLabel: `Дії для фонду ${fond.name}`

--- a/app/(logged_in)/archive/(components)/archive-fonds-table/ArchiveFondsTable.tsx
+++ b/app/(logged_in)/archive/(components)/archive-fonds-table/ArchiveFondsTable.tsx
@@ -1,25 +1,20 @@
 'use client';
-import { useMemo } from 'react';
 
-import { ARCHIVE_BASE_PATH, ARCHIVE_EMPTY_STATE_DESCRIPTION, ARCHIVE_EMPTY_STATE_NO_RESULTS_DESCRIPTION, ARCHIVE_EMPTY_STATE_NO_RESULTS_TITLE, ARCHIVE_EMPTY_STATE_TITLE } from '~/constants/archive';
+import {
+  ARCHIVE_BASE_PATH,
+  ARCHIVE_EMPTY_STATE_DESCRIPTION,
+  ARCHIVE_EMPTY_STATE_NO_RESULTS_DESCRIPTION,
+  ARCHIVE_EMPTY_STATE_NO_RESULTS_TITLE,
+  ARCHIVE_EMPTY_STATE_TITLE,
+  ARCHIVE_FONDS_TABLE_HEADERS,
+} from '~/constants/archive';
+import { Fond } from '~/constants/fond';
 import { ActionMenuGroups } from '~/shared/components/dropdown-menu/ActionMenu';
 import { EmptyState } from '~/shared/components/empty-state';
 import { RowActions } from '~/shared/components/table-layout/components/RowActions';
 import { StatusBadge } from '~/shared/components/table-layout/components/StatusBadge';
 import { ColumnDef } from '~/shared/components/table-layout/row-variants/Row.types';
 import { TableLayout } from '~/shared/components/table-layout/TableLayout';
-import { BaseContentStatuses } from '~/types/enums/common.enums';
-
-export type Fond = {
-  id: string;
-  fondNumber: number;
-  name: string;
-  descriptions: number;
-  cases: number;
-  dates: string;
-  status: BaseContentStatuses;
-  updatedAt: string;
-}
 
 export type FondRow = Fond & {
   editAction: { editHref: string; editLabel: string };
@@ -30,6 +25,8 @@ export interface FondsTableProps {
   fonds: Fond[];
   hasActiveCriteria: boolean;
 }
+
+
 
 export const FondsTable = ({ fonds, hasActiveCriteria }: FondsTableProps) => {
   const rows = fonds.map((fond) => ({
@@ -58,61 +55,59 @@ export const FondsTable = ({ fonds, hasActiveCriteria }: FondsTableProps) => {
     },
   }));
 
-  const columns = useMemo<readonly ColumnDef<never, never, FondRow>[]>(() => {
-    return [
-      {
-        id: 'fondId',
-        headerLabel: 'Фонд',
-        align: 'center',
-        width: '46px',
-        hasRightDivider: true,
-        renderPlain: (fond) => fond.id,
-      },
-      {
-        id: 'name',
-        headerLabel: 'Назва фонду',
-        width: 'minmax(300px, 1fr)',
-        renderPlain: (fond) => fond.name,
-      },
-      {
-        id: 'descriptionsCount',
-        headerLabel: 'Описи',
-        width: '96px',
-        renderPlain: (fond) => String(fond.descriptions),
-      },
-      {
-        id: 'casesCount',
-        headerLabel: 'Справи',
-        width: '96px',
-        renderPlain: (fond) => String(fond.cases),
-      },
-      {
-        id: 'dates',
-        headerLabel: 'Дати утворення',
-        width: '160px',
-        renderPlain: (fond) => fond.dates,
-      },
-      {
-        id: 'status',
-        headerLabel: 'Статус',
-        width: '60px',
-        align: 'center',
-        hasLeftDivider: true,
-        hasRightDivider: true,
-        renderPlain: (fond) => <StatusBadge status={fond.status} updatedAt={fond.updatedAt} />,
-      },
-      {
-        id: 'actions',
-        width: '96px',
-        align: 'right',
-        renderPlain: (fond) => <RowActions editAction={{
-          editLabel: fond.editAction.editLabel,
-          editHref: fond.editAction.editHref
-        }} menuActions={fond.menuActions} />
-      }
-    ];
-  }, []);
-
+  const columns: readonly ColumnDef<never, never, FondRow>[] = [
+    {
+      id: 'fondId',
+      headerLabel: ARCHIVE_FONDS_TABLE_HEADERS.fond,
+      align: 'center',
+      width: '46px',
+      hasRightDivider: true,
+      renderPlain: (fond) => fond.id,
+    },
+    {
+      id: 'name',
+      headerLabel: ARCHIVE_FONDS_TABLE_HEADERS.name,
+      width: 'minmax(300px, 1fr)',
+      renderPlain: (fond) => fond.name,
+    },
+    {
+      id: 'descriptionsCount',
+      headerLabel: ARCHIVE_FONDS_TABLE_HEADERS.descr,
+      width: '96px',
+      renderPlain: (fond) => String(fond.descriptions),
+    },
+    {
+      id: 'casesCount',
+      headerLabel: ARCHIVE_FONDS_TABLE_HEADERS.cases,
+      width: '96px',
+      renderPlain: (fond) => String(fond.cases),
+    },
+    {
+      id: 'dates',
+      headerLabel: ARCHIVE_FONDS_TABLE_HEADERS.dates,
+      width: '160px',
+      renderPlain: (fond) => fond.dates,
+    },
+    {
+      id: 'status',
+      headerLabel: ARCHIVE_FONDS_TABLE_HEADERS.status,
+      width: '60px',
+      align: 'center',
+      hasLeftDivider: true,
+      hasRightDivider: true,
+      renderPlain: (fond) => <StatusBadge status={fond.status} updatedAt={fond.updatedAt} />,
+    },
+    {
+      id: 'actions',
+      width: '96px',
+      align: 'right',
+      renderPlain: (fond) => <RowActions editAction={{
+        editLabel: fond.editAction.editLabel,
+        editHref: fond.editAction.editHref
+      }} menuActions={fond.menuActions} />
+    }
+  ];
+ 
   if (rows.length === 0) {
     return (
       <EmptyState

--- a/app/(logged_in)/archive/(hooks)/useArchiveFiltering.tsx
+++ b/app/(logged_in)/archive/(hooks)/useArchiveFiltering.tsx
@@ -8,7 +8,7 @@ import { FilterSelectProps } from '~/shared/components/selector/FilterSelect';
 export const useArchiveFiltering = (): {
   activeStatusFilters: string[],
   searchProps: SearchProps,
-  statusFilterProps: FilterSelectProps
+  statusFilterProps: Omit<FilterSelectProps, 'value'> & { value: string[] }
 } => {
   const [search, setSearch] = useState<string>('');
   const [statusFilters, setStatusFilters] = useState<string[]>([ARCHIVE_STATUS_FILTER_OPTIONS[0].value]);

--- a/app/(logged_in)/archive/(temp)/archive.mock.data.json
+++ b/app/(logged_in)/archive/(temp)/archive.mock.data.json
@@ -1,0 +1,52 @@
+[
+  {
+    "id": "1",
+    "fondNumber": 2,
+    "name": "Pellentesque sit amet felis tortor. Donec sit amet metus mollis lorem tempus aliquet. Vivamus rutrum auctor libero nec mollis. Aenean quis consequat odio. Vivamus ante sem, lacinia ut porttitor nec, euismod vel est. Fusce ut arcu egestas velit facilisis suscipit sed sit amet nisi. Fusce turpis felis, scelerisque nec nisl non, facilisis mattis odio. Sed vitae dui ut risus porta placerat.Curabitur non libero ante. Sed commodo fermentum metus a sodales. Nullam dictum in ipsum in venenatis. Mauris ornare ultrices elit, sit amet eleifend orci luctus a. Nulla eu posuere turpis. Mauris ultricies orci massa, eget ultrices magna volutpat sed. In at tincidunt dolor. Aliquam ornare lacus nec justo facilisis, consectetur vestibulum erat finibus.Vestibulum laoreet orci at massa tristique, sit amet congue urna eleifend. Suspendisse euismod dui quis odio sagittis vehicula. Vivamus pellentesque, augue non placerat ultrices, odio odio tempor tortor, ut elementum lacus sem vitae eros. Praesent viverra.",
+    "descriptions": 2,
+    "cases": 2,
+    "dates": "1920-1930",
+    "status": "published",
+    "updatedAt": "2026-07-27T10:53:19.000Z"
+  },
+  {
+    "id": "2",
+    "fondNumber": 2,
+    "name": "Листи",
+    "descriptions": 2,
+    "cases": 2,
+    "dates": "1931-1945",
+    "status": "published",
+    "updatedAt": "2026-07-27T10:53:19.000Z"
+  },
+  {
+    "id": "3",
+    "fondNumber": 2,
+    "name": "Особисті документи",
+    "descriptions": 2,
+    "cases": 2,
+    "dates": "1946-1960",
+    "status": "published",
+    "updatedAt": "2026-07-27T10:53:19.000Z"
+  },
+  {
+    "id": "4",
+    "fondNumber": 4,
+    "name": "Аудіозаписи",
+    "descriptions": 2,
+    "cases": 2,
+    "dates": "1961-1980",
+    "status": "published",
+    "updatedAt": "2026-07-27T10:53:19.000Z"
+  },
+  {
+    "id": "5",
+    "fondNumber": 5,
+    "name": "Аудіозаписи",
+    "descriptions": 2,
+    "cases": 2,
+    "dates": "1961-1980",
+    "status": "hidden",
+    "updatedAt": "2026-07-27T10:53:19.000Z"
+  }
+]

--- a/app/(logged_in)/archive/(temp)/archive.mock.data.json
+++ b/app/(logged_in)/archive/(temp)/archive.mock.data.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "1",
-    "fondNumber": 2,
+    "fondNumber": 1,
     "name": "Pellentesque sit amet felis tortor. Donec sit amet metus mollis lorem tempus aliquet. Vivamus rutrum auctor libero nec mollis. Aenean quis consequat odio. Vivamus ante sem, lacinia ut porttitor nec, euismod vel est. Fusce ut arcu egestas velit facilisis suscipit sed sit amet nisi. Fusce turpis felis, scelerisque nec nisl non, facilisis mattis odio. Sed vitae dui ut risus porta placerat.Curabitur non libero ante. Sed commodo fermentum metus a sodales. Nullam dictum in ipsum in venenatis. Mauris ornare ultrices elit, sit amet eleifend orci luctus a. Nulla eu posuere turpis. Mauris ultricies orci massa, eget ultrices magna volutpat sed. In at tincidunt dolor. Aliquam ornare lacus nec justo facilisis, consectetur vestibulum erat finibus.Vestibulum laoreet orci at massa tristique, sit amet congue urna eleifend. Suspendisse euismod dui quis odio sagittis vehicula. Vivamus pellentesque, augue non placerat ultrices, odio odio tempor tortor, ut elementum lacus sem vitae eros. Praesent viverra.",
     "descriptions": 2,
     "cases": 2,
@@ -21,7 +21,7 @@
   },
   {
     "id": "3",
-    "fondNumber": 2,
+    "fondNumber": 3,
     "name": "Особисті документи",
     "descriptions": 2,
     "cases": 2,

--- a/app/(logged_in)/archive/(temp)/archive.mock.ts
+++ b/app/(logged_in)/archive/(temp)/archive.mock.ts
@@ -1,30 +1,30 @@
 import seedData from './archive.mock.data.json';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
 
-export type FoundStatus = BaseContentStatuses;
+export type FondStatus = BaseContentStatuses;
 
-export type Found = {
+export type Fond = {
   id: string;
   fondNumber: number;
   name: string;
   descriptions: number;
   cases: number;
   dates: string;
-  status: FoundStatus;
+  status: FondStatus;
   updatedAt: string;
 };
 
-const isFoundStatus = (value: string): value is FoundStatus =>
+const isFondStatus = (value: string): value is FondStatus =>
   Object.values(BaseContentStatuses).includes(value as BaseContentStatuses);
 
-const normalizeStatus = (value: string): FoundStatus =>
-  isFoundStatus(value) ? value : BaseContentStatuses.Draft;
+const normalizeStatus = (value: string): FondStatus =>
+  isFondStatus(value) ? value : BaseContentStatuses.Draft;
 
-type FoundSeed = Omit<Found, 'status'> & { status: string };
+type FondSeed = Omit<Fond, 'status'> & { status: string };
 
-const SEEDS = seedData as FoundSeed[];
+const SEEDS = seedData as FondSeed[];
 
-export const ARCHIVE_FONDS_MOCK_DATA: Found[] = SEEDS.map((item) => ({
+export const ARCHIVE_FONDS_MOCK_DATA: Fond[] = SEEDS.map((item) => ({
   ...item,
   status: normalizeStatus(item.status)
 }));

--- a/app/(logged_in)/archive/(temp)/archive.mock.ts
+++ b/app/(logged_in)/archive/(temp)/archive.mock.ts
@@ -1,18 +1,6 @@
 import seedData from './archive.mock.data.json';
+import { Fond, FondStatus } from '~/constants/fond';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
-
-export type FondStatus = BaseContentStatuses;
-
-export type Fond = {
-  id: string;
-  fondNumber: number;
-  name: string;
-  descriptions: number;
-  cases: number;
-  dates: string;
-  status: FondStatus;
-  updatedAt: string;
-};
 
 const isFondStatus = (value: string): value is FondStatus =>
   Object.values(BaseContentStatuses).includes(value as BaseContentStatuses);

--- a/app/(logged_in)/archive/(temp)/archive.mock.ts
+++ b/app/(logged_in)/archive/(temp)/archive.mock.ts
@@ -1,0 +1,30 @@
+import seedData from './archive.mock.data.json';
+import { BaseContentStatuses } from '~/types/enums/common.enums';
+
+export type FoundStatus = BaseContentStatuses;
+
+export type Found = {
+  id: string;
+  fondNumber: number;
+  name: string;
+  descriptions: number;
+  cases: number;
+  dates: string;
+  status: FoundStatus;
+  updatedAt: string;
+};
+
+const isFoundStatus = (value: string): value is FoundStatus =>
+  Object.values(BaseContentStatuses).includes(value as BaseContentStatuses);
+
+const normalizeStatus = (value: string): FoundStatus =>
+  isFoundStatus(value) ? value : BaseContentStatuses.Draft;
+
+type FoundSeed = Omit<Found, 'status'> & { status: string };
+
+const SEEDS = seedData as FoundSeed[];
+
+export const ARCHIVE_FONDS_MOCK_DATA: Found[] = SEEDS.map((item) => ({
+  ...item,
+  status: normalizeStatus(item.status)
+}));

--- a/app/constants/archive.ts
+++ b/app/constants/archive.ts
@@ -63,3 +63,12 @@ export const ARCHIVE_EMPTY_STATE_DESCRIPTION =
   'Натисніть «Додати фонд», щоб створити перший.';
 export const ARCHIVE_EMPTY_STATE_NO_RESULTS_TITLE = 'Нічого не знайдено';
 export const ARCHIVE_EMPTY_STATE_NO_RESULTS_DESCRIPTION = 'Спробуйте змінити параметри пошуку або фільтрів.';
+
+export const ARCHIVE_FONDS_TABLE_HEADERS = {
+  fond: 'Фонд',
+  name: 'Назва фонду',
+  descr: 'Описи',
+  cases: 'Справи',
+  dates: 'Дати утворення',
+  status: 'Статус',
+} as const;

--- a/app/constants/archive.ts
+++ b/app/constants/archive.ts
@@ -55,3 +55,11 @@ export const INITIAL_PDF_ENTRY: PdfEntry = {
   name: null,
   fileName: null,
 };
+
+export const ARCHIVE_CREATE_PATH = `${ARCHIVE_BASE_PATH}/create`;
+
+export const ARCHIVE_EMPTY_STATE_TITLE = 'Фондів ще немає.';
+export const ARCHIVE_EMPTY_STATE_DESCRIPTION =
+  'Натисніть «Додати фонд», щоб створити перший.';
+export const ARCHIVE_EMPTY_STATE_NO_RESULTS_TITLE = 'Нічого не знайдено';
+export const ARCHIVE_EMPTY_STATE_NO_RESULTS_DESCRIPTION = 'Спробуйте змінити параметри пошуку або фільтрів.';

--- a/app/constants/fond.ts
+++ b/app/constants/fond.ts
@@ -1,0 +1,14 @@
+import { BaseContentStatuses } from '~/types/enums/common.enums';
+
+export type FondStatus = BaseContentStatuses;
+
+export type Fond = {
+  id: string;
+  fondNumber: number;
+  name: string;
+  descriptions: number;
+  cases: number;
+  dates: string;
+  status: FondStatus;
+  updatedAt: string;
+};


### PR DESCRIPTION
### Description

This PR implements the list view and filtering/sorting logic for the Archive page. It introduces the new `FondsTable` component to render list items using `TableLayout`, hooks it up to the existing filtering hooks, and utilizes a consolidated headers constant object for column naming in both the component and its tests.

### Key changes

#### 1. UI

- **ArchiveFondsTable.tsx**: 
  - implemented the `FondsTable` component using `TableLayout` to display mock and filtered fond list items. 
  - added configuration for columns (fond ID, name, descriptions count, cases count, creation dates, status badge, and actions). 
  - header labels are mapped to the new consolidated `ARCHIVE_FONDS_TABLE_HEADERS` object.
- **ArchivePageContent.tsx**: 
  - integrated the `FondsTable` component into the page content structure. 
  - added filtering logic using `useArchiveFiltering` to filter mock data by search query and status, sorted by ID in ascending order.

#### 2. Constants

- **archive.ts**: declared the `ARCHIVE_FONDS_TABLE_HEADERS` as a read-only object holding header text translations (`fond`, `name`, `descr`, `cases`, `dates`, `status`), improving maintainability and clean structure.
- **fond.ts**: created standard typescript interfaces `Fond` and `FondStatus` to type fond records.
- **archive.mock.ts** and **archive.mock.data.json**: added mocks representing real fond records for local testing and data injection.

#### 3. Tests

- **ArchiveFondsTable.test.tsx**: created complete unit/UI tests covering standard table rendering, dynamic header rendering, row data cells, fallback/empty states under active filter conditions, and interactive edit/share buttons.

Closes #671

## Type of change

- [x] New feature
- [ ] Bug fix
- [x] Refactoring/tech debt
- [ ] Documentation update
- [ ] Other

## How to test

1. Navigate to the `/archive` page.
2. Confirm that the list of mock archive fonds displays correctly.
3. Test search filter by typing into the search input. The list should update dynamically.
4. Test status filters (Published, Hidden, etc.). The list should filter according to the status choice.
5. Run the component test suite to ensure all assertions pass:
   ```bash
   npm run test
   ```

## Video / Screenshots

https://github.com/user-attachments/assets/236e3991-8ad4-4f8d-88f0-c919eabe16bf

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [ ] Task moved to the review column on the board
