### PR TITLE
fix: add missing alt text field

### DIFF
--- a/app/lib/utils/mergeLocalizedValue.ts
+++ b/app/lib/utils/mergeLocalizedValue.ts
@@ -1,0 +1,9 @@
+export const mergeLocalizedValue = <L extends string, V>(
+  field: Record<L, V> | undefined,
+  locale: L,
+  value: V
+): Record<L, V> =>
+  ({
+    ...field,
+    [locale]: value
+  }) as Record<L, V>;

--- a/app/lib/utils/prose.test.ts
+++ b/app/lib/utils/prose.test.ts
@@ -1,4 +1,6 @@
-import { proseToHeaderText,proseToText, textToProse } from './prose';
+import { JSONContent } from '@tiptap/react';
+
+import { isProseDoc, proseToHeaderText,proseToText, resolveLocalizedText, textToProse } from './prose';
 import type { ProseDoc, ProseNode } from '~/types/common';
 
 describe('proseToText', () => {
@@ -89,5 +91,56 @@ describe('proseToHeaderText', () => {
 
   it('should use default empty string fallback when second argument is omitted', () => {
     expect(proseToHeaderText(undefined)).toBe('');
+  });
+});
+
+describe('isProseDoc', () => {
+  it('should return true for a valid ProseDoc object', () => {
+    const doc: ProseDoc = { type: 'doc', content: [] };
+    expect(isProseDoc(doc)).toBe(true);
+  });
+
+  it('should return false for null', () => {
+    expect(isProseDoc(null)).toBe(false);
+  });
+
+  it('should return false for undefined', () => {
+    expect(isProseDoc(undefined)).toBe(false);
+  });
+
+  it('should return false for a string', () => {
+    expect(isProseDoc('I am a string')).toBe(false);
+  });
+
+  it('should return false for an object without type="doc"', () => {
+    const doc = { type: 'paragraph', content: [] };
+    expect(isProseDoc(doc)).toBe(false);
+  });
+});
+
+describe('resolveLocalizedText', () => {
+  it('should return empty string for undefined', () => {
+    expect(resolveLocalizedText(undefined)).toBe('');
+  });
+
+  it('should return empty string for null', () => {
+    expect(resolveLocalizedText(null)).toBe('');
+  });
+
+  it('should return the string itself if passed a string', () => {
+    expect(resolveLocalizedText('Direct string')).toBe('Direct string');
+  });
+
+  it('should extract text from a valid ProseDoc', () => {
+    const doc: JSONContent = {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Extracted text' }] }]
+    };
+    expect(resolveLocalizedText(doc)).toBe('Extracted text');
+  });
+
+  it('should return empty string for non-string, non-ProseDoc objects', () => {
+    const invalidObj: JSONContent = { type: 'unknown' };
+    expect(resolveLocalizedText(invalidObj)).toBe('');
   });
 });

--- a/app/lib/utils/prose.ts
+++ b/app/lib/utils/prose.ts
@@ -1,3 +1,5 @@
+import { JSONContent } from '@tiptap/react';
+
 import { ProseDoc, ProseNode, ProseTextNode } from '~/types/common';
 
 export const proseToText = (doc?: ProseDoc): string => {
@@ -22,4 +24,13 @@ export const textToProse = (text: string): ProseDoc => ({
 export const proseToHeaderText = (doc?: ProseDoc, fallback = ''): string => {
   const text = proseToText(doc).replace(/\s+/g, ' ').trim();
   return text || fallback;
+};
+
+export const isProseDoc = (value: unknown): value is ProseDoc =>
+  typeof value === 'object' && value !== null && (value as { type?: unknown }).type === 'doc';
+
+export const resolveLocalizedText = (value?: JSONContent | string | null): string => {
+  if (!value) return '';
+  if (typeof value === 'string') return value;
+  return isProseDoc(value) ? proseToText(value) : '';
 };

--- a/app/shared/components/about-us/Intro-section/IntroSection.test.tsx
+++ b/app/shared/components/about-us/Intro-section/IntroSection.test.tsx
@@ -32,15 +32,20 @@ jest.mock('~/ds-components/photo-block/PhotoBlock', () => ({
   ImagePreviewBlock: ({
     imageUrl,
     fileName,
-    onChangeImage
+    altText,
+    onChangeImage,
+    onChangeAltText
   }: {
     readonly imageUrl: string;
     readonly fileName: string;
+    readonly altText?: string;
     readonly onChangeImage: (url: string, crop?: { x: number; y: number; width: number; height: number }) => void;
+    readonly onChangeAltText?: (value: string) => void;
   }) => (
     <div data-testid="image-preview">
       <span data-testid="image-url">{imageUrl}</span>
       <span data-testid="file-name">{fileName}</span>
+      <span data-testid="alt-text">{altText}</span>
       <button
         data-testid="trigger-image-change-with-crop"
         onClick={() => onChangeImage('https://pub-2b50c59c64954ab89b7837f9f4607e12.r2.dev/photos/updated.jpg', {
@@ -57,6 +62,9 @@ jest.mock('~/ds-components/photo-block/PhotoBlock', () => ({
         onClick={() => onChangeImage('https://pub-2b50c59c64954ab89b7837f9f4607e12.r2.dev/photos/updated.jpg')}
       >
         Change Image Without Crop
+      </button>
+      <button data-testid="trigger-alt-change" onClick={() => onChangeAltText?.('Updated alt text')}>
+        Change Alt Text
       </button>
     </div>
   )
@@ -227,6 +235,37 @@ describe('IntroSection', () => {
       src: 'https://pub-2b50c59c64954ab89b7837f9f4607e12.r2.dev/photos/updated.jpg',
       isTmp: false,
       crop: null
+    });
+  });
+
+  it('should convert legacy JSONContent alt text to a plain string instead of leaking the raw object', () => {
+    
+    runSimulation();
+
+    const altText = within(screen.getByTestId('image-preview')).getByTestId('alt-text');
+    expect(altText).not.toHaveTextContent('[object Object]');
+    expect(altText).toHaveTextContent('Initial Caption');
+  });
+
+  it('should pass an empty alt text string when no alt data exists yet', () => {
+    usePageBlockMock.mockReturnValue({
+      block: {
+        ...mockBlockData,
+        image: { ...mockBlockData.image, alt: undefined }
+      }
+    });
+
+    runSimulation();
+
+    expect(within(screen.getByTestId('image-preview')).getByTestId('alt-text')).toHaveTextContent('');
+  });
+
+  it('should call setField with merged alt text when the alt text field changes', () => {
+    runSimulation('trigger-alt-change');
+
+    expect(setFieldMock).toHaveBeenCalledWith('about-us', 'IntroSection', 'image', {
+      ...mockBlockData.image,
+      alt: { ...mockBlockData.image.alt, uk: 'Updated alt text' }
     });
   });
 });

--- a/app/shared/components/about-us/Intro-section/IntroSection.tsx
+++ b/app/shared/components/about-us/Intro-section/IntroSection.tsx
@@ -9,7 +9,8 @@ import { BLOCK_IDS, PAGE_IDS } from '~/constants/pageBlocks';
 import { CROP_RATIOS } from '~/constants/publications';
 import { ImagePreviewBlock } from '~/ds-components/photo-block/PhotoBlock';
 import { CustomTextField } from '~/ds-components/text-field/TextField';
-import { proseToHeaderText } from '~/lib/utils/prose';
+import { mergeLocalizedValue } from '~/lib/utils/mergeLocalizedValue';
+import { proseToHeaderText, resolveLocalizedText } from '~/lib/utils/prose';
 import type { MediaModalResult } from '~/shared/components/media-modal/MediaModal.types';
 import { usePageBlock } from '~/shared/hooks/use-page-block/usePageBlock';
 import { useStore } from '~/store';
@@ -29,12 +30,13 @@ export const IntroSection = () => {
 
   const headerTitle = proseToHeaderText(block.title[currentLocale] as ProseDoc, 'Вступна секція');
 
-  
+  const imageAltText = resolveLocalizedText(block.image?.alt?.[currentLocale]);
+
   const handleImageAltChange = (val: string) => {
     setField(pageId, blockId, 'image', {
       ...block.image,
-      alt: { ...block.image?.alt, [currentLocale]: val }
-    } as typeof block.image);
+      alt: mergeLocalizedValue(block.image?.alt, currentLocale, val)
+    });
   };
 
 
@@ -68,7 +70,7 @@ export const IntroSection = () => {
             });
           }}
           showAlternativeText
-          altText={block.image?.alt?.[currentLocale] as string}
+          altText={imageAltText}
           onChangeAltText={(value) => handleImageAltChange(value)}
         />
       </Box>

--- a/app/shared/components/about-us/Intro-section/IntroSection.tsx
+++ b/app/shared/components/about-us/Intro-section/IntroSection.tsx
@@ -29,6 +29,15 @@ export const IntroSection = () => {
 
   const headerTitle = proseToHeaderText(block.title[currentLocale] as ProseDoc, 'Вступна секція');
 
+  
+  const handleImageAltChange = (val: string) => {
+    setField(pageId, blockId, 'image', {
+      ...block.image,
+      alt: { ...block.image?.alt, [currentLocale]: val }
+    } as typeof block.image);
+  };
+
+
   return (
     <CollapsibleBlock title={headerTitle}>
       <CustomTextField
@@ -58,6 +67,9 @@ export const IntroSection = () => {
               crop: crop ?? null
             });
           }}
+          showAlternativeText
+          altText={block.image?.alt?.[currentLocale] as string}
+          onChangeAltText={(value) => handleImageAltChange(value)}
         />
       </Box>
 

--- a/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.test.tsx
+++ b/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.test.tsx
@@ -213,6 +213,12 @@ describe('LiatoshynskyFoundation', () => {
 
   it.each([
     [
+      'section title updates',
+      'trigger-change-Заголовок секції',
+      'title',
+      expect.objectContaining({ uk: createDocNode('Updated Заголовок секції') })
+    ],
+    [
       'main organization text sections',
       'trigger-main-text-change',
       'ourOrganisation',

--- a/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.test.tsx
+++ b/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.test.tsx
@@ -17,9 +17,11 @@ interface MockFoundationBlockProps {
   readonly paragraphs: readonly MockParagraph[];
   readonly imageUrl: string;
   readonly fileName: string;
+  readonly imageAlt?: string;
   readonly onMainTextChange: (value: JSONContent) => void;
   readonly onParagraphChange: (idx: number, value: JSONContent) => void;
   readonly onImageChange: (url: string, crop?: CropRect) => void;
+  readonly onAltChange?: (value: string) => void;
 }
 
 const setFieldMock = jest.fn();
@@ -48,9 +50,11 @@ jest.mock('./foundation-block/FoundationBlock', () => ({
     paragraphs,
     imageUrl,
     fileName,
+    imageAlt,
     onMainTextChange,
     onParagraphChange,
-    onImageChange
+    onImageChange,
+    onAltChange
   }: MockFoundationBlockProps) => (
     <div>
       <div data-testid="main-text-json">{JSON.stringify(mainText)}</div>
@@ -82,6 +86,7 @@ jest.mock('./foundation-block/FoundationBlock', () => ({
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img src={imageUrl} alt="Foundation" data-testid="image" />
       <span data-testid="file-name">{fileName}</span>
+      <span data-testid="image-alt-text">{imageAlt}</span>
       <button
         data-testid="trigger-image-change"
         onClick={() => onImageChange('new-image-url.jpg', { x: 0, y: 0, width: 100, height: 100 })}
@@ -90,6 +95,9 @@ jest.mock('./foundation-block/FoundationBlock', () => ({
       </button>
       <button data-testid="trigger-image-change-no-crop" onClick={() => onImageChange('new-image-url.jpg')}>
         Change Image No Crop
+      </button>
+      <button data-testid="trigger-alt-change" onClick={() => onAltChange?.('New alt text')}>
+        Change Alt Text
       </button>
     </div>
   )
@@ -115,7 +123,17 @@ jest.mock('~/ds-components/collapsible-block/CollapsibleBlock', () => ({
   )
 }));
 
-jest.mock('~/lib/utils/prose', () => ({ proseToText: String, proseToHeaderText: (doc: unknown, fallback: string) => (doc ? String(doc) : fallback) }));
+jest.mock('~/lib/utils/prose', () => ({
+  proseToText: (doc: unknown) => {
+    if (!doc) return '';
+    return typeof doc === 'string' ? doc : 'converted-legacy-alt';
+  },
+  proseToHeaderText: (doc: unknown, fallback: string) => (doc ? String(doc) : fallback),
+  resolveLocalizedText: (doc: unknown) => {
+    if (!doc) return '';
+    return typeof doc === 'string' ? doc : 'converted-legacy-alt';
+  }
+}));
 
 const mockNodes = {
   org: createDocNode('Organisation Text'),
@@ -129,7 +147,8 @@ const mockBlock = {
   ourBelief: { uk: mockNodes.belief },
   image: {
     src: 'https://pub-2b50c59c64954ab89b7837f9f4607e12.r2.dev/photos/image-src.jpg',
-    caption: { uk: 'Image Caption' }
+    caption: { uk: 'Image Caption' },
+    alt: { uk: mockNodes.org }
   }
 };
 
@@ -158,6 +177,8 @@ describe('LiatoshynskyFoundation', () => {
       'https://pub-2b50c59c64954ab89b7837f9f4607e12.r2.dev/photos/image-src.jpg'
     );
     expect(screen.getByTestId('file-name')).toHaveTextContent('Image Caption');
+    expect(screen.getByTestId('image-alt-text')).not.toHaveTextContent('[object Object]');
+    expect(screen.getByTestId('image-alt-text')).toHaveTextContent('converted-legacy-alt');
   });
 
   it('should call toggleBlockVisibility with pageId and blockId when the visibility toggle is clicked', () => {
@@ -214,6 +235,12 @@ describe('LiatoshynskyFoundation', () => {
       'trigger-image-change',
       'image',
       expect.objectContaining({ src: 'new-image-url.jpg', isTmp: false, crop: { x: 0, y: 0, width: 100, height: 100 } })
+    ],
+    [
+      'image alt text updates',
+      'trigger-alt-change',
+      'image',
+      expect.objectContaining({ alt: expect.objectContaining({ uk: 'New alt text' }) })
     ]
   ])(
     'should correctly dispatch setField parameters when modifying %s',

--- a/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.tsx
+++ b/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.tsx
@@ -8,7 +8,8 @@ import { FoundationBlock } from './foundation-block/FoundationBlock';
 import { BLOCK_IDS, PAGE_IDS } from '~/constants/pageBlocks';
 import CollapsibleBlock from '~/ds-components/collapsible-block/CollapsibleBlock';
 import { CustomTextField } from '~/ds-components/text-field/TextField';
-import { proseToHeaderText, proseToText } from '~/lib/utils/prose';
+import { mergeLocalizedValue } from '~/lib/utils/mergeLocalizedValue';
+import { proseToHeaderText, proseToText, resolveLocalizedText } from '~/lib/utils/prose';
 import type { MediaModalResult } from '~/shared/components/media-modal/MediaModal.types';
 import { usePageBlock } from '~/shared/hooks/use-page-block/usePageBlock';
 import { useTitleValidation } from '~/shared/hooks/use-title-validation/useTitleValidation';
@@ -48,9 +49,11 @@ export const LiatoshynskyFoundation = () => {
   const handleImageAltChange = (val: string) => {
     setField(pageId, blockId, 'image', {
       ...block.image,
-      alt: { ...block.image?.alt, [currentLocale]: val }
-    } as typeof block.image);
+      alt: mergeLocalizedValue(block.image?.alt, currentLocale, val)
+    });
   };
+
+  const imageAltText = resolveLocalizedText(block.image?.alt?.[currentLocale]);
 
   type LocalizedProse = Record<'uk' | 'en', JSONContent>;
 
@@ -96,7 +99,7 @@ export const LiatoshynskyFoundation = () => {
         imageUrl={getImageUrl(block.image)}
         fileName={proseToText(block.image?.caption?.[currentLocale] as ProseDoc)}
         initialCrop={block.image?.crop}
-        imageAlt={block.image?.alt?.[currentLocale] as string}
+        imageAlt={imageAltText}
         onMainTextChange={handleMainTextChange}
         onParagraphChange={handleParagraphChange}
         onImageChange={(url: string, crop?: MediaModalResult['crop']) => {

--- a/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.tsx
+++ b/app/shared/components/about-us/Liatoshynsky-foundation/LiatoshynskyFoundation.tsx
@@ -45,6 +45,13 @@ export const LiatoshynskyFoundation = () => {
     });
   };
 
+  const handleImageAltChange = (val: string) => {
+    setField(pageId, blockId, 'image', {
+      ...block.image,
+      alt: { ...block.image?.alt, [currentLocale]: val }
+    } as typeof block.image);
+  };
+
   type LocalizedProse = Record<'uk' | 'en', JSONContent>;
 
   const paragraphKeys: ('ourName' | 'ourBelief')[] = ['ourName', 'ourBelief'];
@@ -89,6 +96,7 @@ export const LiatoshynskyFoundation = () => {
         imageUrl={getImageUrl(block.image)}
         fileName={proseToText(block.image?.caption?.[currentLocale] as ProseDoc)}
         initialCrop={block.image?.crop}
+        imageAlt={block.image?.alt?.[currentLocale] as string}
         onMainTextChange={handleMainTextChange}
         onParagraphChange={handleParagraphChange}
         onImageChange={(url: string, crop?: MediaModalResult['crop']) => {
@@ -99,6 +107,7 @@ export const LiatoshynskyFoundation = () => {
             crop: crop ?? null
           } as typeof block.image);
         }}
+        onAltChange={handleImageAltChange}
       />
     </CollapsibleBlock>
   );

--- a/app/shared/components/about-us/Liatoshynsky-foundation/foundation-block/FoundationBlock.test.tsx
+++ b/app/shared/components/about-us/Liatoshynsky-foundation/foundation-block/FoundationBlock.test.tsx
@@ -8,7 +8,9 @@ import { createDocNode } from '~/__mocks__/utils';
 interface MockImagePreviewBlockProps {
   readonly imageUrl: string;
   readonly fileName?: string;
+  readonly altText?: string;
   readonly onChangeImage: (url: string) => void;
+  readonly onChangeAltText?: (value: string) => void;
   readonly title?: string;
 }
 
@@ -16,12 +18,16 @@ jest.mock('~/ds-components/text-field/TextField');
 
 jest.mock('~/ds-components/photo-block/PhotoBlock', () => ({
   __esModule: true,
-  ImagePreviewBlock: ({ imageUrl, fileName, onChangeImage, title }: MockImagePreviewBlockProps) => (
+  ImagePreviewBlock: ({ imageUrl, fileName, altText, onChangeImage, onChangeAltText, title }: MockImagePreviewBlockProps) => (
     <div data-testid="image-preview-block" data-title={title}>
       <span data-testid="preview-url">{imageUrl}</span>
       <span data-testid="preview-filename">{fileName}</span>
+      <span data-testid="preview-alt-text">{altText}</span>
       <button data-testid="trigger-image-upload" onClick={() => onChangeImage('uploaded-image-path.png')}>
         Upload Image
+      </button>
+      <button data-testid="trigger-alt-upload" onClick={() => onChangeAltText?.('Updated alt text')}>
+        Change Alt Text
       </button>
     </div>
   )
@@ -37,9 +43,11 @@ const mockProps = {
   paragraphs: mockParagraphsJson,
   imageUrl: '/images/test.png',
   fileName: 'test.png',
+  imageAlt: 'Existing alt text',
   onMainTextChange: jest.fn(),
   onParagraphChange: jest.fn(),
-  onImageChange: jest.fn()
+  onImageChange: jest.fn(),
+  onAltChange: jest.fn()
 };
 
 const getParagraphLabel = (index: number) => `Текст ${index + 1} абзацу`;
@@ -63,6 +71,7 @@ describe('FoundationBlock', () => {
     expect(screen.getByTestId('image-preview-block')).toBeInTheDocument();
     expect(screen.getByTestId('preview-url')).toHaveTextContent(mockProps.imageUrl);
     expect(screen.getByTestId('preview-filename')).toHaveTextContent(mockProps.fileName);
+    expect(screen.getByTestId('preview-alt-text')).toHaveTextContent(mockProps.imageAlt);
   });
 
   it.each([
@@ -93,6 +102,14 @@ describe('FoundationBlock', () => {
       () => {
         expect(mockProps.onImageChange).toHaveBeenCalledTimes(1);
         expect(mockProps.onImageChange).toHaveBeenCalledWith('uploaded-image-path.png');
+      }
+    ],
+    [
+      'alt text field changes',
+      'trigger-alt-upload',
+      () => {
+        expect(mockProps.onAltChange).toHaveBeenCalledTimes(1);
+        expect(mockProps.onAltChange).toHaveBeenCalledWith('Updated alt text');
       }
     ]
   ])('should dispatch matching callbacks upon executing %s', (_scenario, triggerId, assertionCallback) => {

--- a/app/shared/components/about-us/Liatoshynsky-foundation/foundation-block/FoundationBlock.tsx
+++ b/app/shared/components/about-us/Liatoshynsky-foundation/foundation-block/FoundationBlock.tsx
@@ -15,9 +15,11 @@ interface FoundationBlockProps {
   imageUrl: string;
   fileName?: string;
   initialCrop?: MediaModalResult['crop'];
+  imageAlt?: string;
   onMainTextChange: (val: JSONContent) => void;
   onParagraphChange: (index: number, val: JSONContent) => void;
   onImageChange: (url: string, crop?: MediaModalResult['crop']) => void;
+  onAltChange?: (val: string) => void;
 }
 
 export const FoundationBlock = ({
@@ -26,9 +28,11 @@ export const FoundationBlock = ({
   imageUrl,
   fileName,
   initialCrop,
+  imageAlt,
   onMainTextChange,
   onParagraphChange,
-  onImageChange
+  onImageChange,
+  onAltChange
 }: FoundationBlockProps) => {
   return (
     <Box display="flex" flexDirection="column" gap="16px">
@@ -58,6 +62,9 @@ export const FoundationBlock = ({
         onChangeImage={onImageChange}
         title="Основне зображення"
         aspectRatio={CROP_RATIOS.FUNDATION_PROFILE_SMALL}
+        showAlternativeText
+        altText={imageAlt}
+        onChangeAltText={(value) => onAltChange?.(value)}
       />
     </Box>
   );

--- a/app/shared/components/about-us/our-mission/OurMission.test.tsx
+++ b/app/shared/components/about-us/our-mission/OurMission.test.tsx
@@ -326,4 +326,36 @@ describe('OurMission', () => {
     expect(screen.queryByTestId(`image-block-${keys.upload}`)).not.toBeInTheDocument();
     expect(screen.queryByTestId(`image-block-${keys.bigUpload}`)).not.toBeInTheDocument();
   });
+
+  it('should handle early returns in image and caption handlers when image object becomes falsy', () => {
+    let imageExists = true;
+    const blockWithToggle = {
+      ...mockBlock,
+      get smallImage() {
+        return imageExists ? mockBlock.smallImage : undefined;
+      }
+    };
+
+    usePageBlockMock.mockReturnValue({ block: blockWithToggle });
+    render(<OurMission />);
+
+    imageExists = false;
+    jest.clearAllMocks();
+
+    fireEvent.click(screen.getByTestId(`upload-${keys.upload}`));
+    fireEvent.click(screen.getByTestId(`alt-change-${keys.upload}`));
+    fireEvent.click(screen.getByTestId(`trigger-change-${keys.caption}`));
+
+    expect(setFieldMock).not.toHaveBeenCalled();
+  });
+
+  it('should use fallback title when block title is empty or undefined', () => {
+    usePageBlockMock.mockReturnValue({
+      block: { ...mockBlock, title: undefined }
+    });
+    
+    render(<OurMission />);
+    
+    expect(screen.getByTestId('collapsible-block')).toBeInTheDocument();
+  });
 });

--- a/app/shared/components/about-us/our-mission/OurMission.test.tsx
+++ b/app/shared/components/about-us/our-mission/OurMission.test.tsx
@@ -10,7 +10,9 @@ import { MissionListItemWithId } from '~/types/store/pages/about-us/blocks/missi
 interface MockImagePreviewBlockProps {
   readonly title: string;
   readonly imageUrl: string;
+  readonly altText?: string;
   readonly onChangeImage: (url: string, crop?: unknown) => void;
+  readonly onChangeAltText?: (value: string) => void;
 }
 
 const setFieldMock = jest.fn();
@@ -31,9 +33,10 @@ jest.mock('../../sortable-list/SortableList');
 
 jest.mock('~/ds-components/photo-block/PhotoBlock', () => ({
   __esModule: true,
-  ImagePreviewBlock: ({ title, imageUrl, onChangeImage }: MockImagePreviewBlockProps) => (
+  ImagePreviewBlock: ({ title, imageUrl, altText, onChangeImage, onChangeAltText }: MockImagePreviewBlockProps) => (
     <div data-testid={`image-block-${title}`}>
       <span data-testid={`image-url-${title}`}>{imageUrl}</span>
+      <span data-testid={`alt-text-${title}`}>{altText}</span>
       <button data-testid={`upload-${title}`} onClick={() => onChangeImage('new-image-path.jpg')}>
         Upload
       </button>
@@ -42,6 +45,9 @@ jest.mock('~/ds-components/photo-block/PhotoBlock', () => ({
         onClick={() => onChangeImage('new-image-path.jpg', { rect: { x: 0, y: 0, width: 10, height: 10 } })}
       >
         Upload With Crop
+      </button>
+      <button data-testid={`alt-change-${title}`} onClick={() => onChangeAltText?.('Updated alt text')}>
+        Change Alt Text
       </button>
     </div>
   )
@@ -67,6 +73,7 @@ beforeAll(() => {
 const mockTitleJson = createDocNode('Initial title');
 const mockItemJson = createDocNode('Initial point');
 const mockCaptionJson = createDocNode('caption');
+const mockAltJson = createDocNode('legacy alt text');
 
 const mockBlock = {
   title: { uk: mockTitleJson },
@@ -75,13 +82,13 @@ const mockBlock = {
     src: 'small.jpg',
     generatedSrc: '',
     caption: { uk: mockCaptionJson, en: {} },
-    alt: { uk: {}, en: {} }
+    alt: { uk: mockAltJson, en: {} }
   },
   bigImage: {
     src: 'big.jpg',
     generatedSrc: '',
     caption: { uk: mockCaptionJson, en: {} },
-    alt: { uk: {}, en: {} }
+    alt: { uk: mockAltJson, en: {} }
   }
 };
 
@@ -104,6 +111,9 @@ describe('OurMission', () => {
     expect(screen.getByTestId('collapsible-block')).toBeInTheDocument();
     expect(screen.getByTestId(`textfield-json-${keys.title}`)).toHaveTextContent(JSON.stringify(mockTitleJson));
     expect(screen.getByTestId(`textfield-json-${keys.item}`)).toHaveTextContent(JSON.stringify(mockItemJson));
+    expect(screen.getByTestId(`alt-text-${keys.upload}`)).not.toHaveTextContent('[object Object]');
+    expect(screen.getByTestId(`alt-text-${keys.upload}`)).toHaveTextContent('legacy alt text');
+    expect(screen.getByTestId(`alt-text-${keys.bigUpload}`)).toHaveTextContent('legacy alt text');
   });
 
   it('should render skeleton when no block exists', () => {
@@ -184,6 +194,18 @@ describe('OurMission', () => {
       `upload-${keys.bigUpload}`,
       'bigImage',
       expect.objectContaining({ src: 'new-image-path.jpg', isTmp: false, crop: null })
+    ],
+    [
+      'editing alt text for the first image',
+      `alt-change-${keys.upload}`,
+      'smallImage',
+      expect.objectContaining({ alt: expect.objectContaining({ uk: 'Updated alt text' }) })
+    ],
+    [
+      'editing alt text for the second image',
+      `alt-change-${keys.bigUpload}`,
+      'bigImage',
+      expect.objectContaining({ alt: expect.objectContaining({ uk: 'Updated alt text' }) })
     ]
   ])(
     'should correctly invoke setField upon %s',

--- a/app/shared/components/about-us/our-mission/OurMission.tsx
+++ b/app/shared/components/about-us/our-mission/OurMission.tsx
@@ -33,7 +33,7 @@ export type MissionImage = {
   src: string;
   generatedSrc: string;
   caption: LocalizedJSON;
-  alt: LocalizedJSON;
+  alt: Record<'uk' | 'en', string | JSONContent>;
   crop?: CropResult | null;
 };
 
@@ -42,11 +42,13 @@ type MissionImageBlockProps = {
   locale: 'uk' | 'en';
   title: string;
   aspectRatio?: number;
+  imageAlt?: string;
   onChangeCaption: (value: JSONContent) => void;
   onChangeImage: (url: string, crop?: CropResult | null) => void;
+  onAltChange?: (val: string) => void;
 };
 
-const MissionImageBlock = ({ image, locale, title, aspectRatio, onChangeCaption, onChangeImage }: MissionImageBlockProps) => (
+const MissionImageBlock = ({ image, locale, title, aspectRatio, imageAlt, onChangeCaption, onChangeImage, onAltChange}: MissionImageBlockProps) => (
   <Box sx={styles.imageBlockWrapper}>
     <ImagePreviewBlock
       imageUrl={getImageUrl(image)}
@@ -55,6 +57,9 @@ const MissionImageBlock = ({ image, locale, title, aspectRatio, onChangeCaption,
       initialCrop={image.crop}
       aspectRatio = {aspectRatio}
       onChangeImage={onChangeImage}
+      showAlternativeText
+      altText={imageAlt}
+      onChangeAltText={(value) => onAltChange?.(value)}
     />
     <CustomTextField
       fieldType="formatting"
@@ -134,6 +139,13 @@ const OurMission = () => {
     } as typeof image);
   };
 
+  const handleAltChange = (key: 'smallImage' | 'bigImage', val: string) => {
+    const image = block[key]!;
+    setField(pageId, blockId, key, {
+      ...image,
+      alt: { ...image.alt, [currentLocale]: val }
+    } as typeof image);
+  };
 
   const headerTitle = proseToHeaderText(block.title?.[currentLocale] as ProseDoc, 'Наша місія');
 
@@ -200,6 +212,8 @@ const OurMission = () => {
           aspectRatio={CROP_RATIOS.FUNDATION_PROFILE_SMALL}
           onChangeCaption={(value) => handleCaptionChange('smallImage', value)}
           onChangeImage={(url, crop) => handleImageChange('smallImage', url, crop)}
+          imageAlt={block.smallImage.alt?.[currentLocale] as string}
+          onAltChange={(val) => handleAltChange('smallImage', val)}
         />
       )}
 
@@ -211,6 +225,8 @@ const OurMission = () => {
           aspectRatio={CROP_RATIOS.FUNDATION_PROFILE_BIG}
           onChangeCaption={(value) => handleCaptionChange('bigImage', value)}
           onChangeImage={(url, crop) => handleImageChange('bigImage', url, crop)}
+          imageAlt={block.bigImage.alt?.[currentLocale] as string}
+          onAltChange={(val) => handleAltChange('bigImage', val)}
         />
       )}
     </CollapsibleBlock>

--- a/app/shared/components/about-us/our-mission/OurMission.tsx
+++ b/app/shared/components/about-us/our-mission/OurMission.tsx
@@ -17,7 +17,8 @@ import CollapsibleBlock from '~/ds-components/collapsible-block/CollapsibleBlock
 import { ImagePreviewBlock } from '~/ds-components/photo-block/PhotoBlock';
 import { CustomTextField } from '~/ds-components/text-field/TextField';
 import { ensureIds } from '~/lib/utils/ensureIds';
-import { proseToHeaderText } from '~/lib/utils/prose';
+import { mergeLocalizedValue } from '~/lib/utils/mergeLocalizedValue';
+import { proseToHeaderText, resolveLocalizedText } from '~/lib/utils/prose';
 import { handleSortableDragEnd } from '~/lib/utils/sortableDragEndHelper';
 import { usePageBlock } from '~/shared/hooks/use-page-block/usePageBlock';
 import { useTitleValidation } from '~/shared/hooks/use-title-validation/useTitleValidation';
@@ -121,15 +122,18 @@ const OurMission = () => {
   };
 
   const handleCaptionChange = (key: 'smallImage' | 'bigImage', value: JSONContent) => {
-    const image = block[key]!;
+    const image = block[key];
+    if (!image) return;
+
     setField(pageId, blockId, key, {
       ...image,
-      caption: { ...image.caption, [currentLocale]: value }
+      caption: mergeLocalizedValue(image.caption, currentLocale, value)
     });
   };
 
   const handleImageChange = (key: 'smallImage' | 'bigImage', url: string, crop?: CropResult | null) => {
-    const image = block[key]!;
+    const image = block[key];
+    if (!image) return;
 
     setField(pageId, blockId, key, {
       ...image,
@@ -140,11 +144,13 @@ const OurMission = () => {
   };
 
   const handleAltChange = (key: 'smallImage' | 'bigImage', val: string) => {
-    const image = block[key]!;
+    const image = block[key];
+    if (!image) return;
+
     setField(pageId, blockId, key, {
       ...image,
-      alt: { ...image.alt, [currentLocale]: val }
-    } as typeof image);
+      alt: mergeLocalizedValue(image.alt, currentLocale, val)
+    });
   };
 
   const headerTitle = proseToHeaderText(block.title?.[currentLocale] as ProseDoc, 'Наша місія');
@@ -212,7 +218,7 @@ const OurMission = () => {
           aspectRatio={CROP_RATIOS.FUNDATION_PROFILE_SMALL}
           onChangeCaption={(value) => handleCaptionChange('smallImage', value)}
           onChangeImage={(url, crop) => handleImageChange('smallImage', url, crop)}
-          imageAlt={block.smallImage.alt?.[currentLocale] as string}
+          imageAlt={resolveLocalizedText(block.smallImage.alt?.[currentLocale])}
           onAltChange={(val) => handleAltChange('smallImage', val)}
         />
       )}
@@ -225,7 +231,7 @@ const OurMission = () => {
           aspectRatio={CROP_RATIOS.FUNDATION_PROFILE_BIG}
           onChangeCaption={(value) => handleCaptionChange('bigImage', value)}
           onChangeImage={(url, crop) => handleImageChange('bigImage', url, crop)}
-          imageAlt={block.bigImage.alt?.[currentLocale] as string}
+          imageAlt={resolveLocalizedText(block.bigImage.alt?.[currentLocale])}
           onAltChange={(val) => handleAltChange('bigImage', val)}
         />
       )}

--- a/app/types/common.ts
+++ b/app/types/common.ts
@@ -12,11 +12,6 @@ export interface LocalizedJSON {
   en: JSONContent;
 }
 
-export interface LocalizedAltText {
-  uk: JSONContent | string;
-  en: JSONContent | string;
-}
-
 export interface CropRect {
   x: number;
   y: number;
@@ -35,7 +30,7 @@ export interface CropResult {
 
 export interface ImageBlock {
   src: string;
-  alt: LocalizedAltText;
+  alt: Record<'uk' | 'en', JSONContent | string>;
   caption: LocalizedJSON;
   isTmp?: boolean;
   crop?: CropResult | null;
@@ -43,7 +38,7 @@ export interface ImageBlock {
 
 export type ImageType = {
   src: string;
-  alt: LocalizedAltText;
+  alt: Record<'uk' | 'en', JSONContent | string>;
   caption: LocalizedJSON;
   generatedSrc: string;
   crop?: CropResult | null;

--- a/app/types/common.ts
+++ b/app/types/common.ts
@@ -12,6 +12,11 @@ export interface LocalizedJSON {
   en: JSONContent;
 }
 
+export interface LocalizedAltText {
+  uk: JSONContent | string;
+  en: JSONContent | string;
+}
+
 export interface CropRect {
   x: number;
   y: number;
@@ -30,7 +35,7 @@ export interface CropResult {
 
 export interface ImageBlock {
   src: string;
-  alt: LocalizedJSON;
+  alt: LocalizedAltText;
   caption: LocalizedJSON;
   isTmp?: boolean;
   crop?: CropResult | null;
@@ -38,7 +43,7 @@ export interface ImageBlock {
 
 export type ImageType = {
   src: string;
-  alt: LocalizedJSON;
+  alt: LocalizedAltText;
   caption: LocalizedJSON;
   generatedSrc: string;
   crop?: CropResult | null;


### PR DESCRIPTION
## Description

This PR adds the missing "Alt text" input fields for image blocks across the "About the Foundation" admin page to meet design and accessibility requirements. 

**Key Changes:**
- Added `imageAlt` and `onAltChange` / `onChangeAltText` props down to the `ImagePreviewBlock` in `IntroSection`, `LiatoshynskyFoundation`, `FoundationBlock`, and `OurMission` components.
- Introduced a new `LocalizedAltText` type in `common.ts` to replace `LocalizedJSON` for image `alt` properties. This resolves strict type-checking errors by safely supporting both plain `string` inputs and legacy `JSONContent` (TipTap) document objects existing in the database.
- Updated `MissionImage` and `ImageType` definitions to align with the new flexible alt text format.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other:  How to test

1. Log in to the Admin panel and navigate to the **About Us** page editor.
2. Open the **Intro section**, **Liatoshynski Foundation**, and **Our Mission** collapsible blocks.
3. Locate the image editing areas in each section.
4. Verify that the "Alt text" input field is now visible.
5. Enter a descriptive alt text, save the page, and verify the changes persist after a reload.

## Video / Screenshots

<img width="646" height="332" alt="image" src="https://github.com/user-attachments/assets/80fc153a-48d1-48e1-afd7-dc4b435a016b" />

<img width="665" height="415" alt="image" src="https://github.com/user-attachments/assets/645ca464-7c29-47f4-8d57-414d612b4c05" />


## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---

Closes [#530](https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/530)