### PR TITLE
Feature: Implement standalone composition actions

### DIFF
--- a/app/(logged_in)/creativity/(composition)/useDeleteWorkAction.test.ts
+++ b/app/(logged_in)/creativity/(composition)/useDeleteWorkAction.test.ts
@@ -1,0 +1,116 @@
+import { act,renderHook } from '@testing-library/react';
+import toast from 'react-hot-toast';
+
+import { useDeleteWorkAction } from './useDeleteWorkAction';
+import {
+  PaginatedWorksDocument,
+  useDeleteCompositionMutation
+} from '~/types/graphql/generated/graphql';
+
+jest.mock('react-hot-toast', () => ({
+  success: jest.fn(),
+  error: jest.fn()
+}));
+
+jest.mock('~/types/graphql/generated/graphql', () => ({
+  PaginatedWorksDocument: 'PaginatedWorksDocument',
+  useDeleteCompositionMutation: jest.fn()
+}));
+
+const mockUseDeleteCompositionMutation = useDeleteCompositionMutation as jest.MockedFunction<
+  typeof useDeleteCompositionMutation
+>;
+
+describe('useDeleteWorkAction', () => {
+  const mockDeleteCompositionMut = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseDeleteCompositionMutation.mockReturnValue([
+      mockDeleteCompositionMut,
+      { loading: false, data: undefined, reset: jest.fn(), called: false, client: {} as never }
+    ]);
+  });
+
+  it('should return initial state correctly', () => {
+    const { result } = renderHook(() => useDeleteWorkAction());
+
+    expect(result.current.deleteComposition).toBeNull();
+    expect(result.current.isDeleting).toBe(false);
+  });
+
+  it('should update deleteComposition state', () => {
+    const { result } = renderHook(() => useDeleteWorkAction());
+
+    act(() => {
+      result.current.setDeleteComposition('work-123');
+    });
+
+    expect(result.current.deleteComposition).toBe('work-123');
+  });
+
+  it('should return early when handleConfirmCompositionDelete is called with null deleteComposition', async () => {
+    const { result } = renderHook(() => useDeleteWorkAction());
+
+    await act(async () => {
+      await result.current.handleConfirmCompositionDelete();
+    });
+
+    expect(mockDeleteCompositionMut).not.toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('should handle successful composition deletion and call onSuccess', async () => {
+    const onSuccessMock = jest.fn<void, [string]>();
+    mockDeleteCompositionMut.mockResolvedValueOnce({ data: {} });
+
+    const { result } = renderHook(() =>
+      useDeleteWorkAction({ onSuccess: onSuccessMock })
+    );
+
+    act(() => {
+      result.current.setDeleteComposition('work-123');
+    });
+
+    await act(async () => {
+      await result.current.handleConfirmCompositionDelete();
+    });
+
+    expect(mockDeleteCompositionMut).toHaveBeenCalledWith({
+      variables: { id: 'work-123' },
+      refetchQueries: [PaginatedWorksDocument],
+      awaitRefetchQueries: true
+    });
+    expect(toast.success).toHaveBeenCalledWith('Твір успішно видалено');
+    expect(onSuccessMock).toHaveBeenCalledWith('work-123');
+    expect(result.current.deleteComposition).toBeNull();
+  });
+
+  it('should handle deletion failure and show error toast', async () => {
+    mockDeleteCompositionMut.mockRejectedValueOnce(new Error('Mutation failed'));
+
+    const { result } = renderHook(() => useDeleteWorkAction());
+
+    act(() => {
+      result.current.setDeleteComposition('work-123');
+    });
+
+    await act(async () => {
+      await result.current.handleConfirmCompositionDelete();
+    });
+
+    expect(toast.error).toHaveBeenCalledWith('Помилка при видаленні твору');
+  });
+
+  it('should correctly pass loading state from mutation hook', () => {
+    mockUseDeleteCompositionMutation.mockReturnValue([
+      mockDeleteCompositionMut,
+      { loading: true, data: undefined, reset: jest.fn(), called: true, client: {} as never }
+    ]);
+
+    const { result } = renderHook(() => useDeleteWorkAction());
+
+    expect(result.current.isDeleting).toBe(true);
+  });
+});

--- a/app/(logged_in)/creativity/(composition)/useDeleteWorkAction.ts
+++ b/app/(logged_in)/creativity/(composition)/useDeleteWorkAction.ts
@@ -1,0 +1,48 @@
+'use client';
+
+import { useState } from 'react';
+import toast from 'react-hot-toast';
+
+import {
+  PaginatedWorksDocument,
+  useDeleteCompositionMutation
+} from '~/types/graphql/generated/graphql';
+
+const TOAST_MESSAGES = {
+  DELETE_SUCCESS: 'Твір успішно видалено',
+  DELETE_ERROR: 'Помилка при видаленні твору'
+};
+
+interface UseDeleteWorkActionProps {
+  onSuccess?: (deletedId: string) => void;
+}
+
+export function useDeleteWorkAction({ onSuccess }: UseDeleteWorkActionProps = {}) {
+  const [deleteCompositionMut, { loading: isDeleting }] = useDeleteCompositionMutation();
+  const [deleteComposition, setDeleteComposition] = useState<string | null>(null);
+
+  const handleConfirmCompositionDelete = async () => {
+    if (!deleteComposition) return;
+
+    try {
+      await deleteCompositionMut({
+        variables: { id: deleteComposition },
+        refetchQueries: [PaginatedWorksDocument],
+        awaitRefetchQueries: true
+      });
+
+      toast.success(TOAST_MESSAGES.DELETE_SUCCESS);
+      onSuccess?.(deleteComposition);
+      setDeleteComposition(null);
+    } catch {
+      toast.error(TOAST_MESSAGES.DELETE_ERROR);
+    }
+  };
+
+  return {
+    deleteComposition,
+    setDeleteComposition,
+    handleConfirmCompositionDelete,
+    isDeleting
+  };
+}

--- a/app/(logged_in)/creativity/(composition)/useUpdateWorkAction.test.ts
+++ b/app/(logged_in)/creativity/(composition)/useUpdateWorkAction.test.ts
@@ -1,0 +1,200 @@
+import { act,renderHook } from '@testing-library/react';
+import { useRouter } from 'next/navigation';
+import toast from 'react-hot-toast';
+
+import { useUpdateWorkAction } from './useUpdateWorkAction';
+import {
+  PaginatedWorksDocument,
+  useUpdateCompositionMutation
+} from '~/types/graphql/generated/graphql';
+import type { OpusCompositionData } from '~/types/opus';
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn()
+}));
+
+jest.mock('react-hot-toast', () => ({
+  success: jest.fn(),
+  error: jest.fn()
+}));
+
+jest.mock('~/types/graphql/generated/graphql', () => ({
+  PaginatedWorksDocument: 'PaginatedWorksDocument',
+  useUpdateCompositionMutation: jest.fn()
+}));
+
+const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>;
+const mockUseUpdateCompositionMutation = useUpdateCompositionMutation as jest.MockedFunction<
+  typeof useUpdateCompositionMutation
+>;
+
+describe('useUpdateWorkAction', () => {
+  const mockRefresh = jest.fn<void, []>();
+  const mockUpdateCompositionMut = jest.fn();
+
+  const mockComposition: OpusCompositionData = {
+	  name: 'Symphony No. 5',
+	  year: '1808',
+	  genre: 'Symphony',
+	  audios: [
+		  {
+			  name: ' Movement 1 ',
+			  fileUrl: 'http://example.com/audio1.mp3',
+			  id: ''
+		  }
+	  ],
+	  notes: [
+		  {
+			  name: ' Full Score ',
+			  fileUrl: 'http://example.com/score.pdf',
+			  publishDate: ' 1808-12-22 ',
+			  id: ''
+		  }
+	  ],
+	  id: ''
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseRouter.mockReturnValue({
+      refresh: mockRefresh,
+      back: jest.fn(),
+      forward: jest.fn(),
+      push: jest.fn(),
+      replace: jest.fn(),
+      prefetch: jest.fn()
+    });
+    mockUseUpdateCompositionMutation.mockReturnValue([
+      mockUpdateCompositionMut,
+      { loading: false, data: undefined, reset: jest.fn(), called: false, client: {} as never }
+    ]);
+  });
+
+  it('should return initial state correctly', () => {
+    const { result } = renderHook(() => useUpdateWorkAction());
+
+    expect(result.current.isUpdating).toBe(false);
+    expect(typeof result.current.handleUpdateComposition).toBe('function');
+  });
+
+  it('should handle composition update successfully with full data', async () => {
+    mockUpdateCompositionMut.mockResolvedValueOnce({ data: {} });
+
+    const { result } = renderHook(() => useUpdateWorkAction());
+
+    await act(async () => {
+      await result.current.handleUpdateComposition('comp-123', mockComposition);
+    });
+
+    expect(mockUpdateCompositionMut).toHaveBeenCalledWith({
+      variables: {
+        id: 'comp-123',
+        input: {
+          name: { uk: 'Symphony No. 5', en: 'Symphony No. 5' },
+          year: 1808,
+          genre: 'Symphony',
+          audioAvailable: true,
+          sheetAvailable: true,
+          audios: [
+            {
+              name: 'Movement 1',
+              url: 'http://example.com/audio1.mp3'
+            }
+          ],
+          sheetMusic: [
+            {
+              name: 'Full Score',
+              url: 'http://example.com/score.pdf',
+              publishDate: '1808-12-22',
+              isFree: false,
+              dateUploaded: expect.any(String)
+            }
+          ]
+        }
+      },
+      refetchQueries: [PaginatedWorksDocument],
+      awaitRefetchQueries: true
+    });
+
+    expect(toast.success).toHaveBeenCalledWith('Твір успішно оновлено');
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('should map empty optional fields correctly when updating', async () => {
+    mockUpdateCompositionMut.mockResolvedValueOnce({ data: {} });
+
+    const minimalComposition: OpusCompositionData = {
+      name: 'Sonata',
+      year: '   ',
+      genre: '   ',
+      audios: [],
+      notes: [
+        {
+          name: undefined,
+          fileUrl: undefined,
+          publishDate: '   ',
+          id: ''
+        }
+      ],
+      id: ''
+    };
+
+    const { result } = renderHook(() => useUpdateWorkAction());
+
+    await act(async () => {
+      await result.current.handleUpdateComposition('comp-456', minimalComposition);
+    });
+
+    expect(mockUpdateCompositionMut).toHaveBeenCalledWith({
+      variables: {
+        id: 'comp-456',
+        input: {
+          name: { uk: 'Sonata', en: 'Sonata' },
+          year: undefined,
+          genre: undefined,
+          audioAvailable: false,
+          sheetAvailable: false,
+          audios: [],
+          sheetMusic: [
+            {
+              name: '',
+              url: undefined,
+              publishDate: undefined,
+              isFree: false,
+              dateUploaded: expect.any(String)
+            }
+          ]
+        }
+      },
+      refetchQueries: [PaginatedWorksDocument],
+      awaitRefetchQueries: true
+    });
+  });
+
+  it('should handle composition update error and throw', async () => {
+    const mockError = new Error('Update failed');
+    mockUpdateCompositionMut.mockRejectedValueOnce(mockError);
+
+    const { result } = renderHook(() => useUpdateWorkAction());
+
+    await act(async () => {
+      await expect(
+        result.current.handleUpdateComposition('comp-123', mockComposition)
+      ).rejects.toThrow('Update failed');
+    });
+
+    expect(toast.error).toHaveBeenCalledWith('Помилка при оновленні твору');
+    expect(mockRefresh).not.toHaveBeenCalled();
+  });
+
+  it('should reflect loading state from mutation hook', () => {
+    mockUseUpdateCompositionMutation.mockReturnValue([
+      mockUpdateCompositionMut,
+      { loading: true, data: undefined, reset: jest.fn(), called: true, client: {} as never }
+    ]);
+
+    const { result } = renderHook(() => useUpdateWorkAction());
+
+    expect(result.current.isUpdating).toBe(true);
+  });
+});

--- a/app/(logged_in)/creativity/(composition)/useUpdateWorkAction.ts
+++ b/app/(logged_in)/creativity/(composition)/useUpdateWorkAction.ts
@@ -1,0 +1,64 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import toast from 'react-hot-toast';
+
+import {
+  PaginatedWorksDocument,
+  UpdateCompositionInput,
+  useUpdateCompositionMutation
+} from '~/types/graphql/generated/graphql';
+import type { OpusCompositionData } from '~/types/opus';
+
+const TOAST_MESSAGES = {
+  UPDATE_SUCCESS: 'Твір успішно оновлено',
+  UPDATE_ERROR: 'Помилка при оновленні твору'
+};
+
+const mapCompositionToUpdateInput = (composition: OpusCompositionData): UpdateCompositionInput => ({
+  name: { uk: composition.name, en: composition.name },
+  year: composition.year.trim() ? Number(composition.year) : undefined,
+  genre: composition.genre.trim() || undefined,
+  audioAvailable: composition.audios.length > 0,
+  sheetAvailable: composition.notes.some((note) => Boolean(note.fileUrl)),
+  audios: composition.audios.map((audio) => ({
+    name: audio.name.trim(),
+    url: audio.fileUrl
+  })),
+  sheetMusic: composition.notes.map((note) => ({
+    name: note.name?.trim() || '',
+    url: note.fileUrl || undefined,
+    publishDate: note.publishDate?.trim() || undefined,
+    isFree: false,
+    dateUploaded: new Date().toISOString()
+  }))
+});
+
+export function useUpdateWorkAction() {
+  const router = useRouter();
+  const [updateCompositionMut, { loading: isUpdating }] = useUpdateCompositionMutation();
+
+  const handleUpdateComposition = async (id: string, composition: OpusCompositionData) => {
+    try {
+      await updateCompositionMut({
+        variables: {
+          id,
+          input: mapCompositionToUpdateInput(composition)
+        },
+        refetchQueries: [PaginatedWorksDocument],
+        awaitRefetchQueries: true
+      });
+
+      toast.success(TOAST_MESSAGES.UPDATE_SUCCESS);
+      router.refresh();
+    } catch (error) {
+      toast.error(TOAST_MESSAGES.UPDATE_ERROR);
+      throw error;
+    }
+  };
+
+  return {
+    handleUpdateComposition,
+    isUpdating
+  };
+}

--- a/app/(logged_in)/creativity/(composition)/useWorkUrlState.test.ts
+++ b/app/(logged_in)/creativity/(composition)/useWorkUrlState.test.ts
@@ -1,0 +1,289 @@
+import { act, renderHook } from '@testing-library/react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+
+import { useWorkUrlState } from './useWorkUrlState';
+import { COMPOSITION_MODAL_PARAM } from '~/constants/creativity';
+import { createCompositionId } from '~/shared/hooks/use-upsert-opus/useUpsertOpus';
+import {
+  CompositionByIdQuery,
+  useCompositionByIdQuery
+} from '~/types/graphql/generated/graphql';
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+  usePathname: jest.fn(),
+  useSearchParams: jest.fn()
+}));
+
+jest.mock('~/shared/hooks/use-upsert-opus/useUpsertOpus', () => ({
+  createCompositionId: jest.fn()
+}));
+
+jest.mock('~/types/graphql/generated/graphql', () => ({
+  useCompositionByIdQuery: jest.fn()
+}));
+
+const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>;
+const mockUsePathname = usePathname as jest.MockedFunction<typeof usePathname>;
+const mockUseSearchParams = useSearchParams as jest.MockedFunction<typeof useSearchParams>;
+const mockCreateCompositionId = createCompositionId as jest.MockedFunction<
+  typeof createCompositionId
+>;
+const mockUseCompositionByIdQuery = useCompositionByIdQuery as jest.MockedFunction<
+  typeof useCompositionByIdQuery
+>;
+
+type QueryResultType = ReturnType<typeof useCompositionByIdQuery>;
+
+const createMockQueryResult = (
+  overrides: Partial<QueryResultType> = {}
+): QueryResultType =>
+  ({
+    data: undefined,
+    loading: false,
+    error: undefined,
+    called: true,
+    client: {} as QueryResultType['client'],
+    networkStatus: 7,
+    observable: {} as QueryResultType['observable'],
+    variables: { id: '' },
+    refetch: jest.fn(),
+    fetchMore: jest.fn(),
+    startPolling: jest.fn(),
+    stopPolling: jest.fn(),
+    subscribeToMore: jest.fn(),
+    updateQuery: jest.fn(),
+    ...overrides
+  }) as QueryResultType;
+
+describe('useWorkUrlState', () => {
+  const mockReplace = jest.fn<void, [string]>();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseRouter.mockReturnValue({
+      replace: mockReplace,
+      push: jest.fn(),
+      back: jest.fn(),
+      forward: jest.fn(),
+      refresh: jest.fn(),
+      prefetch: jest.fn()
+    });
+    mockUsePathname.mockReturnValue('/works');
+    mockUseSearchParams.mockReturnValue(new URLSearchParams() as never);
+    mockCreateCompositionId
+      .mockReturnValueOnce('mocked-id-1')
+      .mockReturnValueOnce('mocked-id-2')
+      .mockReturnValue('mocked-id-default');
+    mockUseCompositionByIdQuery.mockReturnValue(createMockQueryResult());
+  });
+
+  it('should return initial state when compositionId param is absent', () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams('') as never);
+
+    const { result } = renderHook(() => useWorkUrlState());
+
+    expect(result.current.compositionId).toBeNull();
+    expect(result.current.compositionToEdit).toBeNull();
+    expect(result.current.isCompositionLoading).toBe(false);
+    expect(result.current.isEditOpen).toBe(false);
+    expect(mockUseCompositionByIdQuery).toHaveBeenCalledWith({
+      variables: { id: '' },
+      skip: true,
+      fetchPolicy: 'network-only'
+    });
+  });
+
+  it('should map composition data when compositionId is present in searchParams', () => {
+    mockUseSearchParams.mockReturnValue(
+      new URLSearchParams(`${COMPOSITION_MODAL_PARAM}=comp-123`) as never
+    );
+
+    const mockData: CompositionByIdQuery = {
+      compositionById: {
+        id: 'comp-123',
+        name: { uk: 'Назва укр', en: 'Name eng' },
+        genre: 'Симфонія',
+        year: 1808,
+        audios: [
+          {
+            name: 'Audio 1',
+            url: 'http://example.com/audio1.mp3'
+          }
+        ],
+        sheetMusic: [
+          {
+            name: 'Sheet 1',
+            url: 'http://example.com/sheet1.pdf',
+            publishDate: '2023-01-01'
+          }
+        ]
+      }
+    };
+
+    mockUseCompositionByIdQuery.mockReturnValue(
+      createMockQueryResult({
+        data: mockData
+      })
+    );
+
+    const { result } = renderHook(() => useWorkUrlState());
+
+    expect(result.current.compositionId).toBe('comp-123');
+    expect(result.current.isEditOpen).toBe(true);
+    expect(result.current.compositionToEdit).toEqual({
+      id: 'comp-123',
+      name: 'Назва укр',
+      genre: 'Симфонія',
+      year: '1808',
+      audios: [
+        {
+          id: 'mocked-id-1',
+          name: 'Audio 1',
+          fileUrl: 'http://example.com/audio1.mp3'
+        }
+      ],
+      notes: [
+        {
+          id: 'mocked-id-2',
+          name: 'Sheet 1',
+          fileUrl: 'http://example.com/sheet1.pdf',
+          publishDate: '2023-01-01'
+        }
+      ]
+    });
+  });
+
+  it('should fallback to English name or empty string if Ukrainian name is missing', () => {
+    mockUseSearchParams.mockReturnValue(
+      new URLSearchParams(`${COMPOSITION_MODAL_PARAM}=comp-123`) as never
+    );
+
+    const mockData: CompositionByIdQuery = {
+      compositionById: {
+        id: 'comp-123',
+        name: { uk: null as unknown as string, en: 'English Name' },
+        genre: null,
+        year: null,
+        audios: null,
+        sheetMusic: [
+          {
+            name: null,
+            url: null,
+            publishDate: null
+          }
+        ]
+      }
+    };
+
+    mockUseCompositionByIdQuery.mockReturnValue(
+      createMockQueryResult({
+        data: mockData
+      })
+    );
+
+    const { result } = renderHook(() => useWorkUrlState());
+
+    expect(result.current.compositionToEdit).toEqual({
+      id: 'comp-123',
+      name: 'English Name',
+      genre: '',
+      year: '',
+      audios: [],
+      notes: [
+        {
+          id: 'mocked-id-1',
+          name: '',
+          fileUrl: undefined,
+          publishDate: ''
+        }
+      ]
+    });
+  });
+
+  it('should fallback to empty string when both UK and EN names are missing', () => {
+    mockUseSearchParams.mockReturnValue(
+      new URLSearchParams(`${COMPOSITION_MODAL_PARAM}=comp-123`) as never
+    );
+
+    const mockData: CompositionByIdQuery = {
+      compositionById: {
+        id: 'comp-123',
+        name: { uk: null as unknown as string, en: null as unknown as string },
+        genre: 'Genre',
+        year: 2020,
+        audios: [],
+        sheetMusic: []
+      }
+    };
+
+    mockUseCompositionByIdQuery.mockReturnValue(
+      createMockQueryResult({
+        data: mockData
+      })
+    );
+
+    const { result } = renderHook(() => useWorkUrlState());
+
+    expect(result.current.compositionToEdit?.name).toBe('');
+  });
+
+  it('should open edit composition by updating URL search params', () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams('filter=all') as never);
+
+    const { result } = renderHook(() => useWorkUrlState());
+
+    act(() => {
+      result.current.openEditComposition('comp-789');
+    });
+
+    expect(mockReplace).toHaveBeenCalledWith(
+      `/works?filter=all&${COMPOSITION_MODAL_PARAM}=comp-789`
+    );
+  });
+
+  it('should close edit composition by deleting compositionId from URL search params', () => {
+    mockUseSearchParams.mockReturnValue(
+      new URLSearchParams(`${COMPOSITION_MODAL_PARAM}=comp-789&filter=all`) as never
+    );
+
+    const { result } = renderHook(() => useWorkUrlState());
+
+    act(() => {
+      result.current.closeEditComposition();
+    });
+
+    expect(mockReplace).toHaveBeenCalledWith('/works?filter=all');
+  });
+
+  it('should format URL without query string when closing edit and no other params remain', () => {
+    mockUseSearchParams.mockReturnValue(
+      new URLSearchParams(`${COMPOSITION_MODAL_PARAM}=comp-789`) as never
+    );
+
+    const { result } = renderHook(() => useWorkUrlState());
+
+    act(() => {
+      result.current.closeEditComposition();
+    });
+
+    expect(mockReplace).toHaveBeenCalledWith('/works');
+  });
+
+  it('should reflect loading state from query hook', () => {
+    mockUseSearchParams.mockReturnValue(
+      new URLSearchParams(`${COMPOSITION_MODAL_PARAM}=comp-123`) as never
+    );
+
+    mockUseCompositionByIdQuery.mockReturnValue(
+      createMockQueryResult({
+        loading: true,
+        networkStatus: 1
+      })
+    );
+
+    const { result } = renderHook(() => useWorkUrlState());
+
+    expect(result.current.isCompositionLoading).toBe(true);
+  });
+});

--- a/app/(logged_in)/creativity/(composition)/useWorkUrlState.ts
+++ b/app/(logged_in)/creativity/(composition)/useWorkUrlState.ts
@@ -1,0 +1,82 @@
+'use client';
+
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useCallback, useMemo } from 'react';
+
+import { COMPOSITION_MODAL_PARAM } from '~/constants/creativity';
+import { createCompositionId } from '~/shared/hooks/use-upsert-opus/useUpsertOpus';
+import {
+  CompositionByIdQuery,
+  useCompositionByIdQuery
+} from '~/types/graphql/generated/graphql';
+import type { OpusCompositionData } from '~/types/opus';
+
+type CompositionFetchedData = NonNullable<CompositionByIdQuery['compositionById']>;
+
+const mapFetchedCompositionToForm = (
+  composition?: CompositionFetchedData | null
+): OpusCompositionData | null => {
+  if (!composition) {
+    return null;
+  }
+
+  return {
+    id: composition.id,
+    name: composition.name?.uk ?? composition.name?.en ?? '',
+    genre: composition.genre ?? '',
+    year: composition.year == null ? '' : String(composition.year),
+    audios: (composition.audios ?? []).map((audio) => ({
+	  id: createCompositionId(),
+	  name: audio.name,
+	  fileUrl: audio.url
+    })),
+    notes: (composition.sheetMusic ?? []).map((sheet) => ({
+	  id: createCompositionId(),
+	  name: sheet.name ?? '',
+	  fileUrl: sheet.url ?? undefined,
+	  publishDate: sheet.publishDate ?? ''
+    }))
+  };
+};
+
+export function useWorkUrlState() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const compositionId = searchParams.get(COMPOSITION_MODAL_PARAM);
+
+  const { data: compositionData, loading: isCompositionLoading } = useCompositionByIdQuery({
+    variables: { id: compositionId ?? '' },
+    skip: !compositionId,
+    fetchPolicy: 'network-only'
+  });
+
+  const compositionToEdit = useMemo(
+    () => mapFetchedCompositionToForm(compositionData?.compositionById),
+    [compositionData?.compositionById]
+  );
+
+  const updateUrlParam = useCallback(
+    (id: string | null) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (id) {
+        params.set(COMPOSITION_MODAL_PARAM, id);
+      } else {
+        params.delete(COMPOSITION_MODAL_PARAM);
+      }
+      const query = params.toString();
+      router.replace(query ? `${pathname}?${query}` : pathname);
+    },
+    [pathname, router, searchParams]
+  );
+
+  return {
+    compositionId,
+    compositionToEdit,
+    isCompositionLoading,
+    isEditOpen: Boolean(compositionId),
+    openEditComposition: (id: string) => updateUrlParam(id),
+    closeEditComposition: () => updateUrlParam(null)
+  };
+}

--- a/app/(logged_in)/creativity/(composition)/useWorkUrlState.ts
+++ b/app/(logged_in)/creativity/(composition)/useWorkUrlState.ts
@@ -75,7 +75,7 @@ export function useWorkUrlState() {
     compositionId,
     compositionToEdit,
     isCompositionLoading,
-    isEditOpen: Boolean(compositionId),
+    isEditOpen: Boolean(compositionId && compositionToEdit),
     openEditComposition: (id: string) => updateUrlParam(id),
     closeEditComposition: () => updateUrlParam(null)
   };

--- a/app/(logged_in)/creativity/WorksTable.test.tsx
+++ b/app/(logged_in)/creativity/WorksTable.test.tsx
@@ -2,6 +2,9 @@ import { Box } from '@mui/material';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 
+import { useDeleteWorkAction } from './(composition)/useDeleteWorkAction';
+import { useUpdateWorkAction } from './(composition)/useUpdateWorkAction';
+import { useWorkUrlState } from './(composition)/useWorkUrlState';
 import { useWorksTableActions } from './useWorksTableActions';
 import {
   columns as originalColumns,
@@ -14,8 +17,10 @@ import {
 import { WORKS_TABS_NAMES } from '~/constants/creativity';
 import { ActionMenuGroups } from '~/shared/components/dropdown-menu/ActionMenu';
 import { BaseRowData, ColumnDef } from '~/shared/components/table-layout/row-variants/Row.types';
+import { useShare } from '~/shared/hooks/use-share/useShare';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
 import { OpusStatus } from '~/types/graphql/generated/graphql';
+import { OpusCompositionData } from '~/types/opus';
 
 type WorksTableRowData = BaseRowData<GroupHeaderData, OpusWork, IndividualWork>;
 
@@ -33,14 +38,60 @@ jest.mock('~/shared/components/table-layout/TableLayout', () => ({
 
 jest.mock('~/shared/components/delete-card-modal/DeleteCardModal', () => ({
   __esModule: true,
-  default: ({ open, onClose, onDelete }: { open: boolean; onClose: () => void; onDelete: () => void }) =>
+  default: ({
+    open,
+    onClose,
+    onDelete,
+    title
+  }: {
+    open: boolean;
+    onClose: () => void;
+    onDelete: () => void;
+    title: string;
+  }) =>
     open ? (
-      <div data-testid="delete-card-modal">
-        <button data-testid="modal-close" onClick={onClose}>
+      <div data-testid={`delete-card-modal-${title.includes('розгрупування') ? 'ungroup' : 'composition'}`}>
+        <button
+          data-testid={`modal-close-${title.includes('розгрупування') ? 'ungroup' : 'composition'}`}
+          onClick={onClose}
+        >
           Close
         </button>
-        <button data-testid="modal-delete" onClick={onDelete}>
+        <button
+          data-testid={`modal-delete-${title.includes('розгрупування') ? 'ungroup' : 'composition'}`}
+          onClick={onDelete}
+        >
           Delete
+        </button>
+      </div>
+    ) : null
+}));
+
+jest.mock('~/shared/components/forms/opus-details-block/composition-modal/CompositionModal', () => ({
+  __esModule: true,
+  default: ({
+    open,
+    onClose,
+    onSubmit,
+    initialValue
+  }: {
+    open: boolean;
+    mode: string;
+    initialValue: unknown;
+    onClose: () => void;
+    onSubmit: (data: OpusCompositionData) => Promise<void>;
+  }) =>
+    open ? (
+      <div data-testid="composition-modal">
+        <span data-testid="initial-value">{JSON.stringify(initialValue)}</span>
+        <button data-testid="composition-modal-close" onClick={onClose}>
+          Close Composition
+        </button>
+        <button
+          data-testid="composition-modal-submit"
+          onClick={() => onSubmit({ title: 'New Composition Title' } as unknown as OpusCompositionData)}
+        >
+          Submit Composition
         </button>
       </div>
     ) : null
@@ -48,6 +99,22 @@ jest.mock('~/shared/components/delete-card-modal/DeleteCardModal', () => ({
 
 jest.mock('./useWorksTableActions', () => ({
   useWorksTableActions: jest.fn()
+}));
+
+jest.mock('./(composition)/useWorkUrlState', () => ({
+  useWorkUrlState: jest.fn()
+}));
+
+jest.mock('./(composition)/useDeleteWorkAction', () => ({
+  useDeleteWorkAction: jest.fn()
+}));
+
+jest.mock('./(composition)/useUpdateWorkAction', () => ({
+  useUpdateWorkAction: jest.fn()
+}));
+
+jest.mock('~/shared/hooks/use-share/useShare', () => ({
+  useShare: jest.fn()
 }));
 
 const group: GroupRowData = {
@@ -78,6 +145,13 @@ describe('WorksTable', () => {
   const mockHandleConfirmUngroup = jest.fn();
   const mockHandleShareGroup = jest.fn();
 
+  const mockOpenEditComposition = jest.fn();
+  const mockCloseEditComposition = jest.fn();
+  const mockSetDeleteComposition = jest.fn();
+  const mockHandleConfirmCompositionDelete = jest.fn();
+  const mockHandleUpdateComposition = jest.fn();
+  const mockHandleShare = jest.fn();
+
   beforeEach(() => {
     jest.clearAllMocks();
     (useWorksTableActions as jest.Mock).mockReturnValue({
@@ -87,10 +161,40 @@ describe('WorksTable', () => {
       handleConfirmUngroup: mockHandleConfirmUngroup,
       handleShareGroup: mockHandleShareGroup
     });
+
+    (useWorkUrlState as jest.Mock).mockReturnValue({
+      compositionId: null,
+      compositionToEdit: null,
+      isEditOpen: false,
+      openEditComposition: mockOpenEditComposition,
+      closeEditComposition: mockCloseEditComposition
+    });
+
+    (useDeleteWorkAction as jest.Mock).mockReturnValue({
+      deleteComposition: null,
+      setDeleteComposition: mockSetDeleteComposition,
+      handleConfirmCompositionDelete: mockHandleConfirmCompositionDelete
+    });
+
+    (useUpdateWorkAction as jest.Mock).mockReturnValue({
+      handleUpdateComposition: mockHandleUpdateComposition
+    });
+
+    (useShare as jest.Mock).mockReturnValue({
+      handleShare: mockHandleShare
+    });
   });
 
   it('should render opus groups when activeTab is Opus', () => {
     render(<WorksTable activeTab={WORKS_TABS_NAMES.OPUS} items={{ groups: [group] }} />);
+
+    const { data } = mockTableLayout.mock.calls[0][0] as { data: WorksTableRowData[] };
+    expect(data).toHaveLength(1);
+    expect(data[0]).toMatchObject({ type: 'group', id: 'group-1' });
+  });
+
+  it('should render sineop groups when activeTab is Sineop', () => {
+    render(<WorksTable activeTab={WORKS_TABS_NAMES.SINEOP} items={{ groups: [group] }} />);
 
     const { data } = mockTableLayout.mock.calls[0][0] as { data: WorksTableRowData[] };
     expect(data).toHaveLength(1);
@@ -129,11 +233,40 @@ describe('WorksTable', () => {
       if (individualRow && col.renderPlain) col.renderPlain(individualRow.plainData as IndividualWork);
     });
 
+    const opusColumn = originalColumns.find((c) => c.id === 'opus');
+    expect(opusColumn?.renderGroup?.(groupRow?.groupData as GroupHeaderData)).toBe('op. 1');
+
+    const sineopGroup: GroupHeaderData = { ...(groupRow?.groupData as GroupHeaderData), numberKind: 'sineop' };
+    expect(opusColumn?.renderGroup?.(sineopGroup)).toBe('sine op. 1');
+
+    const titleColumn = originalColumns.find((c) => c.id === 'title');
+    expect(titleColumn?.renderGroup?.(groupRow?.groupData as GroupHeaderData)).toBe('Group title');
+    expect(titleColumn?.renderSub?.(groupRow?.subRows?.[0] as OpusWork, groupRow?.groupData as GroupHeaderData)).toBe(
+      'Work 1'
+    );
+    expect(titleColumn?.renderPlain?.(individualRow?.plainData as IndividualWork)).toBe('Individual work');
+
+    const genreColumn = originalColumns.find((c) => c.id === 'genre');
+    expect(genreColumn?.renderGroup?.(groupRow?.groupData as GroupHeaderData)).toBe('Symphony');
+    expect(genreColumn?.renderPlain?.(individualRow?.plainData as IndividualWork)).toBe('Opera');
+
     const yearsColumn = originalColumns.find((c) => c.id === 'years');
     expect(yearsColumn?.renderGroup?.(groupRow?.groupData as GroupHeaderData)).toBe('2020 - 2022');
+    expect(yearsColumn?.renderPlain?.(individualRow?.plainData as IndividualWork)).toBe('2023');
+
+    const statusColumn = originalColumns.find((c) => c.id === 'status');
+    expect(statusColumn?.renderGroup?.(groupRow?.groupData as GroupHeaderData)).toBeDefined();
+    expect(statusColumn?.renderPlain?.(individualRow?.plainData as IndividualWork)).toBeDefined();
+
+    const actionsColumn = originalColumns.find((c) => c.id === 'actions');
+    expect(actionsColumn?.renderGroup?.(groupRow?.groupData as GroupHeaderData)).toBeDefined();
+    expect(
+      actionsColumn?.renderSub?.(groupRow?.subRows?.[0] as OpusWork, groupRow?.groupData as GroupHeaderData)
+    ).toBeDefined();
+    expect(actionsColumn?.renderPlain?.(individualRow?.plainData as IndividualWork)).toBeDefined();
   });
 
-  it('should trigger menu actions successfully', () => {
+  it('should trigger menu actions and edit click handlers successfully', () => {
     const groupDraft: GroupRowData = { ...group, id: 'group-draft', status: BaseContentStatuses.Draft };
     const groupPublished: GroupRowData = { ...group, id: 'group-published', status: BaseContentStatuses.Published };
 
@@ -157,13 +290,16 @@ describe('WorksTable', () => {
     };
 
     rowsData.forEach((row) => {
-      const actions = row.type === 'group' ? row.groupData?.menuActions : row.plainData?.menuActions;
-      triggerMenuClicks(actions?.menuItems);
-
-      if (row.type === 'group' && row.subRows) {
-        row.subRows.forEach((subRow) => {
-          triggerMenuClicks(subRow.menuActions?.menuItems);
-        });
+      if (row.type === 'group') {
+        triggerMenuClicks(row.groupData?.menuActions?.menuItems);
+        if (row.subRows) {
+          row.subRows.forEach((subRow) => {
+            triggerMenuClicks(subRow.menuActions?.menuItems);
+          });
+        }
+      } else {
+        triggerMenuClicks(row.plainData?.menuActions?.menuItems);
+        row.plainData?.editAction?.onEditClick?.();
       }
     });
 
@@ -171,6 +307,10 @@ describe('WorksTable', () => {
     expect(mockSetGroupToUngroup).toHaveBeenCalled();
     expect(mockHandlePublishStatusChange).toHaveBeenCalledWith('group-draft', OpusStatus.Published);
     expect(mockHandlePublishStatusChange).toHaveBeenCalledWith('group-published', OpusStatus.Draft);
+
+    expect(mockSetDeleteComposition).toHaveBeenCalledWith('individual-1');
+    expect(mockOpenEditComposition).toHaveBeenCalledWith('individual-1');
+    expect(mockHandleShare).toHaveBeenCalled();
   });
 
   it('renders DeleteCardModal and handles modal actions when groupToUngroup is set', () => {
@@ -184,13 +324,67 @@ describe('WorksTable', () => {
 
     render(<WorksTable activeTab={WORKS_TABS_NAMES.OPUS} items={{ groups: [group] }} />);
 
-    expect(screen.getByTestId('delete-card-modal')).toBeInTheDocument();
+    expect(screen.getByTestId('delete-card-modal-ungroup')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByTestId('modal-close'));
+    fireEvent.click(screen.getByTestId('modal-close-ungroup'));
     expect(mockSetGroupToUngroup).toHaveBeenCalledWith(null);
 
-    fireEvent.click(screen.getByTestId('modal-delete'));
+    fireEvent.click(screen.getByTestId('modal-delete-ungroup'));
     expect(mockHandleConfirmUngroup).toHaveBeenCalled();
+  });
+
+  it('renders DeleteCardModal for composition deletion and handles modal actions', () => {
+    (useDeleteWorkAction as jest.Mock).mockReturnValue({
+      deleteComposition: 'work-1',
+      setDeleteComposition: mockSetDeleteComposition,
+      handleConfirmCompositionDelete: mockHandleConfirmCompositionDelete
+    });
+
+    render(<WorksTable activeTab={WORKS_TABS_NAMES.WORKS} items={{ works: [individualWork] }} />);
+
+    expect(screen.getByTestId('delete-card-modal-composition')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('modal-close-composition'));
+    expect(mockSetDeleteComposition).toHaveBeenCalledWith(null);
+
+    fireEvent.click(screen.getByTestId('modal-delete-composition'));
+    expect(mockHandleConfirmCompositionDelete).toHaveBeenCalled();
+  });
+
+  it('renders CompositionModal and handles submit and close actions', async () => {
+    (useWorkUrlState as jest.Mock).mockReturnValue({
+      compositionId: 'comp-123',
+      compositionToEdit: { id: 'comp-123', name: 'Composition' },
+      isEditOpen: true,
+      openEditComposition: mockOpenEditComposition,
+      closeEditComposition: mockCloseEditComposition
+    });
+
+    render(<WorksTable activeTab={WORKS_TABS_NAMES.WORKS} items={{ works: [individualWork] }} />);
+
+    expect(screen.getByTestId('composition-modal')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('composition-modal-close'));
+    expect(mockCloseEditComposition).toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId('composition-modal-submit'));
+    expect(mockHandleUpdateComposition).toHaveBeenCalledWith('comp-123', { title: 'New Composition Title' });
+  });
+
+  it('does not call handleUpdateComposition on submit when compositionId is null', async () => {
+    (useWorkUrlState as jest.Mock).mockReturnValue({
+      compositionId: null,
+      compositionToEdit: null,
+      isEditOpen: true,
+      openEditComposition: mockOpenEditComposition,
+      closeEditComposition: mockCloseEditComposition
+    });
+
+    render(<WorksTable activeTab={WORKS_TABS_NAMES.WORKS} items={{ works: [individualWork] }} />);
+
+    fireEvent.click(screen.getByTestId('composition-modal-submit'));
+    expect(mockHandleUpdateComposition).not.toHaveBeenCalled();
+    expect(mockCloseEditComposition).not.toHaveBeenCalled();
   });
 
   it('should correctly map GroupRowData to groupData internal format', () => {
@@ -208,23 +402,6 @@ describe('WorksTable', () => {
     } else {
       throw new Error('Group row not found');
     }
-  });
-
-  it('should successfully execute all defined render functions (renderGroup, renderSub, renderPlain)', () => {
-    render(<WorksTable activeTab={WORKS_TABS_NAMES.ALL} items={{ groups: [group], works: [individualWork] }} />);
-
-    const { data: rowsData } = mockTableLayout.mock.calls[0][0] as { data: WorksTableRowData[] };
-    const groupRow = rowsData.find((r) => r.type === 'group')!;
-    const individualRow = rowsData.find((r) => r.type === 'individual')!;
-
-    originalColumns.forEach((col) => {
-      if (col.renderGroup) col.renderGroup(groupRow.groupData as GroupHeaderData);
-      if (col.renderSub && groupRow.subRows)
-        col.renderSub(groupRow.subRows[0] as OpusWork, groupRow.groupData as GroupHeaderData);
-      if (col.renderPlain) col.renderPlain(individualRow.plainData as IndividualWork);
-    });
-
-    expect(mockTableLayout).toHaveBeenCalled();
   });
 
   it('should format years correctly when endDate is equal to startDate', () => {
@@ -255,14 +432,5 @@ describe('WorksTable', () => {
       updatedAt: ''
     };
     expect(yearsCol?.renderGroup?.(diffYearData)).toBe('2020 - 2022');
-  });
-
-  it('should format numberLabel with "op" suffix when numberKind is "op"', () => {
-    const groupOp: GroupRowData = { ...group, number: 1, numberKind: 'op' };
-    render(<WorksTable activeTab={WORKS_TABS_NAMES.OPUS} items={{ groups: [groupOp] }} />);
-
-    const { data } = mockTableLayout.mock.calls[0][0] as { data: WorksTableRowData[] };
-    const row = data[0];
-    expect(row.type === 'group' && row.groupData?.numberLabel).toBe(1);
   });
 });

--- a/app/(logged_in)/creativity/WorksTable.test.tsx
+++ b/app/(logged_in)/creativity/WorksTable.test.tsx
@@ -1,6 +1,7 @@
 import { Box } from '@mui/material';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
+import toast from 'react-hot-toast';
 
 import { useDeleteWorkAction } from './(composition)/useDeleteWorkAction';
 import { useUpdateWorkAction } from './(composition)/useUpdateWorkAction';
@@ -115,6 +116,14 @@ jest.mock('./(composition)/useUpdateWorkAction', () => ({
 
 jest.mock('~/shared/hooks/use-share/useShare', () => ({
   useShare: jest.fn()
+}));
+
+jest.mock('react-hot-toast', () => ({
+  __esModule: true,
+  default: {
+    error: jest.fn(),
+    success: jest.fn()
+  }
 }));
 
 const group: GroupRowData = {
@@ -432,5 +441,55 @@ describe('WorksTable', () => {
       updatedAt: ''
     };
     expect(yearsCol?.renderGroup?.(diffYearData)).toBe('2020 - 2022');
+  });
+
+  describe('useEffect composition validation', () => {
+    it('should not call toast or closeEditComposition if compositionId is missing or loading', () => {
+      (useWorkUrlState as jest.Mock).mockReturnValue({
+        compositionId: null,
+        compositionToEdit: null,
+        isCompositionLoading: true,
+        isEditOpen: false,
+        openEditComposition: mockOpenEditComposition,
+        closeEditComposition: mockCloseEditComposition
+      });
+
+      render(<WorksTable activeTab={WORKS_TABS_NAMES.WORKS} items={{ works: [individualWork] }} />);
+
+      expect(toast.error).not.toHaveBeenCalled();
+      expect(mockCloseEditComposition).not.toHaveBeenCalled();
+    });
+
+    it('should show error toast and close edit modal if compositionId exists and is not loading, but compositionToEdit is missing', () => {
+      (useWorkUrlState as jest.Mock).mockReturnValue({
+        compositionId: 'non-existent-id',
+        compositionToEdit: null,
+        isCompositionLoading: false,
+        isEditOpen: true,
+        openEditComposition: mockOpenEditComposition,
+        closeEditComposition: mockCloseEditComposition
+      });
+
+      render(<WorksTable activeTab={WORKS_TABS_NAMES.WORKS} items={{ works: [individualWork] }} />);
+
+      expect(toast.error).toHaveBeenCalledWith('Композицію не знайдено');
+      expect(mockCloseEditComposition).toHaveBeenCalled();
+    });
+
+    it('should not trigger error toast if compositionToEdit is present', () => {
+      (useWorkUrlState as jest.Mock).mockReturnValue({
+        compositionId: 'existing-id',
+        compositionToEdit: { id: 'existing-id', name: 'Test' },
+        isCompositionLoading: false,
+        isEditOpen: true,
+        openEditComposition: mockOpenEditComposition,
+        closeEditComposition: mockCloseEditComposition
+      });
+
+      render(<WorksTable activeTab={WORKS_TABS_NAMES.WORKS} items={{ works: [individualWork] }} />);
+
+      expect(toast.error).not.toHaveBeenCalled();
+      expect(mockCloseEditComposition).not.toHaveBeenCalled();
+    });
   });
 });

--- a/app/(logged_in)/creativity/WorksTable.tsx
+++ b/app/(logged_in)/creativity/WorksTable.tsx
@@ -3,11 +3,15 @@
 import { Box } from '@mui/material';
 import React from 'react';
 
+import { useDeleteWorkAction } from './(composition)/useDeleteWorkAction';
+import { useUpdateWorkAction } from './(composition)/useUpdateWorkAction';
+import { useWorkUrlState } from './(composition)/useWorkUrlState';
 import { useWorksTableActions } from './useWorksTableActions';
 import { styles } from './WorksTable.styles';
 import { GroupMenuItems, WorkMenuItems } from './WorksTableMenuItems';
 import {
   AllTab,
+  COMPOSITION_MODAL_PARAM,
   OpusTab,
   SineopTab,
   WORKS_BASE_PATH,
@@ -17,15 +21,18 @@ import {
 } from '~/constants/creativity';
 import DeleteCardModal from '~/shared/components/delete-card-modal/DeleteCardModal';
 import { ActionMenuGroups } from '~/shared/components/dropdown-menu/ActionMenu';
+import CompositionModal from '~/shared/components/forms/opus-details-block/composition-modal/CompositionModal';
 import { RowActions } from '~/shared/components/table-layout/components/RowActions';
 import { StatusBadge } from '~/shared/components/table-layout/components/StatusBadge';
 import { BaseRowData, ColumnDef } from '~/shared/components/table-layout/row-variants/Row.types';
 import { TableLayout } from '~/shared/components/table-layout/TableLayout';
+import { useShare } from '~/shared/hooks/use-share/useShare';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
 import { OpusStatus } from '~/types/graphql/generated/graphql';
+import { OpusCompositionData } from '~/types/opus';
 
 type ActionFields = {
-  editAction?: { editHref: string; editLabel: string };
+  editAction?: { editHref?: string; onEditClick?: () => void; editLabel: string };
   menuActions?: { menuItems: ActionMenuGroups; menuTriggerLabel: string };
 };
 
@@ -155,6 +162,21 @@ type WorksTableProps =
 export function WorksTable({ items, activeTab }: WorksTableProps) {
   const { groupToUngroup, setGroupToUngroup, handlePublishStatusChange, handleConfirmUngroup, handleShareGroup } =
     useWorksTableActions();
+  const { compositionId, compositionToEdit, isEditOpen, openEditComposition, closeEditComposition } = useWorkUrlState();
+  const { deleteComposition, setDeleteComposition, handleConfirmCompositionDelete } = useDeleteWorkAction();
+  const { handleUpdateComposition } = useUpdateWorkAction();
+  const { handleShare } = useShare();
+
+  const handleSubmitComposition = async (compositionData: OpusCompositionData) => {
+    if (!compositionId) return;
+    await handleUpdateComposition(compositionId, compositionData);
+    closeEditComposition();
+  };
+
+  const handleShareComposition = (id: string) => {
+    const url = `${window.location.origin}${WORKS_BASE_PATH}?${COMPOSITION_MODAL_PARAM}=${id}`;
+    handleShare(url);
+  };
 
   function groupsRow(group: GroupRowData): BaseRowData<GroupHeaderData, OpusWork, IndividualWork> {
     const isPublished = group.status === BaseContentStatuses.Published;
@@ -194,7 +216,9 @@ export function WorksTable({ items, activeTab }: WorksTableProps) {
           menuItems: WorkMenuItems({
             id: work.id,
             isPublished,
-            setDeleteModalOpen: modalMock
+            onDelete: () => modalMock(),
+            onShare: () => modalMock(),
+            onEdit: () => modalMock()
           }),
           menuTriggerLabel: `Дії твору ${work.name}`
         }
@@ -216,14 +240,16 @@ export function WorksTable({ items, activeTab }: WorksTableProps) {
         status: work.status,
         updatedAt: work.updatedAt,
         editAction: {
-          editHref: `${WORKS_BASE_PATH}/work/${work.id}/edit`,
+          onEditClick: () => openEditComposition(work.id),
           editLabel: `Редагувати твір ${work.name}`
         },
         menuActions: {
           menuItems: WorkMenuItems({
             id: work.id,
             isPublished,
-            setDeleteModalOpen: modalMock
+            onDelete: (id) => setDeleteComposition(id),
+            onShare: (id) => handleShareComposition(id),
+            onEdit: (id) => openEditComposition(id)
           }),
           menuTriggerLabel: `Дії твору ${work.name}`
         }
@@ -258,6 +284,7 @@ export function WorksTable({ items, activeTab }: WorksTableProps) {
   return (
     <Box sx={styles.worksListContainer}>
       <TableLayout data={rows} columns={columns} />
+
       <DeleteCardModal
         open={!!groupToUngroup}
         onClose={() => setGroupToUngroup(null)}
@@ -265,6 +292,23 @@ export function WorksTable({ items, activeTab }: WorksTableProps) {
         title="Підтвердити розгрупування"
         confirmButtonText="Розгрупувати"
         description="Ви впевнені, що хочете розгрупувати групу? Опис сторінки буде видалено, але композиції залишаться в системі."
+      />
+
+      <DeleteCardModal
+        open={Boolean(deleteComposition)}
+        onClose={() => setDeleteComposition(null)}
+        onDelete={handleConfirmCompositionDelete}
+        title="Підтвердити видалення композиції"
+        confirmButtonText="Видалити"
+        description="Ви впевнені, що хочете видалити цю композицію? Це дію можна скасувати лише шляхом повторного додавання композиції."
+      />
+
+      <CompositionModal
+        open={isEditOpen}
+        mode="edit"
+        initialValue={compositionToEdit}
+        onClose={closeEditComposition}
+        onSubmit={handleSubmitComposition}
       />
     </Box>
   );

--- a/app/(logged_in)/creativity/WorksTable.tsx
+++ b/app/(logged_in)/creativity/WorksTable.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { Box } from '@mui/material';
-import React from 'react';
+import React, { useEffect } from 'react';
+import toast from 'react-hot-toast';
 
 import { useDeleteWorkAction } from './(composition)/useDeleteWorkAction';
 import { useUpdateWorkAction } from './(composition)/useUpdateWorkAction';
@@ -162,7 +163,14 @@ type WorksTableProps =
 export function WorksTable({ items, activeTab }: WorksTableProps) {
   const { groupToUngroup, setGroupToUngroup, handlePublishStatusChange, handleConfirmUngroup, handleShareGroup } =
     useWorksTableActions();
-  const { compositionId, compositionToEdit, isEditOpen, openEditComposition, closeEditComposition } = useWorkUrlState();
+  const {
+    compositionId,
+    compositionToEdit,
+    isCompositionLoading,
+    isEditOpen,
+    openEditComposition,
+    closeEditComposition
+  } = useWorkUrlState();
   const { deleteComposition, setDeleteComposition, handleConfirmCompositionDelete } = useDeleteWorkAction();
   const { handleUpdateComposition } = useUpdateWorkAction();
   const { handleShare } = useShare();
@@ -177,6 +185,17 @@ export function WorksTable({ items, activeTab }: WorksTableProps) {
     const url = `${window.location.origin}${WORKS_BASE_PATH}?${COMPOSITION_MODAL_PARAM}=${id}`;
     handleShare(url);
   };
+
+  useEffect(() => {
+    if (!compositionId || isCompositionLoading) {
+      return;
+    }
+
+    if (!compositionToEdit) {
+      toast.error('Композицію не знайдено');
+      closeEditComposition();
+    }
+  }, [compositionId, compositionToEdit, isCompositionLoading, closeEditComposition]);
 
   function groupsRow(group: GroupRowData): BaseRowData<GroupHeaderData, OpusWork, IndividualWork> {
     const isPublished = group.status === BaseContentStatuses.Published;

--- a/app/(logged_in)/creativity/WorksTableMenuItems.test.ts
+++ b/app/(logged_in)/creativity/WorksTableMenuItems.test.ts
@@ -1,9 +1,15 @@
 import { GroupMenuItems, WorkMenuItems } from './WorksTableMenuItems';
 import { WORKS_BASE_PATH } from '~/constants/creativity';
-import { MenuItemConfig } from '~/shared/components/dropdown-menu/ActionMenu';
+
+type MenuItem = {
+  id: string;
+  text: { name: string };
+  href?: string;
+  onClick?: () => void;
+};
 
 describe('WorksTableMenusItems', () => {
-  const triggerItemClicks = (menuItems: readonly MenuItemConfig[]) => {
+  const triggerItemClicks = (menuItems: readonly MenuItem[]) => {
     menuItems.forEach((item) => {
       if (typeof item.onClick === 'function') {
         item.onClick();
@@ -11,10 +17,12 @@ describe('WorksTableMenusItems', () => {
     });
   };
 
-  const mockOnPublish = jest.fn();
-  const mockOnUnpublish = jest.fn();
-  const mockOnUngroup = jest.fn();
-  const mockOnShare = jest.fn();
+  const mockOnPublish = jest.fn<(id: string) => void, [string]>();
+  const mockOnUnpublish = jest.fn<(id: string) => void, [string]>();
+  const mockOnUngroup = jest.fn<(id: string) => void, [string]>();
+  const mockOnShare = jest.fn<(id: string) => void, [string]>();
+  const mockOnEdit = jest.fn<(id: string) => void, [string]>();
+  const mockOnDelete = jest.fn<(id: string) => void, [string]>();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -27,18 +35,16 @@ describe('WorksTableMenusItems', () => {
       onPublish: mockOnPublish,
       onUnpublish: mockOnUnpublish,
       onUngroup: mockOnUngroup,
-      onShare: mockOnShare
+      onShare: mockOnShare,
     });
 
-    const firstGroupItems = groups[0].items;
-    expect(firstGroupItems).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ id: 'edit-seo', href: `${WORKS_BASE_PATH}/group/group-1/edit` }),
-        expect.objectContaining({ id: 'edit-content', href: `${WORKS_BASE_PATH}/group/group-1/content` }),
-        expect.objectContaining({ id: 'share' }),
-        expect.objectContaining({ id: 'ungroup' })
-      ])
-    );
+    const firstGroupItems = groups[0].items as MenuItem[];
+    expect(firstGroupItems).toEqual([
+      { id: 'edit-seo', text: { name: 'Редагувати групу (SEO)' }, href: `${WORKS_BASE_PATH}/group/group-1/edit` },
+      { id: 'edit-content', text: { name: 'Редагувати контент' }, href: `${WORKS_BASE_PATH}/group/group-1/content` },
+      { id: 'share', text: { name: 'Поширити' }, onClick: expect.any(Function) },
+      { id: 'ungroup', text: { name: 'Розгрупувати' }, onClick: expect.any(Function) },
+    ]);
 
     triggerItemClicks(firstGroupItems);
     expect(mockOnShare).toHaveBeenCalledWith('group-1');
@@ -52,12 +58,13 @@ describe('WorksTableMenusItems', () => {
       onPublish: mockOnPublish,
       onUnpublish: mockOnUnpublish,
       onUngroup: mockOnUngroup,
-      onShare: mockOnShare
+      onShare: mockOnShare,
     });
 
-    expect(groups[1].items[0].id).toBe('unpublish');
+    const secondGroupItems = groups[1].items as MenuItem[];
+    expect(secondGroupItems[0].id).toBe('unpublish');
 
-    triggerItemClicks(groups[1].items);
+    triggerItemClicks(secondGroupItems);
     expect(mockOnUnpublish).toHaveBeenCalledWith('group-1');
     expect(mockOnPublish).not.toHaveBeenCalled();
   });
@@ -69,38 +76,47 @@ describe('WorksTableMenusItems', () => {
       onPublish: mockOnPublish,
       onUnpublish: mockOnUnpublish,
       onUngroup: mockOnUngroup,
-      onShare: mockOnShare
+      onShare: mockOnShare,
     });
 
-    expect(groups[1].items[0].id).toBe('publish');
+    const secondGroupItems = groups[1].items as MenuItem[];
+    expect(secondGroupItems[0].id).toBe('publish');
 
-    triggerItemClicks(groups[1].items);
+    triggerItemClicks(secondGroupItems);
     expect(mockOnPublish).toHaveBeenCalledWith('group-2');
     expect(mockOnUnpublish).not.toHaveBeenCalled();
   });
 
-  it('should build WorkMenuItems with edit, share and delete actions', () => {
-    const setDeleteModalOpen = jest.fn();
-
+  it('should build WorkMenuItems with edit, share and delete actions and trigger callbacks correctly', () => {
     const groups = WorkMenuItems({
       id: 'work-1',
       isPublished: true,
-      setDeleteModalOpen
+      onEdit: mockOnEdit,
+      onShare: mockOnShare,
+      onDelete: mockOnDelete,
     });
 
     expect(groups).toHaveLength(2);
 
-    expect(groups[0].items).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ id: 'edit', href: `${WORKS_BASE_PATH}/work-1/edit` }),
-        expect.objectContaining({ id: 'share', href: `${WORKS_BASE_PATH}/work-1/share` })
-      ])
-    );
+    const firstGroupItems = groups[0].items as MenuItem[];
+    const secondGroupItems = groups[1].items as MenuItem[];
 
-    expect(groups[1].items[0].id).toBe('delete');
+    expect(firstGroupItems).toEqual([
+      { id: 'edit', text: { name: 'Редагувати композицію' }, onClick: expect.any(Function) },
+      { id: 'share', text: { name: 'Поширити' }, onClick: expect.any(Function) },
+    ]);
 
-    groups.forEach((group) => triggerItemClicks(group.items));
+    expect(secondGroupItems[0]).toEqual({
+      id: 'delete',
+      text: { name: 'Видалити' },
+      onClick: expect.any(Function),
+    });
 
-    expect(setDeleteModalOpen).toHaveBeenCalledWith(true);
+    triggerItemClicks(firstGroupItems);
+    triggerItemClicks(secondGroupItems);
+
+    expect(mockOnEdit).toHaveBeenCalledWith('work-1');
+    expect(mockOnShare).toHaveBeenCalledWith('work-1');
+    expect(mockOnDelete).toHaveBeenCalledWith('work-1');
   });
 });

--- a/app/(logged_in)/creativity/WorksTableMenuItems.ts
+++ b/app/(logged_in)/creativity/WorksTableMenuItems.ts
@@ -13,7 +13,9 @@ interface GroupMenuProps {
 interface WorkMenuProps {
   id: string;
   isPublished: boolean;
-  setDeleteModalOpen: (open: boolean) => void;
+  onDelete: (id: string) => void;
+  onShare: (id: string) => void;
+  onEdit: (id: string) => void;
 }
 
 export const GroupMenuItems = ({
@@ -43,17 +45,19 @@ export const GroupMenuItems = ({
 
 export const WorkMenuItems = ({
   id,
-  setDeleteModalOpen,
+  onDelete,
+  onShare,
+  onEdit
 }: WorkMenuProps): ActionMenuGroups => [
   {
     items: [
-      { id: 'edit', text: { name: 'Редагувати композицію' }, href: `${WORKS_BASE_PATH}/${id}/edit` },
-      { id: 'share', text: { name: 'Поширити' }, href: `${WORKS_BASE_PATH}/${id}/share` },
+      { id: 'edit', text: { name: 'Редагувати композицію' }, onClick: () => onEdit(id) },
+      { id: 'share', text: { name: 'Поширити' }, onClick: () => onShare(id) },
     ],
   },
   {
     items: [
-      { id: 'delete', text: { name: 'Видалити' }, onClick: () => setDeleteModalOpen(true) },
+      { id: 'delete', text: { name: 'Видалити' }, onClick: () => onDelete(id) },
     ],
   },
 ];

--- a/app/(logged_in)/creativity/page.test.tsx
+++ b/app/(logged_in)/creativity/page.test.tsx
@@ -3,9 +3,39 @@ import { fireEvent, render, screen, within } from '@testing-library/react';
 import React from 'react';
 
 import CreativityPage from './page';
+import { usePaginatedWorks } from '~/shared/hooks/use-opuses/useOpuses';
+import { BaseContentStatuses } from '~/types/enums/common.enums';
 
 const MOCK_GROUP_LABEL = 'Дії групи Перший струнний квартет';
 const MOCK_WORK_LABEL = 'Дії твору №1 «Після бою»';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+    back: jest.fn(),
+    forward: jest.fn(),
+    refresh: jest.fn()
+  }),
+  usePathname: () => '/creativity',
+  useSearchParams: () => new URLSearchParams()
+}));
+
+jest.mock('@apollo/client', () => {
+  const originalApollo = jest.requireActual('@apollo/client');
+  return {
+    ...originalApollo,
+    useQuery: jest.fn(() => ({
+      data: undefined,
+      loading: false,
+      error: undefined,
+      refetch: jest.fn()
+    })),
+    useLazyQuery: jest.fn(() => [jest.fn(), { data: undefined, loading: false, error: undefined }]),
+    useMutation: jest.fn(() => [jest.fn(), { loading: false, data: undefined }])
+  };
+});
 
 jest.mock('~/shared/hooks/use-opuses/useOpuses', () => ({
   usePaginatedWorks: jest.fn(),
@@ -55,10 +85,26 @@ jest.mock('~/shared/components/filtering-toolbar', () => ({
 
 jest.mock('./useWorksFiltering', () => ({
   useWorksFiltering: jest.fn(() => ({
-    sortValue: 'default',
-    selectedFilters: { status: null, language: null },
-    toolbarProps: { search: { search: '' }, activeFiltersCount: 0 },
-    sortProps: {}
+    sortValue: 'date_desc',
+    selectedFilters: { status: [], language: [], genre: [] },
+    requestFilters: {},
+    toolbarProps: {
+      search: { search: '', setSearch: jest.fn(), options: [], placeholder: 'Пошук' },
+      filters: [],
+      isFiltersOpen: true,
+      onToggleFilters: jest.fn(),
+      activeFiltersCount: 0,
+      onClearFilters: jest.fn()
+    },
+    sortProps: {
+      fieldOptions: [],
+      orderOptions: {},
+      fieldValue: 'date',
+      value: 'date_desc',
+      triggerLabel: 'Нові спочатку',
+      onFieldChange: jest.fn(),
+      onValueChange: jest.fn()
+    }
   }))
 }));
 
@@ -125,30 +171,6 @@ jest.mock('~/shared/components/page-header/PageHeader', () => ({
   )
 }));
 
-jest.mock('./useWorksFiltering', () => ({
-  useWorksFiltering: jest.fn(() => ({
-    sortValue: 'date_desc',
-    selectedFilters: { status: [], language: [], genre: [] },
-    toolbarProps: {
-      search: { search: '', setSearch: jest.fn(), options: [], placeholder: 'Пошук' },
-      filters: [],
-      isFiltersOpen: true,
-      onToggleFilters: jest.fn(),
-      activeFiltersCount: 0,
-      onClearFilters: jest.fn()
-    },
-    sortProps: {
-      fieldOptions: [],
-      orderOptions: {},
-      fieldValue: 'date',
-      value: 'date_desc',
-      triggerLabel: 'Нові спочатку',
-      onFieldChange: jest.fn(),
-      onValueChange: jest.fn()
-    }
-  }))
-}));
-
 jest.mock('./(composition)/useCreateWorkAction', () => ({
   useCreateWorkAction: jest.fn(() => ({
     handleCreateWork: jest.fn(),
@@ -161,14 +183,16 @@ jest.mock('./(composition)/useCreateWorkAction', () => ({
   }))
 }));
 
-import { usePaginatedWorks } from '~/shared/hooks/use-opuses/useOpuses';
-import { BaseContentStatuses } from '~/types/enums/common.enums';
+jest.mock('~/shared/components/forms/opus-details-block/composition-modal/CompositionModal', () => ({
+  __esModule: true,
+  default: ({ open }: { open: boolean }) => (open ? <div data-testid="composition-modal" /> : null)
+}));
 
 const mockUsePaginatedWorks = usePaginatedWorks as jest.Mock;
 
 describe('Creativity page', () => {
   beforeEach(() => {
-    mockUsePaginatedWorks.mockReset();
+    jest.clearAllMocks();
     mockUsePaginatedWorks.mockReturnValue({
       items: [],
       totalPages: 0,

--- a/app/constants/creativity.ts
+++ b/app/constants/creativity.ts
@@ -173,3 +173,5 @@ export const SHEET_MUSIC_MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024;
 export const SHEET_MUSIC_FILE_SIZE_ERROR = 'Розмір файлу перевищує максимально допустимий ліміт (50 МБ).';
 
 export const ITEMS_PER_PAGE = 8;
+
+export const COMPOSITION_MODAL_PARAM = 'composition-id';

--- a/app/shared/hooks/use-share/useShare.test.ts
+++ b/app/shared/hooks/use-share/useShare.test.ts
@@ -1,0 +1,113 @@
+import { act,renderHook } from '@testing-library/react';
+import toast from 'react-hot-toast';
+
+import { useShare } from './useShare';
+
+jest.mock('react-hot-toast', () => ({
+  success: jest.fn(),
+  error: jest.fn()
+}));
+
+describe('useShare', () => {
+  const originalClipboard = navigator.clipboard;
+  const mockWriteText = jest.fn<Promise<void>, [string]>();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: mockWriteText },
+      writable: true,
+      configurable: true
+    });
+  });
+
+  afterAll(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: originalClipboard,
+      writable: true,
+      configurable: true
+    });
+  });
+
+  it('should successfully write text to clipboard and call success callbacks with default messages', async () => {
+    mockWriteText.mockResolvedValueOnce(undefined);
+    const onSuccessMock = jest.fn<void, []>();
+
+    const { result } = renderHook(() =>
+      useShare({ onSuccess: onSuccessMock })
+    );
+
+    await act(async () => {
+      await result.current.handleShare('https://example.com');
+    });
+
+    expect(mockWriteText).toHaveBeenCalledWith('https://example.com');
+    expect(toast.success).toHaveBeenCalledWith('Cкопійовано в буфер обміну.');
+    expect(onSuccessMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should use custom success and error messages when provided', async () => {
+    mockWriteText.mockResolvedValueOnce(undefined);
+
+    const { result } = renderHook(() =>
+      useShare({
+        message: {
+          success: 'Custom success message',
+          error: 'Custom error message'
+        }
+      })
+    );
+
+    await act(async () => {
+      await result.current.handleShare('https://example.com');
+    });
+
+    expect(toast.success).toHaveBeenCalledWith('Custom success message');
+  });
+
+  it('should handle failure during writeText, call error callbacks and toast error message', async () => {
+    const errorObj = new Error('Clipboard write rejected');
+    mockWriteText.mockRejectedValueOnce(errorObj);
+    const onErrorMock = jest.fn<void, [unknown]>();
+
+    const { result } = renderHook(() =>
+      useShare({ onError: onErrorMock })
+    );
+
+    await act(async () => {
+      await result.current.handleShare('https://example.com');
+    });
+
+    expect(toast.error).toHaveBeenCalledWith('Не вдалося скопіювати. Спробуйте ще раз.');
+    expect(onErrorMock).toHaveBeenCalledWith(errorObj);
+  });
+
+  it('should use custom error message when copy fails', async () => {
+    const errorObj = new Error('Clipboard failed');
+    mockWriteText.mockRejectedValueOnce(errorObj);
+
+    const { result } = renderHook(() =>
+      useShare({
+        message: { error: 'Помилка копіювання' }
+      })
+    );
+
+    await act(async () => {
+      await result.current.handleShare('https://example.com');
+    });
+
+    expect(toast.error).toHaveBeenCalledWith('Помилка копіювання');
+  });
+
+  it('should execute without crashing when options are omitted', async () => {
+    mockWriteText.mockResolvedValueOnce(undefined);
+
+    const { result } = renderHook(() => useShare());
+
+    await act(async () => {
+      await result.current.handleShare('https://example.com');
+    });
+
+    expect(toast.success).toHaveBeenCalledWith('Cкопійовано в буфер обміну.');
+  });
+});

--- a/app/shared/hooks/use-share/useShare.ts
+++ b/app/shared/hooks/use-share/useShare.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useCallback } from 'react';
+import toast from 'react-hot-toast';
+
+export interface UseShareOptions {
+  message?: { success?: string; error?: string };
+  onSuccess?: () => void;
+  onError?: (error: unknown) => void;
+}
+
+const DEFAULT_MESSAGES = {
+  SUCCESS: 'Cкопійовано в буфер обміну.',
+  ERROR: 'Не вдалося скопіювати. Спробуйте ще раз.'
+};
+
+export function useShare({
+  message,
+  onSuccess,
+  onError
+}: UseShareOptions = {}) {
+  const successMessage = message?.success ?? DEFAULT_MESSAGES.SUCCESS;
+  const errorMessage = message?.error ?? DEFAULT_MESSAGES.ERROR;
+
+  const handleShare = useCallback(
+    async (text: string) => {
+      try {
+        await navigator.clipboard.writeText(text);
+        toast.success(successMessage);
+        onSuccess?.();
+      } catch (error) {
+        toast.error(errorMessage);
+        onError?.(error);
+      }
+    },
+    [successMessage, errorMessage, onSuccess, onError]
+  );
+
+  return {
+    handleShare
+  };
+}

--- a/app/types/graphql/mutations/compositions.graphql
+++ b/app/types/graphql/mutations/compositions.graphql
@@ -24,3 +24,34 @@ mutation CreateComposition($input: CreateCompositionInput!) {
     updatedAt
   }
 }
+
+mutation UpdateComposition($id: ID!, $input: UpdateCompositionInput!) {
+  updateComposition(id: $id, input: $input) {
+    id
+    name {
+      uk
+      en
+    }
+    genre
+    year
+    audioAvailable
+    sheetAvailable
+    audios {
+      name
+      url
+    }
+    sheetMusic {
+      name
+      url
+      publishDate
+      isFree
+      dateUploaded
+    }
+    createdAt
+    updatedAt
+  }
+}
+
+mutation DeleteComposition($id: ID!) {
+  deleteComposition(id: $id)
+}

--- a/app/types/graphql/queries/opus.graphql
+++ b/app/types/graphql/queries/opus.graphql
@@ -114,6 +114,31 @@ query OpusById($id: ID!) {
   }
 }
 
+query CompositionById($id: ID!) {
+  compositionById(id: $id) {
+    id
+    name {
+      uk
+      en
+    }
+    year
+    genre
+    audioAvailable
+    sheetAvailable
+    sheetMusic {
+      url
+      name
+      publishDate
+      isFree
+      dateUploaded
+    }
+    audios {
+      name
+      url
+    }
+  }
+}
+
 query PaginatedWorks($tab: WorksTab, $filters: WorksFiltersInput) {
   paginatedWorks(tab: $tab, filters: $filters) {
     total

--- a/src/interfaces/graphql/resolvers/compositions/compositionsMutation.test.ts
+++ b/src/interfaces/graphql/resolvers/compositions/compositionsMutation.test.ts
@@ -5,38 +5,73 @@ import type { GraphQLContext } from '~/back-shared/types/container/types';
 import { graphqlErrors } from '~/constants/errors';
 import type { Composition } from '~/domain/entities/Composition';
 import { compositionsServiceErrors } from '~/src/constants/errors';
-import type { CreateCompositionInput } from '~/types/graphql/generated/graphql';
+import type { CompositionInput, ICompositionRepository } from '~/src/domain/repositories/compositionRepository';
+import type {
+  CompositionAudioInput,
+  CompositionSheetMusicInput,
+  CreateCompositionInput,
+  UpdateCompositionInput
+} from '~/types/graphql/generated/graphql';
+
+type AdminContextType = NonNullable<GraphQLContext['admin']>;
+
+type MockCompositionsRepository = {
+  [K in keyof ICompositionRepository]-?: jest.Mock;
+};
+
+type MockOpusRepository = {
+  moveCompositionsToCompositionsOpus: jest.Mock;
+  removeCompositionsFromCompositionsOpus: jest.Mock;
+};
 
 describe('CompositionsMutation', () => {
-  const MOCK_ADMIN = { id: 'admin-id' };
+  const MOCK_ADMIN: AdminContextType = {
+    id: 'admin-id',
+    email: 'admin@example.com',
+    role: 'ADMIN',
+  } as unknown as AdminContextType;
+
   const MOCK_COMPOSITION_ID = 'composition-id';
+
+  const MOCK_SHEET_MUSIC: CompositionSheetMusicInput[] = [
+    { title: 'Sheet 1', fileUrl: 'https://example.com/sheet1.pdf' } as CompositionSheetMusicInput,
+  ];
+
+  const MOCK_AUDIOS: CompositionAudioInput[] = [
+    { title: 'Audio 1', fileUrl: 'https://example.com/audio1.mp3' } as unknown as CompositionAudioInput,
+  ];
+
   const MOCK_INPUT: CreateCompositionInput = {
-    name: 'Test Composition',
+    name: { uk: 'Тестова композиція', en: 'Test Composition' },
     year: 2026,
     genre: 'Classical',
     audioAvailable: true,
     sheetAvailable: false,
+    sheetMusic: MOCK_SHEET_MUSIC,
+    audios: MOCK_AUDIOS,
   };
 
   const MOCK_INPUT_PARTIAL: CreateCompositionInput = {
-    name: 'Partial Composition',
+    name: { uk: 'Часткова композиція', en: 'Partial Composition' },
     year: undefined,
     genre: undefined,
     audioAvailable: undefined,
     sheetAvailable: undefined,
+    sheetMusic: undefined,
+    audios: undefined,
   };
 
-  const MOCK_MAPPED_INPUT = {
+  const MOCK_MAPPED_INPUT: CompositionInput = {
     name: MOCK_INPUT.name,
-    year: MOCK_INPUT.year,
-    genre: MOCK_INPUT.genre,
-    audioAvailable: MOCK_INPUT.audioAvailable,
-    sheetAvailable: MOCK_INPUT.sheetAvailable,
-    sheetMusic: [],
-    audios: [],
+    year: MOCK_INPUT.year ?? null,
+    genre: MOCK_INPUT.genre ?? null,
+    audioAvailable: MOCK_INPUT.audioAvailable ?? false,
+    sheetAvailable: MOCK_INPUT.sheetAvailable ?? false,
+    sheetMusic: MOCK_INPUT.sheetMusic ?? [],
+    audios: MOCK_INPUT.audios ?? [],
   };
 
-  const MOCK_MAPPED_INPUT_PARTIAL = {
+  const MOCK_MAPPED_INPUT_PARTIAL: CompositionInput = {
     name: MOCK_INPUT_PARTIAL.name,
     year: null,
     genre: null,
@@ -47,10 +82,10 @@ describe('CompositionsMutation', () => {
   };
 
   const MOCK_COMPOSITION: Composition = {
-    name: { uk: MOCK_INPUT.name, en: MOCK_INPUT.name },
     id: MOCK_COMPOSITION_ID,
-    createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
+    name: MOCK_INPUT.name,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
     year: MOCK_INPUT.year ?? null,
     genre: MOCK_INPUT.genre ?? null,
     audioAvailable: MOCK_INPUT.audioAvailable ?? false,
@@ -59,63 +94,280 @@ describe('CompositionsMutation', () => {
     audios: [],
   };
 
-  const createMockContext = (admin: unknown = MOCK_ADMIN, repoMock = {}, opusRepoMock = {}): GraphQLContext => ({
-    admin,
-    requestContainer: {
-      cradle: {
-        compositionsRepository: {
-          create: jest.fn().mockResolvedValue(MOCK_COMPOSITION),
-          ...repoMock,
+  const createMockCompositionsRepository = (
+    overrides: Partial<MockCompositionsRepository> = {}
+  ): MockCompositionsRepository =>
+    new Proxy(
+      {
+        findById: jest.fn().mockResolvedValue(MOCK_COMPOSITION),
+        create: jest.fn().mockResolvedValue(MOCK_COMPOSITION),
+        update: jest.fn().mockResolvedValue(MOCK_COMPOSITION),
+        delete: jest.fn().mockResolvedValue(true),
+        findAll: jest.fn().mockResolvedValue([MOCK_COMPOSITION]),
+        ...overrides,
+      } as MockCompositionsRepository,
+      {
+        get: (target, prop: string | symbol) => {
+          if (prop in target) {
+            return target[prop as keyof MockCompositionsRepository];
+          }
+          return jest.fn();
         },
-        opusRepository: {
-          moveCompositionsToCompositionsOpus: jest.fn().mockResolvedValue(undefined),
-          ...opusRepoMock,
+      }
+    );
+
+  const createMockOpusRepository = (
+    overrides: Partial<MockOpusRepository> = {}
+  ): MockOpusRepository => ({
+    moveCompositionsToCompositionsOpus: jest.fn().mockResolvedValue(undefined),
+    removeCompositionsFromCompositionsOpus: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  });
+
+  const createMockContext = (
+    admin: AdminContextType | null = MOCK_ADMIN,
+    compositionsRepoMock: Partial<MockCompositionsRepository> = {},
+    opusRepoMock: Partial<MockOpusRepository> = {}
+  ): GraphQLContext => {
+    const compositionsRepository = createMockCompositionsRepository(compositionsRepoMock);
+    const opusRepository = createMockOpusRepository(opusRepoMock);
+
+    return {
+      admin,
+      requestContainer: {
+        cradle: {
+          compositionsRepository,
+          opusRepository,
         },
       },
-    },
-  } as unknown as GraphQLContext);
+    } as unknown as GraphQLContext;
+  };
 
-  it('should throw unauthenticated error when admin is missing', async () => {
-    const context = createMockContext(null);
+  describe('createComposition', () => {
+    it('should throw unauthenticated error when admin is missing', async () => {
+      const context = createMockContext(null);
 
-    await expect(
-      CompositionsMutation.createComposition(null, { input: MOCK_INPUT }, context)
-    ).rejects.toThrow(
-      new GraphQLError(graphqlErrors.UNAUTHENTICATED.message, {
-        extensions: { code: graphqlErrors.UNAUTHENTICATED.code },
-      })
-    );
-  });
-
-  it('should throw error when composition creation fails', async () => {
-    const context = createMockContext(MOCK_ADMIN, {
-      create: jest.fn().mockResolvedValue(null),
+      await expect(
+        CompositionsMutation.createComposition(null, { input: MOCK_INPUT }, context)
+      ).rejects.toThrow(
+        new GraphQLError(graphqlErrors.UNAUTHENTICATED.message, {
+          extensions: { code: graphqlErrors.UNAUTHENTICATED.code },
+        })
+      );
     });
 
-    await expect(
-      CompositionsMutation.createComposition(null, { input: MOCK_INPUT }, context)
-    ).rejects.toThrow(new Error(compositionsServiceErrors.COMPOSITION_NOT_CREATED));
+    it('should throw error when composition creation fails', async () => {
+      const context = createMockContext(MOCK_ADMIN, {
+        create: jest.fn().mockResolvedValue(null),
+      });
+
+      await expect(
+        CompositionsMutation.createComposition(null, { input: MOCK_INPUT }, context)
+      ).rejects.toThrow(new Error(compositionsServiceErrors.COMPOSITION_NOT_CREATED));
+    });
+
+    it('should successfully create composition and move it to compositions opus', async () => {
+      const createMock = jest.fn().mockResolvedValue(MOCK_COMPOSITION);
+      const moveMock = jest.fn().mockResolvedValue(undefined);
+      const context = createMockContext(
+        MOCK_ADMIN,
+        { create: createMock },
+        { moveCompositionsToCompositionsOpus: moveMock }
+      );
+
+      const result = await CompositionsMutation.createComposition(null, { input: MOCK_INPUT }, context);
+
+      expect(createMock).toHaveBeenCalledWith(MOCK_MAPPED_INPUT);
+      expect(moveMock).toHaveBeenCalledWith([MOCK_COMPOSITION_ID]);
+      expect(result).toEqual(MOCK_COMPOSITION);
+    });
+
+    it('should correctly fallback optional fields when input values are missing', async () => {
+      const createMock = jest.fn().mockResolvedValue(MOCK_COMPOSITION);
+      const moveMock = jest.fn().mockResolvedValue(undefined);
+      const context = createMockContext(
+        MOCK_ADMIN,
+        { create: createMock },
+        { moveCompositionsToCompositionsOpus: moveMock }
+      );
+
+      await CompositionsMutation.createComposition(null, { input: MOCK_INPUT_PARTIAL }, context);
+
+      expect(createMock).toHaveBeenCalledWith(MOCK_MAPPED_INPUT_PARTIAL);
+    });
   });
 
-  it('should successfully create composition and move it to compositions opus', async () => {
-    const createMock = jest.fn().mockResolvedValue(MOCK_COMPOSITION);
-    const moveMock = jest.fn().mockResolvedValue(undefined);
-    const context = createMockContext(MOCK_ADMIN, { create: createMock }, { moveCompositionsToCompositionsOpus: moveMock });
+  describe('updateComposition', () => {
+    const updateInputFull: UpdateCompositionInput = {
+      name: { uk: 'Оновлена назва', en: 'Updated Name' },
+      year: 2025,
+      genre: 'Jazz',
+      audioAvailable: false,
+      sheetAvailable: true,
+      sheetMusic: MOCK_SHEET_MUSIC,
+      audios: MOCK_AUDIOS,
+    };
 
-    const result = await CompositionsMutation.createComposition(null, { input: MOCK_INPUT }, context);
+    it('should throw unauthenticated error when admin is missing', async () => {
+      const context = createMockContext(null);
 
-    expect(createMock).toHaveBeenCalledWith(MOCK_MAPPED_INPUT);
-    expect(moveMock).toHaveBeenCalledWith([MOCK_COMPOSITION_ID]);
-    expect(result).toEqual(MOCK_COMPOSITION);
+      await expect(
+        CompositionsMutation.updateComposition(
+          null,
+          { id: MOCK_COMPOSITION_ID, input: updateInputFull },
+          context
+        )
+      ).rejects.toThrow(
+        new GraphQLError(graphqlErrors.UNAUTHENTICATED.message, {
+          extensions: { code: graphqlErrors.UNAUTHENTICATED.code },
+        })
+      );
+    });
+
+    it('should throw GraphQLError when composition is not found', async () => {
+      const context = createMockContext(MOCK_ADMIN, {
+        findById: jest.fn().mockResolvedValue(null),
+      });
+
+      await expect(
+        CompositionsMutation.updateComposition(
+          null,
+          { id: MOCK_COMPOSITION_ID, input: updateInputFull },
+          context
+        )
+      ).rejects.toThrow(
+        new GraphQLError(compositionsServiceErrors.COMPOSITION_NOT_FOUND(MOCK_COMPOSITION_ID), {
+          extensions: { code: 'COMPOSITION_NOT_FOUND' },
+        })
+      );
+    });
+
+    it('should throw GraphQLError when update returns null', async () => {
+      const context = createMockContext(MOCK_ADMIN, {
+        findById: jest.fn().mockResolvedValue(MOCK_COMPOSITION),
+        update: jest.fn().mockResolvedValue(null),
+      });
+
+      await expect(
+        CompositionsMutation.updateComposition(
+          null,
+          { id: MOCK_COMPOSITION_ID, input: updateInputFull },
+          context
+        )
+      ).rejects.toThrow(
+        new GraphQLError(`Failed to update composition with id ${MOCK_COMPOSITION_ID}`, {
+          extensions: { code: 'COMPOSITION_UPDATE_FAILED' },
+        })
+      );
+    });
+
+    it('should successfully update composition with all provided input fields', async () => {
+      const updateMock = jest.fn().mockResolvedValue({
+        ...MOCK_COMPOSITION,
+        ...updateInputFull,
+      });
+
+      const context = createMockContext(MOCK_ADMIN, {
+        findById: jest.fn().mockResolvedValue(MOCK_COMPOSITION),
+        update: updateMock,
+      });
+
+      const result = await CompositionsMutation.updateComposition(
+        null,
+        { id: MOCK_COMPOSITION_ID, input: updateInputFull },
+        context
+      );
+
+      expect(updateMock).toHaveBeenCalledWith(MOCK_COMPOSITION_ID, {
+        name: updateInputFull.name,
+        year: updateInputFull.year,
+        genre: updateInputFull.genre,
+        audioAvailable: updateInputFull.audioAvailable,
+        sheetAvailable: updateInputFull.sheetAvailable,
+        sheetMusic: updateInputFull.sheetMusic,
+        audios: updateInputFull.audios,
+      });
+      expect(result).toEqual({
+        ...MOCK_COMPOSITION,
+        ...updateInputFull,
+      });
+    });
+
+    it('should process undefined and null values in update input correctly', async () => {
+      const partialUpdateInput: UpdateCompositionInput = {
+        year: null,
+      };
+
+      const updateMock = jest.fn().mockResolvedValue(MOCK_COMPOSITION);
+
+      const context = createMockContext(MOCK_ADMIN, {
+        findById: jest.fn().mockResolvedValue(MOCK_COMPOSITION),
+        update: updateMock,
+      });
+
+      await CompositionsMutation.updateComposition(
+        null,
+        { id: MOCK_COMPOSITION_ID, input: partialUpdateInput },
+        context
+      );
+
+      expect(updateMock).toHaveBeenCalledWith(MOCK_COMPOSITION_ID, {
+        year: null,
+      });
+    });
   });
 
-  it('should correctly fallback optional fields when input values are missing', async () => {
-    const createMock = jest.fn().mockResolvedValue(MOCK_COMPOSITION);
-    const moveMock = jest.fn().mockResolvedValue(undefined);
-    const context = createMockContext(MOCK_ADMIN, { create: createMock }, { moveCompositionsToCompositionsOpus: moveMock });
+  describe('deleteComposition', () => {
+    it('should throw unauthenticated error when admin is missing', async () => {
+      const context = createMockContext(null);
 
-    await CompositionsMutation.createComposition(null, { input: MOCK_INPUT_PARTIAL }, context);
+      await expect(
+        CompositionsMutation.deleteComposition(null, { id: MOCK_COMPOSITION_ID }, context)
+      ).rejects.toThrow(
+        new GraphQLError(graphqlErrors.UNAUTHENTICATED.message, {
+          extensions: { code: graphqlErrors.UNAUTHENTICATED.code },
+        })
+      );
+    });
 
-    expect(createMock).toHaveBeenCalledWith(MOCK_MAPPED_INPUT_PARTIAL);
+    it('should throw error when composition to delete is not found', async () => {
+      const context = createMockContext(MOCK_ADMIN, {
+        findById: jest.fn().mockResolvedValue(null),
+      });
+
+      await expect(
+        CompositionsMutation.deleteComposition(null, { id: MOCK_COMPOSITION_ID }, context)
+      ).rejects.toThrow(
+        new GraphQLError(compositionsServiceErrors.COMPOSITION_NOT_FOUND(MOCK_COMPOSITION_ID), {
+          extensions: { code: 'COMPOSITION_NOT_FOUND' },
+        })
+      );
+    });
+
+    it('should successfully remove composition from opus repository and delete it', async () => {
+      const deleteMock = jest.fn().mockResolvedValue(true);
+      const removeMock = jest.fn().mockResolvedValue(undefined);
+
+      const context = createMockContext(
+        MOCK_ADMIN,
+        {
+          findById: jest.fn().mockResolvedValue(MOCK_COMPOSITION),
+          delete: deleteMock,
+        },
+        {
+          removeCompositionsFromCompositionsOpus: removeMock,
+        }
+      );
+
+      const result = await CompositionsMutation.deleteComposition(
+        null,
+        { id: MOCK_COMPOSITION_ID },
+        context
+      );
+
+      expect(removeMock).toHaveBeenCalledWith([MOCK_COMPOSITION_ID]);
+      expect(deleteMock).toHaveBeenCalledWith(MOCK_COMPOSITION_ID);
+      expect(result).toBe(true);
+    });
   });
 });

--- a/src/interfaces/graphql/resolvers/compositions/compositionsMutation.ts
+++ b/src/interfaces/graphql/resolvers/compositions/compositionsMutation.ts
@@ -4,10 +4,11 @@ import type { GraphQLContext } from '~/back-shared/types/container/types';
 import { graphqlErrors } from '~/constants/errors';
 import type { Composition } from '~/domain/entities/Composition';
 import { compositionsServiceErrors } from '~/src/constants/errors';
-import { CompositionInput } from '~/src/domain/repositories/compositionRepository';
-import { CreateCompositionInput } from '~/types/graphql/generated/graphql';
+import { CompositionInput, ICompositionRepository } from '~/src/domain/repositories/compositionRepository';
+import { CreateCompositionInput, UpdateCompositionInput } from '~/types/graphql/generated/graphql';
 
 type CreateCompositionArgs = { input: CreateCompositionInput };
+type UpdateCompositionArgs = { id: string; input: UpdateCompositionInput };
 
 const assertAuthenticated = (context: GraphQLContext): void => {
   if (!context.admin) {
@@ -16,6 +17,16 @@ const assertAuthenticated = (context: GraphQLContext): void => {
     });
   }
 };
+
+async function findExistingComposition(repo: ICompositionRepository, id: string): Promise<Composition> {
+  const existing = await repo.findById(id);
+  if (!existing) {
+    throw new GraphQLError(compositionsServiceErrors?.COMPOSITION_NOT_FOUND?.(id), {
+      extensions: { code: 'COMPOSITION_NOT_FOUND' }
+    });
+  }
+  return existing;
+}
 
 const mapCompositionInput = (input: CreateCompositionInput): CompositionInput => ({
   name: input.name,
@@ -51,4 +62,42 @@ export const CompositionsMutation = {
 
     return composition;
   },
+
+  updateComposition: async (_: unknown, { id, input }: UpdateCompositionArgs, context: GraphQLContext): Promise<Composition> => {
+    assertAuthenticated(context);
+    const repo = context.requestContainer.cradle.compositionsRepository;
+
+    await findExistingComposition(repo, id);
+
+    const updateData: CompositionInput = {
+      ...(input.name && { name: input.name }),
+      ...(input.year !== undefined && { year: input.year ?? null }),
+      ...(input.genre !== undefined && { genre: input.genre }),
+      ...(input.audioAvailable !== undefined && { audioAvailable: input.audioAvailable }),
+      ...(input.sheetAvailable !== undefined && { sheetAvailable: input.sheetAvailable }),
+      ...(input.sheetMusic !== undefined && { sheetMusic: input.sheetMusic }),
+      ...(input.audios !== undefined && { audios: input.audios })
+    };
+
+    const updatedComposition = await repo.update(id, updateData);
+
+    if (!updatedComposition) {
+      throw new GraphQLError(`Failed to update composition with id ${id}`, {
+        extensions: { code: 'COMPOSITION_UPDATE_FAILED' }
+      });
+    }
+
+    return updatedComposition;
+  },
+
+  deleteComposition: async (_: unknown, { id }: { id: string }, context: GraphQLContext): Promise<boolean> => {
+    assertAuthenticated(context);
+    const repo = context.requestContainer.cradle.compositionsRepository;
+    await findExistingComposition(repo, id);
+	
+    const opusRepo = context.requestContainer.cradle.opusRepository;
+    await opusRepo.removeCompositionsFromCompositionsOpus([id]);
+
+    return repo.delete(id);
+  }
 };

--- a/src/interfaces/graphql/resolvers/compositions/compositionsQuery.test.ts
+++ b/src/interfaces/graphql/resolvers/compositions/compositionsQuery.test.ts
@@ -1,0 +1,75 @@
+import { GraphQLError } from 'graphql';
+
+import { CompositionsQuery } from './compositionsQuery';
+import type { GraphQLContext } from '~/back-shared/types/container/types';
+import { graphqlErrors } from '~/constants/errors';
+import type { Composition } from '~/domain/entities/Composition';
+
+describe('CompositionsQuery', () => {
+  const mockComposition: Composition = {
+    id: 'comp-123',
+  } as Composition;
+
+  const createMockContext = (
+    admin: GraphQLContext['admin'] = null,
+    findByIdMock = jest.fn()
+  ): GraphQLContext =>
+    ({
+      admin,
+      requestContainer: {
+        cradle: {
+          compositionsRepository: {
+            findById: findByIdMock,
+          },
+        },
+      },
+    } as unknown as GraphQLContext);
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('compositionById', () => {
+    it('should throw UNAUTHENTICATED error when user is not an admin', async () => {
+      const context = createMockContext(null);
+
+      await expect(
+        CompositionsQuery.compositionById({}, { id: 'comp-123' }, context)
+      ).rejects.toThrow(
+        new GraphQLError(graphqlErrors.UNAUTHENTICATED.message, {
+          extensions: { code: graphqlErrors.UNAUTHENTICATED.code },
+        })
+      );
+    });
+
+    it('should return composition when found', async () => {
+      const findByIdMock = jest.fn().mockResolvedValue(mockComposition);
+      const mockAdmin = { id: 'admin-1' } as NonNullable<GraphQLContext['admin']>;
+      const context = createMockContext(mockAdmin, findByIdMock);
+
+      const result = await CompositionsQuery.compositionById(
+        {},
+        { id: 'comp-123' },
+        context
+      );
+
+      expect(findByIdMock).toHaveBeenCalledWith('comp-123');
+      expect(result).toEqual(mockComposition);
+    });
+
+    it('should return null when composition is not found', async () => {
+      const findByIdMock = jest.fn().mockResolvedValue(null);
+      const mockAdmin = { id: 'admin-1' } as NonNullable<GraphQLContext['admin']>;
+      const context = createMockContext(mockAdmin, findByIdMock);
+
+      const result = await CompositionsQuery.compositionById(
+        {},
+        { id: 'comp-123' },
+        context
+      );
+
+      expect(findByIdMock).toHaveBeenCalledWith('comp-123');
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/src/interfaces/graphql/resolvers/compositions/compositionsQuery.ts
+++ b/src/interfaces/graphql/resolvers/compositions/compositionsQuery.ts
@@ -1,0 +1,36 @@
+import { GraphQLError } from 'graphql';
+
+import type { GraphQLContext } from '~/back-shared/types/container/types';
+import { graphqlErrors } from '~/constants/errors';
+import type { Composition } from '~/domain/entities/Composition';
+
+interface CompositionByIdArgs {
+  id: string;
+}
+
+const assertAuthenticated = (context: GraphQLContext): void => {
+  if (!context.admin) {
+    throw new GraphQLError(graphqlErrors.UNAUTHENTICATED.message, {
+      extensions: { code: graphqlErrors.UNAUTHENTICATED.code }
+    });
+  }
+};
+
+export const CompositionsQuery = {
+  compositionById: async (
+    _: unknown,
+    { id }: CompositionByIdArgs,
+    context: GraphQLContext
+  ): Promise<Composition | null> => {
+    assertAuthenticated(context);
+
+    const repo = context.requestContainer.cradle.compositionsRepository;
+    const composition = await repo.findById(id);
+
+    if (!composition) {
+      return null;
+    }
+
+    return composition;
+  }
+};

--- a/src/interfaces/graphql/resolvers/index.ts
+++ b/src/interfaces/graphql/resolvers/index.ts
@@ -2,6 +2,7 @@ import { authMutation as AdminMutation } from './admin/AuthMutation';
 import { authQuery as AuthQuery } from './admin/AuthQuery';
 import { AssetsMutation, AssetsQuery } from './assets/Query';
 import { CompositionsMutation } from './compositions/compositionsMutation';
+import { CompositionsQuery } from './compositions/compositionsQuery';
 import { EventsMutation } from './events/eventsMutation';
 import { EventsQuery } from './events/eventsQuery';
 import { MediaMentionsMutation } from './media-mentions/mediaMentionMutation';
@@ -31,6 +32,7 @@ export const resolvers = {
     ...MediaMentionsQuery,
     ...EventsQuery,
     ...OpusQuery,
-    ...AssetsQuery
+    ...AssetsQuery,
+    ...CompositionsQuery
   }
 };

--- a/src/interfaces/graphql/schemas/composition.graphql
+++ b/src/interfaces/graphql/schemas/composition.graphql
@@ -24,6 +24,10 @@ type Composition {
   updatedAt: String!
 }
 
+extend type Query {
+  compositionById(id: ID!): Composition
+}
+
 input CompositionSheetMusicInput {
   url: String
   name: String
@@ -47,6 +51,18 @@ input CreateCompositionInput {
   audios: [CompositionAudioInput!]
 }
 
-type Mutation {
+input UpdateCompositionInput {
+  name: JSON
+  year: Int
+  genre: String
+  audioAvailable: Boolean
+  sheetAvailable: Boolean
+  sheetMusic: [CompositionSheetMusicInput!]
+  audios: [CompositionAudioInput!]
+}
+
+extend type Mutation {
   createComposition(input: CreateCompositionInput!): Composition!
+  updateComposition(id: ID!, input: UpdateCompositionInput!): Composition!
+  deleteComposition(id: ID!): Boolean!
 }


### PR DESCRIPTION
## Description

Implements URL-driven composition editing from the works table, including deep-link support and full-path sharing for composition edit links.

### What was changed

- Connected composition row actions (**Edit**, **Share**, **Delete**) to the works table flow.
- Added URL-based editing by storing the selected `composition-id` in the page query parameters and opening `CompositionModal` in edit mode.
- Added composition loading by ID to prefill the edit modal when opened from either table actions or direct URL navigation.
- Created the **useShare** hook for copying text to the clipboard.
- Used `useShare` to copy the full current page URL with the `composition-id` query parameter, allowing the same composition to be reopened in edit mode when the link is shared.- Preserved the existing delete flow with a confirmation dialog and automatic list refresh after successful deletion.
- Added backend GraphQL support for fetching a composition by ID, including the required schema and resolver updates.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Check out this branch.
2. Run `npm run generate` to generate typescript types and React hooks for GraphQL
3. Navigate to the **Creativity** page.
4. Open the actions menu for a composition and select **Редагувати композицію**.
5. Verify the URL contains `?composition-id=<id>`.
6. Verify `CompositionModal` opens in **edit mode** and is prefilled with the selected composition data.
7. Close the modal and verify the `composition-id` query parameter is removed from the URL.
8. Open the actions menu again and select **Поширити**.
9. Paste the copied link into a new browser tab and verify:
   - the page opens with `?composition-id=<id>`;
   - the edit modal opens automatically;
   - the correct composition is loaded.
10. Select **Видалити** for a composition, confirm the deletion, and verify the composition is removed from the list after refresh.

## Video / Screenshots

https://github.com/user-attachments/assets/6a1d6fcc-0ee7-4fee-b7ea-512a7b56c4fd

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
Closes #728

