### PR TITLE
feat: session inactivity timeout

### DIFF
--- a/app/(logged_in)/layout.tsx
+++ b/app/(logged_in)/layout.tsx
@@ -6,6 +6,7 @@ import BodyProvider from '~/providers/body-provider/BodyProvider';
 import { SideBarNavigation } from '~/shared/components/side-navigation/SideNavigation';
 import { Toaster } from '~/shared/components/toaster/Toaster';
 import DiscardModalProvider from '~/shared/providers/discard-modal-provider/DiscardModalProvider';
+import { SessionTimeoutProvider } from '~/shared/providers/session-timeout-provider/SessionTimeoutProvider';
 import { Wrapper } from '~/types/common';
 
 export { metadata } from '~/providers/body-provider/BodyProvider';
@@ -13,12 +14,14 @@ export { metadata } from '~/providers/body-provider/BodyProvider';
 export default async function RootLayout({ children }: Wrapper) {
   return (
     <BodyProvider>
-      <DiscardModalProvider>
-        <Box sx={styles.body}>
-          <SideBarNavigation />
-          <Box sx={styles.container}>{children}</Box>
-        </Box>
-      </DiscardModalProvider>
+      <SessionTimeoutProvider>
+        <DiscardModalProvider>
+          <Box sx={styles.body}>
+            <SideBarNavigation />
+            <Box sx={styles.container}>{children}</Box>
+          </Box>
+        </DiscardModalProvider>
+      </SessionTimeoutProvider>
       <Toaster />
     </BodyProvider>
   );

--- a/app/login/LoginInactivityToast.test.tsx
+++ b/app/login/LoginInactivityToast.test.tsx
@@ -1,0 +1,47 @@
+import '@testing-library/jest-dom';
+import { render, waitFor } from '@testing-library/react';
+import { useSearchParams } from 'next/navigation';
+import toast from 'react-hot-toast';
+
+import { LoginInactivityToast } from './LoginInactivityToast';
+
+jest.mock('next/navigation', () => ({
+  useSearchParams: jest.fn()
+}));
+
+jest.mock('react-hot-toast', () => ({
+  __esModule: true,
+  default: {
+    error: jest.fn()
+  }
+}));
+
+describe('LoginInactivityToast', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows inactivity toast when reason=inactivity', async () => {
+    (useSearchParams as jest.Mock).mockReturnValue({
+      get: jest.fn().mockReturnValue('inactivity')
+    });
+
+    render(<LoginInactivityToast />);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Сесію завершено через бездіяльність. Будь ласка, увійдіть знову.');
+    });
+  });
+
+  it('does not show toast when reason is missing', async () => {
+    (useSearchParams as jest.Mock).mockReturnValue({
+      get: jest.fn().mockReturnValue(null)
+    });
+
+    render(<LoginInactivityToast />);
+
+    await waitFor(() => {
+      expect(toast.error).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/login/LoginInactivityToast.tsx
+++ b/app/login/LoginInactivityToast.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+import { useEffect } from 'react';
+import toast from 'react-hot-toast';
+
+export function LoginInactivityToast() {
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    if (searchParams.get('reason') === 'inactivity') {
+      toast.error('Сесію завершено через бездіяльність. Будь ласка, увійдіть знову.');
+    }
+  }, [searchParams]);
+
+  return null;
+}

--- a/app/login/page.test.tsx
+++ b/app/login/page.test.tsx
@@ -35,7 +35,8 @@ jest.mock('~/types/graphql/generated/graphql', () => ({
 jest.mock('next/navigation', () => ({
   useRouter: () => ({
     push: routerMockPush
-  })
+  }),
+  useSearchParams: () => new URLSearchParams()
 }));
 
 jest.mock('react-hot-toast', () => ({

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useRouter, useSearchParams } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Suspense, useState } from 'react';
 import toast from 'react-hot-toast';
 
+import { LoginInactivityToast } from './LoginInactivityToast';
 import { loginErrors } from '~/constants/errors';
 import LoginModal from '~/shared/components/login-modal/LoginModal';
 import { type LoginSubmitData } from '~/types/adminLogin';
@@ -11,14 +12,7 @@ import { useLoginMutation } from '~/types/graphql/generated/graphql';
 
 export default function LoginPage() {
   const router = useRouter();
-  const searchParams = useSearchParams();
   const [triggerErrorClear, setTriggerErrorClear] = useState<number>(0);
-
-  useEffect(() => {
-    if (searchParams.get('reason') === 'inactivity') {
-      toast.error('Сесію завершено через бездіяльність. Будь ласка, увійдіть знову.');
-    }
-  }, [searchParams]);
 
   const [loginMutation, { loading }] = useLoginMutation({
     onCompleted: (data) => {
@@ -58,5 +52,13 @@ export default function LoginPage() {
     });
   };
 
-  return <LoginModal onSubmit={handleLoginSubmit} submitError={triggerErrorClear.toString()} loading={loading} />;
+  return (
+    <>
+      <Suspense fallback={null}>
+        <LoginInactivityToast />
+      </Suspense>
+
+      <LoginModal onSubmit={handleLoginSubmit} submitError={triggerErrorClear.toString()} loading={loading} />
+    </>
+  );
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
 
 import { loginErrors } from '~/constants/errors';
@@ -11,7 +11,14 @@ import { useLoginMutation } from '~/types/graphql/generated/graphql';
 
 export default function LoginPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [triggerErrorClear, setTriggerErrorClear] = useState<number>(0);
+
+  useEffect(() => {
+    if (searchParams.get('reason') === 'inactivity') {
+      toast.error('Сесію завершено через бездіяльність. Будь ласка, увійдіть знову.');
+    }
+  }, [searchParams]);
 
   const [loginMutation, { loading }] = useLoginMutation({
     onCompleted: (data) => {

--- a/app/shared/providers/session-timeout-provider/SessionTimeoutProvider.test.tsx
+++ b/app/shared/providers/session-timeout-provider/SessionTimeoutProvider.test.tsx
@@ -1,0 +1,186 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useRouter } from 'next/navigation';
+import React from 'react';
+
+import { SessionTimeoutProvider } from './SessionTimeoutProvider';
+import { logoutAction } from '~/shared/actions/auth';
+import { useStore } from '~/store';
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn()
+}));
+
+jest.mock('~/shared/actions/auth', () => ({
+  logoutAction: jest.fn()
+}));
+
+jest.mock('~/store', () => ({
+  useStore: jest.fn()
+}));
+
+const mockPush = jest.fn();
+const mockRefresh = jest.fn();
+const mockLogout = jest.fn();
+
+describe('SessionTimeoutProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+
+    (useRouter as jest.Mock).mockReturnValue({ push: mockPush, refresh: mockRefresh });
+    (useStore as unknown as jest.Mock).mockImplementation((selector) => selector({ logout: mockLogout }));
+    (logoutAction as jest.Mock).mockResolvedValue(undefined);
+
+    process.env.NEXT_PUBLIC_SESSION_INACTIVITY_TIMEOUT_MINUTES = '60';
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders children', () => {
+    render(
+      <SessionTimeoutProvider>
+        <div>Protected content</div>
+      </SessionTimeoutProvider>
+    );
+
+    expect(screen.getByText('Protected content')).toBeInTheDocument();
+  });
+
+  it('does not log out before the timeout period has elapsed', () => {
+    render(
+      <SessionTimeoutProvider>
+        <div>Protected content</div>
+      </SessionTimeoutProvider>
+    );
+
+    jest.advanceTimersByTime(59 * 60 * 1000);
+
+    expect(logoutAction).not.toHaveBeenCalled();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('logs out and redirects after the configured inactivity period', async () => {
+    render(
+      <SessionTimeoutProvider>
+        <div>Protected content</div>
+      </SessionTimeoutProvider>
+    );
+
+    jest.advanceTimersByTime(60 * 60 * 1000);
+
+    await waitFor(() => expect(logoutAction).toHaveBeenCalledTimes(1));
+    expect(mockLogout).toHaveBeenCalledTimes(1);
+    expect(mockPush).toHaveBeenCalledWith('/login?reason=inactivity');
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the default 60 minute timeout when the env variable is not set', async () => {
+    delete process.env.NEXT_PUBLIC_SESSION_INACTIVITY_TIMEOUT_MINUTES;
+
+    render(
+      <SessionTimeoutProvider>
+        <div>Protected content</div>
+      </SessionTimeoutProvider>
+    );
+
+    jest.advanceTimersByTime(60 * 60 * 1000);
+
+    await waitFor(() => expect(logoutAction).toHaveBeenCalledTimes(1));
+  });
+
+  it('respects a custom timeout value from the env variable', async () => {
+    process.env.NEXT_PUBLIC_SESSION_INACTIVITY_TIMEOUT_MINUTES = '1';
+
+    render(
+      <SessionTimeoutProvider>
+        <div>Protected content</div>
+      </SessionTimeoutProvider>
+    );
+
+    jest.advanceTimersByTime(60 * 1000);
+
+    await waitFor(() => expect(logoutAction).toHaveBeenCalledTimes(1));
+  });
+
+  it('resets the timer on mousemove activity', async () => {
+    render(
+      <SessionTimeoutProvider>
+        <div>Protected content</div>
+      </SessionTimeoutProvider>
+    );
+
+    jest.advanceTimersByTime(59 * 60 * 1000);
+    fireEvent.mouseMove(window);
+    jest.advanceTimersByTime(59 * 60 * 1000);
+
+    expect(logoutAction).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1 * 60 * 1000);
+
+    await waitFor(() => expect(logoutAction).toHaveBeenCalledTimes(1));
+  });
+
+  it('resets the timer on keypress activity', () => {
+    render(
+      <SessionTimeoutProvider>
+        <div>Protected content</div>
+      </SessionTimeoutProvider>
+    );
+
+    jest.advanceTimersByTime(59 * 60 * 1000);
+    fireEvent.keyPress(window, { key: 'a', code: 'KeyA', charCode: 97 });
+    jest.advanceTimersByTime(59 * 60 * 1000);
+
+    expect(logoutAction).not.toHaveBeenCalled();
+  });
+
+  it('resets the timer on click activity', () => {
+    render(
+      <SessionTimeoutProvider>
+        <div>Protected content</div>
+      </SessionTimeoutProvider>
+    );
+
+    jest.advanceTimersByTime(59 * 60 * 1000);
+    fireEvent.click(window);
+    jest.advanceTimersByTime(59 * 60 * 1000);
+
+    expect(logoutAction).not.toHaveBeenCalled();
+  });
+
+  it('still redirects even if logoutAction rejects', async () => {
+    (logoutAction as jest.Mock).mockRejectedValueOnce(new Error('Network error'));
+
+    render(
+      <SessionTimeoutProvider>
+        <div>Protected content</div>
+      </SessionTimeoutProvider>
+    );
+
+    jest.advanceTimersByTime(60 * 60 * 1000);
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/login?reason=inactivity'));
+    expect(mockLogout).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes event listeners on unmount', () => {
+    const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
+
+    const { unmount } = render(
+      <SessionTimeoutProvider>
+        <div>Protected content</div>
+      </SessionTimeoutProvider>
+    );
+
+    unmount();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('mousemove', expect.any(Function));
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('keypress', expect.any(Function));
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('click', expect.any(Function));
+
+    removeEventListenerSpy.mockRestore();
+  });
+});

--- a/app/shared/providers/session-timeout-provider/SessionTimeoutProvider.test.tsx
+++ b/app/shared/providers/session-timeout-provider/SessionTimeoutProvider.test.tsx
@@ -20,7 +20,6 @@ jest.mock('~/store', () => ({
 }));
 
 const mockPush = jest.fn();
-const mockRefresh = jest.fn();
 const mockLogout = jest.fn();
 
 describe('SessionTimeoutProvider', () => {
@@ -28,8 +27,12 @@ describe('SessionTimeoutProvider', () => {
     jest.clearAllMocks();
     jest.useFakeTimers();
 
-    (useRouter as jest.Mock).mockReturnValue({ push: mockPush, refresh: mockRefresh });
+    (useRouter as jest.Mock).mockReturnValue({
+      push: mockPush
+    });
+
     (useStore as unknown as jest.Mock).mockImplementation((selector) => selector({ logout: mockLogout }));
+
     (logoutAction as jest.Mock).mockResolvedValue(undefined);
 
     process.env.NEXT_PUBLIC_SESSION_INACTIVITY_TIMEOUT_MINUTES = '60';
@@ -72,9 +75,9 @@ describe('SessionTimeoutProvider', () => {
     jest.advanceTimersByTime(60 * 60 * 1000);
 
     await waitFor(() => expect(logoutAction).toHaveBeenCalledTimes(1));
+
     expect(mockLogout).toHaveBeenCalledTimes(1);
     expect(mockPush).toHaveBeenCalledWith('/login?reason=inactivity');
-    expect(mockRefresh).toHaveBeenCalledTimes(1);
   });
 
   it('uses the default 60 minute timeout when the env variable is not set', async () => {
@@ -113,12 +116,14 @@ describe('SessionTimeoutProvider', () => {
     );
 
     jest.advanceTimersByTime(59 * 60 * 1000);
+
     fireEvent.mouseMove(window);
+
     jest.advanceTimersByTime(59 * 60 * 1000);
 
     expect(logoutAction).not.toHaveBeenCalled();
 
-    jest.advanceTimersByTime(1 * 60 * 1000);
+    jest.advanceTimersByTime(60 * 1000);
 
     await waitFor(() => expect(logoutAction).toHaveBeenCalledTimes(1));
   });
@@ -131,7 +136,13 @@ describe('SessionTimeoutProvider', () => {
     );
 
     jest.advanceTimersByTime(59 * 60 * 1000);
-    fireEvent.keyPress(window, { key: 'a', code: 'KeyA', charCode: 97 });
+
+    fireEvent.keyPress(window, {
+      key: 'a',
+      code: 'KeyA',
+      charCode: 97
+    });
+
     jest.advanceTimersByTime(59 * 60 * 1000);
 
     expect(logoutAction).not.toHaveBeenCalled();
@@ -145,7 +156,9 @@ describe('SessionTimeoutProvider', () => {
     );
 
     jest.advanceTimersByTime(59 * 60 * 1000);
+
     fireEvent.click(window);
+
     jest.advanceTimersByTime(59 * 60 * 1000);
 
     expect(logoutAction).not.toHaveBeenCalled();
@@ -162,8 +175,10 @@ describe('SessionTimeoutProvider', () => {
 
     jest.advanceTimersByTime(60 * 60 * 1000);
 
-    await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/login?reason=inactivity'));
-    expect(mockLogout).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(mockLogout).toHaveBeenCalledTimes(1);
+      expect(mockPush).toHaveBeenCalledWith('/login?reason=inactivity');
+    });
   });
 
   it('removes event listeners on unmount', () => {

--- a/app/shared/providers/session-timeout-provider/SessionTimeoutProvider.test.tsx
+++ b/app/shared/providers/session-timeout-provider/SessionTimeoutProvider.test.tsx
@@ -20,6 +20,7 @@ jest.mock('~/store', () => ({
 }));
 
 const mockPush = jest.fn();
+const mockRefresh = jest.fn();
 const mockLogout = jest.fn();
 
 describe('SessionTimeoutProvider', () => {
@@ -28,7 +29,8 @@ describe('SessionTimeoutProvider', () => {
     jest.useFakeTimers();
 
     (useRouter as jest.Mock).mockReturnValue({
-      push: mockPush
+      push: mockPush,
+      refresh: mockRefresh
     });
 
     (useStore as unknown as jest.Mock).mockImplementation((selector) => selector({ logout: mockLogout }));
@@ -128,7 +130,7 @@ describe('SessionTimeoutProvider', () => {
     await waitFor(() => expect(logoutAction).toHaveBeenCalledTimes(1));
   });
 
-  it('resets the timer on keypress activity', () => {
+  it('resets the timer on keydown activity', () => {
     render(
       <SessionTimeoutProvider>
         <div>Protected content</div>
@@ -137,10 +139,9 @@ describe('SessionTimeoutProvider', () => {
 
     jest.advanceTimersByTime(59 * 60 * 1000);
 
-    fireEvent.keyPress(window, {
+    fireEvent.keyDown(window, {
       key: 'a',
-      code: 'KeyA',
-      charCode: 97
+      code: 'KeyA'
     });
 
     jest.advanceTimersByTime(59 * 60 * 1000);
@@ -181,6 +182,22 @@ describe('SessionTimeoutProvider', () => {
     });
   });
 
+  it('resets the timer on pointerdown activity', () => {
+    render(
+      <SessionTimeoutProvider>
+        <div>Protected content</div>
+      </SessionTimeoutProvider>
+    );
+
+    jest.advanceTimersByTime(59 * 60 * 1000);
+
+    fireEvent.pointerDown(window);
+
+    jest.advanceTimersByTime(59 * 60 * 1000);
+
+    expect(logoutAction).not.toHaveBeenCalled();
+  });
+
   it('removes event listeners on unmount', () => {
     const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
 
@@ -193,8 +210,9 @@ describe('SessionTimeoutProvider', () => {
     unmount();
 
     expect(removeEventListenerSpy).toHaveBeenCalledWith('mousemove', expect.any(Function));
-    expect(removeEventListenerSpy).toHaveBeenCalledWith('keypress', expect.any(Function));
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('keydown', expect.any(Function));
     expect(removeEventListenerSpy).toHaveBeenCalledWith('click', expect.any(Function));
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('pointerdown', expect.any(Function));
 
     removeEventListenerSpy.mockRestore();
   });

--- a/app/shared/providers/session-timeout-provider/SessionTimeoutProvider.tsx
+++ b/app/shared/providers/session-timeout-provider/SessionTimeoutProvider.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useRef } from 'react';
+
+import { logoutAction } from '~/shared/actions/auth';
+import { useStore } from '~/store';
+import { Wrapper } from '~/types/common';
+
+const DEFAULT_TIMEOUT_MINUTES = 60;
+
+const getTimeoutMs = () => {
+  const minutes = Number(process.env.NEXT_PUBLIC_SESSION_INACTIVITY_TIMEOUT_MINUTES) || DEFAULT_TIMEOUT_MINUTES;
+  return minutes * 60 * 1000;
+};
+
+const ACTIVITY_EVENTS = ['mousemove', 'mousedown', 'keypress', 'scroll', 'click', 'touchstart'] as const;
+
+export function SessionTimeoutProvider({ children }: Wrapper) {
+  const router = useRouter();
+  const logout = useStore((state) => state.logout);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleInactivity = useCallback(async () => {
+    try {
+      await logoutAction();
+    } catch (error) {
+      console.error('Помилка при завершенні сесії через бездіяльність', error);
+    }
+    logout();
+    router.push('/login?reason=inactivity');
+    router.refresh();
+  }, [logout, router]);
+
+  const resetTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+    timerRef.current = setTimeout(handleInactivity, getTimeoutMs());
+  }, [handleInactivity]);
+
+  useEffect(() => {
+    resetTimer();
+
+    ACTIVITY_EVENTS.forEach((event) => window.addEventListener(event, resetTimer));
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      ACTIVITY_EVENTS.forEach((event) => window.removeEventListener(event, resetTimer));
+    };
+  }, [resetTimer]);
+
+  return <>{children}</>;
+}

--- a/app/shared/providers/session-timeout-provider/SessionTimeoutProvider.tsx
+++ b/app/shared/providers/session-timeout-provider/SessionTimeoutProvider.tsx
@@ -24,10 +24,12 @@ export function SessionTimeoutProvider({ children }: Wrapper) {
   const handleInactivity = useCallback(async () => {
     try {
       await logoutAction();
-    } finally {
-      logout();
-      router.push('/login?reason=inactivity');
+    } catch {
+      // Ignore logout action errors and continue client-side logout.
     }
+
+    logout();
+    router.push('/login?reason=inactivity');
   }, [logout, router]);
 
   const resetTimer = useCallback(() => {

--- a/app/shared/providers/session-timeout-provider/SessionTimeoutProvider.tsx
+++ b/app/shared/providers/session-timeout-provider/SessionTimeoutProvider.tsx
@@ -8,31 +8,38 @@ import { useStore } from '~/store';
 import { Wrapper } from '~/types/common';
 
 const DEFAULT_TIMEOUT_MINUTES = 60;
+const THROTTLE_MS = 1000;
 
 const getTimeoutMs = () => {
   const minutes = Number(process.env.NEXT_PUBLIC_SESSION_INACTIVITY_TIMEOUT_MINUTES) || DEFAULT_TIMEOUT_MINUTES;
   return minutes * 60 * 1000;
 };
 
-const ACTIVITY_EVENTS = ['mousemove', 'mousedown', 'keypress', 'scroll', 'click', 'touchstart'] as const;
+const ACTIVITY_EVENTS = ['mousemove', 'mousedown', 'keydown', 'scroll', 'click', 'pointerdown'] as const;
 
 export function SessionTimeoutProvider({ children }: Wrapper) {
   const router = useRouter();
   const logout = useStore((state) => state.logout);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastResetRef = useRef(0);
 
   const handleInactivity = useCallback(async () => {
     try {
       await logoutAction();
-    } catch (error){
+    } catch (error) {
       console.error('Failed to clear session on inactivity logout:', error);
     }
 
     logout();
     router.push('/login?reason=inactivity');
+    router.refresh();
   }, [logout, router]);
 
   const resetTimer = useCallback(() => {
+    const now = Date.now();
+    if (now - lastResetRef.current < THROTTLE_MS) return;
+    lastResetRef.current = now;
+
     if (timerRef.current) {
       clearTimeout(timerRef.current);
     }

--- a/app/shared/providers/session-timeout-provider/SessionTimeoutProvider.tsx
+++ b/app/shared/providers/session-timeout-provider/SessionTimeoutProvider.tsx
@@ -24,12 +24,10 @@ export function SessionTimeoutProvider({ children }: Wrapper) {
   const handleInactivity = useCallback(async () => {
     try {
       await logoutAction();
-    } catch (error) {
-      console.error('Помилка при завершенні сесії через бездіяльність', error);
+    } finally {
+      logout();
+      router.push('/login?reason=inactivity');
     }
-    logout();
-    router.push('/login?reason=inactivity');
-    router.refresh();
   }, [logout, router]);
 
   const resetTimer = useCallback(() => {

--- a/app/shared/providers/session-timeout-provider/SessionTimeoutProvider.tsx
+++ b/app/shared/providers/session-timeout-provider/SessionTimeoutProvider.tsx
@@ -24,8 +24,8 @@ export function SessionTimeoutProvider({ children }: Wrapper) {
   const handleInactivity = useCallback(async () => {
     try {
       await logoutAction();
-    } catch {
-      // Ignore logout action errors and continue client-side logout.
+    } catch (error){
+      console.error('Failed to clear session on inactivity logout:', error);
     }
 
     logout();


### PR DESCRIPTION
## Description

Implemented automatic session timeout for inactive admin users.

### Changes:
- Added `SessionTimeoutProvider` to monitor user activity.
- Configured inactivity timeout using `NEXT_PUBLIC_SESSION_INACTIVITY_TIMEOUT_MINUTES`.
- Automatically logs out inactive users, clears the client session, and redirects to `/login?reason=inactivity`.
- Added a toast notification on the login page informing users that the session expired due to inactivity.

> **Note:** Please add the new environment variable to your local `.env` file:
>
> `NEXT_PUBLIC_SESSION_INACTIVITY_TIMEOUT_MINUTES=60`

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Add `NEXT_PUBLIC_SESSION_INACTIVITY_TIMEOUT_MINUTES` to your local `.env` file (for testing you can temporarily set it to `1`).
2. Start the application and log in to the admin panel.
3. Do not interact with the application until the inactivity timeout expires.
4. Verify that you are automatically redirected to `/login?reason=inactivity`.
5. Verify that the toast message "Сесію завершено через бездіяльність. Будь ласка, увійдіть знову." is displayed.

## Video / Screenshots


https://github.com/user-attachments/assets/90b12436-4709-4b6d-a64c-a8fee9c57117

note: the inactivity timeout was temporarily set to **1 minute** for the video. After 1 minute of inactivity, the user is automatically redirected to the login page, where the inactivity notification is displayed.

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---

Close #669 