### PR TITLE
feat: implement Case (Sprava) backend CRUD & uniqueness

### DIFF
--- a/app/constants/case.ts
+++ b/app/constants/case.ts
@@ -1,0 +1,42 @@
+import { BaseContentStatuses } from '~/types/enums/common.enums';
+
+export type CaseStatus = BaseContentStatuses;
+
+export type CaseListItem = {
+  id: string;
+  fondId: string;
+  descriptionNumber: number;
+  caseNumber: number;
+  caseName: string;
+  status: CaseStatus;
+  updatedAt: string;
+};
+
+export const CASE_VALIDATION_MESSAGES = {
+  fondIdRequired: 'Фонд є обов’язковим.',
+  fondIdNotFound: 'Вказаний фонд не знайдено.',
+
+  descriptionNumberRequired: 'Номер опису є обов’язковим.',
+  descriptionNumberInvalid: 'Номер опису має бути цілим позитивним числом.',
+
+  caseNumberRequired: 'Номер справи є обов’язковим.',
+  caseNumberInvalid: 'Номер справи має бути цілим позитивним числом.',
+
+  caseNameRequired: 'Назва справи є обов’язковою.',
+  caseNameMaxLength: 'Назва справи не може перевищувати 150 символів.',
+
+  caseDateRequired: 'Дати справи є обов’язковими.',
+  caseDateMaxLength: 'Значення не може перевищувати 150 символів.',
+
+  sheetsNumberRequired: 'Кількість аркушів є обов’язковою.',
+  sheetsNumberInvalid: 'Кількість аркушів має бути цілим позитивним числом.',
+
+  caseDescriptionsRequired: 'Поле «Склад і зміст документів справи» є обов’язковим.',
+  caseDescriptionsMaxLength: 'Значення не може перевищувати 300 символів.',
+
+  detailedCaseDescriptionMaxLength: 'Опис не може перевищувати 1000 символів.',
+
+  pdfInvalidType: 'Можна прикріпити лише PDF-файл.',
+
+  duplicateNumbers: 'Справа з таким номером опису та номером справи вже існує в цьому фонді. Змініть один із номерів.'
+} as const;

--- a/app/constants/errors.ts
+++ b/app/constants/errors.ts
@@ -112,6 +112,21 @@ export const FondErrorCodes: Record<keyof typeof FondErrors, string> = {
   FOND_NOT_FOUND: 'FOND_NOT_FOUND'
 };
 
+export const CaseErrors = {
+  DUPLICATE_NUMBERS: () =>
+    'Справа з таким номером опису та номером справи вже існує в цьому фонді. Змініть один із номерів.',
+  CASE_NOT_FOUND: (id: string) => `Case with id "${id}" not found`,
+  FOND_NOT_FOUND: (fondId: string) => `Fond with id "${fondId}" not found`,
+  INVALID_PDF_FILE: () => 'Можна прикріпити лише PDF-файл.'
+};
+
+export const CaseErrorCodes: Record<keyof typeof CaseErrors, string> = {
+  DUPLICATE_NUMBERS: 'DUPLICATE_CASE_NUMBERS',
+  CASE_NOT_FOUND: 'CASE_NOT_FOUND',
+  FOND_NOT_FOUND: 'FOND_NOT_FOUND',
+  INVALID_PDF_FILE: 'INVALID_PDF_FILE'
+};
+
 export const galleryErrors = {
   FAILED_TO_FETCH: 'Upload files failed'
 };

--- a/src/container/modules/repositories.module.ts
+++ b/src/container/modules/repositories.module.ts
@@ -20,8 +20,10 @@ import { OpusRepository } from '~/infrastructure/repositories/opusRepository/opu
 import { PageRepository } from '~/infrastructure/repositories/pageRepository/pageRepository';
 import { RateLimitRepository } from '~/infrastructure/repositories/rateLimitRepository/rateLimitRepository';
 import { RefreshTokenRepository } from '~/infrastructure/repositories/refreshTokenRepository/refreshTokenRepository';
+import CaseModel from '~/src/infrastructure/models/case.model';
 import FondModel from '~/src/infrastructure/models/fond.model';
 import { MediaMentionModel } from '~/src/infrastructure/models/mediaMention.model';
+import { CaseRepository } from '~/src/infrastructure/repositories/caseRepository/caseRepository';
 import { FondRepository } from '~/src/infrastructure/repositories/fondRepository/fondRepository';
 
 export type RepositoriesModule = {
@@ -36,6 +38,7 @@ export type RepositoriesModule = {
   opusRepository: ReturnType<typeof OpusRepository>;
   compositionsRepository: ReturnType<typeof CompositionRepository>;
   fondRepository: ReturnType<typeof FondRepository>;
+  caseRepository: ReturnType<typeof CaseRepository>;
 };
 
 export const registerRepositories = (container: AwilixContainer) => {
@@ -51,6 +54,7 @@ export const registerRepositories = (container: AwilixContainer) => {
     GenreModel: asValue(GenreModel),
     CategoryModel: asValue(CategoryModel),
     FondModel: asValue(FondModel),
+    CaseModel: asValue(CaseModel),
 
     RateLimitModel: asValue(RateLimit),
 
@@ -65,6 +69,7 @@ export const registerRepositories = (container: AwilixContainer) => {
     compositionsRepository: asFunction(CompositionRepository).scoped(),
     assetsRepository: asFunction(AssetRepository).scoped(),
     rateLimitRepository: asFunction(RateLimitRepository).scoped(),
-    fondRepository: asFunction(FondRepository).scoped()
+    fondRepository: asFunction(FondRepository).scoped(),
+    caseRepository: asFunction(CaseRepository).scoped()
   });
 };

--- a/src/domain/entities/Case.ts
+++ b/src/domain/entities/Case.ts
@@ -1,0 +1,24 @@
+import { LocalizedString } from './BaseContent';
+import { BaseContentStatuses } from '~/types/enums/common.enums';
+
+export type CasePdfFile = {
+  filename: string;
+  url: string;
+  mimeType: string;
+};
+
+export interface Case {
+  id: string;
+  fondId: string;
+  descriptionNumber: number;
+  caseNumber: number;
+  caseName: LocalizedString;
+  caseDate: LocalizedString;
+  sheetsNumber: number;
+  caseDescriptions: LocalizedString;
+  detailedCaseDescription?: LocalizedString;
+  pdfFile?: CasePdfFile | null;
+  status: BaseContentStatuses;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/src/domain/repositories/caseRepository.ts
+++ b/src/domain/repositories/caseRepository.ts
@@ -1,0 +1,19 @@
+import { Case } from '../entities/Case';
+import { FiltersInput, IBaseRepository } from './baseRepository';
+
+export type CaseFilters = Omit<FiltersInput, 'slug'> & {
+  fondId?: string;
+};
+
+export type CreateCaseInput = Omit<Case, 'id' | 'createdAt' | 'updatedAt'>;
+
+export type UpdateCaseInput = Partial<Omit<Case, 'id' | 'createdAt' | 'updatedAt'>>;
+
+export type ICaseRepository = IBaseRepository<Case, CaseFilters> & {
+  create(input: CreateCaseInput): Promise<Case>;
+  findByFondAndNumbers(
+    fondId: Case['fondId'],
+    descriptionNumber: Case['descriptionNumber'],
+    caseNumber: Case['caseNumber']
+  ): Promise<Case | null>;
+};

--- a/src/infrastructure/models/case.model.ts
+++ b/src/infrastructure/models/case.model.ts
@@ -16,11 +16,11 @@ const casePdfFileSchema = new Schema(
 const caseSchema = new Schema(
   {
     fondId: { type: Schema.Types.ObjectId, ref: 'Fond', required: true, index: true },
-    descriptionNumber: { type: Number, required: true, set: (v: unknown) => (v != null ? Number(v) : v) },
-    caseNumber: { type: Number, required: true, set: (v: unknown) => (v != null ? Number(v) : v) },
+    descriptionNumber: { type: Number, required: true, set: (v: unknown) => (v !== null && v !== undefined ? Number(v) : v) },
+    caseNumber: { type: Number, required: true, set: (v: unknown) => (v !== null && v !== undefined ? Number(v) : v) },
     caseName: { type: translatedFieldSchema, required: true },
     caseDate: { type: translatedFieldSchema, required: true },
-    sheetsNumber: { type: Number, required: true, set: (v: unknown) => (v != null ? Number(v) : v) },
+    sheetsNumber: { type: Number, required: true, set: (v: unknown) => (v !== null && v !== undefined ? Number(v) : v) },
     caseDescriptions: { type: translatedFieldSchema, required: true },
     detailedCaseDescription: { type: optionalTranslatedFieldSchema, default: null },
     pdfFile: { type: casePdfFileSchema, default: null },

--- a/src/infrastructure/models/case.model.ts
+++ b/src/infrastructure/models/case.model.ts
@@ -1,0 +1,44 @@
+import mongoose, { Model, Schema } from 'mongoose';
+
+import { optionalTranslatedFieldSchema, translatedFieldSchema } from './commonSchemas';
+import { Case } from '~/src/domain/entities/Case';
+import { BaseContentStatuses } from '~/types/enums/common.enums';
+
+const casePdfFileSchema = new Schema(
+  {
+    filename: { type: String, required: true },
+    url: { type: String, required: true },
+    mimeType: { type: String, required: true }
+  },
+  { _id: false }
+);
+
+const caseSchema = new Schema(
+  {
+    fondId: { type: Schema.Types.ObjectId, ref: 'Fond', required: true, index: true },
+    descriptionNumber: { type: Number, required: true, set: (v: unknown) => (v != null ? Number(v) : v) },
+    caseNumber: { type: Number, required: true, set: (v: unknown) => (v != null ? Number(v) : v) },
+    caseName: { type: translatedFieldSchema, required: true },
+    caseDate: { type: translatedFieldSchema, required: true },
+    sheetsNumber: { type: Number, required: true, set: (v: unknown) => (v != null ? Number(v) : v) },
+    caseDescriptions: { type: translatedFieldSchema, required: true },
+    detailedCaseDescription: { type: optionalTranslatedFieldSchema, default: null },
+    pdfFile: { type: casePdfFileSchema, default: null },
+    status: {
+      type: String,
+      required: true,
+      enum: Array.from(Object.values(BaseContentStatuses)),
+      default: BaseContentStatuses.Hidden
+    }
+  },
+  {
+    timestamps: true,
+    collection: 'cases'
+  }
+);
+
+caseSchema.index({ fondId: 1, descriptionNumber: 1, caseNumber: 1 }, { unique: true });
+
+const CaseModel: Model<Case> = mongoose.models.Case || mongoose.model<Case>('Case', caseSchema);
+
+export default CaseModel;

--- a/src/infrastructure/repositories/caseRepository/caseRepository.test.ts
+++ b/src/infrastructure/repositories/caseRepository/caseRepository.test.ts
@@ -1,0 +1,170 @@
+import { Model } from 'mongoose';
+
+import { CaseRepository, DbCase } from './caseRepository';
+import { Case } from '~/src/domain/entities/Case';
+import { CreateCaseInput } from '~/src/domain/repositories/caseRepository';
+import { BaseContentStatuses } from '~/types/enums/common.enums';
+
+const mockId = '65eddf5e2f1a2b3c4d5e6f7a';
+const mockFondId = '65eddf5e2f1a2b3c4d5e6f7b';
+
+const createMockCaseDoc = (overrides: Partial<DbCase> = {}): DbCase => ({
+  _id: { toString: () => mockId },
+  fondId: mockFondId,
+  descriptionNumber: 1,
+  caseNumber: 1,
+  caseName: { uk: 'Справа', en: 'Case' },
+  caseDate: { uk: '1917-1918', en: '1917-1918' },
+  sheetsNumber: 10,
+  caseDescriptions: { uk: 'Опис', en: 'Description' },
+  detailedCaseDescription: { uk: 'Детальний опис', en: 'Detailed description' },
+  pdfFile: null,
+  status: BaseContentStatuses.Hidden,
+  createdAt: '2026-07-29T10:00:00.000Z',
+  updatedAt: '2026-07-29T10:00:00.000Z',
+  ...overrides
+});
+
+jest.mock('../../db/connect', () => jest.fn());
+
+const saveMock = jest.fn();
+const findOneMock = jest.fn();
+const findAllMock = jest.fn();
+
+describe('caseRepository', () => {
+  const MockCaseModel = jest.fn().mockImplementation(() => ({
+    save: saveMock
+  })) as unknown as Model<DbCase>;
+
+  Object.assign(MockCaseModel, {
+    findOne: findOneMock,
+    find: findAllMock
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const repository = CaseRepository({ CaseModel: MockCaseModel });
+
+  it('should create a case and return the mapped entity', async () => {
+    const newCase: CreateCaseInput = {
+      fondId: mockFondId,
+      descriptionNumber: 2,
+      caseNumber: 3,
+      caseName: { uk: 'Справа 2', en: 'Case 2' },
+      caseDate: { uk: '1918', en: '1918' },
+      sheetsNumber: 20,
+      caseDescriptions: { uk: 'Опис 2', en: 'Description 2' },
+      detailedCaseDescription: { uk: 'Деталі', en: 'Details' },
+      status: BaseContentStatuses.Hidden
+    };
+
+    saveMock.mockResolvedValue({ toObject: () => createMockCaseDoc({ ...newCase }) });
+    const result = await repository.create(newCase);
+
+    expect(saveMock).toHaveBeenCalled();
+
+    expect(result.descriptionNumber).toEqual(newCase.descriptionNumber);
+    expect(result.caseNumber).toEqual(newCase.caseNumber);
+    expect(result.caseName).toStrictEqual(newCase.caseName);
+
+    expect(result.id).toBeDefined();
+    expect(result.updatedAt).toBeDefined();
+    expect(result.createdAt).toBeDefined();
+  });
+
+  it('should NOT create a case if the fondId+descriptionNumber+caseNumber combination already exists', async () => {
+    const duplicateCase = createMockCaseDoc();
+    saveMock.mockRejectedValue(new Error('E11000 duplicate key error'));
+
+    await expect(repository.create(duplicateCase)).rejects.toThrow();
+  });
+
+  it('should find a case by fondId, descriptionNumber and caseNumber and return the mapped entity', async () => {
+    const existedCase = createMockCaseDoc();
+    findOneMock.mockResolvedValue({ toObject: () => existedCase });
+
+    const result = await repository.findByFondAndNumbers(
+      existedCase.fondId,
+      existedCase.descriptionNumber,
+      existedCase.caseNumber
+    );
+
+    expect(findOneMock).toHaveBeenCalledWith({
+      fondId: existedCase.fondId,
+      descriptionNumber: existedCase.descriptionNumber,
+      caseNumber: existedCase.caseNumber
+    });
+
+    expect(result).not.toBeNull();
+    expect((result as Case).caseNumber).toEqual(existedCase.caseNumber);
+    expect((result as Case).descriptionNumber).toEqual(existedCase.descriptionNumber);
+
+    expect((result as Case).id).toBeDefined();
+    expect((result as Case).updatedAt).toBeDefined();
+    expect((result as Case).createdAt).toBeDefined();
+  });
+
+  it('should return null if no case found by fondId, descriptionNumber and caseNumber', async () => {
+    findOneMock.mockResolvedValue(null);
+    const result = await repository.findByFondAndNumbers(mockFondId, 999, 999);
+
+    expect(result).toBeNull();
+  });
+
+  it('should map fondId, detailedCaseDescription and pdfFile fallbacks correctly', async () => {
+    const doc = createMockCaseDoc({
+      fondId: undefined as unknown as string,
+      detailedCaseDescription: undefined,
+      pdfFile: { filename: 'archive.pdf', url: 'https://cdn/archive.pdf', mimeType: 'application/pdf' }
+    });
+    findOneMock.mockResolvedValue({ toObject: () => doc });
+
+    const result = await repository.findByFondAndNumbers(mockFondId, 1, 1);
+
+    expect(result?.fondId).toBeUndefined();
+    expect(result?.detailedCaseDescription).toBeUndefined();
+    expect(result?.pdfFile).toStrictEqual(doc.pdfFile);
+  });
+
+  describe('findAll (buildCaseQuery)', () => {
+    const createMockQueryBuilder = (resolvedValue: DbCase[]) => ({
+      sort: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue(resolvedValue)
+    });
+
+    it('should query without a fondId condition when the fondId filter is not provided', async () => {
+      findAllMock.mockReturnValue(createMockQueryBuilder([]));
+
+      await repository.findAll({ search: 'Справа' });
+
+      expect(findAllMock).toHaveBeenCalledWith({
+        $or: [{ 'caseName.uk': expect.any(RegExp) }, { 'caseName.en': expect.any(RegExp) }]
+      });
+    });
+
+    it('should add a fondId condition to the query when the fondId filter is provided', async () => {
+      findAllMock.mockReturnValue(createMockQueryBuilder([]));
+
+      await repository.findAll({ fondId: mockFondId });
+
+      expect(findAllMock).toHaveBeenCalledWith({ fondId: mockFondId });
+    });
+
+    it('should combine the fondId condition with other filters using $and', async () => {
+      findAllMock.mockReturnValue(createMockQueryBuilder([]));
+
+      await repository.findAll({ fondId: mockFondId, search: 'Справа' });
+
+      expect(findAllMock).toHaveBeenCalledWith({
+        $and: [
+          { $or: [{ 'caseName.uk': expect.any(RegExp) }, { 'caseName.en': expect.any(RegExp) }] },
+          { fondId: mockFondId }
+        ]
+      });
+    });
+  });
+});

--- a/src/infrastructure/repositories/caseRepository/caseRepository.ts
+++ b/src/infrastructure/repositories/caseRepository/caseRepository.ts
@@ -1,0 +1,82 @@
+import { FilterQuery, Model } from 'mongoose';
+
+import dbConnect from '../../db/connect';
+import { createBaseRepository } from '../baseRepository/baseRepository';
+import { buildBaseQuery, combineConditions, createToEntity, getBaseSort } from '../helpers';
+import { Case } from '~/src/domain/entities/Case';
+import { CaseFilters, CreateCaseInput, ICaseRepository } from '~/src/domain/repositories/caseRepository';
+
+export type DbCase = {
+  _id: { toString(): string };
+  fondId: Case['fondId'];
+  descriptionNumber: Case['descriptionNumber'];
+  caseNumber: Case['caseNumber'];
+  caseName: Case['caseName'];
+  caseDate: Case['caseDate'];
+  sheetsNumber: Case['sheetsNumber'];
+  caseDescriptions: Case['caseDescriptions'];
+  detailedCaseDescription: Case['detailedCaseDescription'];
+  pdfFile: Case['pdfFile'];
+  status: Case['status'];
+  createdAt: string;
+  updatedAt: string;
+};
+
+type CaseRepoDeps = Readonly<{
+  CaseModel: Model<DbCase>;
+}>;
+
+const toEntity = (doc: DbCase): Case =>
+  createToEntity<Case, DbCase>(doc, {
+    fondId: doc.fondId?.toString ? doc.fondId.toString() : doc.fondId,
+    descriptionNumber: doc.descriptionNumber,
+    caseNumber: doc.caseNumber,
+    caseName: doc.caseName,
+    caseDate: doc.caseDate,
+    sheetsNumber: doc.sheetsNumber,
+    caseDescriptions: doc.caseDescriptions,
+    detailedCaseDescription: doc.detailedCaseDescription ?? undefined,
+    pdfFile: doc.pdfFile ?? undefined,
+    status: doc.status
+  });
+
+const buildCaseQuery = (filters?: CaseFilters): FilterQuery<DbCase> =>
+  combineConditions<DbCase>([
+    buildBaseQuery<DbCase>(filters, ['caseName.uk', 'caseName.en'], 'caseName'),
+    filters?.fondId ? ({ fondId: filters.fondId } as FilterQuery<DbCase>) : null
+  ]);
+
+export const CaseRepository = ({ CaseModel }: CaseRepoDeps): ICaseRepository => {
+  const baseRepo = createBaseRepository<Case, DbCase, CaseFilters>({
+    model: CaseModel,
+    toEntity,
+    buildQuery: buildCaseQuery,
+    getDefaultSort: getBaseSort
+  });
+
+  return {
+    ...baseRepo,
+
+    create: async (input: CreateCaseInput): Promise<Case> => {
+      await dbConnect();
+
+      const newCase = await new CaseModel(input as unknown as DbCase).save();
+      return toEntity(newCase.toObject() as unknown as DbCase);
+    },
+
+    findByFondAndNumbers: async (
+      fondId: Case['fondId'],
+      descriptionNumber: Case['descriptionNumber'],
+      caseNumber: Case['caseNumber']
+    ): Promise<Case | null> => {
+      await dbConnect();
+
+      const existing = await CaseModel.findOne({ fondId, descriptionNumber, caseNumber });
+
+      if (!existing) {
+        return null;
+      }
+      return toEntity(existing.toObject() as unknown as DbCase);
+    }
+  };
+};

--- a/src/interfaces/graphql/resolvers/case/caseMutation.test.ts
+++ b/src/interfaces/graphql/resolvers/case/caseMutation.test.ts
@@ -164,6 +164,14 @@ describe('CaseMutation', () => {
 
       await expect(CaseMutation.createCase({}, { input }, adminContext)).rejects.toThrow(unrelatedError);
     });
+
+    it('should rethrow a non-object rejection from repo.create as-is', async () => {
+      const input = createMockCreateCaseInput();
+      mockFindByFondAndNumbers.mockResolvedValue(null);
+      mockCreate.mockRejectedValue('unexpected string rejection');
+
+      await expect(CaseMutation.createCase({}, { input }, adminContext)).rejects.toBe('unexpected string rejection');
+    });
   });
 
   describe('updateCase', () => {
@@ -231,29 +239,6 @@ describe('CaseMutation', () => {
       expect(mockUpdate).toHaveBeenCalledTimes(1);
     });
 
-    it('should throw custom error if the case is deleted concurrently and the update finds no document', async () => {
-      mockFindById.mockResolvedValue({ id, fondId: mockFondId, descriptionNumber: 1, caseNumber: 1 });
-      mockUpdate.mockResolvedValue(null);
-      const input = createMockUpdateCaseInput();
-
-      await expect(CaseMutation.updateCase({}, { id, input }, adminContext)).rejects.toEqual(
-        new GraphQLError(CaseErrors.CASE_NOT_FOUND(id), {
-          extensions: { code: CaseErrorCodes.CASE_NOT_FOUND }
-        })
-      );
-    });
-
-    it('should fall back to the current caseNumber when it is not part of the update input', async () => {
-      mockFindById.mockResolvedValue({ id, fondId: mockFondId, descriptionNumber: 1, caseNumber: 7 });
-      mockFindByFondAndNumbers.mockResolvedValue(null);
-      mockUpdate.mockResolvedValue({ id, fondId: mockFondId, descriptionNumber: 2, caseNumber: 7 });
-      const input = createMockUpdateCaseInput({ descriptionNumber: 2 });
-
-      await CaseMutation.updateCase({}, { id, input }, adminContext);
-
-      expect(mockFindByFondAndNumbers).toHaveBeenCalledWith(mockFondId, 2, 7);
-    });
-
     it('should not re-check numbers when neither fondId, descriptionNumber, nor caseNumber change', async () => {
       mockFindById.mockResolvedValue({ id, fondId: mockFondId, descriptionNumber: 1, caseNumber: 1 });
       mockUpdate.mockResolvedValue({ id, fondId: mockFondId, descriptionNumber: 1, caseNumber: 1 });
@@ -275,6 +260,18 @@ describe('CaseMutation', () => {
 
       expect(mockUpdate).toHaveBeenCalledWith(id, input);
       expect(result).toStrictEqual(updatedCase);
+    });
+
+    it('should throw custom error if the case is deleted concurrently and the update finds no document', async () => {
+      mockFindById.mockResolvedValue({ id, fondId: mockFondId, descriptionNumber: 1, caseNumber: 1 });
+      mockUpdate.mockResolvedValue(null);
+      const input = createMockUpdateCaseInput();
+
+      await expect(CaseMutation.updateCase({}, { id, input }, adminContext)).rejects.toEqual(
+        new GraphQLError(CaseErrors.CASE_NOT_FOUND(id), {
+          extensions: { code: CaseErrorCodes.CASE_NOT_FOUND }
+        })
+      );
     });
 
     it('should convert a MongoDB duplicate key error (race condition) from repo.update into the friendly duplicate error', async () => {

--- a/src/interfaces/graphql/resolvers/case/caseMutation.test.ts
+++ b/src/interfaces/graphql/resolvers/case/caseMutation.test.ts
@@ -143,6 +143,27 @@ describe('CaseMutation', () => {
         expect.objectContaining({ status: BaseContentStatuses.Hidden })
       );
     });
+
+    it('should convert a MongoDB duplicate key error (race condition) from repo.create into the friendly duplicate error', async () => {
+      const input = createMockCreateCaseInput();
+      mockFindByFondAndNumbers.mockResolvedValue(null);
+      mockCreate.mockRejectedValue(Object.assign(new Error('E11000 duplicate key error'), { code: 11000 }));
+
+      await expect(CaseMutation.createCase({}, { input }, adminContext)).rejects.toEqual(
+        new GraphQLError(CaseErrors.DUPLICATE_NUMBERS(), {
+          extensions: { code: CaseErrorCodes.DUPLICATE_NUMBERS }
+        })
+      );
+    });
+
+    it('should rethrow unrelated errors from repo.create as-is', async () => {
+      const input = createMockCreateCaseInput();
+      mockFindByFondAndNumbers.mockResolvedValue(null);
+      const unrelatedError = new Error('Database connection lost');
+      mockCreate.mockRejectedValue(unrelatedError);
+
+      await expect(CaseMutation.createCase({}, { input }, adminContext)).rejects.toThrow(unrelatedError);
+    });
   });
 
   describe('updateCase', () => {
@@ -254,6 +275,27 @@ describe('CaseMutation', () => {
 
       expect(mockUpdate).toHaveBeenCalledWith(id, input);
       expect(result).toStrictEqual(updatedCase);
+    });
+
+    it('should convert a MongoDB duplicate key error (race condition) from repo.update into the friendly duplicate error', async () => {
+      mockFindById.mockResolvedValue({ id, fondId: mockFondId, descriptionNumber: 1, caseNumber: 1 });
+      mockUpdate.mockRejectedValue(Object.assign(new Error('E11000 duplicate key error'), { code: 11000 }));
+      const input = createMockUpdateCaseInput();
+
+      await expect(CaseMutation.updateCase({}, { id, input }, adminContext)).rejects.toEqual(
+        new GraphQLError(CaseErrors.DUPLICATE_NUMBERS(), {
+          extensions: { code: CaseErrorCodes.DUPLICATE_NUMBERS }
+        })
+      );
+    });
+
+    it('should rethrow unrelated errors from repo.update as-is', async () => {
+      mockFindById.mockResolvedValue({ id, fondId: mockFondId, descriptionNumber: 1, caseNumber: 1 });
+      const unrelatedError = new Error('Database connection lost');
+      mockUpdate.mockRejectedValue(unrelatedError);
+      const input = createMockUpdateCaseInput();
+
+      await expect(CaseMutation.updateCase({}, { id, input }, adminContext)).rejects.toThrow(unrelatedError);
     });
   });
 

--- a/src/interfaces/graphql/resolvers/case/caseMutation.test.ts
+++ b/src/interfaces/graphql/resolvers/case/caseMutation.test.ts
@@ -1,0 +1,321 @@
+import { GraphQLError } from 'graphql';
+import { ZodError } from 'zod';
+
+import { createMockContext } from '../testUtils';
+import { CaseMutation } from './caseMutation';
+import { CaseErrorCodes, CaseErrors, graphqlErrors } from '~/constants/errors';
+import { CreateCaseInput, ICaseRepository, UpdateCaseInput } from '~/src/domain/repositories/caseRepository';
+import { IFondRepository } from '~/src/domain/repositories/fondRepository';
+import { BaseContentStatuses } from '~/types/enums/common.enums';
+
+const mockFondId = '65eddf5e2f1a2b3c4d5e6f7b';
+
+const createMockCreateCaseInput = (overrides: Partial<CreateCaseInput> = {}): CreateCaseInput => ({
+  fondId: mockFondId,
+  descriptionNumber: 1,
+  caseNumber: 1,
+  caseName: { uk: 'Справа', en: 'Case' },
+  caseDate: { uk: '1917-1918', en: '1917-1918' },
+  sheetsNumber: 10,
+  caseDescriptions: { uk: 'Опис', en: 'Description' },
+  detailedCaseDescription: undefined,
+  pdfFile: undefined,
+  status: BaseContentStatuses.Hidden,
+  ...overrides
+});
+
+const createMockUpdateCaseInput = (overrides: Partial<UpdateCaseInput> = {}): UpdateCaseInput => ({
+  caseName: { uk: 'Оновлена справа', en: 'Updated case' },
+  ...overrides
+});
+
+const mockCreate = jest.fn();
+const mockUpdate = jest.fn();
+const mockDelete = jest.fn();
+const mockFindById = jest.fn();
+const mockFindByFondAndNumbers = jest.fn();
+
+const mockCaseRepo: Partial<ICaseRepository> = {
+  create: mockCreate,
+  update: mockUpdate,
+  delete: mockDelete,
+  findById: mockFindById,
+  findByFondAndNumbers: mockFindByFondAndNumbers
+};
+
+const mockFondFindById = jest.fn();
+
+const mockFondRepo: Partial<IFondRepository> = {
+  findById: mockFondFindById
+};
+
+const createContext = (isAdmin: boolean) => ({
+  admin: isAdmin,
+  requestContainer: {
+    cradle: {
+      caseRepository: mockCaseRepo,
+      fondRepository: mockFondRepo
+    }
+  }
+} as unknown as ReturnType<typeof createMockContext>);
+
+const adminContext = createContext(true);
+const userContext = createContext(false);
+
+describe('CaseMutation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFondFindById.mockResolvedValue({ id: mockFondId });
+  });
+
+  describe('createCase', () => {
+    it('should throw GraphQLError if user is not an admin', async () => {
+      const input = createMockCreateCaseInput();
+      await expect(CaseMutation.createCase({}, { input }, userContext)).rejects.toEqual(
+        new GraphQLError(graphqlErrors.UNAUTHENTICATED.message, {
+          extensions: { code: graphqlErrors.UNAUTHENTICATED.code }
+        })
+      );
+
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it('should throw ZodError for invalid input', async () => {
+      const input = createMockCreateCaseInput({ descriptionNumber: -1 });
+
+      await expect(CaseMutation.createCase({}, { input }, adminContext)).rejects.toThrow(ZodError);
+      expect(mockFondFindById).not.toHaveBeenCalled();
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it('should throw custom error if fondId does not reference an existing Fond', async () => {
+      const input = createMockCreateCaseInput();
+      mockFondFindById.mockResolvedValue(null);
+
+      await expect(CaseMutation.createCase({}, { input }, adminContext)).rejects.toEqual(
+        new GraphQLError(CaseErrors.FOND_NOT_FOUND(mockFondId), {
+          extensions: { code: CaseErrorCodes.FOND_NOT_FOUND }
+        })
+      );
+
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it('should throw custom error if descriptionNumber+caseNumber combination already exists within the Fond', async () => {
+      const input = createMockCreateCaseInput();
+      mockFindByFondAndNumbers.mockResolvedValue({ id: 'existing-case' });
+
+      await expect(CaseMutation.createCase({}, { input }, adminContext)).rejects.toEqual(
+        new GraphQLError(CaseErrors.DUPLICATE_NUMBERS(), {
+          extensions: { code: CaseErrorCodes.DUPLICATE_NUMBERS }
+        })
+      );
+
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it('should reject a pdfFile that is not a PDF', async () => {
+      const input = createMockCreateCaseInput({
+        pdfFile: { filename: 'scan.png', url: 'https://cdn/scan.png', mimeType: 'image/png' }
+      });
+
+      await expect(CaseMutation.createCase({}, { input }, adminContext)).rejects.toThrow(ZodError);
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it('should successfully call repo create method and return the new case', async () => {
+      const input = createMockCreateCaseInput();
+      mockFindByFondAndNumbers.mockResolvedValue(null);
+
+      await CaseMutation.createCase({}, { input }, adminContext);
+
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      expect(mockCreate).toHaveBeenCalledWith(input);
+    });
+
+    it('should provide a fallback hidden status when missing', async () => {
+      const { status: _status, ...inputWithoutStatus } = createMockCreateCaseInput();
+      mockFindByFondAndNumbers.mockResolvedValue(null);
+
+      await CaseMutation.createCase({}, { input: inputWithoutStatus }, adminContext);
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ status: BaseContentStatuses.Hidden })
+      );
+    });
+  });
+
+  describe('updateCase', () => {
+    const id = 'case-id';
+
+    it('should throw GraphQLError if user is not an admin', async () => {
+      const input = createMockUpdateCaseInput();
+      await expect(CaseMutation.updateCase({}, { id, input }, userContext)).rejects.toEqual(
+        new GraphQLError(graphqlErrors.UNAUTHENTICATED.message, {
+          extensions: { code: graphqlErrors.UNAUTHENTICATED.code }
+        })
+      );
+
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('should throw custom error if the case does not exist', async () => {
+      mockFindById.mockResolvedValue(null);
+      const input = createMockUpdateCaseInput();
+
+      await expect(CaseMutation.updateCase({}, { id, input }, adminContext)).rejects.toEqual(
+        new GraphQLError(CaseErrors.CASE_NOT_FOUND(id), {
+          extensions: { code: CaseErrorCodes.CASE_NOT_FOUND }
+        })
+      );
+
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('should throw custom error if new fondId does not reference an existing Fond', async () => {
+      mockFindById.mockResolvedValue({ id, fondId: mockFondId, descriptionNumber: 1, caseNumber: 1 });
+      mockFondFindById.mockResolvedValue(null);
+      const input = createMockUpdateCaseInput({ fondId: 'other-fond-id' });
+
+      await expect(CaseMutation.updateCase({}, { id, input }, adminContext)).rejects.toEqual(
+        new GraphQLError(CaseErrors.FOND_NOT_FOUND('other-fond-id'), {
+          extensions: { code: CaseErrorCodes.FOND_NOT_FOUND }
+        })
+      );
+
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('should throw custom error when the updated descriptionNumber+caseNumber duplicates another case in the same Fond', async () => {
+      mockFindById.mockResolvedValue({ id, fondId: mockFondId, descriptionNumber: 1, caseNumber: 1 });
+      mockFindByFondAndNumbers.mockResolvedValue({ id: 'another-case-id' });
+      const input = createMockUpdateCaseInput({ caseNumber: 2 });
+
+      await expect(CaseMutation.updateCase({}, { id, input }, adminContext)).rejects.toEqual(
+        new GraphQLError(CaseErrors.DUPLICATE_NUMBERS(), {
+          extensions: { code: CaseErrorCodes.DUPLICATE_NUMBERS }
+        })
+      );
+
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('should NOT treat the case itself as a duplicate when numbers are unchanged', async () => {
+      mockFindById.mockResolvedValue({ id, fondId: mockFondId, descriptionNumber: 1, caseNumber: 1 });
+      mockFindByFondAndNumbers.mockResolvedValue({ id });
+      mockUpdate.mockResolvedValue({ id, fondId: mockFondId, descriptionNumber: 1, caseNumber: 1 });
+      const input = createMockUpdateCaseInput({ caseNumber: 1 });
+
+      await expect(CaseMutation.updateCase({}, { id, input }, adminContext)).resolves.toBeDefined();
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw custom error if the case is deleted concurrently and the update finds no document', async () => {
+      mockFindById.mockResolvedValue({ id, fondId: mockFondId, descriptionNumber: 1, caseNumber: 1 });
+      mockUpdate.mockResolvedValue(null);
+      const input = createMockUpdateCaseInput();
+
+      await expect(CaseMutation.updateCase({}, { id, input }, adminContext)).rejects.toEqual(
+        new GraphQLError(CaseErrors.CASE_NOT_FOUND(id), {
+          extensions: { code: CaseErrorCodes.CASE_NOT_FOUND }
+        })
+      );
+    });
+
+    it('should fall back to the current caseNumber when it is not part of the update input', async () => {
+      mockFindById.mockResolvedValue({ id, fondId: mockFondId, descriptionNumber: 1, caseNumber: 7 });
+      mockFindByFondAndNumbers.mockResolvedValue(null);
+      mockUpdate.mockResolvedValue({ id, fondId: mockFondId, descriptionNumber: 2, caseNumber: 7 });
+      const input = createMockUpdateCaseInput({ descriptionNumber: 2 });
+
+      await CaseMutation.updateCase({}, { id, input }, adminContext);
+
+      expect(mockFindByFondAndNumbers).toHaveBeenCalledWith(mockFondId, 2, 7);
+    });
+
+    it('should not re-check numbers when neither fondId, descriptionNumber, nor caseNumber change', async () => {
+      mockFindById.mockResolvedValue({ id, fondId: mockFondId, descriptionNumber: 1, caseNumber: 1 });
+      mockUpdate.mockResolvedValue({ id, fondId: mockFondId, descriptionNumber: 1, caseNumber: 1 });
+      const input = createMockUpdateCaseInput();
+
+      await CaseMutation.updateCase({}, { id, input }, adminContext);
+
+      expect(mockFindByFondAndNumbers).not.toHaveBeenCalled();
+      expect(mockUpdate).toHaveBeenCalledWith(id, input);
+    });
+
+    it('should successfully call repo update method and return the updated case', async () => {
+      mockFindById.mockResolvedValue({ id, fondId: mockFondId, descriptionNumber: 1, caseNumber: 1 });
+      const updatedCase = { id, caseName: { uk: 'Оновлена справа', en: 'Updated case' } };
+      mockUpdate.mockResolvedValue(updatedCase);
+      const input = createMockUpdateCaseInput();
+
+      const result = await CaseMutation.updateCase({}, { id, input }, adminContext);
+
+      expect(mockUpdate).toHaveBeenCalledWith(id, input);
+      expect(result).toStrictEqual(updatedCase);
+    });
+  });
+
+  describe('validation', () => {
+    beforeEach(() => {
+      mockFindByFondAndNumbers.mockResolvedValue(null);
+    });
+
+    it.each([
+      ['missing fondId', { fondId: '' }],
+
+      ['non-positive descriptionNumber', { descriptionNumber: -1 }],
+      ['float descriptionNumber', { descriptionNumber: 1.5 }],
+      ['missing descriptionNumber', { descriptionNumber: undefined as unknown as number }],
+
+      ['non-positive caseNumber', { caseNumber: -1 }],
+      ['float caseNumber', { caseNumber: 1.5 }],
+      ['missing caseNumber', { caseNumber: undefined as unknown as number }],
+
+      ['caseName uk empty', { caseName: { uk: '', en: 'Case' } }],
+      ['caseName en empty', { caseName: { uk: 'Справа', en: '' } }],
+      ['caseName uk exceeding 150 characters', { caseName: { uk: 'a'.repeat(151), en: 'Case' } }],
+
+      ['caseDate uk empty', { caseDate: { uk: '', en: '1917' } }],
+      ['caseDate uk exceeding 150 characters', { caseDate: { uk: 'a'.repeat(151), en: '1917' } }],
+
+      ['non-positive sheetsNumber', { sheetsNumber: -1 }],
+      ['float sheetsNumber', { sheetsNumber: 1.5 }],
+
+      ['caseDescriptions uk empty', { caseDescriptions: { uk: '', en: 'Description' } }],
+      ['caseDescriptions uk exceeding 300 characters', { caseDescriptions: { uk: 'a'.repeat(301), en: 'Description' } }],
+
+      ['detailedCaseDescription uk exceeding 1000 characters', { detailedCaseDescription: { uk: 'a'.repeat(1001), en: 'Valid' } }],
+
+      ['pdfFile with a non-pdf extension', { pdfFile: { filename: 'scan.jpg', url: 'https://cdn/scan.jpg', mimeType: 'application/pdf' } }],
+      ['pdfFile with a non-pdf mimetype', { pdfFile: { filename: 'scan.pdf', url: 'https://cdn/scan.pdf', mimeType: 'image/jpeg' } }],
+
+      ['invalid status value', { status: 'INVALID_STATUS' as unknown as CreateCaseInput['status'] }]
+    ])('should reject %s on create', async (_label, overrides) => {
+      const input = createMockCreateCaseInput(overrides);
+
+      await expect(CaseMutation.createCase({}, { input }, adminContext)).rejects.toThrow(ZodError);
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteCase', () => {
+    it('should throw GraphQLError if user is not an admin', async () => {
+      await expect(CaseMutation.deleteCase({}, { id: 'some-id' }, userContext)).rejects.toThrow(GraphQLError);
+      expect(mockDelete).not.toHaveBeenCalled();
+    });
+
+    it('should return false when the case could not be deleted', async () => {
+      mockDelete.mockResolvedValue(false);
+      const result = await CaseMutation.deleteCase({}, { id: 'non-existent' }, adminContext);
+      expect(result).toBe(false);
+    });
+
+    it('should return true on successful delete', async () => {
+      mockDelete.mockResolvedValue(true);
+      const result = await CaseMutation.deleteCase({}, { id: 'some-id' }, adminContext);
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/src/interfaces/graphql/resolvers/case/caseMutation.ts
+++ b/src/interfaces/graphql/resolvers/case/caseMutation.ts
@@ -36,6 +36,14 @@ const caseNotFoundError = (id: string): GraphQLError =>
     extensions: { code: CaseErrorCodes.CASE_NOT_FOUND }
   });
 
+const MONGO_DUPLICATE_KEY_ERROR_CODE = 11000;
+
+const isDuplicateKeyError = (error: unknown): boolean =>
+  typeof error === 'object' &&
+  error !== null &&
+  'code' in error &&
+  (error as { code: unknown }).code === MONGO_DUPLICATE_KEY_ERROR_CODE;
+
 export const CaseMutation = {
   createCase: async (_: unknown, { input }: CreateCaseArgs, context: GraphQLContext): Promise<Case> => {
     assertAuthenticated(context);
@@ -55,7 +63,14 @@ export const CaseMutation = {
       throw duplicateNumbersError();
     }
 
-    return repo.create(validatedInput);
+    try {
+      return await repo.create(validatedInput);
+    } catch (error) {
+      if (isDuplicateKeyError(error)) {
+        throw duplicateNumbersError();
+      }
+      throw error;
+    }
   },
 
   updateCase: async (_: unknown, { id, input }: UpdateCaseArgs, context: GraphQLContext): Promise<Case> => {
@@ -92,7 +107,15 @@ export const CaseMutation = {
       }
     }
 
-    const updatedCase = await repo.update(id, validatedInput);
+    let updatedCase: Case | null;
+    try {
+      updatedCase = await repo.update(id, validatedInput);
+    } catch (error) {
+      if (isDuplicateKeyError(error)) {
+        throw duplicateNumbersError();
+      }
+      throw error;
+    }
 
     if (!updatedCase) {
       throw caseNotFoundError(id);

--- a/src/interfaces/graphql/resolvers/case/caseMutation.ts
+++ b/src/interfaces/graphql/resolvers/case/caseMutation.ts
@@ -1,0 +1,110 @@
+import { GraphQLError } from 'graphql';
+
+import { CaseErrorCodes, CaseErrors, graphqlErrors } from '~/constants/errors';
+import { Case } from '~/src/domain/entities/Case';
+import { CreateCaseInput, UpdateCaseInput } from '~/src/domain/repositories/caseRepository';
+import { GraphQLContext } from '~/src/shared/types/container/types';
+import { zCaseSchema, zCaseUpdateSchema } from '~/src/validators/case.schema';
+
+export type CreateCaseGQLInput = Omit<CreateCaseInput, 'status'> & { status?: Case['status'] };
+export type UpdateCaseGQLInput = UpdateCaseInput;
+
+type CreateCaseArgs = { input: CreateCaseGQLInput };
+type UpdateCaseArgs = { id: string; input: UpdateCaseGQLInput };
+type DeleteCaseArgs = { id: string };
+
+const assertAuthenticated = (context: GraphQLContext) => {
+  if (!context.admin) {
+    throw new GraphQLError(graphqlErrors.UNAUTHENTICATED.message, {
+      extensions: { code: graphqlErrors.UNAUTHENTICATED.code }
+    });
+  }
+};
+
+const fondNotFoundError = (fondId: string): GraphQLError =>
+  new GraphQLError(CaseErrors.FOND_NOT_FOUND(fondId), {
+    extensions: { code: CaseErrorCodes.FOND_NOT_FOUND }
+  });
+
+const duplicateNumbersError = (): GraphQLError =>
+  new GraphQLError(CaseErrors.DUPLICATE_NUMBERS(), {
+    extensions: { code: CaseErrorCodes.DUPLICATE_NUMBERS }
+  });
+
+const caseNotFoundError = (id: string): GraphQLError =>
+  new GraphQLError(CaseErrors.CASE_NOT_FOUND(id), {
+    extensions: { code: CaseErrorCodes.CASE_NOT_FOUND }
+  });
+
+export const CaseMutation = {
+  createCase: async (_: unknown, { input }: CreateCaseArgs, context: GraphQLContext): Promise<Case> => {
+    assertAuthenticated(context);
+
+    const { caseRepository: repo, fondRepository } = context.requestContainer.cradle;
+    const validatedInput = zCaseSchema.parse(input);
+
+    const { fondId, descriptionNumber, caseNumber } = validatedInput;
+
+    const fond = await fondRepository.findById(fondId);
+    if (!fond) {
+      throw fondNotFoundError(fondId);
+    }
+
+    const existing = await repo.findByFondAndNumbers(fondId, descriptionNumber, caseNumber);
+    if (existing) {
+      throw duplicateNumbersError();
+    }
+
+    return repo.create(validatedInput);
+  },
+
+  updateCase: async (_: unknown, { id, input }: UpdateCaseArgs, context: GraphQLContext): Promise<Case> => {
+    assertAuthenticated(context);
+
+    const { caseRepository: repo, fondRepository } = context.requestContainer.cradle;
+    const validatedInput = zCaseUpdateSchema.parse(input);
+
+    const current = await repo.findById(id);
+    if (!current) {
+      throw caseNotFoundError(id);
+    }
+
+    if (validatedInput.fondId !== undefined) {
+      const fond = await fondRepository.findById(validatedInput.fondId);
+      if (!fond) {
+        throw fondNotFoundError(validatedInput.fondId);
+      }
+    }
+
+    const numbersChanged =
+      validatedInput.fondId !== undefined ||
+      validatedInput.descriptionNumber !== undefined ||
+      validatedInput.caseNumber !== undefined;
+
+    if (numbersChanged) {
+      const effectiveFondId = validatedInput.fondId ?? current.fondId;
+      const effectiveDescriptionNumber = validatedInput.descriptionNumber ?? current.descriptionNumber;
+      const effectiveCaseNumber = validatedInput.caseNumber ?? current.caseNumber;
+
+      const existing = await repo.findByFondAndNumbers(effectiveFondId, effectiveDescriptionNumber, effectiveCaseNumber);
+      if (existing && existing.id !== id) {
+        throw duplicateNumbersError();
+      }
+    }
+
+    const updatedCase = await repo.update(id, validatedInput);
+
+    if (!updatedCase) {
+      throw caseNotFoundError(id);
+    }
+
+    return updatedCase;
+  },
+
+  deleteCase: async (_: unknown, { id }: DeleteCaseArgs, context: GraphQLContext): Promise<boolean> => {
+    assertAuthenticated(context);
+    const repo = context.requestContainer.cradle.caseRepository;
+
+    return repo.delete(id);
+  }
+};

--- a/src/interfaces/graphql/resolvers/case/caseQuery.test.ts
+++ b/src/interfaces/graphql/resolvers/case/caseQuery.test.ts
@@ -1,0 +1,97 @@
+import { GraphQLError } from 'graphql';
+
+import { createMockContext } from '../testUtils';
+import { CaseQuery, FiltersGQLInput } from './caseQuery';
+import { ICaseRepository } from '~/src/domain/repositories/caseRepository';
+
+describe('CaseQuery Resolvers', () => {
+  const mockRepo: jest.Mocked<Partial<ICaseRepository>> = {
+    findById: jest.fn(),
+    findAll: jest.fn(),
+    findPaginated: jest.fn()
+  };
+
+  const authorizedContext = createMockContext(true, 'caseRepository', mockRepo);
+  const unauthorizedContext = createMockContext(false, 'caseRepository', mockRepo);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('caseById', () => {
+    const mockId = 'some-id';
+
+    it('should throw GraphQLError when admin is falsy', async () => {
+      await expect(CaseQuery.caseById({}, { id: mockId }, unauthorizedContext)).rejects.toThrow(GraphQLError);
+    });
+
+    it('should call findById of repo with correct id', async () => {
+      await CaseQuery.caseById({}, { id: mockId }, authorizedContext);
+
+      expect(mockRepo.findById).toHaveBeenCalledWith(mockId);
+    });
+  });
+
+  describe('allCases', () => {
+    it('should throw GraphQLError when admin is falsy', async () => {
+      await expect(CaseQuery.allCases({}, { filters: {} }, unauthorizedContext)).rejects.toThrow(GraphQLError);
+    });
+
+    it('should call findAll', async () => {
+      await CaseQuery.allCases({}, { filters: {} }, authorizedContext);
+
+      expect(mockRepo.findAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('should pass undefined to findAll when filters argument is not provided', async () => {
+      await CaseQuery.allCases({}, { filters: undefined as unknown as FiltersGQLInput }, authorizedContext);
+
+      expect(mockRepo.findAll).toHaveBeenCalledWith(undefined);
+    });
+
+    it('should call findAll with all filters including fondId', async () => {
+      const filters: FiltersGQLInput = {
+        search: 'search',
+        fondId: 'fond-id',
+        sort: [{ field: 'caseNumber', order: 'asc' }]
+      };
+      await CaseQuery.allCases({}, { filters }, authorizedContext);
+
+      expect(mockRepo.findAll).toHaveBeenCalledWith({
+        search: 'search',
+        sort: [{ sortBy: 'caseNumber', sortOrder: 'asc' }],
+        languages: undefined,
+        limit: undefined,
+        skip: undefined,
+        statuses: undefined,
+        slug: undefined,
+        fondId: 'fond-id'
+      });
+    });
+  });
+
+  describe('paginatedCases', () => {
+    const paginationParams = {
+      limit: 10,
+      page: 1,
+      filters: {
+        search: 'search'
+      }
+    };
+
+    it('should throw GraphQLError when admin is falsy', async () => {
+      await expect(CaseQuery.paginatedCases({}, paginationParams, unauthorizedContext)).rejects.toThrow(GraphQLError);
+    });
+
+    it('should call findPaginated of repo with args', async () => {
+      await CaseQuery.paginatedCases({}, paginationParams, authorizedContext);
+
+      expect(mockRepo.findPaginated).toHaveBeenCalledTimes(1);
+      expect(mockRepo.findPaginated).toHaveBeenCalledWith(
+        paginationParams.page,
+        paginationParams.limit,
+        expect.objectContaining({ search: 'search' })
+      );
+    });
+  });
+});

--- a/src/interfaces/graphql/resolvers/case/caseQuery.ts
+++ b/src/interfaces/graphql/resolvers/case/caseQuery.ts
@@ -1,0 +1,33 @@
+import { endpointRepositoryHandler, mapFilters } from '../helpers';
+import { Case } from '~/src/domain/entities/Case';
+import { CaseFilters } from '~/src/domain/repositories/caseRepository';
+
+interface FindByIdArgs { id: string }
+export type FiltersGQLInput = Parameters<typeof mapFilters>[0] & { fondId?: string | null };
+interface FilterArgs {
+  filters: FiltersGQLInput;
+}
+interface PaginatedArgs { page: number, limit: number, filters: FiltersGQLInput }
+
+interface PaginatedResponse {
+  items: Case[]; total: number; page: number; totalPages: number
+}
+
+const mapCaseFilters = (filters?: FiltersGQLInput): CaseFilters | undefined => {
+  if (!filters) return undefined;
+
+  const mapped = mapFilters<CaseFilters>(filters) ?? {};
+
+  return {
+    ...mapped,
+    fondId: filters.fondId ?? undefined
+  } as CaseFilters;
+};
+
+const endpointHandler = endpointRepositoryHandler('caseRepository');
+
+export const CaseQuery = {
+  caseById: endpointHandler<FindByIdArgs, Case | null>(async ({ args: { id }, repo }) => repo.findById(id)),
+  allCases: endpointHandler<FilterArgs, Case[]>(async ({ repo, args: { filters } }) => repo.findAll(mapCaseFilters(filters))),
+  paginatedCases: endpointHandler<PaginatedArgs, PaginatedResponse>(async ({ args: { page, limit, filters }, repo }) => repo.findPaginated(page, limit, mapCaseFilters(filters)))
+};

--- a/src/interfaces/graphql/resolvers/index.ts
+++ b/src/interfaces/graphql/resolvers/index.ts
@@ -1,6 +1,8 @@
 import { authMutation as AdminMutation } from './admin/AuthMutation';
 import { authQuery as AuthQuery } from './admin/AuthQuery';
 import { AssetsMutation, AssetsQuery } from './assets/Query';
+import { CaseMutation } from './case/caseMutation';
+import { CaseQuery } from './case/caseQuery';
 import { CompositionsMutation } from './compositions/compositionsMutation';
 import { EventsMutation } from './events/eventsMutation';
 import { EventsQuery } from './events/eventsQuery';
@@ -22,7 +24,8 @@ export const resolvers = {
     ...EventsMutation,
     ...OpusMutation,
     ...AssetsMutation,
-    ...CompositionsMutation
+    ...CompositionsMutation,
+    ...CaseMutation
   },
   Query: {
     ...AdminQuery,
@@ -31,6 +34,7 @@ export const resolvers = {
     ...MediaMentionsQuery,
     ...EventsQuery,
     ...OpusQuery,
-    ...AssetsQuery
+    ...AssetsQuery,
+    ...CaseQuery
   }
 };

--- a/src/interfaces/graphql/resolvers/index.ts
+++ b/src/interfaces/graphql/resolvers/index.ts
@@ -6,6 +6,8 @@ import { CaseQuery } from './case/caseQuery';
 import { CompositionsMutation } from './compositions/compositionsMutation';
 import { EventsMutation } from './events/eventsMutation';
 import { EventsQuery } from './events/eventsQuery';
+import { FondMutation } from './fond/fondMutation';
+import { FondQuery } from './fond/fondQuery';
 import { MediaMentionsMutation } from './media-mentions/mediaMentionMutation';
 import { MediaMentionsQuery } from './media-mentions/mediaMentionQuery';
 import { NewsMutation } from './news/newsMutation';
@@ -25,7 +27,8 @@ export const resolvers = {
     ...OpusMutation,
     ...AssetsMutation,
     ...CompositionsMutation,
-    ...CaseMutation
+    ...CaseMutation,
+    ...FondMutation
   },
   Query: {
     ...AdminQuery,
@@ -35,6 +38,7 @@ export const resolvers = {
     ...EventsQuery,
     ...OpusQuery,
     ...AssetsQuery,
-    ...CaseQuery
+    ...CaseQuery,
+    ...FondQuery
   }
 };

--- a/src/interfaces/graphql/schemas/case.graphql
+++ b/src/interfaces/graphql/schemas/case.graphql
@@ -1,0 +1,93 @@
+enum CaseStatus {
+    draft
+    published
+    hidden
+    archived
+    editing
+}
+
+type CasePdfFile {
+    filename: String!
+    url: String!
+    mimeType: String!
+}
+
+input CasePdfFileInput {
+    filename: String!
+    url: String!
+    mimeType: String!
+}
+
+type Case {
+    id: ID!
+    fondId: ID!
+    descriptionNumber: Int!
+    caseNumber: Int!
+    caseName: LocalizedString!
+    caseDate: LocalizedString!
+    sheetsNumber: Int!
+    caseDescriptions: LocalizedString!
+    detailedCaseDescription: LocalizedString
+    pdfFile: CasePdfFile
+    status: CaseStatus!
+    updatedAt: String!
+    createdAt: String!
+}
+
+input CreateCaseInput {
+    fondId: ID!
+    descriptionNumber: Int!
+    caseNumber: Int!
+    caseName: JSON!
+    caseDate: JSON!
+    sheetsNumber: Int!
+    caseDescriptions: JSON!
+    detailedCaseDescription: JSON
+    pdfFile: CasePdfFileInput
+    status: CaseStatus
+}
+
+input UpdateCaseInput {
+    fondId: ID
+    descriptionNumber: Int
+    caseNumber: Int
+    caseName: JSON
+    caseDate: JSON
+    sheetsNumber: Int
+    caseDescriptions: JSON
+    detailedCaseDescription: JSON
+    pdfFile: CasePdfFileInput
+    status: CaseStatus
+}
+
+type PaginatedCases {
+    items: [Case!]!
+    total: Int!
+    page: Int!
+    totalPages: Int!
+}
+
+input CaseFiltersInput {
+    fondId: ID
+    limit: Int
+    skip: Int
+    search: String
+    languages: [ContentLanguage!]
+    sort: [SortOptions!]
+}
+
+extend type Query {
+    caseById(id: ID!): Case
+    allCases(filters: CaseFiltersInput): [Case!]
+    paginatedCases(
+        page: Int!,
+        limit: Int!,
+        filters: CaseFiltersInput
+    ): PaginatedCases
+}
+
+extend type Mutation {
+    createCase(input: CreateCaseInput!): Case!
+    updateCase(id: ID!, input: UpdateCaseInput!): Case!
+    deleteCase(id: ID!): Boolean!
+}

--- a/src/validators/case.schema.ts
+++ b/src/validators/case.schema.ts
@@ -1,0 +1,88 @@
+import z from 'zod';
+
+import { CASE_VALIDATION_MESSAGES } from '~/constants/case';
+import { BaseContentStatuses } from '~/types/enums/common.enums';
+
+const positiveIntSchema = (requiredMessage: string, invalidMessage: string) =>
+  z
+    .int({
+      error: (issue) => {
+        if (issue.code === 'invalid_type') {
+          if (issue.input === undefined || issue.input === null) {
+            return { message: requiredMessage };
+          }
+          return { message: invalidMessage };
+        }
+        return undefined;
+      }
+    })
+    .positive({ message: invalidMessage });
+
+const requiredLocalizedField = (requiredMessage: string, maxLength: number, maxLengthMessage: string) =>
+  z.object({
+    uk: z.string().trim().min(1, { message: requiredMessage }).max(maxLength, { message: maxLengthMessage }),
+    en: z.string().trim().min(1, { message: requiredMessage }).max(maxLength, { message: maxLengthMessage })
+  });
+
+const pdfFileSchema = z
+  .object({
+    filename: z.string().trim().min(1),
+    url: z.string().trim().min(1),
+    mimeType: z.string().trim().min(1)
+  })
+  .refine(
+    (file) => file.mimeType === 'application/pdf' && file.filename.toLowerCase().endsWith('.pdf'),
+    { message: CASE_VALIDATION_MESSAGES.pdfInvalidType }
+  );
+
+export const zCaseSchema = z.object({
+  fondId: z.string().trim().min(1, { message: CASE_VALIDATION_MESSAGES.fondIdRequired }),
+
+  descriptionNumber: positiveIntSchema(
+    CASE_VALIDATION_MESSAGES.descriptionNumberRequired,
+    CASE_VALIDATION_MESSAGES.descriptionNumberInvalid
+  ),
+
+  caseNumber: positiveIntSchema(
+    CASE_VALIDATION_MESSAGES.caseNumberRequired,
+    CASE_VALIDATION_MESSAGES.caseNumberInvalid
+  ),
+
+  caseName: requiredLocalizedField(
+    CASE_VALIDATION_MESSAGES.caseNameRequired,
+    150,
+    CASE_VALIDATION_MESSAGES.caseNameMaxLength
+  ),
+
+  caseDate: requiredLocalizedField(
+    CASE_VALIDATION_MESSAGES.caseDateRequired,
+    150,
+    CASE_VALIDATION_MESSAGES.caseDateMaxLength
+  ),
+
+  sheetsNumber: positiveIntSchema(
+    CASE_VALIDATION_MESSAGES.sheetsNumberRequired,
+    CASE_VALIDATION_MESSAGES.sheetsNumberInvalid
+  ),
+
+  caseDescriptions: requiredLocalizedField(
+    CASE_VALIDATION_MESSAGES.caseDescriptionsRequired,
+    300,
+    CASE_VALIDATION_MESSAGES.caseDescriptionsMaxLength
+  ),
+
+  detailedCaseDescription: z
+    .object({
+      uk: z.string().trim().max(1000, { message: CASE_VALIDATION_MESSAGES.detailedCaseDescriptionMaxLength }),
+      en: z.string().trim().max(1000, { message: CASE_VALIDATION_MESSAGES.detailedCaseDescriptionMaxLength })
+    })
+    .optional(),
+
+  pdfFile: pdfFileSchema.nullable().optional(),
+
+  status: z.enum(BaseContentStatuses).default(BaseContentStatuses.Hidden)
+});
+
+export const zCaseUpdateSchema = zCaseSchema.partial().extend({
+  status: z.enum(BaseContentStatuses).optional()
+});


### PR DESCRIPTION
## Description
Implements backend CRUD for Case (Справа) under a parent Fond — issue #749. Adds domain entity, Mongoose model, repository, Zod validation, GraphQL schema and resolvers.

- Data model: `fondId`, `descriptionNumber`, `caseNumber`, `caseName`, `caseDate`, `sheetsNumber`, `caseDescriptions`, `detailedCaseDescription`, `pdfFile`, `status` (default `hidden`)
- Uniqueness constraint: `descriptionNumber` + `caseNumber` unique within a single Fond (DB index + resolver-level check with UA error message)
- PDF attachment validation (extension + mimetype)
- GraphQL: `createCase`, `updateCase`, `deleteCase`, `caseById`, `allCases`, `paginatedCases` — mutations restricted to authenticated admins

## Type of change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test
1. `npm run generate` — regenerate GraphQL types
2. `npm run typecheck` / `npm run lint` — clean
3. `npx jest src/infrastructure/repositories/caseRepository src/interfaces/graphql/resolvers/case --coverage` — 55 tests pass, 80%+ coverage
4. Via GraphQL playground: `createCase` with a valid `fondId`, verify duplicate `descriptionNumber`+`caseNumber` in the same Fond is rejected, verify non-PDF file is rejected
