### PR TITLE
feat: implement case counters sync & cipher generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "apollo-server-errors": "^3.3.1",
         "awilix": "^12.0.5",
         "bcrypt": "^6.0.0",
+        "dataloader": "^2.2.3",
         "dayjs": "^1.11.20",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-unused-imports": "^4.1.4",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "apollo-server-errors": "^3.3.1",
     "awilix": "^12.0.5",
     "bcrypt": "^6.0.0",
+    "dataloader": "^2.2.3",
     "dayjs": "^1.11.20",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-unused-imports": "^4.1.4",

--- a/src/container/modules/repositories.module.ts
+++ b/src/container/modules/repositories.module.ts
@@ -25,6 +25,7 @@ import FondModel from '~/src/infrastructure/models/fond.model';
 import { MediaMentionModel } from '~/src/infrastructure/models/mediaMention.model';
 import { CaseRepository } from '~/src/infrastructure/repositories/caseRepository/caseRepository';
 import { FondRepository } from '~/src/infrastructure/repositories/fondRepository/fondRepository';
+import { createFondLoader } from '~/src/interfaces/graphql/resolvers/case/fondLoader';
 
 export type RepositoriesModule = {
   assetsRepository: ReturnType<typeof AssetRepository>;
@@ -39,6 +40,7 @@ export type RepositoriesModule = {
   compositionsRepository: ReturnType<typeof CompositionRepository>;
   fondRepository: ReturnType<typeof FondRepository>;
   caseRepository: ReturnType<typeof CaseRepository>;
+  fondLoader: ReturnType<typeof createFondLoader>;
 };
 
 export const registerRepositories = (container: AwilixContainer) => {
@@ -70,6 +72,7 @@ export const registerRepositories = (container: AwilixContainer) => {
     assetsRepository: asFunction(AssetRepository).scoped(),
     rateLimitRepository: asFunction(RateLimitRepository).scoped(),
     fondRepository: asFunction(FondRepository).scoped(),
-    caseRepository: asFunction(CaseRepository).scoped()
+    caseRepository: asFunction(CaseRepository).scoped(),
+    fondLoader: asFunction(createFondLoader).scoped()
   });
 };

--- a/src/domain/entities/Fond.ts
+++ b/src/domain/entities/Fond.ts
@@ -10,6 +10,8 @@ export interface Fond {
     organizationForm?: LocalizedString;
     description?: LocalizedString;
     status: BaseContentStatuses;
+    casesCount: number;
+    descriptionsCount: number;
     createdAt: string;
     updatedAt: string;
 }

--- a/src/domain/repositories/caseRepository.ts
+++ b/src/domain/repositories/caseRepository.ts
@@ -16,4 +16,5 @@ export type ICaseRepository = IBaseRepository<Case, CaseFilters> & {
     descriptionNumber: Case['descriptionNumber'],
     caseNumber: Case['caseNumber']
   ): Promise<Case | null>;
+  countDistinctDescriptionNumbers(fondId: Case['fondId']): Promise<number>;
 };

--- a/src/domain/repositories/fondRepository.ts
+++ b/src/domain/repositories/fondRepository.ts
@@ -3,9 +3,11 @@ import { FiltersInput, IBaseRepository } from './baseRepository';
 
 export type FondFilters = Omit<FiltersInput, 'slug'>
 
-export type CreateFondInput = Omit<Fond, 'id' | 'createdAt' | 'updatedAt'>
+// casesCount/descriptionsCount are derived automatically from Cases and are not
+// user-settable via the create/update GraphQL mutations.
+export type CreateFondInput = Omit<Fond, 'id' | 'createdAt' | 'updatedAt' | 'casesCount' | 'descriptionsCount'>
 
-export type UpdateFondInput = Partial<Omit<Fond, 'id' | 'createdAt' | 'updatedAt'>>
+export type UpdateFondInput = Partial<Omit<Fond, 'id' | 'createdAt' | 'updatedAt' | 'casesCount' | 'descriptionsCount'>>
 
 export type IFondRepository = IBaseRepository<Fond, FondFilters> & {
     create(input: CreateFondInput): Promise<Fond>;

--- a/src/domain/repositories/fondRepository.ts
+++ b/src/domain/repositories/fondRepository.ts
@@ -3,8 +3,6 @@ import { FiltersInput, IBaseRepository } from './baseRepository';
 
 export type FondFilters = Omit<FiltersInput, 'slug'>
 
-// casesCount/descriptionsCount are derived automatically from Cases and are not
-// user-settable via the create/update GraphQL mutations.
 export type CreateFondInput = Omit<Fond, 'id' | 'createdAt' | 'updatedAt' | 'casesCount' | 'descriptionsCount'>
 
 export type UpdateFondInput = Partial<Omit<Fond, 'id' | 'createdAt' | 'updatedAt' | 'casesCount' | 'descriptionsCount'>>

--- a/src/domain/repositories/fondRepository.ts
+++ b/src/domain/repositories/fondRepository.ts
@@ -10,4 +10,5 @@ export type UpdateFondInput = Partial<Omit<Fond, 'id' | 'createdAt' | 'updatedAt
 export type IFondRepository = IBaseRepository<Fond, FondFilters> & {
     create(input: CreateFondInput): Promise<Fond>;
     findByFondNumber(fondNumber: Fond['fondNumber']): Promise<Fond | null>;
+    findByIds(ids: readonly string[]): Promise<Fond[]>;
 }

--- a/src/infrastructure/models/fond.model.ts
+++ b/src/infrastructure/models/fond.model.ts
@@ -32,6 +32,8 @@ const fondSchema = new Schema<Fond>(
       enum: Array.from(Object.values(BaseContentStatuses)),
       default: BaseContentStatuses.Hidden
     },
+    casesCount: { type: Number, required: true, default: 0 },
+    descriptionsCount: { type: Number, required: true, default: 0 },
   },
   {
     timestamps: true,

--- a/src/infrastructure/repositories/caseRepository/caseRepository.test.ts
+++ b/src/infrastructure/repositories/caseRepository/caseRepository.test.ts
@@ -30,6 +30,7 @@ jest.mock('../../db/connect', () => jest.fn());
 const saveMock = jest.fn();
 const findOneMock = jest.fn();
 const findAllMock = jest.fn();
+const distinctMock = jest.fn();
 
 describe('caseRepository', () => {
   const MockCaseModel = jest.fn().mockImplementation(() => ({
@@ -38,7 +39,8 @@ describe('caseRepository', () => {
 
   Object.assign(MockCaseModel, {
     findOne: findOneMock,
-    find: findAllMock
+    find: findAllMock,
+    distinct: distinctMock
   });
 
   beforeEach(() => {
@@ -126,6 +128,25 @@ describe('caseRepository', () => {
     expect(result?.fondId).toBeUndefined();
     expect(result?.detailedCaseDescription).toBeUndefined();
     expect(result?.pdfFile).toStrictEqual(doc.pdfFile);
+  });
+
+  describe('countDistinctDescriptionNumbers', () => {
+    it('should return the number of distinct descriptionNumber values for a fond', async () => {
+      distinctMock.mockResolvedValue([1, 2, 3]);
+
+      const result = await repository.countDistinctDescriptionNumbers(mockFondId);
+
+      expect(distinctMock).toHaveBeenCalledWith('descriptionNumber', { fondId: mockFondId });
+      expect(result).toBe(3);
+    });
+
+    it('should return 0 when the fond has no cases', async () => {
+      distinctMock.mockResolvedValue([]);
+
+      const result = await repository.countDistinctDescriptionNumbers(mockFondId);
+
+      expect(result).toBe(0);
+    });
   });
 
   describe('findAll (buildCaseQuery)', () => {

--- a/src/infrastructure/repositories/caseRepository/caseRepository.ts
+++ b/src/infrastructure/repositories/caseRepository/caseRepository.ts
@@ -77,6 +77,13 @@ export const CaseRepository = ({ CaseModel }: CaseRepoDeps): ICaseRepository => 
         return null;
       }
       return toEntity(existing.toObject() as unknown as DbCase);
+    },
+
+    countDistinctDescriptionNumbers: async (fondId: Case['fondId']): Promise<number> => {
+      await dbConnect();
+
+      const distinctDescriptionNumbers = await CaseModel.distinct('descriptionNumber', { fondId });
+      return distinctDescriptionNumbers.length;
     }
   };
 };

--- a/src/infrastructure/repositories/fondRepository/fondRepository.test.ts
+++ b/src/infrastructure/repositories/fondRepository/fondRepository.test.ts
@@ -26,6 +26,22 @@ const createMockFondDoc = (overrides: Partial<DbFond> = {}): DbFond => ({
 
 jest.mock('../../db/connect', () => jest.fn());
 
+jest.mock('mongoose', () => {
+  const MockObjectId = function (this: { toString: () => string }, id: string) {
+    this.toString = () => id;
+  };
+
+  type ObjectIdMock = typeof MockObjectId & { isValid: (id: string) => boolean };
+
+  (MockObjectId as unknown as ObjectIdMock).isValid = (id: string) => /^[0-9a-fA-F]{24}$/.test(id);
+
+  return {
+    Types: {
+      ObjectId: MockObjectId
+    }
+  };
+});
+
 const saveMock = jest.fn();
 const findOneMock = jest.fn();
 const findAllMock = jest.fn();

--- a/src/infrastructure/repositories/fondRepository/fondRepository.test.ts
+++ b/src/infrastructure/repositories/fondRepository/fondRepository.test.ts
@@ -17,6 +17,8 @@ const createMockFondDoc = (overrides: Partial<DbFond> = {}): DbFond => ({
   chronologicalBoundaries: { uk: '1918', en: '1918' },
   description: { uk: 'опис', en: 'desc' },
   organizationForm: { uk: 'оргФорм', en: 'orgForm' },
+  casesCount: 0,
+  descriptionsCount: 0,
   createdAt: '2026-07-29T10:00:00.000Z',
   updatedAt: '2026-07-29T10:00:00.000Z',
   ...overrides
@@ -93,5 +95,28 @@ describe('fondRepository', () => {
     const result = await repository.findByFondNumber(999);
 
     expect(result).toBeNull();
+  });
+
+  it('should default casesCount and descriptionsCount to 0 when missing on the document', async () => {
+    const doc = createMockFondDoc({
+      casesCount: undefined as unknown as number,
+      descriptionsCount: undefined as unknown as number
+    });
+    findOneMock.mockResolvedValue({ toObject: () => doc });
+
+    const result = await repository.findByFondNumber(doc.fondNumber);
+
+    expect((result as Fond).casesCount).toBe(0);
+    expect((result as Fond).descriptionsCount).toBe(0);
+  });
+
+  it('should map casesCount and descriptionsCount when present on the document', async () => {
+    const doc = createMockFondDoc({ casesCount: 5, descriptionsCount: 2 });
+    findOneMock.mockResolvedValue({ toObject: () => doc });
+
+    const result = await repository.findByFondNumber(doc.fondNumber);
+
+    expect((result as Fond).casesCount).toBe(5);
+    expect((result as Fond).descriptionsCount).toBe(2);
   });
 });

--- a/src/infrastructure/repositories/fondRepository/fondRepository.test.ts
+++ b/src/infrastructure/repositories/fondRepository/fondRepository.test.ts
@@ -119,4 +119,37 @@ describe('fondRepository', () => {
     expect((result as Fond).casesCount).toBe(5);
     expect((result as Fond).descriptionsCount).toBe(2);
   });
+
+  describe('findByIds', () => {
+    const otherId = '65eddf5e2f1a2b3c4d5e6f7b';
+
+    it('should query only by the valid ObjectIds and return the mapped entities', async () => {
+      const docs = [createMockFondDoc(), createMockFondDoc({ _id: { toString: () => otherId }, fondNumber: 2 })];
+      const leanMock = jest.fn().mockResolvedValue(docs);
+      findAllMock.mockReturnValue({ lean: leanMock });
+
+      const result = await repository.findByIds([mockId, otherId]);
+
+      expect(findAllMock).toHaveBeenCalledWith({ _id: { $in: [mockId, otherId] } });
+      expect(result).toHaveLength(2);
+      expect(result[0].fondNumber).toBe(1);
+      expect(result[1].fondNumber).toBe(2);
+    });
+
+    it('should filter out invalid ObjectIds before querying', async () => {
+      const leanMock = jest.fn().mockResolvedValue([createMockFondDoc()]);
+      findAllMock.mockReturnValue({ lean: leanMock });
+
+      await repository.findByIds([mockId, 'not-a-valid-object-id']);
+
+      expect(findAllMock).toHaveBeenCalledWith({ _id: { $in: [mockId] } });
+    });
+
+    it('should return an empty array without querying when no valid ids are provided', async () => {
+      const result = await repository.findByIds(['not-a-valid-object-id']);
+
+      expect(findAllMock).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+  });
 });

--- a/src/infrastructure/repositories/fondRepository/fondRepository.ts
+++ b/src/infrastructure/repositories/fondRepository/fondRepository.ts
@@ -15,6 +15,8 @@ export type DbFond = {
   organizationForm: Fond['organizationForm'];
   description: Fond['description'];
   status: Fond['status']
+  casesCount: Fond['casesCount'];
+  descriptionsCount: Fond['descriptionsCount'];
   createdAt: string;
   updatedAt: string;
 }
@@ -32,6 +34,8 @@ const toEntity = (doc: DbFond): Fond =>
     organizationForm: doc.organizationForm,
     description: doc.description,
     status: doc.status,
+    casesCount: doc.casesCount ?? 0,
+    descriptionsCount: doc.descriptionsCount ?? 0,
   });
 
 export const FondRepository = ({ FondModel }: FondRepoDeps): IFondRepository => {

--- a/src/infrastructure/repositories/fondRepository/fondRepository.ts
+++ b/src/infrastructure/repositories/fondRepository/fondRepository.ts
@@ -1,4 +1,4 @@
-import { Model } from 'mongoose';
+import { Model, Types } from 'mongoose';
 
 import dbConnect from '../../db/connect';
 import { createBaseRepository } from '../baseRepository/baseRepository';
@@ -69,6 +69,18 @@ export const FondRepository = ({ FondModel }: FondRepoDeps): IFondRepository => 
         return null;
       }
       return toEntity(existing.toObject() as unknown as DbFond);
+    },
+
+    findByIds: async (ids: readonly string[]): Promise<Fond[]> => {
+      await dbConnect();
+
+      const validIds = ids.filter((id) => Types.ObjectId.isValid(id));
+      if (!validIds.length) {
+        return [];
+      }
+
+      const docs = await FondModel.find({ _id: { $in: validIds } }).lean<DbFond[]>();
+      return docs.map(toEntity);
     }
   };
 };

--- a/src/interfaces/graphql/resolvers/case/caseMutation.test.ts
+++ b/src/interfaces/graphql/resolvers/case/caseMutation.test.ts
@@ -34,19 +34,25 @@ const mockUpdate = jest.fn();
 const mockDelete = jest.fn();
 const mockFindById = jest.fn();
 const mockFindByFondAndNumbers = jest.fn();
+const mockCount = jest.fn();
+const mockCountDistinctDescriptionNumbers = jest.fn();
 
 const mockCaseRepo: Partial<ICaseRepository> = {
   create: mockCreate,
   update: mockUpdate,
   delete: mockDelete,
   findById: mockFindById,
-  findByFondAndNumbers: mockFindByFondAndNumbers
+  findByFondAndNumbers: mockFindByFondAndNumbers,
+  count: mockCount,
+  countDistinctDescriptionNumbers: mockCountDistinctDescriptionNumbers
 };
 
 const mockFondFindById = jest.fn();
+const mockFondUpdate = jest.fn();
 
 const mockFondRepo: Partial<IFondRepository> = {
-  findById: mockFondFindById
+  findById: mockFondFindById,
+  update: mockFondUpdate
 };
 
 const createContext = (isAdmin: boolean) => ({
@@ -66,6 +72,9 @@ describe('CaseMutation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockFondFindById.mockResolvedValue({ id: mockFondId });
+    mockCount.mockResolvedValue(0);
+    mockCountDistinctDescriptionNumbers.mockResolvedValue(0);
+    mockFondUpdate.mockResolvedValue({ id: mockFondId });
   });
 
   describe('createCase', () => {
@@ -131,6 +140,22 @@ describe('CaseMutation', () => {
 
       expect(mockCreate).toHaveBeenCalledTimes(1);
       expect(mockCreate).toHaveBeenCalledWith(input);
+    });
+
+    it('should recalculate and persist the parent Fond stats after a successful create', async () => {
+      const input = createMockCreateCaseInput();
+      mockFindByFondAndNumbers.mockResolvedValue(null);
+      mockCount.mockResolvedValue(3);
+      mockCountDistinctDescriptionNumbers.mockResolvedValue(2);
+
+      await CaseMutation.createCase({}, { input }, adminContext);
+
+      expect(mockCount).toHaveBeenCalledWith({ fondId: mockFondId });
+      expect(mockCountDistinctDescriptionNumbers).toHaveBeenCalledWith(mockFondId);
+      expect(mockFondUpdate).toHaveBeenCalledWith(mockFondId, {
+        casesCount: 3,
+        descriptionsCount: 2
+      });
     });
 
     it('should provide a fallback hidden status when missing', async () => {
@@ -294,6 +319,45 @@ describe('CaseMutation', () => {
 
       await expect(CaseMutation.updateCase({}, { id, input }, adminContext)).rejects.toThrow(unrelatedError);
     });
+
+    describe('Fond stats recalculation', () => {
+      const otherFondId = 'other-fond-id';
+
+      it('should recalculate stats for both the old and new Fond when the case is reassigned', async () => {
+        mockFindById.mockResolvedValue({ id, fondId: mockFondId, descriptionNumber: 1, caseNumber: 1 });
+        mockFindByFondAndNumbers.mockResolvedValue(null);
+        mockUpdate.mockResolvedValue({ id, fondId: otherFondId, descriptionNumber: 1, caseNumber: 1 });
+        const input = createMockUpdateCaseInput({ fondId: otherFondId });
+
+        await CaseMutation.updateCase({}, { id, input }, adminContext);
+
+        expect(mockFondUpdate).toHaveBeenCalledWith(mockFondId, expect.any(Object));
+        expect(mockFondUpdate).toHaveBeenCalledWith(otherFondId, expect.any(Object));
+        expect(mockFondUpdate).toHaveBeenCalledTimes(2);
+      });
+
+      it('should recalculate stats once for the same Fond when only descriptionNumber changes', async () => {
+        mockFindById.mockResolvedValue({ id, fondId: mockFondId, descriptionNumber: 1, caseNumber: 1 });
+        mockFindByFondAndNumbers.mockResolvedValue(null);
+        mockUpdate.mockResolvedValue({ id, fondId: mockFondId, descriptionNumber: 2, caseNumber: 1 });
+        const input = createMockUpdateCaseInput({ descriptionNumber: 2 });
+
+        await CaseMutation.updateCase({}, { id, input }, adminContext);
+
+        expect(mockFondUpdate).toHaveBeenCalledTimes(1);
+        expect(mockFondUpdate).toHaveBeenCalledWith(mockFondId, expect.any(Object));
+      });
+
+      it('should NOT recalculate stats when neither fondId nor descriptionNumber changed', async () => {
+        mockFindById.mockResolvedValue({ id, fondId: mockFondId, descriptionNumber: 1, caseNumber: 1 });
+        mockUpdate.mockResolvedValue({ id, fondId: mockFondId, descriptionNumber: 1, caseNumber: 1 });
+        const input = createMockUpdateCaseInput();
+
+        await CaseMutation.updateCase({}, { id, input }, adminContext);
+
+        expect(mockFondUpdate).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe('validation', () => {
@@ -346,15 +410,36 @@ describe('CaseMutation', () => {
     });
 
     it('should return false when the case could not be deleted', async () => {
+      mockFindById.mockResolvedValue({ id: 'non-existent', fondId: mockFondId });
       mockDelete.mockResolvedValue(false);
       const result = await CaseMutation.deleteCase({}, { id: 'non-existent' }, adminContext);
       expect(result).toBe(false);
+      expect(mockFondUpdate).not.toHaveBeenCalled();
     });
 
-    it('should return true on successful delete', async () => {
+    it('should return true on successful delete and recalculate the parent Fond stats', async () => {
+      mockFindById.mockResolvedValue({ id: 'some-id', fondId: mockFondId });
       mockDelete.mockResolvedValue(true);
+      mockCount.mockResolvedValue(1);
+      mockCountDistinctDescriptionNumbers.mockResolvedValue(1);
+
       const result = await CaseMutation.deleteCase({}, { id: 'some-id' }, adminContext);
+
       expect(result).toBe(true);
+      expect(mockFondUpdate).toHaveBeenCalledWith(mockFondId, {
+        casesCount: 1,
+        descriptionsCount: 1
+      });
+    });
+
+    it('should NOT recalculate Fond stats when the case to delete cannot be found', async () => {
+      mockFindById.mockResolvedValue(null);
+      mockDelete.mockResolvedValue(false);
+
+      const result = await CaseMutation.deleteCase({}, { id: 'non-existent' }, adminContext);
+
+      expect(result).toBe(false);
+      expect(mockFondUpdate).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/interfaces/graphql/resolvers/case/caseMutation.ts
+++ b/src/interfaces/graphql/resolvers/case/caseMutation.ts
@@ -1,5 +1,6 @@
 import { GraphQLError } from 'graphql';
 
+import { recalculateFondStats } from './recalculateFondStats';
 import { CaseErrorCodes, CaseErrors, graphqlErrors } from '~/constants/errors';
 import { Case } from '~/src/domain/entities/Case';
 import { CreateCaseInput, UpdateCaseInput } from '~/src/domain/repositories/caseRepository';
@@ -64,7 +65,9 @@ export const CaseMutation = {
     }
 
     try {
-      return await repo.create(validatedInput);
+      const createdCase = await repo.create(validatedInput);
+      await recalculateFondStats(fondId, { caseRepository: repo, fondRepository });
+      return createdCase;
     } catch (error) {
       if (isDuplicateKeyError(error)) {
         throw duplicateNumbersError();
@@ -121,13 +124,33 @@ export const CaseMutation = {
       throw caseNotFoundError(id);
     }
 
+    const statsAffectingChange =
+      validatedInput.fondId !== undefined || validatedInput.descriptionNumber !== undefined;
+
+    if (statsAffectingChange) {
+      const affectedFondIds = new Set([current.fondId, updatedCase.fondId]);
+
+      await Promise.all(
+        Array.from(affectedFondIds).map((affectedFondId) =>
+          recalculateFondStats(affectedFondId, { caseRepository: repo, fondRepository })
+        )
+      );
+    }
+
     return updatedCase;
   },
 
   deleteCase: async (_: unknown, { id }: DeleteCaseArgs, context: GraphQLContext): Promise<boolean> => {
     assertAuthenticated(context);
-    const repo = context.requestContainer.cradle.caseRepository;
+    const { caseRepository: repo, fondRepository } = context.requestContainer.cradle;
 
-    return repo.delete(id);
+    const existingCase = await repo.findById(id);
+    const deleted = await repo.delete(id);
+
+    if (deleted && existingCase) {
+      await recalculateFondStats(existingCase.fondId, { caseRepository: repo, fondRepository });
+    }
+
+    return deleted;
   }
 };

--- a/src/interfaces/graphql/resolvers/case/caseType.test.ts
+++ b/src/interfaces/graphql/resolvers/case/caseType.test.ts
@@ -1,0 +1,62 @@
+import { CaseType, formatCipher } from './caseType';
+import { Case } from '~/src/domain/entities/Case';
+import { IFondRepository } from '~/src/domain/repositories/fondRepository';
+import { BaseContentStatuses } from '~/types/enums/common.enums';
+
+const mockFondFindById = jest.fn();
+
+const mockFondRepo: Partial<IFondRepository> = {
+  findById: mockFondFindById
+};
+
+const createContext = () =>
+  ({
+    requestContainer: {
+      cradle: {
+        fondRepository: mockFondRepo
+      }
+    }
+  }) as never;
+
+const mockCase: Case = {
+  id: 'case-id',
+  fondId: 'fond-id',
+  descriptionNumber: 1,
+  caseNumber: 3,
+  caseName: { uk: 'Справа', en: 'Case' },
+  caseDate: { uk: '1917', en: '1917' },
+  sheetsNumber: 10,
+  caseDescriptions: { uk: 'Опис', en: 'Description' },
+  status: BaseContentStatuses.Published,
+  createdAt: '2026-07-29T10:00:00.000Z',
+  updatedAt: '2026-07-29T10:00:00.000Z'
+};
+
+describe('formatCipher', () => {
+  it('should format the cipher according to the strict "Ф. {fondNumber}, оп. {descriptionNumber}, спр. {caseNumber}" pattern', () => {
+    expect(formatCipher(1, 1, 3)).toBe('Ф. 1, оп. 1, спр. 3');
+  });
+});
+
+describe('CaseType.cipher', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should resolve the cipher using the parent Case and its Fond number', async () => {
+    mockFondFindById.mockResolvedValue({ id: 'fond-id', fondNumber: 1 });
+
+    const result = await CaseType.cipher(mockCase, {}, createContext());
+
+    expect(mockFondFindById).toHaveBeenCalledWith('fond-id');
+    expect(result).toBe('Ф. 1, оп. 1, спр. 3');
+  });
+
+  it('should fall back to 0 for fondNumber when the referenced Fond cannot be found', async () => {
+    mockFondFindById.mockResolvedValue(null);
+
+    const result = await CaseType.cipher(mockCase, {}, createContext());
+
+    expect(result).toBe('Ф. 0, оп. 1, спр. 3');
+  });
+});

--- a/src/interfaces/graphql/resolvers/case/caseType.test.ts
+++ b/src/interfaces/graphql/resolvers/case/caseType.test.ts
@@ -1,22 +1,15 @@
+import { createMockContext } from '../testUtils';
 import { CaseType, formatCipher } from './caseType';
 import { Case } from '~/src/domain/entities/Case';
-import { IFondRepository } from '~/src/domain/repositories/fondRepository';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
 
-const mockFondFindById = jest.fn();
+const mockFondLoaderLoad = jest.fn();
 
-const mockFondRepo: Partial<IFondRepository> = {
-  findById: mockFondFindById
+const mockFondLoader = {
+  load: mockFondLoaderLoad
 };
 
-const createContext = () =>
-  ({
-    requestContainer: {
-      cradle: {
-        fondRepository: mockFondRepo
-      }
-    }
-  }) as never;
+const createContext = () => createMockContext(true, 'fondLoader', mockFondLoader);
 
 const mockCase: Case = {
   id: 'case-id',
@@ -43,17 +36,17 @@ describe('CaseType.cipher', () => {
     jest.clearAllMocks();
   });
 
-  it('should resolve the cipher using the parent Case and its Fond number', async () => {
-    mockFondFindById.mockResolvedValue({ id: 'fond-id', fondNumber: 1 });
+  it('should resolve the cipher using the parent Case and its Fond number via the batching fondLoader', async () => {
+    mockFondLoaderLoad.mockResolvedValue({ id: 'fond-id', fondNumber: 1 });
 
     const result = await CaseType.cipher(mockCase, {}, createContext());
 
-    expect(mockFondFindById).toHaveBeenCalledWith('fond-id');
+    expect(mockFondLoaderLoad).toHaveBeenCalledWith('fond-id');
     expect(result).toBe('Ф. 1, оп. 1, спр. 3');
   });
 
   it('should fall back to 0 for fondNumber when the referenced Fond cannot be found', async () => {
-    mockFondFindById.mockResolvedValue(null);
+    mockFondLoaderLoad.mockResolvedValue(null);
 
     const result = await CaseType.cipher(mockCase, {}, createContext());
 

--- a/src/interfaces/graphql/resolvers/case/caseType.ts
+++ b/src/interfaces/graphql/resolvers/case/caseType.ts
@@ -6,8 +6,8 @@ export const formatCipher = (fondNumber: number, descriptionNumber: number, case
 
 export const CaseType = {
   cipher: async (parent: Case, _args: unknown, context: GraphQLContext): Promise<string> => {
-    const { fondRepository } = context.requestContainer.cradle;
-    const fond = await fondRepository.findById(parent.fondId);
+    const { fondLoader } = context.requestContainer.cradle;
+    const fond = await fondLoader.load(parent.fondId);
 
     return formatCipher(fond?.fondNumber ?? 0, parent.descriptionNumber, parent.caseNumber);
   }

--- a/src/interfaces/graphql/resolvers/case/caseType.ts
+++ b/src/interfaces/graphql/resolvers/case/caseType.ts
@@ -1,10 +1,6 @@
 import { Case } from '~/src/domain/entities/Case';
 import { GraphQLContext } from '~/src/shared/types/container/types';
 
-/**
- * Formats the archival reference (Шифр справи) for a Case.
- * Strict format: `Ф. {fondNumber}, оп. {descriptionNumber}, спр. {caseNumber}`.
- */
 export const formatCipher = (fondNumber: number, descriptionNumber: number, caseNumber: number): string =>
   `Ф. ${fondNumber}, оп. ${descriptionNumber}, спр. ${caseNumber}`;
 

--- a/src/interfaces/graphql/resolvers/case/caseType.ts
+++ b/src/interfaces/graphql/resolvers/case/caseType.ts
@@ -1,0 +1,18 @@
+import { Case } from '~/src/domain/entities/Case';
+import { GraphQLContext } from '~/src/shared/types/container/types';
+
+/**
+ * Formats the archival reference (Шифр справи) for a Case.
+ * Strict format: `Ф. {fondNumber}, оп. {descriptionNumber}, спр. {caseNumber}`.
+ */
+export const formatCipher = (fondNumber: number, descriptionNumber: number, caseNumber: number): string =>
+  `Ф. ${fondNumber}, оп. ${descriptionNumber}, спр. ${caseNumber}`;
+
+export const CaseType = {
+  cipher: async (parent: Case, _args: unknown, context: GraphQLContext): Promise<string> => {
+    const { fondRepository } = context.requestContainer.cradle;
+    const fond = await fondRepository.findById(parent.fondId);
+
+    return formatCipher(fond?.fondNumber ?? 0, parent.descriptionNumber, parent.caseNumber);
+  }
+};

--- a/src/interfaces/graphql/resolvers/case/fondLoader.test.ts
+++ b/src/interfaces/graphql/resolvers/case/fondLoader.test.ts
@@ -1,0 +1,84 @@
+import { createFondLoader } from './fondLoader';
+import { IFondRepository } from '~/src/domain/repositories/fondRepository';
+
+const mockFindByIds = jest.fn();
+
+const mockFondRepo: Partial<IFondRepository> = {
+  findByIds: mockFindByIds
+};
+
+describe('createFondLoader', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should batch multiple .load() calls issued in the same tick into a single findByIds call', async () => {
+    mockFindByIds.mockResolvedValue([
+      { id: 'fond-1', fondNumber: 1 },
+      { id: 'fond-2', fondNumber: 2 }
+    ]);
+
+    const loader = createFondLoader({ fondRepository: mockFondRepo as IFondRepository });
+
+    const [fond1, fond2] = await Promise.all([loader.load('fond-1'), loader.load('fond-2')]);
+
+    expect(mockFindByIds).toHaveBeenCalledTimes(1);
+    expect(mockFindByIds).toHaveBeenCalledWith(['fond-1', 'fond-2']);
+    expect(fond1).toEqual({ id: 'fond-1', fondNumber: 1 });
+    expect(fond2).toEqual({ id: 'fond-2', fondNumber: 2 });
+  });
+
+  it('should deduplicate repeated ids within the same batch (e.g. many Cases sharing one Fond)', async () => {
+    mockFindByIds.mockResolvedValue([{ id: 'fond-1', fondNumber: 1 }]);
+
+    const loader = createFondLoader({ fondRepository: mockFondRepo as IFondRepository });
+
+    const results = await Promise.all([
+      loader.load('fond-1'),
+      loader.load('fond-1'),
+      loader.load('fond-1')
+    ]);
+
+    expect(mockFindByIds).toHaveBeenCalledTimes(1);
+    expect(mockFindByIds).toHaveBeenCalledWith(['fond-1']);
+    expect(results).toEqual([
+      { id: 'fond-1', fondNumber: 1 },
+      { id: 'fond-1', fondNumber: 1 },
+      { id: 'fond-1', fondNumber: 1 }
+    ]);
+  });
+
+  it('should cache results across separate .load() calls for the lifetime of the loader instance', async () => {
+    mockFindByIds.mockResolvedValue([{ id: 'fond-1', fondNumber: 1 }]);
+
+    const loader = createFondLoader({ fondRepository: mockFondRepo as IFondRepository });
+
+    await loader.load('fond-1');
+    await loader.load('fond-1');
+
+    expect(mockFindByIds).toHaveBeenCalledTimes(1);
+  });
+
+  it('should resolve null for ids that findByIds did not return (e.g. a stale/broken fondId)', async () => {
+    mockFindByIds.mockResolvedValue([{ id: 'fond-1', fondNumber: 1 }]);
+
+    const loader = createFondLoader({ fondRepository: mockFondRepo as IFondRepository });
+
+    const [fond1, missing] = await Promise.all([loader.load('fond-1'), loader.load('missing-fond')]);
+
+    expect(fond1).toEqual({ id: 'fond-1', fondNumber: 1 });
+    expect(missing).toBeNull();
+  });
+
+  it('should NOT share a cache between two separate loader instances (per-request isolation)', async () => {
+    mockFindByIds.mockResolvedValue([{ id: 'fond-1', fondNumber: 1 }]);
+
+    const requestOneLoader = createFondLoader({ fondRepository: mockFondRepo as IFondRepository });
+    const requestTwoLoader = createFondLoader({ fondRepository: mockFondRepo as IFondRepository });
+
+    await requestOneLoader.load('fond-1');
+    await requestTwoLoader.load('fond-1');
+
+    expect(mockFindByIds).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/interfaces/graphql/resolvers/case/fondLoader.ts
+++ b/src/interfaces/graphql/resolvers/case/fondLoader.ts
@@ -1,0 +1,16 @@
+import DataLoader from 'dataloader';
+
+import { Fond } from '~/src/domain/entities/Fond';
+import { IFondRepository } from '~/src/domain/repositories/fondRepository';
+
+type FondLoaderDeps = Readonly<{
+  fondRepository: IFondRepository;
+}>;
+
+export const createFondLoader = ({ fondRepository }: FondLoaderDeps): DataLoader<string, Fond | null> =>
+  new DataLoader<string, Fond | null>(async (fondIds) => {
+    const fonds = await fondRepository.findByIds(fondIds);
+    const fondsById = new Map(fonds.map((fond) => [fond.id, fond]));
+
+    return fondIds.map((id) => fondsById.get(id) ?? null);
+  });

--- a/src/interfaces/graphql/resolvers/case/recalculateFondStats.test.ts
+++ b/src/interfaces/graphql/resolvers/case/recalculateFondStats.test.ts
@@ -1,0 +1,69 @@
+import { recalculateFondStats } from './recalculateFondStats';
+import { ICaseRepository } from '~/src/domain/repositories/caseRepository';
+import { IFondRepository } from '~/src/domain/repositories/fondRepository';
+
+const mockFondId = '65eddf5e2f1a2b3c4d5e6f7b';
+
+const mockCount = jest.fn();
+const mockCountDistinctDescriptionNumbers = jest.fn();
+const mockFondUpdate = jest.fn();
+
+const mockCaseRepo: Partial<ICaseRepository> = {
+  count: mockCount,
+  countDistinctDescriptionNumbers: mockCountDistinctDescriptionNumbers
+};
+
+const mockFondRepo: Partial<IFondRepository> = {
+  update: mockFondUpdate
+};
+
+describe('recalculateFondStats', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should recalculate casesCount and descriptionsCount and persist them on the Fond', async () => {
+    mockCount.mockResolvedValue(4);
+    mockCountDistinctDescriptionNumbers.mockResolvedValue(2);
+
+    await recalculateFondStats(mockFondId, {
+      caseRepository: mockCaseRepo as ICaseRepository,
+      fondRepository: mockFondRepo as IFondRepository
+    });
+
+    expect(mockCount).toHaveBeenCalledWith({ fondId: mockFondId });
+    expect(mockCountDistinctDescriptionNumbers).toHaveBeenCalledWith(mockFondId);
+    expect(mockFondUpdate).toHaveBeenCalledWith(mockFondId, {
+      casesCount: 4,
+      descriptionsCount: 2
+    });
+  });
+
+  it('should persist zero counts when the fond has no remaining cases', async () => {
+    mockCount.mockResolvedValue(0);
+    mockCountDistinctDescriptionNumbers.mockResolvedValue(0);
+
+    await recalculateFondStats(mockFondId, {
+      caseRepository: mockCaseRepo as ICaseRepository,
+      fondRepository: mockFondRepo as IFondRepository
+    });
+
+    expect(mockFondUpdate).toHaveBeenCalledWith(mockFondId, {
+      casesCount: 0,
+      descriptionsCount: 0
+    });
+  });
+
+  it('should propagate errors from the fond repository update', async () => {
+    mockCount.mockResolvedValue(1);
+    mockCountDistinctDescriptionNumbers.mockResolvedValue(1);
+    mockFondUpdate.mockRejectedValue(new Error('DB unavailable'));
+
+    await expect(
+      recalculateFondStats(mockFondId, {
+        caseRepository: mockCaseRepo as ICaseRepository,
+        fondRepository: mockFondRepo as IFondRepository
+      })
+    ).rejects.toThrow('DB unavailable');
+  });
+});

--- a/src/interfaces/graphql/resolvers/case/recalculateFondStats.ts
+++ b/src/interfaces/graphql/resolvers/case/recalculateFondStats.ts
@@ -7,14 +7,6 @@ type RecalculateFondStatsDeps = {
   fondRepository: IFondRepository;
 };
 
-/**
- * Recalculates and persists the aggregated Case statistics on a Fond document:
- * - casesCount: total number of Cases that belong to the Fond.
- * - descriptionsCount: number of unique descriptionNumber values used by those Cases.
- *
- * Must be called after every Case create/update/delete that could affect the
- * counts of the given Fond (see callers in caseMutation.ts).
- */
 export const recalculateFondStats = async (
   fondId: Case['fondId'],
   { caseRepository, fondRepository }: RecalculateFondStatsDeps

--- a/src/interfaces/graphql/resolvers/case/recalculateFondStats.ts
+++ b/src/interfaces/graphql/resolvers/case/recalculateFondStats.ts
@@ -1,0 +1,28 @@
+import { Case } from '~/src/domain/entities/Case';
+import { ICaseRepository } from '~/src/domain/repositories/caseRepository';
+import { IFondRepository } from '~/src/domain/repositories/fondRepository';
+
+type RecalculateFondStatsDeps = {
+  caseRepository: ICaseRepository;
+  fondRepository: IFondRepository;
+};
+
+/**
+ * Recalculates and persists the aggregated Case statistics on a Fond document:
+ * - casesCount: total number of Cases that belong to the Fond.
+ * - descriptionsCount: number of unique descriptionNumber values used by those Cases.
+ *
+ * Must be called after every Case create/update/delete that could affect the
+ * counts of the given Fond (see callers in caseMutation.ts).
+ */
+export const recalculateFondStats = async (
+  fondId: Case['fondId'],
+  { caseRepository, fondRepository }: RecalculateFondStatsDeps
+): Promise<void> => {
+  const [casesCount, descriptionsCount] = await Promise.all([
+    caseRepository.count({ fondId }),
+    caseRepository.countDistinctDescriptionNumbers(fondId)
+  ]);
+
+  await fondRepository.update(fondId, { casesCount, descriptionsCount });
+};

--- a/src/interfaces/graphql/resolvers/index.ts
+++ b/src/interfaces/graphql/resolvers/index.ts
@@ -3,6 +3,7 @@ import { authQuery as AuthQuery } from './admin/AuthQuery';
 import { AssetsMutation, AssetsQuery } from './assets/Query';
 import { CaseMutation } from './case/caseMutation';
 import { CaseQuery } from './case/caseQuery';
+import { CaseType } from './case/caseType';
 import { CompositionsMutation } from './compositions/compositionsMutation';
 import { CompositionsQuery } from './compositions/compositionsQuery';
 import { EventsMutation } from './events/eventsMutation';
@@ -42,5 +43,8 @@ export const resolvers = {
     ...CompositionsQuery,
     ...CaseQuery,
     ...FondQuery
+  },
+  Case: {
+    ...CaseType
   }
 };

--- a/src/interfaces/graphql/schemas/case.graphql
+++ b/src/interfaces/graphql/schemas/case.graphql
@@ -30,6 +30,7 @@ type Case {
     detailedCaseDescription: LocalizedString
     pdfFile: CasePdfFile
     status: CaseStatus!
+    cipher: String!
     updatedAt: String!
     createdAt: String!
 }

--- a/src/interfaces/graphql/schemas/fond.graphql
+++ b/src/interfaces/graphql/schemas/fond.graphql
@@ -22,10 +22,12 @@ type Fond {
     name: LocalizedString!
     documentCreationDate: LocalizedString!
     chronologicalBoundaries: LocalizedString
-    organizationForm: LocalizedString 
-    description: LocalizedString 
+    organizationForm: LocalizedString
+    description: LocalizedString
     status: FondStatus!
-    updatedAt: String! 
+    casesCount: Int!
+    descriptionsCount: Int!
+    updatedAt: String!
     createdAt: String!
 }
 


### PR DESCRIPTION
## Description

Implements the business rules that bind Fonds and Cases together:

- **Automatic Fond statistics sync.** On every Case create/update/delete, the parent Fond's `casesCount` (total cases in the fond) and `descriptionsCount` (number of unique `descriptionNumber` values used by its cases) are automatically recalculated and persisted. Reassigning a Case to a different Fond recalculates **both** the old and the new Fond.
- **Automatic archival reference (cipher) generation.** The `Case` GraphQL type now resolves a computed `cipher` field in the strict format `Ф. {fondNumber}, оп. {descriptionNumber}, спр. {caseNumber}` (e.g. `Ф. 1, оп. 1, спр. 3`).

### What was changed

- `Fond` entity/schema/repository/GraphQL type: added `casesCount` and `descriptionsCount` (derived fields, excluded from `CreateFondInput`/`UpdateFondInput` — not user-settable).
- `caseRepository`: added `countDistinctDescriptionNumbers(fondId)`.
- New `recalculateFondStats(fondId, deps)` helper that recomputes and persists both counters for a given Fond.
- `caseMutation.ts`: wired the recalculation into `createCase` (new fond), `updateCase` (old + new fond when `fondId` or `descriptionNumber` changes), and `deleteCase` (fond of the deleted case).
- New `caseType.ts` field resolver: `Case.cipher`, added to the schema and merged into `resolvers/index.ts`.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other:

## How to test

1. Check out this branch and run `npm run codegen` (GraphQL schema changed: `cipher`, `casesCount`, `descriptionsCount`).
2. Start the app and open the GraphQL playground / API route.
3. **Cipher:** query `caseById(id: "...")  { cipher }` (or any Case list query) for an existing Case and confirm it returns `Ф. {fondNumber}, оп. {descriptionNumber}, спр. {caseNumber}`.
4. **Counters — create:** run `createCase` for a Fond, then query `findFondById(id: "<fondId>") { casesCount descriptionsCount }` and confirm `casesCount` incremented and `descriptionsCount` reflects the number of distinct `descriptionNumber` values.
5. **Counters — update (reassign):** run `updateCase` changing `fondId` to a different Fond, then query both the old and the new Fond — confirm `casesCount`/`descriptionsCount` updated on **both**.
6. **Counters — update (descriptionNumber):** run `updateCase` changing only `descriptionNumber`, confirm `descriptionsCount` on the (same) Fond is recalculated.
7. **Counters — delete:** run `deleteCase`, then query the parent Fond and confirm `casesCount`/`descriptionsCount` decreased accordingly.
8. Run the automated suite: `npm run test` (new/updated tests: `caseMutation.test.ts`, `caseType.test.ts`, `recalculateFondStats.test.ts`, `caseRepository.test.ts`, `fondRepository.test.ts`).

## Video / Screenshots
<img width="1396" height="700" alt="1" src="https://github.com/user-attachments/assets/0d5617fd-0da8-460b-816c-d0d5373c49aa" />
<img width="1396" height="700" alt="2" src="https://github.com/user-attachments/assets/57535cfb-e5bc-4446-9fac-6c727ba729b0" />
<img width="1396" height="700" alt="3" src="https://github.com/user-attachments/assets/f42c6a3b-33a3-4628-9d1f-c0ce17633c55" />
<img width="1421" height="713" alt="4" src="https://github.com/user-attachments/assets/524960c8-895f-4e0d-99c9-d76e58425508" />
