### PR TITLE
Fix news meta description validation

### DIFF
--- a/src/constants/errors.ts
+++ b/src/constants/errors.ts
@@ -33,7 +33,8 @@ export const newsServiceErrors = {
   FAILED_TO_DELETE: (id: string) => `News with id "${id}" not found or could not be deleted`,
   TITLE_REQUIRED_FOR_SLUG: 'Title is required to generate a slug',
   TITLE_TOO_SHORT_FOR_SLUG: 'Title must be at least 2 characters long to generate a slug',
-  TITLE_TOO_LONG_FOR_SLUG: 'Title must not exceed 150 characters'
+  TITLE_TOO_LONG_FOR_SLUG: 'Title must not exceed 150 characters',
+  DESCRIPTION_LENGTH_INVALID: 'Description must contain from 2 to 250 characters'
 };
 
 export const opusServiceErrors = {

--- a/src/interfaces/graphql/resolvers/news/newsMutation.test.ts
+++ b/src/interfaces/graphql/resolvers/news/newsMutation.test.ts
@@ -163,6 +163,25 @@ describe('NewsMutation Resolvers', () => {
     it('should throw GraphQLError for updateNews if user is unauthenticated', async () => {
       await expect(NewsMutation.updateNews({}, { id: '1', input: {} }, userContext)).rejects.toThrow();
     });
+
+    it('should throw GraphQLError with BAD_USER_INPUT if description has fewer than 2 characters (bug #501)', async () => {
+      expect.assertions(5);
+
+      const invalidInput = {
+        ...baseInput,
+        description: { uk: 'T', en: 'T' }
+      };
+
+      try {
+        await NewsMutation.createNews({}, { input: invalidInput }, adminContext);
+      } catch (error) {
+        expect(error).toBeInstanceOf(GraphQLError);
+        expect((error as GraphQLError).message).toBe(newsServiceErrors.DESCRIPTION_LENGTH_INVALID);
+        expect((error as GraphQLError).extensions.code).toBe('BAD_USER_INPUT');
+        expect((error as GraphQLError).extensions.fields).toEqual(['description.uk', 'description.en']);
+        expect(mockRepo.create).not.toHaveBeenCalled();
+      }
+    });
   });
 
   describe('createNews', () => {

--- a/src/interfaces/graphql/resolvers/news/newsMutation.test.ts
+++ b/src/interfaces/graphql/resolvers/news/newsMutation.test.ts
@@ -164,40 +164,32 @@ describe('NewsMutation Resolvers', () => {
       await expect(NewsMutation.updateNews({}, { id: '1', input: {} }, userContext)).rejects.toThrow();
     });
 
-    it('should throw GraphQLError with BAD_USER_INPUT if description has fewer than 2 characters', async () => {
-
+    it.each([
+      {
+        caseName: 'has fewer than 2 characters',
+        description: { uk: 'T', en: 'T' },
+        fields: ['description.uk', 'description.en']
+      },
+      {
+        caseName: 'exceeds 250 characters',
+        description: { uk: 'a'.repeat(251), en: 'Valid description' },
+        fields: ['description.uk']
+      }
+    ])('should throw GraphQLError with BAD_USER_INPUT if description $caseName', async ({ description, fields }) => {
       const invalidInput = {
         ...baseInput,
-        description: { uk: 'T', en: 'T' }
+        description
       };
 
-      try {
-        await NewsMutation.createNews({}, { input: invalidInput }, adminContext);
-        throw new Error('Expected createNews to throw');
-      } catch (error) {
-        expect(error).toBeInstanceOf(GraphQLError);
-        expect((error as GraphQLError).message).toBe(newsServiceErrors.DESCRIPTION_LENGTH_INVALID);
-        expect((error as GraphQLError).extensions.code).toBe('BAD_USER_INPUT');
-        expect((error as GraphQLError).extensions.fields).toEqual(['description.uk', 'description.en']);
-        expect(mockRepo.create).not.toHaveBeenCalled();
-      }
-    });
-    it('should throw GraphQLError with BAD_USER_INPUT if description exceeds 250 characters', async () => {
-      const invalidInput = {
-        ...baseInput,
-        description: { uk: 'a'.repeat(251), en: 'Valid description' }
-      };
+      await expect(NewsMutation.createNews({}, { input: invalidInput }, adminContext)).rejects.toMatchObject({
+        message: newsServiceErrors.DESCRIPTION_LENGTH_INVALID,
+        extensions: {
+          code: 'BAD_USER_INPUT',
+          fields
+        }
+      });
 
-      try {
-        await NewsMutation.createNews({}, { input: invalidInput }, adminContext);
-        throw new Error('Expected createNews to throw');
-      } catch (error) {
-        expect(error).toBeInstanceOf(GraphQLError);
-        expect((error as GraphQLError).message).toBe(newsServiceErrors.DESCRIPTION_LENGTH_INVALID);
-        expect((error as GraphQLError).extensions.code).toBe('BAD_USER_INPUT');
-        expect((error as GraphQLError).extensions.fields).toEqual(['description.uk']);
-        expect(mockRepo.create).not.toHaveBeenCalled();
-      }
+      expect(mockRepo.create).not.toHaveBeenCalled();
     });
 
     it('should allow updateNews when description has only one valid locale', async () => {

--- a/src/interfaces/graphql/resolvers/news/newsMutation.test.ts
+++ b/src/interfaces/graphql/resolvers/news/newsMutation.test.ts
@@ -164,8 +164,7 @@ describe('NewsMutation Resolvers', () => {
       await expect(NewsMutation.updateNews({}, { id: '1', input: {} }, userContext)).rejects.toThrow();
     });
 
-    it('should throw GraphQLError with BAD_USER_INPUT if description has fewer than 2 characters (bug #501)', async () => {
-      expect.assertions(5);
+    it('should throw GraphQLError with BAD_USER_INPUT if description has fewer than 2 characters', async () => {
 
       const invalidInput = {
         ...baseInput,
@@ -174,6 +173,7 @@ describe('NewsMutation Resolvers', () => {
 
       try {
         await NewsMutation.createNews({}, { input: invalidInput }, adminContext);
+        throw new Error('Expected createNews to throw');
       } catch (error) {
         expect(error).toBeInstanceOf(GraphQLError);
         expect((error as GraphQLError).message).toBe(newsServiceErrors.DESCRIPTION_LENGTH_INVALID);
@@ -181,6 +181,37 @@ describe('NewsMutation Resolvers', () => {
         expect((error as GraphQLError).extensions.fields).toEqual(['description.uk', 'description.en']);
         expect(mockRepo.create).not.toHaveBeenCalled();
       }
+    });
+    it('should throw GraphQLError with BAD_USER_INPUT if description exceeds 250 characters', async () => {
+      const invalidInput = {
+        ...baseInput,
+        description: { uk: 'a'.repeat(251), en: 'Valid description' }
+      };
+
+      try {
+        await NewsMutation.createNews({}, { input: invalidInput }, adminContext);
+        throw new Error('Expected createNews to throw');
+      } catch (error) {
+        expect(error).toBeInstanceOf(GraphQLError);
+        expect((error as GraphQLError).message).toBe(newsServiceErrors.DESCRIPTION_LENGTH_INVALID);
+        expect((error as GraphQLError).extensions.code).toBe('BAD_USER_INPUT');
+        expect((error as GraphQLError).extensions.fields).toEqual(['description.uk']);
+        expect(mockRepo.create).not.toHaveBeenCalled();
+      }
+    });
+
+    it('should allow updateNews when description has only one valid locale', async () => {
+      mockAction('findById', createMockNews({ id }));
+      mockAction('update', createMockNews({ id }));
+
+      const updateInput = {
+        description: { uk: 'Valid description' }
+      } as unknown as UpdateNewsGQLInput;
+
+      const result = await NewsMutation.updateNews({}, { id, input: updateInput }, adminContext);
+
+      expect(result.id).toBe(id);
+      expect(mockRepo.update).toHaveBeenCalled();
     });
   });
 

--- a/src/interfaces/graphql/resolvers/news/newsMutation.ts
+++ b/src/interfaces/graphql/resolvers/news/newsMutation.ts
@@ -63,60 +63,83 @@ const TITLE_MAX_LENGTH = 150;
 const DESCRIPTION_MIN_LENGTH = 2;
 const DESCRIPTION_MAX_LENGTH = 250;
 
-const validateDescriptionLength = (description: LocalizedString | undefined): void => {
-  if (!description) return;
+type LocalizedLengthValidationOptions = {
+  fieldName: 'title' | 'description';
+  minLength?: number;
+  maxLength?: number;
+};
 
-  const invalidFields = (['uk', 'en'] as const)
+const getInvalidLocalizedLengthFields = (
+  value: LocalizedString | undefined,
+  { fieldName, minLength, maxLength }: LocalizedLengthValidationOptions
+): string[] => {
+  if (!value) return [];
+
+  return (['uk', 'en'] as const)
     .filter((lang) => {
-      const value = description[lang];
+      const localizedValue = value[lang];
 
-      if (typeof value !== 'string') {
+      if (typeof localizedValue !== 'string') {
         return false;
       }
 
-      const length = value.trim().length;
+      const length = localizedValue.trim().length;
 
-      return length < DESCRIPTION_MIN_LENGTH || length > DESCRIPTION_MAX_LENGTH;
+      return (
+        (minLength !== undefined && length < minLength) ||
+        (maxLength !== undefined && length > maxLength)
+      );
     })
-    .map((lang) => `description.${lang}`);
-
-  if (invalidFields.length > 0) {
-    throw new GraphQLError(newsServiceErrors.DESCRIPTION_LENGTH_INVALID, {
-      extensions: {
-        code: 'BAD_USER_INPUT',
-        fields: invalidFields
-      }
-    });
-  }
+    .map((lang) => `${fieldName}.${lang}`);
 };
 
-const validateTitleMaxLength = (title: LocalizedString | undefined): void => {
-  if (!title) return;
+const throwBadUserInput = (message: string, fields: string[]): void => {
+  if (fields.length === 0) return;
 
-  (['uk', 'en'] as const).forEach((lang) => {
-    const value = title[lang];
-    if (typeof value === 'string' && value.trim().length > TITLE_MAX_LENGTH) {
-      throw new GraphQLError(newsServiceErrors.TITLE_TOO_LONG_FOR_SLUG, {
-        extensions: { code: 'BAD_USER_INPUT' }
-      });
+  throw new GraphQLError(message, {
+    extensions: {
+      code: 'BAD_USER_INPUT',
+      fields
     }
   });
 };
 
-const trimLocalizedTitle = (title: LocalizedString | undefined): LocalizedString | undefined => {
-  if (!title) return title;
+const validateDescriptionLength = (description: LocalizedString | undefined): void => {
+  const invalidFields = getInvalidLocalizedLengthFields(description, {
+    fieldName: 'description',
+    minLength: DESCRIPTION_MIN_LENGTH,
+    maxLength: DESCRIPTION_MAX_LENGTH
+  });
 
-  const trimmed: LocalizedString = { ...title };
+  throwBadUserInput(newsServiceErrors.DESCRIPTION_LENGTH_INVALID, invalidFields);
+};
+
+const validateTitleMaxLength = (title: LocalizedString | undefined): void => {
+  const invalidFields = getInvalidLocalizedLengthFields(title, {
+    fieldName: 'title',
+    maxLength: TITLE_MAX_LENGTH
+  });
+
+  throwBadUserInput(newsServiceErrors.TITLE_TOO_LONG_FOR_SLUG, invalidFields);
+};
+
+const trimLocalizedString = (value: LocalizedString | undefined): LocalizedString | undefined => {
+  if (!value) return value;
+
+  const trimmed: LocalizedString = { ...value };
 
   (['uk', 'en'] as const).forEach((lang) => {
-    const value = title[lang];
-    if (typeof value === 'string') {
-      trimmed[lang] = value.trim();
+    const localizedValue = value[lang];
+
+    if (typeof localizedValue === 'string') {
+      trimmed[lang] = localizedValue.trim();
     }
   });
 
   return trimmed;
 };
+
+
 
 const endpointHandler = endpointRepositoryHandler('newsRepository');
 
@@ -130,7 +153,13 @@ export const NewsMutation = {
 
     const repo = context.requestContainer.cradle.newsRepository;
 
-    const titleForSlug = extractTitleForSlug(input.title);
+    const trimmedInput = {
+      ...input,
+      title: trimLocalizedString(input.title) ?? input.title,
+      description: trimLocalizedString(input.description) ?? input.description
+    };
+
+    const titleForSlug = extractTitleForSlug(trimmedInput.title);
 
     if (!titleForSlug) {
       throw new Error(newsServiceErrors.TITLE_REQUIRED_FOR_SLUG);
@@ -138,8 +167,8 @@ export const NewsMutation = {
       throw new Error(newsServiceErrors.TITLE_TOO_SHORT_FOR_SLUG);
     }
 
-    validateTitleMaxLength(input.title);
-    validateDescriptionLength(input.description);
+    validateTitleMaxLength(trimmedInput.title);
+    validateDescriptionLength(trimmedInput.description);
 
     const slug = await generateUniqueSlug(titleForSlug, {
       checkExists: async (slug: string) => {
@@ -148,11 +177,12 @@ export const NewsMutation = {
       }
     });
 
-    const processedInput = await processNewsContent(input);
+    const processedInput = await processNewsContent(trimmedInput);
 
     const newsData: CreateNewsInput = {
       ...processedInput,
-      title: trimLocalizedTitle(input.title) ?? input.title,
+      title: trimmedInput.title,
+      description: processedInput.description,
       slug,
       newsDate: input.newsDate,
       status: input.status || NewsStatus.Draft,
@@ -195,24 +225,30 @@ export const NewsMutation = {
       ...input
     };
 
-    validateDescriptionLength(input.description);
+    const trimmedInput = {
+      ...input,
+      title: trimLocalizedString(input.title) ?? input.title,
+      description: trimLocalizedString(input.description) ?? input.description
+    };
+
+    validateDescriptionLength(trimmedInput.description);
 
     if (input.content || input.description || input.coverImage) {
-      await processContentFields(input, updateData);
+      await processContentFields(trimmedInput, updateData);
     }
 
-    if (input.title) {
-      const titleForSlug = extractTitleForSlug(input.title);
+    if (trimmedInput.title) {
+      const titleForSlug = extractTitleForSlug(trimmedInput.title);
       if (!titleForSlug) {
         throw new Error(newsServiceErrors.TITLE_REQUIRED_FOR_SLUG);
       } else if (titleForSlug.trim().length < 2) {
         throw new Error(newsServiceErrors.TITLE_TOO_SHORT_FOR_SLUG);
       }
 
-      validateTitleMaxLength(input.title);
+      validateTitleMaxLength(trimmedInput.title);
 
-      await processSlugUpdate(id, input.title, repo, updateData);
-      updateData.title = trimLocalizedTitle(input.title) ?? input.title;
+      await processSlugUpdate(id, trimmedInput.title, repo, updateData);
+      updateData.title = trimmedInput.title;
     }
 
     const res = await repo.update(id, updateData);

--- a/src/interfaces/graphql/resolvers/news/newsMutation.ts
+++ b/src/interfaces/graphql/resolvers/news/newsMutation.ts
@@ -75,7 +75,7 @@ const getInvalidLocalizedLengthFields = (
 ): string[] => {
   if (!value) return [];
 
-  return (['uk', 'en'] as const)
+  const invalidFields = (['uk', 'en'] as const)
     .filter((lang) => {
       const localizedValue = value[lang];
 
@@ -85,12 +85,11 @@ const getInvalidLocalizedLengthFields = (
 
       const length = localizedValue.trim().length;
 
-      return (
-        (minLength !== undefined && length < minLength) ||
-        (maxLength !== undefined && length > maxLength)
-      );
+      return (minLength !== undefined && length < minLength) || (maxLength !== undefined && length > maxLength);
     })
     .map((lang) => `${fieldName}.${lang}`);
+
+  return invalidFields;
 };
 
 const throwBadUserInput = (message: string, fields: string[]): void => {
@@ -138,8 +137,6 @@ const trimLocalizedString = (value: LocalizedString | undefined): LocalizedStrin
 
   return trimmed;
 };
-
-
 
 const endpointHandler = endpointRepositoryHandler('newsRepository');
 

--- a/src/interfaces/graphql/resolvers/news/newsMutation.ts
+++ b/src/interfaces/graphql/resolvers/news/newsMutation.ts
@@ -69,7 +69,12 @@ const validateDescriptionLength = (description: LocalizedString | undefined): vo
   const invalidFields = (['uk', 'en'] as const)
     .filter((lang) => {
       const value = description[lang];
-      const length = typeof value === 'string' ? value.trim().length : 0;
+
+      if (typeof value !== 'string') {
+        return false;
+      }
+
+      const length = value.trim().length;
 
       return length < DESCRIPTION_MIN_LENGTH || length > DESCRIPTION_MAX_LENGTH;
     })
@@ -189,7 +194,7 @@ export const NewsMutation = {
     const updateData: UpdateNewsInput = {
       ...input
     };
-    
+
     validateDescriptionLength(input.description);
 
     if (input.content || input.description || input.coverImage) {

--- a/src/interfaces/graphql/resolvers/news/newsMutation.ts
+++ b/src/interfaces/graphql/resolvers/news/newsMutation.ts
@@ -60,6 +60,31 @@ const processContentFields = async (input: UpdateNewsGQLInput, updateData: Updat
 
 const TITLE_MAX_LENGTH = 150;
 
+const DESCRIPTION_MIN_LENGTH = 2;
+const DESCRIPTION_MAX_LENGTH = 250;
+
+const validateDescriptionLength = (description: LocalizedString | undefined): void => {
+  if (!description) return;
+
+  const invalidFields = (['uk', 'en'] as const)
+    .filter((lang) => {
+      const value = description[lang];
+      const length = typeof value === 'string' ? value.trim().length : 0;
+
+      return length < DESCRIPTION_MIN_LENGTH || length > DESCRIPTION_MAX_LENGTH;
+    })
+    .map((lang) => `description.${lang}`);
+
+  if (invalidFields.length > 0) {
+    throw new GraphQLError(newsServiceErrors.DESCRIPTION_LENGTH_INVALID, {
+      extensions: {
+        code: 'BAD_USER_INPUT',
+        fields: invalidFields
+      }
+    });
+  }
+};
+
 const validateTitleMaxLength = (title: LocalizedString | undefined): void => {
   if (!title) return;
 
@@ -109,6 +134,7 @@ export const NewsMutation = {
     }
 
     validateTitleMaxLength(input.title);
+    validateDescriptionLength(input.description);
 
     const slug = await generateUniqueSlug(titleForSlug, {
       checkExists: async (slug: string) => {
@@ -163,6 +189,8 @@ export const NewsMutation = {
     const updateData: UpdateNewsInput = {
       ...input
     };
+    
+    validateDescriptionLength(input.description);
 
     if (input.content || input.description || input.coverImage) {
       await processContentFields(input, updateData);


### PR DESCRIPTION
## Description
This PR fixes bug #501 by adding backend validation for News meta description length.

News can no longer be created when `description.uk` or `description.en` contains fewer than 2 characters or more than 250 characters. The API returns `BAD_USER_INPUT` with invalid description fields.

Closes [Liatoshynsky-Foundation/lf-manual-tests#501](https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/501)

## How to test
1. Run `npm test -- newsMutation.test.ts --coverage=false`.
2. In Postman, send `CreateNews` with `description.uk: "T"` and `description.en: "T"`.
3. Verify the API returns `BAD_USER_INPUT` and `fields: ["description.uk", "description.en"]`.

## Video / Screenshots
Not applicable. API validation change.

## Checklist
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No secret keys of our application
- [x] No Sonar errors

 

