### PR TITLE
Bugfix: Fix SEO metadata image invalid src handling

### DIFF
--- a/app/shared/components/forms/seo-metadata-form/SeoMetadataForm.test.tsx
+++ b/app/shared/components/forms/seo-metadata-form/SeoMetadataForm.test.tsx
@@ -12,18 +12,20 @@ interface MockCropResult {
 
 jest.mock('~/shared/components/design-system/photo-block/PhotoBlock', () => ({
   ImagePreviewBlock: ({
+    imageUrl,
     onChangeImage,
     showAlternativeText,
     altText,
     onChangeAltText
   }: {
+    imageUrl?: string;
     onChangeImage: (url: string, crop?: MockCropResult | null) => void;
     showAlternativeText?: boolean;
     altText?: string;
     onChangeAltText?: (value: string) => void;
   }) => (
-    <div>
-      <button data-testid="photo-block" onClick={() => onChangeImage('https://example.com/mock-image.png')}>
+    <div data-testid="photo-block" data-imageurl={imageUrl}>
+      <button data-testid="photo-block-trigger" onClick={() => onChangeImage('https://example.com/mock-image.png')}>
         PhotoBlock
       </button>
       <button
@@ -38,10 +40,7 @@ jest.mock('~/shared/components/design-system/photo-block/PhotoBlock', () => ({
       <button data-testid="photo-block-root-url" onClick={() => onChangeImage('https://example.com/')}>
         PhotoBlock Root URL
       </button>
-      <button
-        data-testid="photo-block-query-url"
-        onClick={() => onChangeImage('https://example.com/photo.png?v=1.0')}
-      >
+      <button data-testid="photo-block-query-url" onClick={() => onChangeImage('https://example.com/photo.png?v=1.0')}>
         PhotoBlock Query URL
       </button>
       {showAlternativeText && (
@@ -193,7 +192,7 @@ describe('SeoMetadataForm', () => {
       description: 'onImageChange with uploaded url',
       action: async (u: ReturnType<typeof userEvent.setup>) => {
         render(<SeoMetadataForm {...defaultProps} />);
-        await u.click(screen.getByTestId('photo-block'));
+        await u.click(screen.getByTestId('photo-block-trigger'));
       },
       assert: () => expect(defaultProps.onImageChange).toHaveBeenCalledWith('https://example.com/mock-image.png')
     }
@@ -342,7 +341,7 @@ describe('SeoMetadataForm', () => {
     const onChangeCropMock = jest.fn();
     render(<SeoMetadataForm {...defaultProps} onChangeCrop={onChangeCropMock} />);
 
-    await user.click(screen.getByTestId('photo-block'));
+    await user.click(screen.getByTestId('photo-block-trigger'));
 
     expect(onChangeCropMock).toHaveBeenCalledWith(null);
   });
@@ -605,5 +604,19 @@ describe('SeoMetadataForm', () => {
         altText: { uk: '', en: 'b' }
       })
     );
+  });
+
+  it('resets ogImagePreview to null when an invalid or non-URL string is passed', () => {
+    render(<SeoMetadataForm {...defaultProps} ogImage="invalid-image-name.png" />);
+
+    const photoBlock = screen.getByTestId('photo-block');
+    expect(photoBlock).toHaveAttribute('data-imageurl', '');
+  });
+
+  it('keeps ogImagePreview when a valid URL is passed', () => {
+    render(<SeoMetadataForm {...defaultProps} ogImage="https://example.com/valid.png" />);
+
+    const photoBlock = screen.getByTestId('photo-block');
+    expect(photoBlock).toHaveAttribute('data-imageurl', 'https://example.com/valid.png');
   });
 });

--- a/app/shared/components/forms/seo-metadata-form/SeoMetadataForm.tsx
+++ b/app/shared/components/forms/seo-metadata-form/SeoMetadataForm.tsx
@@ -49,6 +49,20 @@ export interface SeoMetadataFormProps {
   };
 }
 
+const getFileNameFromUrl = (url: string | null): string | undefined =>
+  url ? url.split('/').pop()?.split('?')[0] : undefined;
+
+const isValidHttpUrl = (url: string | null): boolean => {
+  if (!url) return false;
+
+  try {
+    const { protocol } = new URL(url);
+    return protocol === 'http:' || protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
+
 export default function SeoMetadataForm({
   value,
   onChange,
@@ -65,18 +79,6 @@ export default function SeoMetadataForm({
   extraFields,
   labels = {}
 }: SeoMetadataFormProps) {
-  const getFileNameFromUrl = (url: string | null) => (url ? url.split('/').pop()?.split('?')[0] : undefined);
-
-  const isValidHttpUrl = (url: string | null): boolean => {
-    if (!url) return false;
-    try {
-      const parsedUrl = new URL(url);
-      return parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:';
-    } catch {
-      return false;
-    }
-  };
-
   const [ogImagePreview, setOgImagePreview] = useState<string | null>(isValidHttpUrl(ogImage) ? ogImage : null);
   const [displayFileName, setDisplayFileName] = useState<string | undefined>(
     isValidHttpUrl(ogImage) ? getFileNameFromUrl(ogImage) : undefined

--- a/app/shared/components/forms/seo-metadata-form/SeoMetadataForm.tsx
+++ b/app/shared/components/forms/seo-metadata-form/SeoMetadataForm.tsx
@@ -67,8 +67,20 @@ export default function SeoMetadataForm({
 }: SeoMetadataFormProps) {
   const getFileNameFromUrl = (url: string | null) => (url ? url.split('/').pop()?.split('?')[0] : undefined);
 
-  const [ogImagePreview, setOgImagePreview] = useState<string | null>(typeof ogImage === 'string' ? ogImage : null);
-  const [displayFileName, setDisplayFileName] = useState<string | undefined>(getFileNameFromUrl(ogImage));
+  const isValidHttpUrl = (url: string | null): boolean => {
+    if (!url) return false;
+    try {
+      const parsedUrl = new URL(url);
+      return parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:';
+    } catch {
+      return false;
+    }
+  };
+
+  const [ogImagePreview, setOgImagePreview] = useState<string | null>(isValidHttpUrl(ogImage) ? ogImage : null);
+  const [displayFileName, setDisplayFileName] = useState<string | undefined>(
+    isValidHttpUrl(ogImage) ? getFileNameFromUrl(ogImage) : undefined
+  );
   const [isUploading, setIsUploading] = useState(false);
   const [touched, setTouched] = useState<Partial<Record<keyof LocalizedMeta, boolean>>>({});
   const [errors, setErrors] = useState<Partial<Record<keyof LocalizedMeta, string>>>({});
@@ -76,9 +88,12 @@ export default function SeoMetadataForm({
   const translationErrors = seoFormErrors[locale];
 
   useEffect(() => {
-    if (typeof ogImage === 'string') {
+    if (isValidHttpUrl(ogImage)) {
       setOgImagePreview(ogImage);
       setDisplayFileName(getFileNameFromUrl(ogImage));
+    } else {
+      setOgImagePreview(null);
+      setDisplayFileName(undefined);
     }
   }, [ogImage]);
 


### PR DESCRIPTION
## Description

This pull request fixes an issue in the `SeoMetadataForm` component where invalid `ogImage` values (plain text, relative paths, or URLs without an `http://` or `https://` protocol) caused incorrect preview behavior and could lead to rendering issues.

The validation logic has been improved so that only valid HTTP/HTTPS URLs are accepted. Invalid values are now safely ignored, preventing broken previews and disabling actions when the URL is invalid.

## What was changed

- Added a robust `isValidHttpUrl` helper that uses the `URL` constructor to validate `ogImage` values.
- Updated the state initialization and `useEffect` logic in `SeoMetadataForm` to ignore invalid URLs and fall back to `null`.
- Added unit tests covering valid URLs.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. Check out this branch.
3. Open a page `compositions` 
4. Chose an opues and open edit that uses `SeoMetadataForm` .
5. Confirm that no chouse image preview is rendered and button `Редагувати` not active.

## Video / Screenshots

<img width="1591" height="828" alt="image" src="https://github.com/user-attachments/assets/b72a690a-82d7-45d3-85ba-f853f4891939" />


## Checklist

- [x] Code compiles and runs correctly
- [ ] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
Closes #760