### PR TITLE
feature: implement actions menu functionality for compositions inside opus

### DIFF
--- a/app/(logged_in)/creativity/(composition)/useDeleteWorkAction.test.ts
+++ b/app/(logged_in)/creativity/(composition)/useDeleteWorkAction.test.ts
@@ -1,10 +1,11 @@
-import { act,renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import toast from 'react-hot-toast';
 
 import { useDeleteWorkAction } from './useDeleteWorkAction';
 import {
   PaginatedWorksDocument,
-  useDeleteCompositionMutation
+  useDeleteCompositionMutation,
+  useUnlinkCompositionMutation
 } from '~/types/graphql/generated/graphql';
 
 jest.mock('react-hot-toast', () => ({
@@ -14,20 +15,30 @@ jest.mock('react-hot-toast', () => ({
 
 jest.mock('~/types/graphql/generated/graphql', () => ({
   PaginatedWorksDocument: 'PaginatedWorksDocument',
-  useDeleteCompositionMutation: jest.fn()
+  useDeleteCompositionMutation: jest.fn(),
+  useUnlinkCompositionMutation: jest.fn()
 }));
 
 const mockUseDeleteCompositionMutation = useDeleteCompositionMutation as jest.MockedFunction<
   typeof useDeleteCompositionMutation
 >;
 
+const mockUseUnlinkCompositionMutation = useUnlinkCompositionMutation as jest.MockedFunction<
+  typeof useUnlinkCompositionMutation
+>;
+
 describe('useDeleteWorkAction', () => {
   const mockDeleteCompositionMut = jest.fn();
+  const mockUnlinkCompositionMut = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseDeleteCompositionMutation.mockReturnValue([
       mockDeleteCompositionMut,
+      { loading: false, data: undefined, reset: jest.fn(), called: false, client: {} as never }
+    ]);
+    mockUseUnlinkCompositionMutation.mockReturnValue([
+      mockUnlinkCompositionMut,
       { loading: false, data: undefined, reset: jest.fn(), called: false, client: {} as never }
     ]);
   });
@@ -36,17 +47,21 @@ describe('useDeleteWorkAction', () => {
     const { result } = renderHook(() => useDeleteWorkAction());
 
     expect(result.current.deleteComposition).toBeNull();
+    expect(result.current.unlinkComposition).toBeNull();
     expect(result.current.isDeleting).toBe(false);
+    expect(result.current.isUnlinking).toBe(false);
   });
 
-  it('should update deleteComposition state', () => {
+  it('should update deleteComposition and unlinkComposition state', () => {
     const { result } = renderHook(() => useDeleteWorkAction());
 
     act(() => {
       result.current.setDeleteComposition('work-123');
+      result.current.setUnlinkComposition({ opusId: 'opus-1', compositionId: 'work-123' });
     });
 
     expect(result.current.deleteComposition).toBe('work-123');
+    expect(result.current.unlinkComposition).toEqual({ opusId: 'opus-1', compositionId: 'work-123' });
   });
 
   it('should return early when handleConfirmCompositionDelete is called with null deleteComposition', async () => {
@@ -57,6 +72,18 @@ describe('useDeleteWorkAction', () => {
     });
 
     expect(mockDeleteCompositionMut).not.toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('should return early when handleConfirmUnlinkComposition is called with null unlinkComposition', async () => {
+    const { result } = renderHook(() => useDeleteWorkAction());
+
+    await act(async () => {
+      await result.current.handleConfirmUnlinkComposition();
+    });
+
+    expect(mockUnlinkCompositionMut).not.toHaveBeenCalled();
     expect(toast.success).not.toHaveBeenCalled();
     expect(toast.error).not.toHaveBeenCalled();
   });
@@ -87,6 +114,32 @@ describe('useDeleteWorkAction', () => {
     expect(result.current.deleteComposition).toBeNull();
   });
 
+  it('should handle successful composition unlink and call onSuccess', async () => {
+    const onSuccessMock = jest.fn<void, [string]>();
+    mockUnlinkCompositionMut.mockResolvedValueOnce({ data: {} });
+
+    const { result } = renderHook(() =>
+      useDeleteWorkAction({ onSuccess: onSuccessMock })
+    );
+
+    act(() => {
+      result.current.setUnlinkComposition({ opusId: 'opus-1', compositionId: 'work-123' });
+    });
+
+    await act(async () => {
+      await result.current.handleConfirmUnlinkComposition();
+    });
+
+    expect(mockUnlinkCompositionMut).toHaveBeenCalledWith({
+      variables: { opusId: 'opus-1', compositionId: 'work-123' },
+      refetchQueries: [PaginatedWorksDocument],
+      awaitRefetchQueries: true
+    });
+    expect(toast.success).toHaveBeenCalledWith('Твір успішно видалено з групи');
+    expect(onSuccessMock).toHaveBeenCalledWith('work-123');
+    expect(result.current.unlinkComposition).toBeNull();
+  });
+
   it('should handle deletion failure and show error toast', async () => {
     mockDeleteCompositionMut.mockRejectedValueOnce(new Error('Mutation failed'));
 
@@ -103,14 +156,35 @@ describe('useDeleteWorkAction', () => {
     expect(toast.error).toHaveBeenCalledWith('Помилка при видаленні твору');
   });
 
-  it('should correctly pass loading state from mutation hook', () => {
+  it('should handle unlink failure and show error toast', async () => {
+    mockUnlinkCompositionMut.mockRejectedValueOnce(new Error('Mutation failed'));
+
+    const { result } = renderHook(() => useDeleteWorkAction());
+
+    act(() => {
+      result.current.setUnlinkComposition({ opusId: 'opus-1', compositionId: 'work-123' });
+    });
+
+    await act(async () => {
+      await result.current.handleConfirmUnlinkComposition();
+    });
+
+    expect(toast.error).toHaveBeenCalledWith('Помилка при видаленні твору');
+  });
+
+  it('should correctly pass loading state from mutation hooks', () => {
     mockUseDeleteCompositionMutation.mockReturnValue([
       mockDeleteCompositionMut,
+      { loading: true, data: undefined, reset: jest.fn(), called: true, client: {} as never }
+    ]);
+    mockUseUnlinkCompositionMutation.mockReturnValue([
+      mockUnlinkCompositionMut,
       { loading: true, data: undefined, reset: jest.fn(), called: true, client: {} as never }
     ]);
 
     const { result } = renderHook(() => useDeleteWorkAction());
 
     expect(result.current.isDeleting).toBe(true);
+    expect(result.current.isUnlinking).toBe(true);
   });
 });

--- a/app/(logged_in)/creativity/(composition)/useDeleteWorkAction.ts
+++ b/app/(logged_in)/creativity/(composition)/useDeleteWorkAction.ts
@@ -5,11 +5,13 @@ import toast from 'react-hot-toast';
 
 import {
   PaginatedWorksDocument,
-  useDeleteCompositionMutation
+  useDeleteCompositionMutation,
+  useUnlinkCompositionMutation
 } from '~/types/graphql/generated/graphql';
 
 const TOAST_MESSAGES = {
   DELETE_SUCCESS: 'Твір успішно видалено',
+  UNLINK_SUCCESS: 'Твір успішно видалено з групи',
   DELETE_ERROR: 'Помилка при видаленні твору'
 };
 
@@ -20,6 +22,8 @@ interface UseDeleteWorkActionProps {
 export function useDeleteWorkAction({ onSuccess }: UseDeleteWorkActionProps = {}) {
   const [deleteCompositionMut, { loading: isDeleting }] = useDeleteCompositionMutation();
   const [deleteComposition, setDeleteComposition] = useState<string | null>(null);
+  const [unlinkCompositionMut, { loading: isUnlinking }] = useUnlinkCompositionMutation();
+  const [unlinkComposition, setUnlinkComposition] = useState<{ opusId: string; compositionId: string } | null>(null);
 
   const handleConfirmCompositionDelete = async () => {
     if (!deleteComposition) return;
@@ -39,10 +43,35 @@ export function useDeleteWorkAction({ onSuccess }: UseDeleteWorkActionProps = {}
     }
   };
 
+  const handleConfirmUnlinkComposition = async () => {
+    if (!unlinkComposition) return;
+    
+    try {
+      await unlinkCompositionMut({
+        variables: {
+          opusId: unlinkComposition.opusId,
+          compositionId: unlinkComposition.compositionId
+        },
+        refetchQueries: [PaginatedWorksDocument],
+        awaitRefetchQueries: true
+      });
+
+      toast.success(TOAST_MESSAGES.UNLINK_SUCCESS);
+      onSuccess?.(unlinkComposition.compositionId);
+      setUnlinkComposition(null);
+    } catch {
+      toast.error(TOAST_MESSAGES.DELETE_ERROR);
+    }
+  };
+
   return {
     deleteComposition,
     setDeleteComposition,
+    unlinkComposition,
+    setUnlinkComposition,
     handleConfirmCompositionDelete,
-    isDeleting
+    handleConfirmUnlinkComposition,
+    isDeleting,
+    isUnlinking
   };
 }

--- a/app/(logged_in)/creativity/(composition)/useWorkUrlState.test.ts
+++ b/app/(logged_in)/creativity/(composition)/useWorkUrlState.test.ts
@@ -57,7 +57,7 @@ const createMockQueryResult = (
   }) as QueryResultType;
 
 describe('useWorkUrlState', () => {
-  const mockReplace = jest.fn<void, [string]>();
+  const mockReplace = jest.fn<void, [string, { scroll?: boolean }?]>();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -238,7 +238,8 @@ describe('useWorkUrlState', () => {
     });
 
     expect(mockReplace).toHaveBeenCalledWith(
-      `/works?filter=all&${COMPOSITION_MODAL_PARAM}=comp-789`
+      `/works?filter=all&${COMPOSITION_MODAL_PARAM}=comp-789`,
+      { scroll: false }
     );
   });
 
@@ -253,7 +254,7 @@ describe('useWorkUrlState', () => {
       result.current.closeEditComposition();
     });
 
-    expect(mockReplace).toHaveBeenCalledWith('/works?filter=all');
+    expect(mockReplace).toHaveBeenCalledWith('/works?filter=all', { scroll: false });
   });
 
   it('should format URL without query string when closing edit and no other params remain', () => {
@@ -267,7 +268,7 @@ describe('useWorkUrlState', () => {
       result.current.closeEditComposition();
     });
 
-    expect(mockReplace).toHaveBeenCalledWith('/works');
+    expect(mockReplace).toHaveBeenCalledWith('/works', { scroll: false });
   });
 
   it('should reflect loading state from query hook', () => {

--- a/app/(logged_in)/creativity/(composition)/useWorkUrlState.ts
+++ b/app/(logged_in)/creativity/(composition)/useWorkUrlState.ts
@@ -66,11 +66,11 @@ export function useWorkUrlState() {
         params.delete(COMPOSITION_MODAL_PARAM);
       }
       const query = params.toString();
-      router.replace(query ? `${pathname}?${query}` : pathname);
+      router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
     },
     [pathname, router, searchParams]
   );
-
+  
   return {
     compositionId,
     compositionToEdit,

--- a/app/(logged_in)/creativity/WorksTable.test.tsx
+++ b/app/(logged_in)/creativity/WorksTable.test.tsx
@@ -158,6 +158,8 @@ describe('WorksTable', () => {
   const mockCloseEditComposition = jest.fn();
   const mockSetDeleteComposition = jest.fn();
   const mockHandleConfirmCompositionDelete = jest.fn();
+  const mockSetUnlinkComposition = jest.fn();
+  const mockHandleConfirmUnlinkComposition = jest.fn();
   const mockHandleUpdateComposition = jest.fn();
   const mockHandleShare = jest.fn();
 
@@ -182,7 +184,10 @@ describe('WorksTable', () => {
     (useDeleteWorkAction as jest.Mock).mockReturnValue({
       deleteComposition: null,
       setDeleteComposition: mockSetDeleteComposition,
-      handleConfirmCompositionDelete: mockHandleConfirmCompositionDelete
+      handleConfirmCompositionDelete: mockHandleConfirmCompositionDelete,
+      unlinkComposition: null,
+      setUnlinkComposition: mockSetUnlinkComposition,
+      handleConfirmUnlinkComposition: mockHandleConfirmUnlinkComposition
     });
 
     (useUpdateWorkAction as jest.Mock).mockReturnValue({
@@ -317,6 +322,7 @@ describe('WorksTable', () => {
     expect(mockHandlePublishStatusChange).toHaveBeenCalledWith('group-draft', OpusStatus.Published);
     expect(mockHandlePublishStatusChange).toHaveBeenCalledWith('group-published', OpusStatus.Draft);
 
+    expect(mockSetUnlinkComposition).toHaveBeenCalledWith({ opusId: 'group-draft', compositionId: 'work-1' });
     expect(mockSetDeleteComposition).toHaveBeenCalledWith('individual-1');
     expect(mockOpenEditComposition).toHaveBeenCalledWith('individual-1');
     expect(mockHandleShare).toHaveBeenCalled();
@@ -346,7 +352,10 @@ describe('WorksTable', () => {
     (useDeleteWorkAction as jest.Mock).mockReturnValue({
       deleteComposition: 'work-1',
       setDeleteComposition: mockSetDeleteComposition,
-      handleConfirmCompositionDelete: mockHandleConfirmCompositionDelete
+      handleConfirmCompositionDelete: mockHandleConfirmCompositionDelete,
+      unlinkComposition: null,
+      setUnlinkComposition: mockSetUnlinkComposition,
+      handleConfirmUnlinkComposition: mockHandleConfirmUnlinkComposition
     });
 
     render(<WorksTable activeTab={WORKS_TABS_NAMES.WORKS} items={{ works: [individualWork] }} />);
@@ -358,6 +367,26 @@ describe('WorksTable', () => {
 
     fireEvent.click(screen.getByTestId('modal-delete-composition'));
     expect(mockHandleConfirmCompositionDelete).toHaveBeenCalled();
+  });
+
+  it('renders DeleteCardModal for unlink composition and handles modal actions', () => {
+    (useDeleteWorkAction as jest.Mock).mockReturnValue({
+      deleteComposition: null,
+      setDeleteComposition: mockSetDeleteComposition,
+      handleConfirmCompositionDelete: mockHandleConfirmCompositionDelete,
+      unlinkComposition: { opusId: 'group-1', compositionId: 'work-1' },
+      setUnlinkComposition: mockSetUnlinkComposition,
+      handleConfirmUnlinkComposition: mockHandleConfirmUnlinkComposition
+    });
+
+    render(<WorksTable activeTab={WORKS_TABS_NAMES.OPUS} items={{ groups: [group] }} />);
+
+    expect(screen.getByTestId('delete-card-modal-composition')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('modal-close-composition'));
+    expect(mockSetUnlinkComposition).toHaveBeenCalledWith(null);
+
+    fireEvent.click(screen.getByTestId('modal-delete-composition'));
   });
 
   it('renders CompositionModal and handles submit and close actions', async () => {

--- a/app/(logged_in)/creativity/WorksTable.tsx
+++ b/app/(logged_in)/creativity/WorksTable.tsx
@@ -78,8 +78,6 @@ export type IndividualWork = Readonly<{
 }> &
   ActionFields;
 
-const modalMock = () => {};
-
 export const columns: readonly ColumnDef<GroupHeaderData, OpusWork, IndividualWork>[] = [
   {
     id: 'opus',
@@ -171,7 +169,14 @@ export function WorksTable({ items, activeTab }: WorksTableProps) {
     openEditComposition,
     closeEditComposition
   } = useWorkUrlState();
-  const { deleteComposition, setDeleteComposition, handleConfirmCompositionDelete } = useDeleteWorkAction();
+  const {
+    deleteComposition,
+    setDeleteComposition,
+    handleConfirmCompositionDelete,
+    handleConfirmUnlinkComposition,
+    unlinkComposition,
+    setUnlinkComposition
+  } = useDeleteWorkAction();
   const { handleUpdateComposition } = useUpdateWorkAction();
   const { handleShare } = useShare();
 
@@ -235,9 +240,9 @@ export function WorksTable({ items, activeTab }: WorksTableProps) {
           menuItems: WorkMenuItems({
             id: work.id,
             isPublished,
-            onDelete: () => modalMock(),
-            onShare: () => modalMock(),
-            onEdit: () => modalMock()
+            onDelete: (id) => setUnlinkComposition({ opusId: group.id, compositionId: id }),
+            onShare: (id) => handleShareComposition(id),
+            onEdit: (id) => openEditComposition(id)
           }),
           menuTriggerLabel: `Дії твору ${work.name}`
         }
@@ -320,6 +325,15 @@ export function WorksTable({ items, activeTab }: WorksTableProps) {
         title="Підтвердити видалення композиції"
         confirmButtonText="Видалити"
         description="Ви впевнені, що хочете видалити цю композицію? Це дію можна скасувати лише шляхом повторного додавання композиції."
+      />
+
+      <DeleteCardModal
+        open={Boolean(unlinkComposition)}
+        onClose={() => setUnlinkComposition(null)}
+        onDelete={() => handleConfirmUnlinkComposition}
+        title="Підтвердити видалення композиції з групи"
+        confirmButtonText="Видалити"
+        description="Ви впевнені, що хочете видалити цю композицію з групи? Цю дію можна скасувати лише шляхом повторного додавання композиції у цю групу."
       />
 
       <CompositionModal

--- a/app/(logged_in)/creativity/WorksTable.tsx
+++ b/app/(logged_in)/creativity/WorksTable.tsx
@@ -330,7 +330,7 @@ export function WorksTable({ items, activeTab }: WorksTableProps) {
       <DeleteCardModal
         open={Boolean(unlinkComposition)}
         onClose={() => setUnlinkComposition(null)}
-        onDelete={() => handleConfirmUnlinkComposition}
+        onDelete={handleConfirmUnlinkComposition}
         title="Підтвердити видалення композиції з групи"
         confirmButtonText="Видалити"
         description="Ви впевнені, що хочете видалити цю композицію з групи? Цю дію можна скасувати лише шляхом повторного додавання композиції у цю групу."

--- a/app/shared/components/forms/opus-details-block/composition-modal/CompositionModal.test.tsx
+++ b/app/shared/components/forms/opus-details-block/composition-modal/CompositionModal.test.tsx
@@ -197,6 +197,46 @@ describe('CompositionModal', () => {
     ).toBeInTheDocument();
   });
 
+  it('clears note errors when editing note name and date after a validation error', () => {
+    const onSubmit = jest.fn();
+    render(<CompositionModal {...baseProps} mode="create" onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByLabelText('Назва твору *'), { target: { value: 'Valid Title' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Додати ноти' }));
+
+    const dateField = screen.getByLabelText('Дата видання');
+    fireEvent.change(dateField, { target: { value: '2023' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Створити' }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(
+      screen.getByText((content) => content.includes(COMPOSITION_MODAL_TEXTS.emptyNoteDateError))
+    ).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Назва нот'), { target: { value: 'Ноти' } });
+    expect(
+      screen.getByText((content) => content.includes(COMPOSITION_MODAL_TEXTS.emptyNoteDateError))
+    ).toBeInTheDocument();
+
+    fireEvent.change(dateField, { target: { value: '2024' } });
+    expect(
+      screen.queryByText((content) => content.includes(COMPOSITION_MODAL_TEXTS.emptyNoteDateError))
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Створити' }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes a note row using its delete button', () => {
+    render(<CompositionModal {...baseProps} mode="create" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Додати ноти' }));
+    expect(screen.getByLabelText('Назва нот')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: COMPOSITION_MODAL_TEXTS.deleteAriaLabel }));
+    expect(screen.queryByLabelText('Назва нот')).not.toBeInTheDocument();
+  });
+
   it('filters out empty note rows on submit', () => {
     const onSubmit = jest.fn();
     render(<CompositionModal {...baseProps} mode="create" onSubmit={onSubmit} />);

--- a/app/shared/components/forms/opus-details-block/composition-modal/CompositionModal.test.tsx
+++ b/app/shared/components/forms/opus-details-block/composition-modal/CompositionModal.test.tsx
@@ -389,4 +389,19 @@ describe('CompositionModal', () => {
     const submitted = onSubmit.mock.calls[0][0] as OpusCompositionData;
     expect(submitted.name).toBe('Редагований твір');
   });
+
+  it('restricts non-numeric input for the year field', () => {
+    render(<CompositionModal {...baseProps} mode="create" />);
+
+    const yearField = screen.getByLabelText('Рік');
+
+    fireEvent.change(yearField, { target: { value: 'abc' } });
+    expect(yearField).toHaveValue('');
+
+    fireEvent.change(yearField, { target: { value: '19a20' } });
+    expect(yearField).toHaveValue('');
+
+    fireEvent.change(yearField, { target: { value: '1920' } });
+    expect(yearField).toHaveValue('1920');
+  });
 });

--- a/app/shared/components/forms/opus-details-block/composition-modal/CompositionModal.tsx
+++ b/app/shared/components/forms/opus-details-block/composition-modal/CompositionModal.tsx
@@ -225,7 +225,12 @@ export default function CompositionModal({
           <TextField
             label={COMPOSITION_MODAL_LABELS.year}
             value={composition.year}
-            onChange={(event) => updateField('year', event.target.value)}
+            onChange={(event) => {
+              const val = event.target.value;
+              if (/^\d*$/.test(val)) {
+                updateField('year', val);
+              }
+            }}
             size="small"
             sx={styles.field}
           />

--- a/app/types/graphql/mutations/opus.graphql
+++ b/app/types/graphql/mutations/opus.graphql
@@ -104,3 +104,31 @@ mutation UpdateOpusStatus($id: ID!, $status: OpusStatus!) {
     status
   }
 }
+
+mutation UnlinkComposition($opusId: ID!, $compositionId: ID!) {
+  unlinkComposition(opusId: $opusId, compositionId: $compositionId) {
+    id
+    number
+    numberKind
+    name {
+      uk
+      en
+    }
+    genre {
+      uk
+      en
+    }
+    status
+    creationYear
+    endYear
+    updatedAt
+    createdAt
+    compositions {
+      id
+      name {
+        uk
+        en
+      }
+    }
+  }
+}

--- a/src/constants/errors.ts
+++ b/src/constants/errors.ts
@@ -57,7 +57,8 @@ export const opusServiceErrors = {
   PERFORMANCES_TITLE_INVALID: 'The video caption is required and must contain between 2 and 250 characters.',
 
   OPUS_NOT_FOUND: (id: string) => `Opus with id "${id}" not found`,
-  FAILED_TO_DELETE: (id: string) => `Opus with id "${id}" not found or could not be deleted`
+  FAILED_TO_DELETE: (id: string) => `Opus with id "${id}" not found or could not be deleted`,
+  COMPOSITION_NOT_FOUND_IN_OPUS: 'Composition not found in this opus'
 };
 
 export const compositionsServiceErrors = {

--- a/src/interfaces/graphql/resolvers/opus/opusMutation.test.ts
+++ b/src/interfaces/graphql/resolvers/opus/opusMutation.test.ts
@@ -851,7 +851,7 @@ describe('OpusMutation Resolvers', () => {
       await expect(
         OpusMutation.unlinkComposition({}, { opusId: OPUS_ID, compositionId: COMPOSITION_ID_1 }, adminContext)
       ).rejects.toThrow(
-        new GraphQLError(opusServiceErrors.COMPOSITION_NOT_FOUND_IN_OPUS ?? 'Composition not found in this opus', {
+        new GraphQLError(opusServiceErrors.COMPOSITION_NOT_FOUND_IN_OPUS, {
           extensions: { code: 'BAD_USER_INPUT' }
         })
       );
@@ -888,5 +888,29 @@ describe('OpusMutation Resolvers', () => {
       expect(mockedOrderCompositionsByIds).toHaveBeenCalledWith([COMPOSITION_ID_2], [MOCK_COMPOSITION_2]);
       expect(result).toEqual({ ...updatedOpusEntity, compositions: [MOCK_COMPOSITION_2] });
     });
+
+    it.each([undefined, null])(
+      'should handle %s opus.compositions gracefully and throw error when composition is not found',
+      async (compositionsValue) => {
+        const opusWithoutCompositions = {
+          ...MOCK_OPUS_ENTITY,
+          compositions: compositionsValue as unknown as string[]
+        };
+
+        mockOpusRepo.findById.mockResolvedValue(opusWithoutCompositions as unknown as Opus);
+
+        await expect(
+          OpusMutation.unlinkComposition(
+            {},
+            { opusId: OPUS_ID, compositionId: COMPOSITION_ID_1 },
+            adminContext
+          )
+        ).rejects.toThrow(
+          new GraphQLError(opusServiceErrors.COMPOSITION_NOT_FOUND_IN_OPUS, {
+            extensions: { code: 'BAD_USER_INPUT' }
+          })
+        );
+      }
+    );
   });
 });

--- a/src/interfaces/graphql/resolvers/opus/opusMutation.test.ts
+++ b/src/interfaces/graphql/resolvers/opus/opusMutation.test.ts
@@ -817,4 +817,76 @@ describe('OpusMutation Resolvers', () => {
       expect(result).toBe(true);
     });
   });
+
+  describe('unlinkComposition', () => {
+    it('should throw UNAUTHENTICATED error when request is not authenticated', async () => {
+      await expect(
+        OpusMutation.unlinkComposition({}, { opusId: OPUS_ID, compositionId: COMPOSITION_ID_1 }, userContext)
+      ).rejects.toThrow(
+        new GraphQLError(graphqlErrors.UNAUTHENTICATED.message, {
+          extensions: { code: graphqlErrors.UNAUTHENTICATED.code }
+        })
+      );
+    });
+
+    it('should throw OPUS_NOT_FOUND if opus does not exist', async () => {
+      mockOpusRepo.findById.mockResolvedValue(null);
+
+      await expect(
+        OpusMutation.unlinkComposition({}, { opusId: OPUS_ID, compositionId: COMPOSITION_ID_1 }, adminContext)
+      ).rejects.toThrow(
+        new GraphQLError(opusServiceErrors.OPUS_NOT_FOUND(OPUS_ID), {
+          extensions: { code: 'OPUS_NOT_FOUND' }
+        })
+      );
+    });
+
+    it('should throw COMPOSITION_NOT_FOUND_IN_OPUS error if composition is not linked to the opus', async () => {
+      const opusWithoutComp = {
+        ...MOCK_OPUS_ENTITY,
+        compositions: [COMPOSITION_ID_2]
+      };
+      mockOpusRepo.findById.mockResolvedValue(opusWithoutComp as unknown as Opus);
+
+      await expect(
+        OpusMutation.unlinkComposition({}, { opusId: OPUS_ID, compositionId: COMPOSITION_ID_1 }, adminContext)
+      ).rejects.toThrow(
+        new GraphQLError(opusServiceErrors.COMPOSITION_NOT_FOUND_IN_OPUS ?? 'Composition not found in this opus', {
+          extensions: { code: 'BAD_USER_INPUT' }
+        })
+      );
+    });
+
+    it('should successfully unlink composition, update opus, move composition, and return ordered compositions', async () => {
+      const initialOpus = {
+        ...MOCK_OPUS_ENTITY,
+        compositions: [COMPOSITION_ID_1, COMPOSITION_ID_2]
+      };
+      const updatedOpusEntity = {
+        ...MOCK_OPUS_ENTITY,
+        compositions: [COMPOSITION_ID_2]
+      };
+
+      mockOpusRepo.findById.mockResolvedValue(initialOpus as unknown as Opus);
+      mockOpusRepo.update.mockResolvedValue(updatedOpusEntity as unknown as Opus);
+      mockOpusRepo.moveCompositionsToCompositionsOpus.mockResolvedValue(undefined as never);
+      mockCompositionsRepo.findByIds.mockResolvedValue([MOCK_COMPOSITION_2]);
+      mockedOrderCompositionsByIds.mockReturnValue([MOCK_COMPOSITION_2]);
+
+      const result = await OpusMutation.unlinkComposition(
+        {},
+        { opusId: OPUS_ID, compositionId: COMPOSITION_ID_1 },
+        adminContext
+      );
+
+      expect(mockOpusRepo.findById).toHaveBeenCalledWith(OPUS_ID);
+      expect(mockOpusRepo.update).toHaveBeenCalledWith(OPUS_ID, {
+        compositions: [COMPOSITION_ID_2]
+      });
+      expect(mockOpusRepo.moveCompositionsToCompositionsOpus).toHaveBeenCalledWith([COMPOSITION_ID_1]);
+      expect(mockCompositionsRepo.findByIds).toHaveBeenCalledWith([COMPOSITION_ID_2]);
+      expect(mockedOrderCompositionsByIds).toHaveBeenCalledWith([COMPOSITION_ID_2], [MOCK_COMPOSITION_2]);
+      expect(result).toEqual({ ...updatedOpusEntity, compositions: [MOCK_COMPOSITION_2] });
+    });
+  });
 });

--- a/src/interfaces/graphql/resolvers/opus/opusMutation.ts
+++ b/src/interfaces/graphql/resolvers/opus/opusMutation.ts
@@ -65,6 +65,7 @@ export type UpdateOpusGQLInput = Omit<CreateOpusGQLInput, 'title' | 'description
 
 type CreateOpusArgs = { input: CreateOpusGQLInput };
 type UpdateOpusArgs = { id: string; input: UpdateOpusGQLInput };
+type UnlinkCompositionArgs = { opusId: string; compositionId: string };
 
 const assertAuthenticated = (context: GraphQLContext): void => {
   if (!context.admin) {
@@ -467,5 +468,37 @@ export const OpusMutation = {
     const repo = context.requestContainer.cradle.opusRepository;
     await repo.unlink(id);
     return repo.delete(id);
-  }
+  },
+
+  unlinkComposition: async (_: unknown, { opusId, compositionId }: UnlinkCompositionArgs, context: GraphQLContext): Promise<OpusFull> => {
+    assertAuthenticated(context);
+
+    const {
+      opusRepository: repo,
+      compositionsRepository: compositionsRepo
+    } = context.requestContainer.cradle;
+
+    const existingOpus = await findExistingOpus(repo, opusId);
+
+    const currentCompositions = (existingOpus.compositions ?? []).map((id) => id.toString());
+    
+    if (!currentCompositions.includes(compositionId)) {
+      throw new GraphQLError(opusServiceErrors.COMPOSITION_NOT_FOUND_IN_OPUS ?? 'Composition not found in this opus', {
+        extensions: { code: 'BAD_USER_INPUT' }
+      });
+    }
+
+    const updatedCompositionIds = currentCompositions.filter((id) => id !== compositionId);
+
+    const updatedOpus = await updateAndVerifyOpus(repo, opusId, {
+      compositions: updatedCompositionIds
+    });
+
+    await repo.moveCompositionsToCompositionsOpus([compositionId]);
+
+    const compositions = await compositionsRepo.findByIds(updatedCompositionIds);
+    const orderedCompositions = orderCompositionsByIds(updatedCompositionIds, compositions);
+
+    return { ...updatedOpus, compositions: orderedCompositions };
+  },
 };

--- a/src/interfaces/graphql/resolvers/opus/opusMutation.ts
+++ b/src/interfaces/graphql/resolvers/opus/opusMutation.ts
@@ -480,10 +480,12 @@ export const OpusMutation = {
 
     const existingOpus = await findExistingOpus(repo, opusId);
 
-    const currentCompositions = (existingOpus.compositions ?? []).map((id) => id.toString());
+    const currentCompositions = (existingOpus.compositions ?? [])
+      .filter((id): id is NonNullable<typeof id> => id != null)
+      .map((id) => id.toString());
     
     if (!currentCompositions.includes(compositionId)) {
-      throw new GraphQLError(opusServiceErrors.COMPOSITION_NOT_FOUND_IN_OPUS ?? 'Composition not found in this opus', {
+      throw new GraphQLError(opusServiceErrors.COMPOSITION_NOT_FOUND_IN_OPUS, {
         extensions: { code: 'BAD_USER_INPUT' }
       });
     }

--- a/src/interfaces/graphql/schemas/opus.graphql
+++ b/src/interfaces/graphql/schemas/opus.graphql
@@ -171,4 +171,5 @@ extend type Mutation {
   updateOpus(id: ID!, input: UpdateOpusInput!): Opus!
   updateOpusStatus(id: ID!, status: OpusStatus!): UpdateOpusStatusPayload!
   deleteOpus(id: ID!): Boolean!
+  unlinkComposition(opusId: ID!, compositionId: ID!): Opus!
 }


### PR DESCRIPTION
## Description

Implements functionality for the composition actions menu inside opus groups. Users can now share, edit, and unlink compositions directly from an opus group on the table using the existing modals and sharing utilities.

### What was changed

- Connected the composition actions menu (`WorkMenuItems`) inside opus groups to functional handlers.
- Integrated the existing `CompositionModal` in edit mode for compositions within an opus.
- Added support for sharing individual compositions via generated URL parameters.
- Implemented the `unlinkComposition` GraphQL mutation, backend resolver, and frontend hook to remove a composition from an opus group without deleting the composition itself.
- Added a dedicated confirmation modal (`DeleteCardModal`) for unlinking compositions from an opus group.
- Added success/error feedback via toasts for all supported actions.
- Updated the `CompositionModal` year input field to restrict user entry exclusively to numerical digits using a regular expression check.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Check out this branch.
2. Navigate to the `/creativity` page.
3. Expand an opus group.
4. Open the actions menu (three dots) for any composition inside the group.
5. Verify the following actions:
   - **Share** – confirm that a shareable link containing the composition id value is generated/copied.
   - **Edit** – confirm that the `CompositionModal` opens with the composition data pre-filled and that changes are saved successfully.
   - **Delete (Unlink)** – confirm that the confirmation modal appears and that, after confirmation, the composition is unlinked from the opus group and becomes an independent composition again.

## Video / Screenshots

https://github.com/user-attachments/assets/3a73ed2a-5401-44aa-b628-0cd4ec3902fc

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---

Closes #729 