### PR TITLE
bugfix: prevent duplicate composition names

### DIFF
--- a/app/(logged_in)/creativity/(composition)/useCreateWorkAction.test.ts
+++ b/app/(logged_in)/creativity/(composition)/useCreateWorkAction.test.ts
@@ -187,7 +187,7 @@ describe('useCreateWorkAction', () => {
   });
 
   it('should handle failed work creation', async () => {
-    jest.mocked(safeMutate).mockResolvedValueOnce(undefined as unknown as Awaited<ReturnType<typeof safeMutate>>);
+    jest.mocked(safeMutate).mockRejectedValueOnce(new Error(MOCK_ERROR_MESSAGE));
     const { result } = renderHook(() => useCreateWorkAction());
 
     await act(async () => {
@@ -200,10 +200,12 @@ describe('useCreateWorkAction', () => {
       expect.any(String),
       expect.any(String)
     );
+
     expect(result.current.isSubmitting).toBe(false);
     expect(result.current.error).toBe(MOCK_ERROR_MESSAGE);
     expect(MOCK_REFRESH).not.toHaveBeenCalled();
-    expect(toast.error).toHaveBeenCalledWith(COMPOSITION_MUTATION_RESULTS.failed);
+    expect(toast.error).toHaveBeenCalledWith(MOCK_ERROR_MESSAGE);
+    expect(toast.success).not.toHaveBeenCalled();
   });
 
   it('should correctly fallback optional fields in audios and sheetMusic mapping', async () => {

--- a/app/(logged_in)/creativity/(composition)/useCreateWorkAction.ts
+++ b/app/(logged_in)/creativity/(composition)/useCreateWorkAction.ts
@@ -63,13 +63,13 @@ const mapToCreateInput = (work: OpusCompositionData): CreateCompositionInput => 
   };
 };
 
+
 export function useCreateWorkAction(): UseCreateWorkActionResult {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  
   const [createComposition] = useCreateComposition();
-  const router = useRouter(); 
+  const router = useRouter();
 
   const openModal = useCallback(() => {
     setError(null);
@@ -86,20 +86,18 @@ export function useCreateWorkAction(): UseCreateWorkActionResult {
     async (work: OpusCompositionData) => {
       setIsSubmitting(true);
       setError(null);
-        
-      const result = await createComposition(mapToCreateInput(work));
-        
-      if (!result) {
-        setError('Не вдалося створити твір. Спробуйте ще раз.');
+      try {
+        await createComposition(mapToCreateInput(work));
+        setIsModalOpen(false);
+        toast.success(COMPOSITION_MUTATION_RESULTS.created);
+        router.refresh();
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Не вдалося створити твір. Спробуйте ще раз.';
+        setError(message);
+        toast.error(`Помилка: ${message}`);
+      } finally {
         setIsSubmitting(false);
-        toast.error(COMPOSITION_MUTATION_RESULTS.failed);
-        return;
       }
-
-      setIsModalOpen(false);
-      setIsSubmitting(false);
-      router.refresh();
-      toast.success(COMPOSITION_MUTATION_RESULTS.created);
     },
     [createComposition, router]
   );

--- a/app/(logged_in)/creativity/(composition)/useCreateWorkAction.ts
+++ b/app/(logged_in)/creativity/(composition)/useCreateWorkAction.ts
@@ -17,6 +17,7 @@ interface UseCreateWorkActionResult {
   error: string | null;
   openModal: () => void;
   closeModal: () => void;
+  clearError: () => void;
   handleSubmit: (work: OpusCompositionData) => Promise<void>;
 }
 
@@ -82,6 +83,8 @@ export function useCreateWorkAction(): UseCreateWorkActionResult {
     setError(null);
   }, [isSubmitting]);
 
+  const clearError = useCallback(() => setError(null), []);
+
   const handleSubmit = useCallback(
     async (work: OpusCompositionData) => {
       setIsSubmitting(true);
@@ -94,7 +97,7 @@ export function useCreateWorkAction(): UseCreateWorkActionResult {
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Не вдалося створити твір. Спробуйте ще раз.';
         setError(message);
-        toast.error(`Помилка: ${message}`);
+        toast.error(message);
       } finally {
         setIsSubmitting(false);
       }
@@ -102,5 +105,5 @@ export function useCreateWorkAction(): UseCreateWorkActionResult {
     [createComposition, router]
   );
 
-  return { isModalOpen, isSubmitting, error, openModal, closeModal, handleSubmit };
+  return { isModalOpen, isSubmitting, error, openModal, closeModal, clearError, handleSubmit };
 }

--- a/app/(logged_in)/creativity/(composition)/useUpdateWorkAction.test.ts
+++ b/app/(logged_in)/creativity/(composition)/useUpdateWorkAction.test.ts
@@ -83,7 +83,8 @@ describe('useUpdateWorkAction', () => {
     const { result } = renderHook(() => useUpdateWorkAction());
 
     await act(async () => {
-      await result.current.handleUpdateComposition('comp-123', mockComposition);
+      const updated = await result.current.handleUpdateComposition('comp-123', mockComposition);
+      expect(updated).toBe(true);
     });
 
     expect(mockUpdateCompositionMut).toHaveBeenCalledWith({
@@ -142,7 +143,8 @@ describe('useUpdateWorkAction', () => {
     const { result } = renderHook(() => useUpdateWorkAction());
 
     await act(async () => {
-      await result.current.handleUpdateComposition('comp-456', minimalComposition);
+      const updated = await result.current.handleUpdateComposition('comp-456', minimalComposition);
+      expect(updated).toBe(true);
     });
 
     expect(mockUpdateCompositionMut).toHaveBeenCalledWith({
@@ -172,15 +174,14 @@ describe('useUpdateWorkAction', () => {
   });
 
   it('should handle composition update error and throw', async () => {
-    const mockError = new Error('Update failed');
+    const mockError = new Error('Помилка при оновленні твору');
     mockUpdateCompositionMut.mockRejectedValueOnce(mockError);
 
     const { result } = renderHook(() => useUpdateWorkAction());
 
     await act(async () => {
-      await expect(
-        result.current.handleUpdateComposition('comp-123', mockComposition)
-      ).rejects.toThrow('Update failed');
+      const updated = await result.current.handleUpdateComposition('comp-123', mockComposition);
+      expect(updated).toBe(false);
     });
 
     expect(toast.error).toHaveBeenCalledWith('Помилка при оновленні твору');

--- a/app/(logged_in)/creativity/(composition)/useUpdateWorkAction.ts
+++ b/app/(logged_in)/creativity/(composition)/useUpdateWorkAction.ts
@@ -5,6 +5,7 @@ import { useCallback, useState } from 'react';
 import toast from 'react-hot-toast';
 
 import {
+  PaginatedWorksDocument,
   UpdateCompositionInput,
   useUpdateCompositionMutation
 } from '~/types/graphql/generated/graphql';
@@ -13,7 +14,8 @@ import type { OpusCompositionData } from '~/types/opus';
 interface UseUpdateWorkActionResult {
   isUpdating: boolean;
   error: string | null;
-  handleUpdateComposition: (id: string, composition: OpusCompositionData) => Promise<void>;
+  clearError: () => void;
+  handleUpdateComposition: (id: string, composition: OpusCompositionData) => Promise<boolean>;
 }
 
 const TOAST_MESSAGES = {
@@ -44,24 +46,31 @@ export function useUpdateWorkAction(): UseUpdateWorkActionResult {
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
   const [updateCompositionMut, { loading: isUpdating }] = useUpdateCompositionMutation();
+  const clearError = useCallback(() => setError(null), []);
 
   const handleUpdateComposition = useCallback(
     async (id: string, composition: OpusCompositionData) => {
       setError(null);
+
       try {
         await updateCompositionMut({
           variables: {
             id,
             input: mapCompositionToUpdateInput(composition)
-          }
+          },
+          refetchQueries: [PaginatedWorksDocument],
+          awaitRefetchQueries: true
         });
+
         toast.success(TOAST_MESSAGES.UPDATE_SUCCESS);
         router.refresh();
+        return true;
       } catch (err) {
         const message = err instanceof Error ? err.message : TOAST_MESSAGES.UPDATE_ERROR;
         setError(message);
-        toast.error(`Помилка: ${message}`);
-        throw err;
+        
+        toast.error(message);
+        return false;
       }
     },
     [updateCompositionMut, router]
@@ -70,6 +79,7 @@ export function useUpdateWorkAction(): UseUpdateWorkActionResult {
   return {
     handleUpdateComposition,
     isUpdating,
-    error
+    error,
+    clearError
   };
 }

--- a/app/(logged_in)/creativity/(composition)/useUpdateWorkAction.ts
+++ b/app/(logged_in)/creativity/(composition)/useUpdateWorkAction.ts
@@ -1,14 +1,20 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import { useCallback, useState } from 'react';
 import toast from 'react-hot-toast';
 
 import {
-  PaginatedWorksDocument,
   UpdateCompositionInput,
   useUpdateCompositionMutation
 } from '~/types/graphql/generated/graphql';
 import type { OpusCompositionData } from '~/types/opus';
+
+interface UseUpdateWorkActionResult {
+  isUpdating: boolean;
+  error: string | null;
+  handleUpdateComposition: (id: string, composition: OpusCompositionData) => Promise<void>;
+}
 
 const TOAST_MESSAGES = {
   UPDATE_SUCCESS: 'Твір успішно оновлено',
@@ -34,31 +40,36 @@ const mapCompositionToUpdateInput = (composition: OpusCompositionData): UpdateCo
   }))
 });
 
-export function useUpdateWorkAction() {
+export function useUpdateWorkAction(): UseUpdateWorkActionResult {
   const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
   const [updateCompositionMut, { loading: isUpdating }] = useUpdateCompositionMutation();
 
-  const handleUpdateComposition = async (id: string, composition: OpusCompositionData) => {
-    try {
-      await updateCompositionMut({
-        variables: {
-          id,
-          input: mapCompositionToUpdateInput(composition)
-        },
-        refetchQueries: [PaginatedWorksDocument],
-        awaitRefetchQueries: true
-      });
-
-      toast.success(TOAST_MESSAGES.UPDATE_SUCCESS);
-      router.refresh();
-    } catch (error) {
-      toast.error(TOAST_MESSAGES.UPDATE_ERROR);
-      throw error;
-    }
-  };
+  const handleUpdateComposition = useCallback(
+    async (id: string, composition: OpusCompositionData) => {
+      setError(null);
+      try {
+        await updateCompositionMut({
+          variables: {
+            id,
+            input: mapCompositionToUpdateInput(composition)
+          }
+        });
+        toast.success(TOAST_MESSAGES.UPDATE_SUCCESS);
+        router.refresh();
+      } catch (err) {
+        const message = err instanceof Error ? err.message : TOAST_MESSAGES.UPDATE_ERROR;
+        setError(message);
+        toast.error(`Помилка: ${message}`);
+        throw err;
+      }
+    },
+    [updateCompositionMut, router]
+  );
 
   return {
     handleUpdateComposition,
-    isUpdating
+    isUpdating,
+    error
   };
 }

--- a/app/(logged_in)/creativity/WorksPageContent.tsx
+++ b/app/(logged_in)/creativity/WorksPageContent.tsx
@@ -54,7 +54,7 @@ function useDropdownState() {
 
 function WorksCreateAction() {
   const { anchorEl, triggerRef, handleClose, handleToggle } = useDropdownState();
-  const { isModalOpen, openModal, closeModal, handleSubmit } = useCreateWorkAction();
+  const { isModalOpen, openModal, closeModal, clearError, error, handleSubmit } = useCreateWorkAction();
 
   return (
     <>
@@ -86,7 +86,14 @@ function WorksCreateAction() {
       />
 
       {isModalOpen && (
-        <CompositionModal open={isModalOpen} mode="create" onClose={closeModal} onSubmit={handleSubmit} />
+        <CompositionModal
+          open={isModalOpen}
+          mode="create"
+          onClose={closeModal}
+          onSubmit={handleSubmit}
+          error={error}
+          onClearError={clearError}
+        />
       )}
     </>
   );

--- a/app/(logged_in)/creativity/WorksTable.test.tsx
+++ b/app/(logged_in)/creativity/WorksTable.test.tsx
@@ -191,7 +191,9 @@ describe('WorksTable', () => {
     });
 
     (useUpdateWorkAction as jest.Mock).mockReturnValue({
-      handleUpdateComposition: mockHandleUpdateComposition
+      handleUpdateComposition: mockHandleUpdateComposition,
+      error: null,
+      clearError: jest.fn()
     });
 
     (useShare as jest.Mock).mockReturnValue({

--- a/app/(logged_in)/creativity/WorksTable.tsx
+++ b/app/(logged_in)/creativity/WorksTable.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Box } from '@mui/material';
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import toast from 'react-hot-toast';
 
 import { useDeleteWorkAction } from './(composition)/useDeleteWorkAction';
@@ -177,17 +177,19 @@ export function WorksTable({ items, activeTab }: WorksTableProps) {
     unlinkComposition,
     setUnlinkComposition
   } = useDeleteWorkAction();
-  
-  const { handleUpdateComposition } = useUpdateWorkAction();
+
+  const { handleUpdateComposition, error, clearError } = useUpdateWorkAction();
   const { handleShare } = useShare();
+
+  const handleCloseComposition = useCallback(() => {
+    clearError();
+    closeEditComposition();
+  }, [clearError, closeEditComposition]);
 
   const handleSubmitComposition = async (compositionData: OpusCompositionData) => {
     if (!compositionId) return;
-    try {
-      await handleUpdateComposition(compositionId, compositionData);
-      closeEditComposition();
-    } catch {
-      // Помилка вже оброблена всередині handleUpdateComposition (setError та toast.error)
+    if (await handleUpdateComposition(compositionId, compositionData)) {
+      handleCloseComposition();
     }
   };
 
@@ -203,9 +205,9 @@ export function WorksTable({ items, activeTab }: WorksTableProps) {
 
     if (!compositionToEdit) {
       toast.error('Композицію не знайдено');
-      closeEditComposition();
+      handleCloseComposition();
     }
-  }, [compositionId, compositionToEdit, isCompositionLoading, closeEditComposition]);
+  }, [compositionId, compositionToEdit, isCompositionLoading, handleCloseComposition]);
 
   function groupsRow(group: GroupRowData): BaseRowData<GroupHeaderData, OpusWork, IndividualWork> {
     const isPublished = group.status === BaseContentStatuses.Published;
@@ -345,8 +347,10 @@ export function WorksTable({ items, activeTab }: WorksTableProps) {
         open={isEditOpen}
         mode="edit"
         initialValue={compositionToEdit}
-        onClose={closeEditComposition}
+        onClose={handleCloseComposition}
         onSubmit={handleSubmitComposition}
+        error={error}
+        onClearError={clearError}
       />
     </Box>
   );

--- a/app/(logged_in)/creativity/WorksTable.tsx
+++ b/app/(logged_in)/creativity/WorksTable.tsx
@@ -177,13 +177,18 @@ export function WorksTable({ items, activeTab }: WorksTableProps) {
     unlinkComposition,
     setUnlinkComposition
   } = useDeleteWorkAction();
+  
   const { handleUpdateComposition } = useUpdateWorkAction();
   const { handleShare } = useShare();
 
   const handleSubmitComposition = async (compositionData: OpusCompositionData) => {
     if (!compositionId) return;
-    await handleUpdateComposition(compositionId, compositionData);
-    closeEditComposition();
+    try {
+      await handleUpdateComposition(compositionId, compositionData);
+      closeEditComposition();
+    } catch {
+      // Помилка вже оброблена всередині handleUpdateComposition (setError та toast.error)
+    }
   };
 
   const handleShareComposition = (id: string) => {

--- a/app/(logged_in)/creativity/group/[id]/content/GroupContentView.tsx
+++ b/app/(logged_in)/creativity/group/[id]/content/GroupContentView.tsx
@@ -37,6 +37,7 @@ export const GroupContentView = ({ id }: GroupContentViewProps) => {
     isDirty,
     currentLanguage,
     errors,
+    invalidCompositionIds,
     anchors,
     publishedTitle,
     isDetailsExpanded,
@@ -108,9 +109,11 @@ export const GroupContentView = ({ id }: GroupContentViewProps) => {
     case 'works':
       return (
         <CollapsibleBlock title="Твори" defaultExpanded grip>
-          <GroupWorksSection 
-            works={groupData.compositions} 
-            onChange={(newWorks) => handleFieldChange('compositions', newWorks)} 
+          <GroupWorksSection
+            works={groupData.compositions}
+            onChange={(newWorks) => handleFieldChange('compositions', newWorks)}
+            compositionErrors={errors}
+            invalidCompositionIds={invalidCompositionIds}
           />
         </CollapsibleBlock>
       );

--- a/app/(logged_in)/creativity/group/[id]/content/GroupContentView.tsx
+++ b/app/(logged_in)/creativity/group/[id]/content/GroupContentView.tsx
@@ -37,7 +37,6 @@ export const GroupContentView = ({ id }: GroupContentViewProps) => {
     isDirty,
     currentLanguage,
     errors,
-    invalidCompositionIds,
     anchors,
     publishedTitle,
     isDetailsExpanded,
@@ -113,7 +112,6 @@ export const GroupContentView = ({ id }: GroupContentViewProps) => {
             works={groupData.compositions}
             onChange={(newWorks) => handleFieldChange('compositions', newWorks)}
             compositionErrors={errors}
-            invalidCompositionIds={invalidCompositionIds}
           />
         </CollapsibleBlock>
       );

--- a/app/(logged_in)/creativity/group/create/OpusView.test.tsx
+++ b/app/(logged_in)/creativity/group/create/OpusView.test.tsx
@@ -65,6 +65,7 @@ const createMockData = (
   details: initialOpusDetails,
   setDetails: jest.fn(),
   detailsErrors: { number: '', name: '', creationYear: '' },
+  duplicateCompositionNames: [],
   seoValue: initialOpusSeoValue,
   setSeoValue: jest.fn(),
   crop: null,

--- a/app/(logged_in)/creativity/group/create/OpusView.test.tsx
+++ b/app/(logged_in)/creativity/group/create/OpusView.test.tsx
@@ -18,16 +18,6 @@ jest.mock('next/navigation', () => ({
   useRouter: jest.fn(() => ({ push: mockPush }))
 }));
 
-const mockToastSuccess = jest.fn();
-const mockToastError = jest.fn();
-jest.mock('react-hot-toast', () => ({
-  __esModule: true,
-  default: {
-    success: (msg: string) => mockToastSuccess(msg),
-    error: (msg: string) => mockToastError(msg)
-  }
-}));
-
 jest.mock('~/shared/components/forms/seo-metadata-form/seo-metadata-block/SeoMetadataBlock', () => ({
   __esModule: true,
   default: ({ onChangeCrop }: MockSeoMetadataBlockProps) => (
@@ -65,8 +55,7 @@ const createMockData = (
   details: initialOpusDetails,
   setDetails: jest.fn(),
   detailsErrors: { number: '', name: '', creationYear: '' },
-  duplicateCompositionNames: [],
-  invalidCompositionIds: [],
+  compositionErrors: {},
   seoValue: initialOpusSeoValue,
   setSeoValue: jest.fn(),
   crop: null,
@@ -104,7 +93,6 @@ describe('OpusView Component', () => {
 
     await waitFor(() => {
       expect(handleSave).toHaveBeenCalled();
-      expect(mockToastSuccess).toHaveBeenCalled();
       expect(mockPush).toHaveBeenCalledWith('/creativity/group/new-opus-id/content?from=create');
     });
   });
@@ -117,7 +105,6 @@ describe('OpusView Component', () => {
 
     await waitFor(() => {
       expect(handleSave).toHaveBeenCalled();
-      expect(mockToastSuccess).toHaveBeenCalled();
       expect(mockPush).toHaveBeenCalledWith('/creativity/group/existing-opus-id/content?from=edit');
     });
   });
@@ -134,29 +121,28 @@ describe('OpusView Component', () => {
     expect(mockPush).not.toHaveBeenCalled();
   });
 
-  it('shows error toast when save fails with an Error instance', async () => {
-    const handleSave = jest.fn().mockRejectedValue(new Error('Network error'));
+  it('does not redirect when save returns no id after an error', async () => {
+    const handleSave = jest.fn().mockResolvedValue(undefined);
     render(<OpusView data={createMockData({ handleSave })} mode="create" />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Перейти до редагування' }));
 
     await waitFor(() => {
       expect(handleSave).toHaveBeenCalled();
-      expect(mockToastError).toHaveBeenCalledWith('Помилка: Network error');
     });
     expect(mockPush).not.toHaveBeenCalled();
   });
 
-  it('shows error toast when save fails with a string error', async () => {
-    const handleSave = jest.fn().mockRejectedValue('Something went wrong');
+  it('does not redirect when save returns no id after validation failure', async () => {
+    const handleSave = jest.fn().mockResolvedValue(undefined);
     render(<OpusView data={createMockData({ handleSave })} mode="create" />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Перейти до редагування' }));
 
     await waitFor(() => {
       expect(handleSave).toHaveBeenCalled();
-      expect(mockToastError).toHaveBeenCalledWith('Помилка: Something went wrong');
     });
+    expect(mockPush).not.toHaveBeenCalled();
   });
 
   it('calls setCrop with new crop data when onChangeCrop is triggered', () => {

--- a/app/(logged_in)/creativity/group/create/OpusView.test.tsx
+++ b/app/(logged_in)/creativity/group/create/OpusView.test.tsx
@@ -66,6 +66,7 @@ const createMockData = (
   setDetails: jest.fn(),
   detailsErrors: { number: '', name: '', creationYear: '' },
   duplicateCompositionNames: [],
+  invalidCompositionIds: [],
   seoValue: initialOpusSeoValue,
   setSeoValue: jest.fn(),
   crop: null,

--- a/app/(logged_in)/creativity/group/create/OpusView.tsx
+++ b/app/(logged_in)/creativity/group/create/OpusView.tsx
@@ -22,8 +22,9 @@ import { useUpsertOpus } from '~/shared/hooks/use-upsert-opus/useUpsertOpus';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
 
 interface OpusViewProps {
-  data: Omit<ReturnType<typeof useUpsertOpus>, 'duplicateCompositionNames'> & {
+  data: Omit<ReturnType<typeof useUpsertOpus>, 'duplicateCompositionNames' | 'invalidCompositionIds'> & {
     duplicateCompositionNames?: string[];
+    invalidCompositionIds?: string[];
   };
   mode?: 'create' | 'edit';
 }
@@ -34,6 +35,7 @@ export default function OpusView({ data, mode = 'create' }: Readonly<OpusViewPro
     setDetails,
     detailsErrors,
     duplicateCompositionNames,
+    invalidCompositionIds,
     seoValue,
     setSeoValue,
     crop,
@@ -86,6 +88,7 @@ export default function OpusView({ data, mode = 'create' }: Readonly<OpusViewPro
               onChange={setDetails}
               errors={detailsErrors}
               duplicateCompositionNames={duplicateCompositionNames}
+              invalidCompositionIds={invalidCompositionIds}
             />
           </AccordionDetails>
         </Accordion>

--- a/app/(logged_in)/creativity/group/create/OpusView.tsx
+++ b/app/(logged_in)/creativity/group/create/OpusView.tsx
@@ -22,7 +22,9 @@ import { useUpsertOpus } from '~/shared/hooks/use-upsert-opus/useUpsertOpus';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
 
 interface OpusViewProps {
-  data: ReturnType<typeof useUpsertOpus>;
+  data: Omit<ReturnType<typeof useUpsertOpus>, 'duplicateCompositionNames'> & {
+    duplicateCompositionNames?: string[];
+  };
   mode?: 'create' | 'edit';
 }
 
@@ -31,6 +33,7 @@ export default function OpusView({ data, mode = 'create' }: Readonly<OpusViewPro
     details,
     setDetails,
     detailsErrors,
+    duplicateCompositionNames,
     seoValue,
     setSeoValue,
     crop,
@@ -78,7 +81,12 @@ export default function OpusView({ data, mode = 'create' }: Readonly<OpusViewPro
             </Typography>
           </AccordionSummary>
           <AccordionDetails sx={styles.detailsContent}>
-            <OpusDetailsBlock value={details} onChange={setDetails} errors={detailsErrors} />
+            <OpusDetailsBlock
+              value={details}
+              onChange={setDetails}
+              errors={detailsErrors}
+              duplicateCompositionNames={duplicateCompositionNames}
+            />
           </AccordionDetails>
         </Accordion>
 

--- a/app/(logged_in)/creativity/group/create/OpusView.tsx
+++ b/app/(logged_in)/creativity/group/create/OpusView.tsx
@@ -3,13 +3,11 @@
 import { Accordion, AccordionDetails, AccordionSummary, Box, Typography } from '@mui/material';
 import { ChevronDown } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import toast from 'react-hot-toast';
 
 import { styles } from './page.styles';
 import {
   OPUS_DETAILS_LABELS,
   OPUS_GROUP_PATH,
-  OPUS_MUTATION_RESULTS,
   OPUS_PAGE_TITLES,
   OPUSES_BASE_PATH
 } from '~/constants/opus';
@@ -22,8 +20,12 @@ import { useUpsertOpus } from '~/shared/hooks/use-upsert-opus/useUpsertOpus';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
 
 interface OpusViewProps {
-  data: Omit<ReturnType<typeof useUpsertOpus>, 'duplicateCompositionNames' | 'invalidCompositionIds'> & {
+  data: Omit<
+    ReturnType<typeof useUpsertOpus>,
+    'duplicateCompositionNames' | 'duplicateCompositionErrors' | 'invalidCompositionIds'
+  > & {
     duplicateCompositionNames?: string[];
+    duplicateCompositionErrors?: Record<string, string>;
     invalidCompositionIds?: string[];
   };
   mode?: 'create' | 'edit';
@@ -35,6 +37,7 @@ export default function OpusView({ data, mode = 'create' }: Readonly<OpusViewPro
     setDetails,
     detailsErrors,
     duplicateCompositionNames,
+    duplicateCompositionErrors,
     invalidCompositionIds,
     seoValue,
     setSeoValue,
@@ -51,18 +54,13 @@ export default function OpusView({ data, mode = 'create' }: Readonly<OpusViewPro
       document.activeElement.blur();
     }
 
-    try {
-      const id = await handleSave(BaseContentStatuses.Draft);
+    const id = await handleSave(BaseContentStatuses.Draft);
 
-      if (!id) {
-        return;
-      }
-
-      toast.success(mode === 'create' ? OPUS_MUTATION_RESULTS.created : OPUS_MUTATION_RESULTS.updated);
-      router.push(`${OPUS_GROUP_PATH}/${id}/content?from=${mode}`);
-    } catch (error) {
-      toast.error(`Помилка: ${error instanceof Error ? error.message : String(error)}`);
+    if (!id) {
+      return;
     }
+
+    router.push(`${OPUS_GROUP_PATH}/${id}/content?from=${mode}`);
   };
 
   return (
@@ -88,6 +86,7 @@ export default function OpusView({ data, mode = 'create' }: Readonly<OpusViewPro
               onChange={setDetails}
               errors={detailsErrors}
               duplicateCompositionNames={duplicateCompositionNames}
+              duplicateCompositionErrors={duplicateCompositionErrors}
               invalidCompositionIds={invalidCompositionIds}
             />
           </AccordionDetails>

--- a/app/(logged_in)/creativity/group/create/OpusView.tsx
+++ b/app/(logged_in)/creativity/group/create/OpusView.tsx
@@ -22,11 +22,9 @@ import { BaseContentStatuses } from '~/types/enums/common.enums';
 interface OpusViewProps {
   data: Omit<
     ReturnType<typeof useUpsertOpus>,
-    'duplicateCompositionNames' | 'duplicateCompositionErrors' | 'invalidCompositionIds'
+    'compositionErrors'
   > & {
-    duplicateCompositionNames?: string[];
-    duplicateCompositionErrors?: Record<string, string>;
-    invalidCompositionIds?: string[];
+    compositionErrors?: Record<string, string>;
   };
   mode?: 'create' | 'edit';
 }
@@ -36,9 +34,7 @@ export default function OpusView({ data, mode = 'create' }: Readonly<OpusViewPro
     details,
     setDetails,
     detailsErrors,
-    duplicateCompositionNames,
-    duplicateCompositionErrors,
-    invalidCompositionIds,
+    compositionErrors,
     seoValue,
     setSeoValue,
     crop,
@@ -85,9 +81,7 @@ export default function OpusView({ data, mode = 'create' }: Readonly<OpusViewPro
               value={details}
               onChange={setDetails}
               errors={detailsErrors}
-              duplicateCompositionNames={duplicateCompositionNames}
-              duplicateCompositionErrors={duplicateCompositionErrors}
-              invalidCompositionIds={invalidCompositionIds}
+              compositionErrors={compositionErrors}
             />
           </AccordionDetails>
         </Accordion>

--- a/app/constants/opus.ts
+++ b/app/constants/opus.ts
@@ -125,6 +125,8 @@ export const OPUS_MUTATION_RESULTS = {
 } as const;
 
 export const COMPOSITION_NAME_REQUIRED_ERROR = 'Заповніть поле назви твору або оберіть твір зі списку';
+export const COMPOSITION_DUPLICATE_ERROR = 'Назви творів мають бути унікальними';
+export const COMPOSITION_REQUIRED_FIELDS_ERROR = 'Заповніть усі обов’язкові поля перед публікацією';
 
 export const COMPOSITION_MUTATION_RESULTS = {
   created: 'Твір створено',

--- a/app/constants/opus.ts
+++ b/app/constants/opus.ts
@@ -124,7 +124,7 @@ export const OPUS_MUTATION_RESULTS = {
   updateFailed: 'Не вдалося оновити групу'
 } as const;
 
-export const COMPOSITION_NAME_REQUIRED_ERROR = 'Заповніть поле назви твору або оберіть твір зі списку';
+export const COMPOSITION_NAME_REQUIRED_ERROR = 'Заповніть всі назви творів перед публікацією';
 export const COMPOSITION_DUPLICATE_ERROR = 'Назви творів мають бути унікальними';
 export const COMPOSITION_REQUIRED_FIELDS_ERROR = 'Заповніть усі обов’язкові поля перед публікацією';
 

--- a/app/constants/opus.ts
+++ b/app/constants/opus.ts
@@ -125,7 +125,8 @@ export const OPUS_MUTATION_RESULTS = {
 } as const;
 
 export const COMPOSITION_NAME_REQUIRED_ERROR = 'Заповніть всі назви творів перед публікацією';
-export const COMPOSITION_DUPLICATE_ERROR = 'Назви творів мають бути унікальними';
+export const COMPOSITION_DUPLICATE_ERROR = 'Група містить твори з однаковими назвами';
+export const COMPOSITION_DUPLICATE_INPUT_ERROR = 'Цю композицію вже додано до групи';
 export const COMPOSITION_REQUIRED_FIELDS_ERROR = 'Заповніть усі обов’язкові поля перед публікацією';
 
 export const COMPOSITION_MUTATION_RESULTS = {

--- a/app/constants/opus.ts
+++ b/app/constants/opus.ts
@@ -119,8 +119,12 @@ export const REQUIRED_FIELD_ERROR = 'Обовʼязкове поле';
 export const OPUS_MUTATION_RESULTS = {
   created: 'Групу створено',
   updated: 'Групу оновлено',
-  deleted: 'Групу видалено'
+  deleted: 'Групу видалено',
+  createFailed: 'Не вдалося створити групу',
+  updateFailed: 'Не вдалося оновити групу'
 } as const;
+
+export const COMPOSITION_NAME_REQUIRED_ERROR = 'Заповніть поле назви твору або оберіть твір зі списку';
 
 export const COMPOSITION_MUTATION_RESULTS = {
   created: 'Твір створено',

--- a/app/lib/utils/compositionErrors.test.ts
+++ b/app/lib/utils/compositionErrors.test.ts
@@ -1,0 +1,57 @@
+import {
+  getCompositionNameRequiredMessage,
+  getDuplicateCompositionError,
+  getDuplicateCompositionIds,
+  getDuplicateCompositionName,
+  getErrorMessage,
+  getInvalidCompositionIds,
+  isCompositionNameRequiredError,
+  normalizeCompositionName
+} from './compositionErrors';
+
+describe('composition error utilities', () => {
+  it('normalizes names using trimming and Ukrainian case folding', () => {
+    expect(normalizeCompositionName('  СОНАТА  ')).toBe('соната');
+  });
+
+  it('returns all ids sharing a non-empty normalized name', () => {
+    expect(
+      getDuplicateCompositionIds([
+        { id: 'one', name: ' Соната ' },
+        { id: 'two', name: 'соната' },
+        { id: 'three', name: '  ' },
+        { id: 'four', name: 'Концерт' }
+      ])
+    ).toEqual(['one', 'two']);
+  });
+
+  it('finds empty composition names', () => {
+    expect(getInvalidCompositionIds([{ id: 'one', name: ' ' }, { id: 'two', name: 'Valid' }])).toEqual(['one']);
+  });
+
+  it('extracts error messages from Error, string, and unknown values', () => {
+    expect(getErrorMessage(new Error('failed'))).toBe('failed');
+    expect(getErrorMessage('failed')).toBe('failed');
+    expect(getErrorMessage({ reason: 'failed' })).toBe('Unknown error');
+  });
+
+  it('parses duplicate and required-name errors', () => {
+    const duplicate = new Error('Композиція "  Соната  " вже існує');
+
+    expect(getDuplicateCompositionError(duplicate)).toEqual({
+      name: 'соната',
+      message: duplicate.message
+    });
+    expect(getDuplicateCompositionError(new Error('other'))).toBeNull();
+    expect(isCompositionNameRequiredError(new Error('Composition name is required'))).toBe(true);
+    expect(isCompositionNameRequiredError(new Error('other'))).toBe(false);
+    expect(getDuplicateCompositionError('not an Error')).toBeNull();
+    expect(getCompositionNameRequiredMessage()).toBeTruthy();
+  });
+
+  it('extracts duplicate names from errors and handles unsupported values', () => {
+    expect(getDuplicateCompositionName(new Error('Композиція "  Соната  " вже існує'))).toBe('соната');
+    expect(getDuplicateCompositionName(new Error('No quoted name'))).toBeNull();
+    expect(getDuplicateCompositionName('not an Error')).toBeNull();
+  });
+});

--- a/app/lib/utils/compositionErrors.ts
+++ b/app/lib/utils/compositionErrors.ts
@@ -1,0 +1,59 @@
+import { COMPOSITION_NAME_REQUIRED_ERROR } from '~/constants/opus';
+
+export const normalizeCompositionName = (name: string): string =>
+  name.trim().toLocaleLowerCase('uk-UA');
+
+export const getErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  return 'Unknown error';
+};
+
+export const getDuplicateCompositionError = (
+  error: unknown
+): { name: string; message: string } | null => {
+  const message = getErrorMessage(error);
+  const match = /"([^"]+)"/.exec(message);
+
+  if (!match?.[1]) {
+    return null;
+  }
+
+  return {
+    name: normalizeCompositionName(match[1]),
+    message
+  };
+};
+
+export const getInvalidCompositionIds = <
+  T extends { id: string; name: string }
+>(
+    compositions: T[]
+  ): string[] =>
+    compositions
+      .filter((composition) => !composition.name.trim())
+      .map((composition) => composition.id);
+
+export const isCompositionNameRequiredError = (
+  error: unknown
+): boolean =>
+  getErrorMessage(error) === 'Composition name is required';
+
+export const getCompositionNameRequiredMessage = (): string =>
+  COMPOSITION_NAME_REQUIRED_ERROR;
+
+export const getDuplicateCompositionName = (error: unknown): string | null => {
+  if (!(error instanceof Error)) {
+    return null;
+  }
+
+  const match = /"([^"]+)"/.exec(error.message);
+
+  return match?.[1] ? normalizeCompositionName(match[1]) : null;
+};

--- a/app/lib/utils/compositionErrors.ts
+++ b/app/lib/utils/compositionErrors.ts
@@ -3,6 +3,25 @@ import { COMPOSITION_NAME_REQUIRED_ERROR } from '~/constants/opus';
 export const normalizeCompositionName = (name: string): string =>
   name.trim().toLocaleLowerCase('uk-UA');
 
+export const getDuplicateCompositionIds = <T extends { id: string; name: string }>(
+  compositions: T[]
+): string[] => {
+  const idsByName = new Map<string, string[]>();
+
+  compositions.forEach((composition) => {
+    const name = normalizeCompositionName(composition.name);
+    if (!name) return;
+
+    const ids = idsByName.get(name) ?? [];
+    ids.push(composition.id);
+    idsByName.set(name, ids);
+  });
+
+  return Array.from(idsByName.values())
+    .filter((ids) => ids.length > 1)
+    .flat();
+};
+
 export const getErrorMessage = (error: unknown): string => {
   if (error instanceof Error) {
     return error.message;

--- a/app/lib/utils/compositionErrors.ts
+++ b/app/lib/utils/compositionErrors.ts
@@ -37,8 +37,10 @@ export const getErrorMessage = (error: unknown): string => {
 export const getDuplicateCompositionError = (
   error: unknown
 ): { name: string; message: string } | null => {
-  const message = getErrorMessage(error);
-  const match = /"([^"]+)"/.exec(message);
+  if (!(error instanceof Error)) {
+    return null;
+  }
+  const match = /^Композиція "([^"]+)" вже існує$/.exec(error.message);
 
   if (!match?.[1]) {
     return null;
@@ -46,7 +48,7 @@ export const getDuplicateCompositionError = (
 
   return {
     name: normalizeCompositionName(match[1]),
-    message
+    message: error.message
   };
 };
 

--- a/app/shared/components/creativity/group/works-section/GroupWorksSection.styles.ts
+++ b/app/shared/components/creativity/group/works-section/GroupWorksSection.styles.ts
@@ -48,5 +48,6 @@ export const styles: Record<string, SxProps<Theme>> = {
   rowIcon: {
     color: 'text.primary',
     flexShrink: 0
+    
   },
 };

--- a/app/shared/components/creativity/group/works-section/GroupWorksSection.test.tsx
+++ b/app/shared/components/creativity/group/works-section/GroupWorksSection.test.tsx
@@ -4,7 +4,7 @@ import React, { ReactNode } from 'react';
 
 import { GroupWorksSection } from './GroupWorksSection';
 import { WorkRowProps } from './WorkRow';
-import { OPUS_DELETE_MODAL, OPUS_DETAILS_LABELS } from '~/constants/opus';
+import { COMPOSITION_DUPLICATE_INPUT_ERROR, OPUS_DELETE_MODAL, OPUS_DETAILS_LABELS } from '~/constants/opus';
 import { handleSortableDragEnd } from '~/lib/utils/sortableDragEndHelper';
 import { useCompositionsForm } from '~/shared/hooks/use-compositions/useCompositions';
 import type { OpusCompositionData, OpusCompositionSuggestion } from '~/types/opus';
@@ -49,9 +49,16 @@ jest.mock('./WorkRow', () => ({
     fillComposition,
     openCreateModal,
     openEditModal,
-    setDeleteTargetId
+    setDeleteTargetId,
+    error,
+    hasError
   }: WorkRowProps) => (
-    <div data-testid={TEST_IDS.row(composition.id)} data-index={TEST_IDS.rowIndex(String(index))}>
+    <div
+      data-testid={TEST_IDS.row(composition.id)}
+      data-index={TEST_IDS.rowIndex(String(index))}
+      data-error={error}
+      data-has-error={String(Boolean(hasError))}
+    >
       <button
         data-testid={TEST_IDS.titleInput(composition.id)}
         onClick={() => updateCompositionTitle(composition.id, 'New')}
@@ -294,11 +301,24 @@ describe('GroupWorksSection Component', () => {
       <GroupWorksSection
         works={defaultWorks}
         onChange={jest.fn()}
-        duplicateCompositionNames={[`  ${defaultWorks[0].name}  `]}
+        compositionErrors={{ 'compositions.1.name': COMPOSITION_DUPLICATE_INPUT_ERROR }}
       />
     );
 
-    expect(screen.getByTestId(TEST_IDS.row('1'))).toBeInTheDocument();
+    expect(screen.getByTestId(TEST_IDS.row('1'))).toHaveAttribute('data-has-error', 'true');
+    expect(screen.getByTestId(TEST_IDS.row('1'))).toHaveAttribute('data-error', COMPOSITION_DUPLICATE_INPUT_ERROR);
+  });
+
+  it('marks the later occurrence of an in-form duplicate name', () => {
+    render(
+      <GroupWorksSection
+        works={[defaultWorks[0], { ...defaultWorks[1], name: ` ${defaultWorks[0].name.toUpperCase()} ` }]}
+        onChange={jest.fn()}
+      />
+    );
+
+    expect(screen.getByTestId(TEST_IDS.row('1'))).toHaveAttribute('data-has-error', 'true');
+    expect(screen.getByTestId(TEST_IDS.row('2'))).toHaveAttribute('data-error', COMPOSITION_DUPLICATE_INPUT_ERROR);
   });
 
   it('resets deleteTargetId to null when delete modal is closed', () => {

--- a/app/shared/components/creativity/group/works-section/GroupWorksSection.test.tsx
+++ b/app/shared/components/creativity/group/works-section/GroupWorksSection.test.tsx
@@ -289,6 +289,18 @@ describe('GroupWorksSection Component', () => {
     expect(screen.queryByTestId(TEST_IDS.deleteModal)).not.toBeInTheDocument();
   });
 
+  it('marks compositions reported as duplicate by the backend', () => {
+    render(
+      <GroupWorksSection
+        works={defaultWorks}
+        onChange={jest.fn()}
+        duplicateCompositionNames={[`  ${defaultWorks[0].name}  `]}
+      />
+    );
+
+    expect(screen.getByTestId(TEST_IDS.row('1'))).toBeInTheDocument();
+  });
+
   it('resets deleteTargetId to null when delete modal is closed', () => {
     mockUseCompositions.mockReturnValue({ ...mockHookReturns, deleteTargetId: '1' });
     render(<GroupWorksSection works={defaultWorks} onChange={jest.fn()} />);

--- a/app/shared/components/creativity/group/works-section/GroupWorksSection.tsx
+++ b/app/shared/components/creativity/group/works-section/GroupWorksSection.tsx
@@ -4,7 +4,7 @@ import { Box, Typography } from '@mui/material';
 import { styles } from './GroupWorksSection.styles';
 import { WorkRow } from './WorkRow';
 import Button from '~/components/design-system/button/Button';
-import { COMPOSITION_DUPLICATE_ERROR, COMPOSITION_NAME_REQUIRED_ERROR, OPUS_DETAILS_LABELS } from '~/constants/opus';
+import { COMPOSITION_DUPLICATE_ERROR, OPUS_DETAILS_LABELS } from '~/constants/opus';
 import { handleSortableDragEnd } from '~/lib/utils/sortableDragEndHelper';
 import { DeleteCompositionModal } from '~/shared/components/delete-composition-modal/DeleteCompositionModal';
 import CompositionModal from '~/shared/components/forms/opus-details-block/composition-modal/CompositionModal';
@@ -69,10 +69,6 @@ export const GroupWorksSection = ({
       return duplicateCompositionErrors[normalizedName] ?? COMPOSITION_DUPLICATE_ERROR;
     }
 
-    if (invalidCompositionIds.includes(composition.id)) {
-      return COMPOSITION_NAME_REQUIRED_ERROR;
-    }
-
     return undefined;
   };
 
@@ -114,6 +110,7 @@ export const GroupWorksSection = ({
                 composition={composition}
                 index={index}
                 error={getCompositionError(composition)}
+                hasError={invalidCompositionIds.includes(composition.id)}
                 excludedSuggestionIds={getExcludedSuggestionIds(works, index)}
                 updateCompositionTitle={updateCompositionTitle}
                 fillComposition={fillComposition}

--- a/app/shared/components/creativity/group/works-section/GroupWorksSection.tsx
+++ b/app/shared/components/creativity/group/works-section/GroupWorksSection.tsx
@@ -4,13 +4,14 @@ import { Box, Typography } from '@mui/material';
 import { styles } from './GroupWorksSection.styles';
 import { WorkRow } from './WorkRow';
 import Button from '~/components/design-system/button/Button';
-import { COMPOSITION_NAME_REQUIRED_ERROR, OPUS_DETAILS_LABELS } from '~/constants/opus';
+import { COMPOSITION_DUPLICATE_ERROR, COMPOSITION_NAME_REQUIRED_ERROR, OPUS_DETAILS_LABELS } from '~/constants/opus';
 import { handleSortableDragEnd } from '~/lib/utils/sortableDragEndHelper';
 import { DeleteCompositionModal } from '~/shared/components/delete-composition-modal/DeleteCompositionModal';
 import CompositionModal from '~/shared/components/forms/opus-details-block/composition-modal/CompositionModal';
 import { SortableItemWrapper } from '~/shared/components/sortable-item-wrapper/SortableItemWrapper';
 import { SortableList } from '~/shared/components/sortable-list/SortableList';
 import { getExcludedSuggestionIds, useCompositionsForm } from '~/shared/hooks/use-compositions/useCompositions';
+import { useDebounce } from '~/shared/hooks/use-debounce/useDebounce';
 import type { OpusCompositionData } from '~/types/opus';
 
 type GroupWorksSectionProps = {
@@ -31,10 +32,11 @@ export const GroupWorksSection = ({
   invalidCompositionIds = []
 }: GroupWorksSectionProps) => {
   const normalizeName = (name: string) => name.trim().toLocaleLowerCase('uk-UA');
+  const debouncedWorks = useDebounce(works);
 
   const compositionIdsByName = new Map<string, string[]>();
 
-  works.forEach((work) => {
+  debouncedWorks.forEach((work) => {
     const normalizedName = normalizeName(work.name);
 
     if (!normalizedName) return;
@@ -64,7 +66,7 @@ export const GroupWorksSection = ({
     }
 
     if (duplicateCompositionIds.has(composition.id)) {
-      return duplicateCompositionErrors[normalizedName];
+      return duplicateCompositionErrors[normalizedName] ?? COMPOSITION_DUPLICATE_ERROR;
     }
 
     if (invalidCompositionIds.includes(composition.id)) {

--- a/app/shared/components/creativity/group/works-section/GroupWorksSection.tsx
+++ b/app/shared/components/creativity/group/works-section/GroupWorksSection.tsx
@@ -11,31 +11,20 @@ import CompositionModal from '~/shared/components/forms/opus-details-block/compo
 import { SortableItemWrapper } from '~/shared/components/sortable-item-wrapper/SortableItemWrapper';
 import { SortableList } from '~/shared/components/sortable-list/SortableList';
 import { getExcludedSuggestionIds, useCompositionsForm } from '~/shared/hooks/use-compositions/useCompositions';
-import { useDebounce } from '~/shared/hooks/use-debounce/useDebounce';
 import type { OpusCompositionData } from '~/types/opus';
 
 type GroupWorksSectionProps = {
   works: OpusCompositionData[];
   onChange: (works: OpusCompositionData[]) => void;
-  duplicateCompositionNames?: string[];
-  duplicateCompositionErrors?: Record<string, string>;
   compositionErrors?: Record<string, string>;
-  invalidCompositionIds?: string[];
 };
 
-export const GroupWorksSection = ({
-  works,
-  onChange,
-  duplicateCompositionNames = [],
-  compositionErrors = {},
-  invalidCompositionIds = []
-}: GroupWorksSectionProps) => {
+export const GroupWorksSection = ({ works, onChange, compositionErrors = {} }: GroupWorksSectionProps) => {
   const normalizeName = (name: string) => name.trim().toLocaleLowerCase('uk-UA');
-  const debouncedWorks = useDebounce(works);
-
   const compositionIdsByName = new Map<string, string[]>();
+  const compositionFieldErrors = { ...compositionErrors };
 
-  debouncedWorks.forEach((work) => {
+  works.forEach((work) => {
     const normalizedName = normalizeName(work.name);
 
     if (!normalizedName) return;
@@ -45,31 +34,14 @@ export const GroupWorksSection = ({
     compositionIdsByName.set(normalizedName, ids);
   });
 
-  const externalDuplicateNames = new Set(duplicateCompositionNames.map(normalizeName));
+  compositionIdsByName.forEach((ids) => {
+    if (ids.length < 2) return;
 
-  const duplicateCompositionIds = new Set<string>();
-  const duplicateMessageCompositionIds = new Set<string>();
-
-  compositionIdsByName.forEach((ids, name) => {
-    if (ids.length > 1 || externalDuplicateNames.has(name)) {
-      ids.forEach((id) => duplicateCompositionIds.add(id));
-      ids.slice(1).forEach((id) => duplicateMessageCompositionIds.add(id));
-    }
+    ids.forEach((id, index) => {
+      const fieldPath = `compositions.${id}.name`;
+      compositionFieldErrors[fieldPath] ??= index === 0 ? '' : COMPOSITION_DUPLICATE_INPUT_ERROR;
+    });
   });
-
-  const getCompositionError = (composition: OpusCompositionData) => {
-    if (duplicateMessageCompositionIds.has(composition.id)) {
-      return COMPOSITION_DUPLICATE_INPUT_ERROR;
-    }
-
-    const compositionError = compositionErrors[`compositions.${composition.id}.name`];
-
-    if (compositionError && compositionError !== COMPOSITION_DUPLICATE_INPUT_ERROR) {
-      return compositionError;
-    }
-
-    return undefined;
-  };
 
   const {
     isModalOpen,
@@ -103,26 +75,26 @@ export const GroupWorksSection = ({
 
       <Box sx={styles.compositionsList}>
         <SortableList id="group-works-list" items={works.map((work) => work.id)} onDragEnd={handleDragEnd}>
-          {works.map((composition, index) => (
-            <SortableItemWrapper key={composition.id} id={composition.id} gripHandle={true}>
-              <WorkRow
-                composition={composition}
-                index={index}
-                error={getCompositionError(composition)}
-                hasError={
-                  invalidCompositionIds.includes(composition.id) ||
-                  duplicateCompositionIds.has(composition.id) ||
-                  Boolean(compositionErrors[`compositions.${composition.id}.name`])
-                }
-                excludedSuggestionIds={getExcludedSuggestionIds(works, index)}
-                updateCompositionTitle={updateCompositionTitle}
-                fillComposition={fillComposition}
-                openCreateModal={openCreateModal}
-                openEditModal={openEditModal}
-                setDeleteTargetId={setDeleteTargetId}
-              />
-            </SortableItemWrapper>
-          ))}
+          {works.map((composition, index) => {
+            const fieldError = compositionFieldErrors[`compositions.${composition.id}.name`];
+
+            return (
+              <SortableItemWrapper key={composition.id} id={composition.id} gripHandle={true}>
+                <WorkRow
+                  composition={composition}
+                  index={index}
+                  error={fieldError || undefined}
+                  hasError={fieldError !== undefined}
+                  excludedSuggestionIds={getExcludedSuggestionIds(works, index)}
+                  updateCompositionTitle={updateCompositionTitle}
+                  fillComposition={fillComposition}
+                  openCreateModal={openCreateModal}
+                  openEditModal={openEditModal}
+                  setDeleteTargetId={setDeleteTargetId}
+                />
+              </SortableItemWrapper>
+            );
+          })}
         </SortableList>
       </Box>
 

--- a/app/shared/components/creativity/group/works-section/GroupWorksSection.tsx
+++ b/app/shared/components/creativity/group/works-section/GroupWorksSection.tsx
@@ -10,16 +10,22 @@ import { DeleteCompositionModal } from '~/shared/components/delete-composition-m
 import CompositionModal from '~/shared/components/forms/opus-details-block/composition-modal/CompositionModal';
 import { SortableItemWrapper } from '~/shared/components/sortable-item-wrapper/SortableItemWrapper';
 import { SortableList } from '~/shared/components/sortable-list/SortableList';
-import { useCompositionsForm } from '~/shared/hooks/use-compositions/useCompositions';
+import { getExcludedSuggestionIds, useCompositionsForm } from '~/shared/hooks/use-compositions/useCompositions';
 import type { OpusCompositionData } from '~/types/opus';
 
 type GroupWorksSectionProps = {
   works: OpusCompositionData[];
   onChange: (works: OpusCompositionData[]) => void;
   duplicateCompositionNames?: string[];
+  invalidCompositionIds?: string[];
 };
 
-export const GroupWorksSection = ({ works, onChange, duplicateCompositionNames = [] }: GroupWorksSectionProps) => {
+export const GroupWorksSection = ({
+  works,
+  onChange,
+  duplicateCompositionNames = [],
+  invalidCompositionIds = []
+}: GroupWorksSectionProps) => {
   const normalizeName = (name: string) => name.trim().toLocaleLowerCase('uk-UA');
 
   const compositionIdsByName = new Map<string, string[]>();
@@ -82,6 +88,8 @@ export const GroupWorksSection = ({ works, onChange, duplicateCompositionNames =
                 composition={composition}
                 index={index}
                 hasDuplicateName={duplicateCompositionIds.has(composition.id)}
+                hasNameError={invalidCompositionIds.includes(composition.id)}
+                excludedSuggestionIds={getExcludedSuggestionIds(works, index)}
                 updateCompositionTitle={updateCompositionTitle}
                 fillComposition={fillComposition}
                 openCreateModal={openCreateModal}

--- a/app/shared/components/creativity/group/works-section/GroupWorksSection.tsx
+++ b/app/shared/components/creativity/group/works-section/GroupWorksSection.tsx
@@ -4,7 +4,7 @@ import { Box, Typography } from '@mui/material';
 import { styles } from './GroupWorksSection.styles';
 import { WorkRow } from './WorkRow';
 import Button from '~/components/design-system/button/Button';
-import { COMPOSITION_DUPLICATE_ERROR, OPUS_DETAILS_LABELS } from '~/constants/opus';
+import { COMPOSITION_DUPLICATE_INPUT_ERROR, OPUS_DETAILS_LABELS } from '~/constants/opus';
 import { handleSortableDragEnd } from '~/lib/utils/sortableDragEndHelper';
 import { DeleteCompositionModal } from '~/shared/components/delete-composition-modal/DeleteCompositionModal';
 import CompositionModal from '~/shared/components/forms/opus-details-block/composition-modal/CompositionModal';
@@ -27,7 +27,6 @@ export const GroupWorksSection = ({
   works,
   onChange,
   duplicateCompositionNames = [],
-  duplicateCompositionErrors = {},
   compositionErrors = {},
   invalidCompositionIds = []
 }: GroupWorksSectionProps) => {
@@ -49,24 +48,24 @@ export const GroupWorksSection = ({
   const externalDuplicateNames = new Set(duplicateCompositionNames.map(normalizeName));
 
   const duplicateCompositionIds = new Set<string>();
+  const duplicateMessageCompositionIds = new Set<string>();
 
   compositionIdsByName.forEach((ids, name) => {
     if (ids.length > 1 || externalDuplicateNames.has(name)) {
       ids.forEach((id) => duplicateCompositionIds.add(id));
+      ids.slice(1).forEach((id) => duplicateMessageCompositionIds.add(id));
     }
   });
 
   const getCompositionError = (composition: OpusCompositionData) => {
-    const normalizedName = normalizeName(composition.name);
+    if (duplicateMessageCompositionIds.has(composition.id)) {
+      return COMPOSITION_DUPLICATE_INPUT_ERROR;
+    }
 
     const compositionError = compositionErrors[`compositions.${composition.id}.name`];
 
-    if (compositionError) {
+    if (compositionError && compositionError !== COMPOSITION_DUPLICATE_INPUT_ERROR) {
       return compositionError;
-    }
-
-    if (duplicateCompositionIds.has(composition.id)) {
-      return duplicateCompositionErrors[normalizedName] ?? COMPOSITION_DUPLICATE_ERROR;
     }
 
     return undefined;
@@ -110,7 +109,11 @@ export const GroupWorksSection = ({
                 composition={composition}
                 index={index}
                 error={getCompositionError(composition)}
-                hasError={invalidCompositionIds.includes(composition.id)}
+                hasError={
+                  invalidCompositionIds.includes(composition.id) ||
+                  duplicateCompositionIds.has(composition.id) ||
+                  Boolean(compositionErrors[`compositions.${composition.id}.name`])
+                }
                 excludedSuggestionIds={getExcludedSuggestionIds(works, index)}
                 updateCompositionTitle={updateCompositionTitle}
                 fillComposition={fillComposition}

--- a/app/shared/components/creativity/group/works-section/GroupWorksSection.tsx
+++ b/app/shared/components/creativity/group/works-section/GroupWorksSection.tsx
@@ -16,9 +16,34 @@ import type { OpusCompositionData } from '~/types/opus';
 type GroupWorksSectionProps = {
   works: OpusCompositionData[];
   onChange: (works: OpusCompositionData[]) => void;
+  duplicateCompositionNames?: string[];
 };
 
-export const GroupWorksSection = ({ works, onChange }: GroupWorksSectionProps) => {
+export const GroupWorksSection = ({ works, onChange, duplicateCompositionNames = [] }: GroupWorksSectionProps) => {
+  const normalizeName = (name: string) => name.trim().toLocaleLowerCase('uk-UA');
+
+  const compositionIdsByName = new Map<string, string[]>();
+
+  works.forEach((work) => {
+    const normalizedName = normalizeName(work.name);
+
+    if (!normalizedName) return;
+
+    const ids = compositionIdsByName.get(normalizedName) ?? [];
+    ids.push(work.id);
+    compositionIdsByName.set(normalizedName, ids);
+  });
+
+  const externalDuplicateNames = new Set(duplicateCompositionNames.map(normalizeName));
+
+  const duplicateCompositionIds = new Set<string>();
+
+  compositionIdsByName.forEach((ids, name) => {
+    if (ids.length > 1 || externalDuplicateNames.has(name)) {
+      ids.forEach((id) => duplicateCompositionIds.add(id));
+    }
+  });
+  
   const {
     isModalOpen,
     modalMode,
@@ -56,6 +81,7 @@ export const GroupWorksSection = ({ works, onChange }: GroupWorksSectionProps) =
               <WorkRow
                 composition={composition}
                 index={index}
+                hasDuplicateName={duplicateCompositionIds.has(composition.id)}
                 updateCompositionTitle={updateCompositionTitle}
                 fillComposition={fillComposition}
                 openCreateModal={openCreateModal}

--- a/app/shared/components/creativity/group/works-section/GroupWorksSection.tsx
+++ b/app/shared/components/creativity/group/works-section/GroupWorksSection.tsx
@@ -4,7 +4,7 @@ import { Box, Typography } from '@mui/material';
 import { styles } from './GroupWorksSection.styles';
 import { WorkRow } from './WorkRow';
 import Button from '~/components/design-system/button/Button';
-import { OPUS_DETAILS_LABELS } from '~/constants/opus';
+import { COMPOSITION_NAME_REQUIRED_ERROR, OPUS_DETAILS_LABELS } from '~/constants/opus';
 import { handleSortableDragEnd } from '~/lib/utils/sortableDragEndHelper';
 import { DeleteCompositionModal } from '~/shared/components/delete-composition-modal/DeleteCompositionModal';
 import CompositionModal from '~/shared/components/forms/opus-details-block/composition-modal/CompositionModal';
@@ -17,6 +17,8 @@ type GroupWorksSectionProps = {
   works: OpusCompositionData[];
   onChange: (works: OpusCompositionData[]) => void;
   duplicateCompositionNames?: string[];
+  duplicateCompositionErrors?: Record<string, string>;
+  compositionErrors?: Record<string, string>;
   invalidCompositionIds?: string[];
 };
 
@@ -24,6 +26,8 @@ export const GroupWorksSection = ({
   works,
   onChange,
   duplicateCompositionNames = [],
+  duplicateCompositionErrors = {},
+  compositionErrors = {},
   invalidCompositionIds = []
 }: GroupWorksSectionProps) => {
   const normalizeName = (name: string) => name.trim().toLocaleLowerCase('uk-UA');
@@ -49,7 +53,27 @@ export const GroupWorksSection = ({
       ids.forEach((id) => duplicateCompositionIds.add(id));
     }
   });
-  
+
+  const getCompositionError = (composition: OpusCompositionData) => {
+    const normalizedName = normalizeName(composition.name);
+
+    const compositionError = compositionErrors[`compositions.${composition.id}.name`];
+
+    if (compositionError) {
+      return compositionError;
+    }
+
+    if (duplicateCompositionIds.has(composition.id)) {
+      return duplicateCompositionErrors[normalizedName];
+    }
+
+    if (invalidCompositionIds.includes(composition.id)) {
+      return COMPOSITION_NAME_REQUIRED_ERROR;
+    }
+
+    return undefined;
+  };
+
   const {
     isModalOpen,
     modalMode,
@@ -87,8 +111,7 @@ export const GroupWorksSection = ({
               <WorkRow
                 composition={composition}
                 index={index}
-                hasDuplicateName={duplicateCompositionIds.has(composition.id)}
-                hasNameError={invalidCompositionIds.includes(composition.id)}
+                error={getCompositionError(composition)}
                 excludedSuggestionIds={getExcludedSuggestionIds(works, index)}
                 updateCompositionTitle={updateCompositionTitle}
                 fillComposition={fillComposition}

--- a/app/shared/components/creativity/group/works-section/WorkRow.test.tsx
+++ b/app/shared/components/creativity/group/works-section/WorkRow.test.tsx
@@ -31,9 +31,9 @@ const mockProps: WorkRowProps = {
 
 jest.mock('~/shared/components/forms/opus-details-block/composition-title-input/CompositionTitleInput', () => ({
   __esModule: true,
-  default: ({ onChangeText, onSelectSuggestion, onCreateNew }: CompositionTitleInputProps) => (
+  default: ({ onChangeText, onSelectSuggestion, onCreateNew, error, helperMessage }: CompositionTitleInputProps) => (
     <div>
-      <input data-testid="title-input" onChange={(e) => onChangeText(e.target.value)} />
+      <input data-testid="title-input" data-error={String(Boolean(error))} data-helper={helperMessage} onChange={(e) => onChangeText(e.target.value)} />
       <button
         data-testid="suggest-btn"
         onClick={() => onSelectSuggestion({ id: 'test' } as OpusCompositionSuggestion)}
@@ -94,5 +94,12 @@ describe('WorkRow', () => {
       fireEvent.click(screen.getByTestId('create-btn'));
       expect(mockProps.openCreateModal).toHaveBeenCalledWith(0);
     });
+  });
+
+  it('passes composition validation errors to the title input', () => {
+    render(<WorkRow {...mockProps} error="Duplicate" hasError />);
+
+    expect(screen.getByTestId('title-input')).toHaveAttribute('data-error', 'true');
+    expect(screen.getByTestId('title-input')).toHaveAttribute('data-helper', 'Duplicate');
   });
 });

--- a/app/shared/components/creativity/group/works-section/WorkRow.tsx
+++ b/app/shared/components/creativity/group/works-section/WorkRow.tsx
@@ -9,6 +9,8 @@ export type WorkRowProps = {
   composition: OpusCompositionData;
   index: number;
   hasDuplicateName?: boolean;
+  hasNameError?: boolean;
+  excludedSuggestionIds?: string[];
   updateCompositionTitle: (id: string, title: string) => void;
   fillComposition: (index: number, suggestion: OpusCompositionSuggestion) => void;
   openCreateModal: (index: number) => void;
@@ -20,6 +22,8 @@ export const WorkRow = ({
   composition,
   index,
   hasDuplicateName = false,
+  hasNameError = false,
+  excludedSuggestionIds = [],
   updateCompositionTitle,
   fillComposition,
   openCreateModal,
@@ -31,7 +35,8 @@ export const WorkRow = ({
       <Box sx={styles.compositionInput}>
         <CompositionTitleInput
           value={composition.name}
-          error={hasDuplicateName}
+          error={hasDuplicateName || hasNameError}
+          excludedSuggestionIds={excludedSuggestionIds}
           onChangeText={(name) => updateCompositionTitle(composition.id, name)}
           onSelectSuggestion={(suggestion) => fillComposition(index, suggestion)}
           onCreateNew={() => openCreateModal(index)}

--- a/app/shared/components/creativity/group/works-section/WorkRow.tsx
+++ b/app/shared/components/creativity/group/works-section/WorkRow.tsx
@@ -9,6 +9,7 @@ export type WorkRowProps = {
   composition: OpusCompositionData;
   index: number;
   error?: string;
+  hasError?: boolean;
   excludedSuggestionIds?: string[];
   updateCompositionTitle: (id: string, title: string) => void;
   fillComposition: (index: number, suggestion: OpusCompositionSuggestion) => void;
@@ -21,6 +22,7 @@ export const WorkRow = ({
   composition,
   index,
   error,
+  hasError = false,
   excludedSuggestionIds = [],
   updateCompositionTitle,
   fillComposition,
@@ -32,7 +34,7 @@ export const WorkRow = ({
     <>
       <CompositionTitleInput
         value={composition.name}
-        error={Boolean(error)}
+        error={hasError || Boolean(error)}
         helperMessage={error}
         excludedSuggestionIds={excludedSuggestionIds}
         onChangeText={(name) => updateCompositionTitle(composition.id, name)}

--- a/app/shared/components/creativity/group/works-section/WorkRow.tsx
+++ b/app/shared/components/creativity/group/works-section/WorkRow.tsx
@@ -8,6 +8,7 @@ import type { OpusCompositionData, OpusCompositionSuggestion } from '~/types/opu
 export type WorkRowProps = {
   composition: OpusCompositionData;
   index: number;
+  hasDuplicateName?: boolean;
   updateCompositionTitle: (id: string, title: string) => void;
   fillComposition: (index: number, suggestion: OpusCompositionSuggestion) => void;
   openCreateModal: (index: number) => void;
@@ -18,6 +19,7 @@ export type WorkRowProps = {
 export const WorkRow = ({
   composition,
   index,
+  hasDuplicateName = false,
   updateCompositionTitle,
   fillComposition,
   openCreateModal,
@@ -29,6 +31,7 @@ export const WorkRow = ({
       <Box sx={styles.compositionInput}>
         <CompositionTitleInput
           value={composition.name}
+          error={hasDuplicateName}
           onChangeText={(name) => updateCompositionTitle(composition.id, name)}
           onSelectSuggestion={(suggestion) => fillComposition(index, suggestion)}
           onCreateNew={() => openCreateModal(index)}

--- a/app/shared/components/creativity/group/works-section/WorkRow.tsx
+++ b/app/shared/components/creativity/group/works-section/WorkRow.tsx
@@ -1,4 +1,4 @@
-import { Box, IconButton } from '@mui/material';
+import { IconButton } from '@mui/material';
 import { Pencil, Trash2 } from 'lucide-react';
 
 import { styles } from './GroupWorksSection.styles';
@@ -8,8 +8,7 @@ import type { OpusCompositionData, OpusCompositionSuggestion } from '~/types/opu
 export type WorkRowProps = {
   composition: OpusCompositionData;
   index: number;
-  hasDuplicateName?: boolean;
-  hasNameError?: boolean;
+  error?: string;
   excludedSuggestionIds?: string[];
   updateCompositionTitle: (id: string, title: string) => void;
   fillComposition: (index: number, suggestion: OpusCompositionSuggestion) => void;
@@ -21,8 +20,7 @@ export type WorkRowProps = {
 export const WorkRow = ({
   composition,
   index,
-  hasDuplicateName = false,
-  hasNameError = false,
+  error,
   excludedSuggestionIds = [],
   updateCompositionTitle,
   fillComposition,
@@ -32,20 +30,20 @@ export const WorkRow = ({
 }: WorkRowProps) => {
   return (
     <>
-      <Box sx={styles.compositionInput}>
-        <CompositionTitleInput
-          value={composition.name}
-          error={hasDuplicateName || hasNameError}
-          excludedSuggestionIds={excludedSuggestionIds}
-          onChangeText={(name) => updateCompositionTitle(composition.id, name)}
-          onSelectSuggestion={(suggestion) => fillComposition(index, suggestion)}
-          onCreateNew={() => openCreateModal(index)}
-        />
-      </Box>
+      <CompositionTitleInput
+        value={composition.name}
+        error={Boolean(error)}
+        helperMessage={error}
+        excludedSuggestionIds={excludedSuggestionIds}
+        onChangeText={(name) => updateCompositionTitle(composition.id, name)}
+        onSelectSuggestion={(suggestion) => fillComposition(index, suggestion)}
+        onCreateNew={() => openCreateModal(index)}
+      />
 
       <IconButton aria-label="Редагувати" onClick={() => openEditModal(index)} sx={styles.rowIcon}>
         <Pencil size={18} strokeWidth={1.5} />
       </IconButton>
+
       <IconButton aria-label="Видалити" onClick={() => setDeleteTargetId(composition.id)} sx={styles.rowIcon}>
         <Trash2 size={18} strokeWidth={1.5} />
       </IconButton>

--- a/app/shared/components/forms/opus-details-block/OpusDetailsBlock.tsx
+++ b/app/shared/components/forms/opus-details-block/OpusDetailsBlock.tsx
@@ -12,9 +12,10 @@ interface OpusDetailsBlockProps {
   value: OpusDetailsValue;
   onChange: (updater: (prev: OpusDetailsValue) => OpusDetailsValue) => void;
   errors: OpusDetailsErrors;
+  duplicateCompositionNames?: string[];
 }
 
-export default function OpusDetailsBlock({ value, onChange, errors }: Readonly<OpusDetailsBlockProps>) {
+export default function OpusDetailsBlock({ value, onChange, errors, duplicateCompositionNames }: Readonly<OpusDetailsBlockProps>) {
   const updateField = <Key extends keyof OpusDetailsValue>(key: Key, fieldValue: OpusDetailsValue[Key]): void => {
     onChange((prev) => ({ ...prev, [key]: fieldValue }));
   };
@@ -100,6 +101,7 @@ export default function OpusDetailsBlock({ value, onChange, errors }: Readonly<O
       <GroupWorksSection
         works={value.compositions}
         onChange={(compositions) => updateField('compositions', compositions)}
+        duplicateCompositionNames={duplicateCompositionNames}
       />
     </Box>
   );

--- a/app/shared/components/forms/opus-details-block/OpusDetailsBlock.tsx
+++ b/app/shared/components/forms/opus-details-block/OpusDetailsBlock.tsx
@@ -13,6 +13,7 @@ interface OpusDetailsBlockProps {
   onChange: (updater: (prev: OpusDetailsValue) => OpusDetailsValue) => void;
   errors: OpusDetailsErrors;
   duplicateCompositionNames?: string[];
+  duplicateCompositionErrors?: Record<string, string>;
   invalidCompositionIds?: string[];
 }
 
@@ -21,6 +22,7 @@ export default function OpusDetailsBlock({
   onChange,
   errors,
   duplicateCompositionNames,
+  duplicateCompositionErrors,
   invalidCompositionIds
 }: Readonly<OpusDetailsBlockProps>) {
   const updateField = <Key extends keyof OpusDetailsValue>(key: Key, fieldValue: OpusDetailsValue[Key]): void => {
@@ -109,6 +111,7 @@ export default function OpusDetailsBlock({
         works={value.compositions}
         onChange={(compositions) => updateField('compositions', compositions)}
         duplicateCompositionNames={duplicateCompositionNames}
+        duplicateCompositionErrors={duplicateCompositionErrors}
         invalidCompositionIds={invalidCompositionIds}
       />
     </Box>

--- a/app/shared/components/forms/opus-details-block/OpusDetailsBlock.tsx
+++ b/app/shared/components/forms/opus-details-block/OpusDetailsBlock.tsx
@@ -13,9 +13,16 @@ interface OpusDetailsBlockProps {
   onChange: (updater: (prev: OpusDetailsValue) => OpusDetailsValue) => void;
   errors: OpusDetailsErrors;
   duplicateCompositionNames?: string[];
+  invalidCompositionIds?: string[];
 }
 
-export default function OpusDetailsBlock({ value, onChange, errors, duplicateCompositionNames }: Readonly<OpusDetailsBlockProps>) {
+export default function OpusDetailsBlock({
+  value,
+  onChange,
+  errors,
+  duplicateCompositionNames,
+  invalidCompositionIds
+}: Readonly<OpusDetailsBlockProps>) {
   const updateField = <Key extends keyof OpusDetailsValue>(key: Key, fieldValue: OpusDetailsValue[Key]): void => {
     onChange((prev) => ({ ...prev, [key]: fieldValue }));
   };
@@ -102,6 +109,7 @@ export default function OpusDetailsBlock({ value, onChange, errors, duplicateCom
         works={value.compositions}
         onChange={(compositions) => updateField('compositions', compositions)}
         duplicateCompositionNames={duplicateCompositionNames}
+        invalidCompositionIds={invalidCompositionIds}
       />
     </Box>
   );

--- a/app/shared/components/forms/opus-details-block/OpusDetailsBlock.tsx
+++ b/app/shared/components/forms/opus-details-block/OpusDetailsBlock.tsx
@@ -12,18 +12,14 @@ interface OpusDetailsBlockProps {
   value: OpusDetailsValue;
   onChange: (updater: (prev: OpusDetailsValue) => OpusDetailsValue) => void;
   errors: OpusDetailsErrors;
-  duplicateCompositionNames?: string[];
-  duplicateCompositionErrors?: Record<string, string>;
-  invalidCompositionIds?: string[];
+  compositionErrors?: Record<string, string>;
 }
 
 export default function OpusDetailsBlock({
   value,
   onChange,
   errors,
-  duplicateCompositionNames,
-  duplicateCompositionErrors,
-  invalidCompositionIds
+  compositionErrors
 }: Readonly<OpusDetailsBlockProps>) {
   const updateField = <Key extends keyof OpusDetailsValue>(key: Key, fieldValue: OpusDetailsValue[Key]): void => {
     onChange((prev) => ({ ...prev, [key]: fieldValue }));
@@ -110,9 +106,7 @@ export default function OpusDetailsBlock({
       <GroupWorksSection
         works={value.compositions}
         onChange={(compositions) => updateField('compositions', compositions)}
-        duplicateCompositionNames={duplicateCompositionNames}
-        duplicateCompositionErrors={duplicateCompositionErrors}
-        invalidCompositionIds={invalidCompositionIds}
+        compositionErrors={compositionErrors}
       />
     </Box>
   );

--- a/app/shared/components/forms/opus-details-block/composition-modal/CompositionModal.tsx
+++ b/app/shared/components/forms/opus-details-block/composition-modal/CompositionModal.tsx
@@ -19,6 +19,8 @@ interface CompositionModalProps {
   initialValue?: OpusCompositionData | null;
   onClose: () => void;
   onSubmit: (composition: OpusCompositionData) => void;
+  error?: string | null;
+  onClearError?: () => void;
 }
 
 type MediaTarget = { field: 'audios' | 'notes'; rowId?: string };
@@ -48,7 +50,9 @@ export default function CompositionModal({
   mode,
   initialValue,
   onClose,
-  onSubmit
+  onSubmit,
+  error,
+  onClearError
 }: Readonly<CompositionModalProps>) {
   const [composition, setComposition] = useState<OpusCompositionData>(emptyComposition);
   const [titleError, setTitleError] = useState('');
@@ -69,6 +73,7 @@ export default function CompositionModal({
 
     if (key === 'name' && typeof value === 'string' && value.trim()) {
       setTitleError('');
+      onClearError?.();
     }
   };
 
@@ -194,8 +199,8 @@ export default function CompositionModal({
           label={`${COMPOSITION_MODAL_LABELS.name} *`}
           value={composition.name}
           onChange={(event) => updateField('name', event.target.value)}
-          error={Boolean(titleError)}
-          helperText={titleError}
+          error={Boolean(titleError || error)}
+          helperText={titleError || error}
           fullWidth
           size="small"
           sx={styles.field}

--- a/app/shared/components/forms/opus-details-block/composition-title-input/CompositionTitleInput.test.tsx
+++ b/app/shared/components/forms/opus-details-block/composition-title-input/CompositionTitleInput.test.tsx
@@ -77,6 +77,58 @@ describe('CompositionTitleInput', () => {
     expect(onSelectSuggestion).toHaveBeenCalledWith(expect.objectContaining({ id: 'c1' }));
   });
 
+  it('does not render suggestions already selected in another row', () => {
+    mockUseSearchCompositions.mockReturnValue({
+      data: {
+        searchCompositions: [
+          { id: 'selected', name: { uk: 'Already selected' } },
+          { id: 'available', name: { uk: 'Available suggestion' } }
+        ]
+      }
+    });
+
+    render(<CompositionTitleInput {...baseProps} value="" excludedSuggestionIds={['selected']} />);
+
+    const input = screen.getByRole('combobox');
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+    expect(screen.queryByText('Already selected')).not.toBeInTheDocument();
+    expect(screen.getByText('Available suggestion')).toBeInTheDocument();
+  });
+
+  it('closes the suggestions popup when the input loses focus', () => {
+    mockUseSearchCompositions.mockReturnValue({
+      data: { searchCompositions: [{ id: 'c1', name: { uk: 'Suggestion' } }] }
+    });
+
+    render(<CompositionTitleInput {...baseProps} value="Suggestion" />);
+
+    const input = screen.getByRole('combobox');
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    expect(screen.getByText('Suggestion')).toBeInTheDocument();
+
+    fireEvent.blur(input);
+    expect(screen.queryByText('Suggestion')).not.toBeInTheDocument();
+  });
+
+  it('ignores selection of the no-results option', () => {
+    mockUseSearchCompositions.mockReturnValue({ data: { searchCompositions: [] } });
+    const onSelectSuggestion = jest.fn();
+
+    render(<CompositionTitleInput {...baseProps} value="Missing" onSelectSuggestion={onSelectSuggestion} />);
+
+    const input = screen.getByRole('combobox');
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+    const noResultsOption = screen.getByText('Нічого не знайдено');
+    fireEvent.click(noResultsOption);
+
+    expect(onSelectSuggestion).not.toHaveBeenCalled();
+  });
+
   it('uses English title when Ukrainian title is missing, and empty string if both are missing', () => {
     mockUseSearchCompositions.mockReturnValue({
       data: {

--- a/app/shared/components/forms/opus-details-block/composition-title-input/CompositionTitleInput.tsx
+++ b/app/shared/components/forms/opus-details-block/composition-title-input/CompositionTitleInput.tsx
@@ -23,6 +23,7 @@ interface CompositionOption {
 
 export interface CompositionTitleInputProps {
   value: string;
+  error?: boolean;
   onChangeText: (title: string) => void;
   onSelectSuggestion: (suggestion: OpusCompositionSuggestion) => void;
   onCreateNew: () => void;
@@ -30,6 +31,7 @@ export interface CompositionTitleInputProps {
 
 export default function CompositionTitleInput({
   value,
+  error = false,
   onChangeText,
   onSelectSuggestion,
   onCreateNew
@@ -123,7 +125,7 @@ export default function CompositionTitleInput({
           </Box>
         );
       }}
-      renderInput={(params) => <TextField {...params} size="small" sx={styles.input} />}
+      renderInput={(params) => <TextField {...params} size="small" error={error} sx={styles.input} />}
     />
   );
 }

--- a/app/shared/components/forms/opus-details-block/composition-title-input/CompositionTitleInput.tsx
+++ b/app/shared/components/forms/opus-details-block/composition-title-input/CompositionTitleInput.tsx
@@ -24,6 +24,7 @@ interface CompositionOption {
 export interface CompositionTitleInputProps {
   value: string;
   error?: boolean;
+  excludedSuggestionIds?: string[];
   onChangeText: (title: string) => void;
   onSelectSuggestion: (suggestion: OpusCompositionSuggestion) => void;
   onCreateNew: () => void;
@@ -32,6 +33,7 @@ export interface CompositionTitleInputProps {
 export default function CompositionTitleInput({
   value,
   error = false,
+  excludedSuggestionIds = [],
   onChangeText,
   onSelectSuggestion,
   onCreateNew
@@ -40,7 +42,13 @@ export default function CompositionTitleInput({
 
   const debouncedSearch = useDebounce(value.trim(), 300);
   const { data } = useSearchCompositions(debouncedSearch);
-  const suggestions = useMemo(() => data?.searchCompositions ?? [], [data]);
+  const suggestions = useMemo(() => {
+    const excludedIds = new Set(excludedSuggestionIds);
+
+    return (data?.searchCompositions ?? []).filter(
+      (suggestion) => !suggestion.id || !excludedIds.has(suggestion.id)
+    );
+  }, [data, excludedSuggestionIds]);
 
   const options = useMemo<CompositionOption[]>(() => {
     const suggestionOptions = suggestions.map((suggestion, index) => ({

--- a/app/shared/components/forms/opus-details-block/composition-title-input/CompositionTitleInput.tsx
+++ b/app/shared/components/forms/opus-details-block/composition-title-input/CompositionTitleInput.tsx
@@ -24,6 +24,7 @@ interface CompositionOption {
 export interface CompositionTitleInputProps {
   value: string;
   error?: boolean;
+  helperMessage?: string;
   excludedSuggestionIds?: string[];
   onChangeText: (title: string) => void;
   onSelectSuggestion: (suggestion: OpusCompositionSuggestion) => void;
@@ -33,6 +34,7 @@ export interface CompositionTitleInputProps {
 export default function CompositionTitleInput({
   value,
   error = false,
+  helperMessage,
   excludedSuggestionIds = [],
   onChangeText,
   onSelectSuggestion,
@@ -45,9 +47,7 @@ export default function CompositionTitleInput({
   const suggestions = useMemo(() => {
     const excludedIds = new Set(excludedSuggestionIds);
 
-    return (data?.searchCompositions ?? []).filter(
-      (suggestion) => !suggestion.id || !excludedIds.has(suggestion.id)
-    );
+    return (data?.searchCompositions ?? []).filter((suggestion) => !suggestion.id || !excludedIds.has(suggestion.id));
   }, [data, excludedSuggestionIds]);
 
   const options = useMemo<CompositionOption[]>(() => {
@@ -133,7 +133,9 @@ export default function CompositionTitleInput({
           </Box>
         );
       }}
-      renderInput={(params) => <TextField {...params} size="small" error={error} sx={styles.input} />}
+      renderInput={(params) => (
+        <TextField {...params} size="small" error={error} helperText={helperMessage} sx={styles.input} />
+      )}
     />
   );
 }

--- a/app/shared/hooks/use-compositions/useCompositions.test.ts
+++ b/app/shared/hooks/use-compositions/useCompositions.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 
-import { toSuggestionAudio, toSuggestionNote, useCompositionsForm } from './useCompositions';
+import { getExcludedSuggestionIds, toSuggestionAudio, toSuggestionNote, useCompositionsForm } from './useCompositions';
 import { OpusCompositionData, OpusCompositionSuggestion } from '~/types/opus';
 
 jest.mock('../use-upsert-opus/useUpsertOpus', () => ({
@@ -56,6 +56,11 @@ describe('useCompositions Hook', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  it('returns ids of compositions selected in other rows', () => {
+    expect(getExcludedSuggestionIds(defaultWorks, 0)).toEqual(['2']);
+    expect(getExcludedSuggestionIds(defaultWorks, 1)).toEqual(['1']);
   });
 
   it('adds a new empty composition', () => {

--- a/app/shared/hooks/use-compositions/useCompositions.ts
+++ b/app/shared/hooks/use-compositions/useCompositions.ts
@@ -25,6 +25,9 @@ export const toSuggestionNote = (sheet: SheetMusicItem): OpusMediaFileData => ({
   publishDate: sheet.publishDate ?? ''
 });
 
+export const getExcludedSuggestionIds = (works: OpusCompositionData[], currentIndex: number): string[] =>
+  works.filter((_, index) => index !== currentIndex).map((work) => work.id);
+
 export const useCompositionsForm = (works: OpusCompositionData[], onChange: (works: OpusCompositionData[]) => void) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [modalMode, setModalMode] = useState<'create' | 'edit'>('create');

--- a/app/shared/hooks/use-group-content/useGroupContent.test.ts
+++ b/app/shared/hooks/use-group-content/useGroupContent.test.ts
@@ -4,14 +4,16 @@ import toast from 'react-hot-toast';
 
 import { useGroupContent } from './useGroupContent';
 import { useNavigationGuard } from '~/shared/hooks/use-navigation-guard/useNavigationGuard';
-import { useOpusById } from '~/shared/hooks/use-opuses/useOpuses';
+import { useDeleteOpus, useOpusById, useUpdateOpus } from '~/shared/hooks/use-opuses/useOpuses';
 import { useUnsavedChanges } from '~/shared/hooks/use-unsaved-changes/useUnsavedChanges';
-import { useDeleteOpusMutation, useUpdateOpusMutation } from '~/types/graphql/generated/graphql';
+import type { DeleteOpusMutationVariables, UpdateOpusMutationVariables } from '~/types/graphql/generated/graphql';
 import { OpusCompositionData } from '~/types/opus';
 
 const mockNavigate = jest.fn();
 const mockUpdateOpus = jest.fn();
 const mockDeleteOpus = jest.fn();
+const updateOpusForTest = (variables: UpdateOpusMutationVariables) => mockUpdateOpus({ variables });
+const deleteOpusForTest = (variables: DeleteOpusMutationVariables) => mockDeleteOpus({ variables });
 
 jest.mock('next/navigation', () => ({
   useSearchParams: jest.fn(() => ({
@@ -33,14 +35,9 @@ jest.mock('~/shared/hooks/use-unsaved-changes/useUnsavedChanges', () => ({
 }));
 
 jest.mock('~/shared/hooks/use-opuses/useOpuses', () => ({
-  useOpusById: jest.fn()
-}));
-
-jest.mock('~/types/graphql/generated/graphql', () => ({
-  useUpdateOpusMutation: jest.fn(),
-  useDeleteOpusMutation: jest.fn(),
-  OpusNumberKind: { Op: 'op', Sineop: 'sineop' },
-  OpusStatus: { Draft: 'draft', Published: 'published' }
+  useOpusById: jest.fn(),
+  useUpdateOpus: jest.fn(),
+  useDeleteOpus: jest.fn()
 }));
 
 jest.mock('~/constants/opus', () => ({
@@ -61,8 +58,13 @@ jest.mock('~/constants/opus', () => ({
     captionTooLong: 'captionTooLong'
   },
   OPUS_MUTATION_RESULTS: {
-    deleted: 'deleted'
+    deleted: 'deleted',
+    createFailed: 'createFailed',
+    updateFailed: 'updateFailed'
   },
+  COMPOSITION_DUPLICATE_ERROR: 'duplicate compositions',
+  COMPOSITION_NAME_REQUIRED_ERROR: 'required composition name',
+  COMPOSITION_REQUIRED_FIELDS_ERROR: 'Заповніть усі обов’язкові поля перед публікацією.',
   REQUIRED_FIELD_ERROR: 'REQUIRED_FIELD_ERROR'
 }));
 
@@ -99,6 +101,7 @@ const mockFetchedOpus = {
   compositions: [
     {
       id: 'comp-1',
+      name: { uk: 'Comp 1', en: 'Comp 1 EN' },
       title: { uk: 'Comp 1', en: 'Comp 1 EN' },
       genre: 'Sonata',
       year: 1920,
@@ -114,8 +117,8 @@ describe('useGroupContent Hook', () => {
     jest.clearAllMocks();
     (useNavigationGuard as jest.Mock).mockReturnValue({ navigate: mockNavigate });
     (useOpusById as jest.Mock).mockReturnValue({ data: undefined, loading: false, error: undefined });
-    (useUpdateOpusMutation as jest.Mock).mockReturnValue([mockUpdateOpus, { loading: false }]);
-    (useDeleteOpusMutation as jest.Mock).mockReturnValue([mockDeleteOpus, { loading: false }]);
+    (useUpdateOpus as jest.Mock).mockReturnValue([updateOpusForTest, { loading: false }]);
+    (useDeleteOpus as jest.Mock).mockReturnValue([deleteOpusForTest, { loading: false }]);
   });
 
   describe('Initialization & Data Parsing', () => {
@@ -467,7 +470,18 @@ describe('useGroupContent Hook', () => {
 
       mockUpdateOpus.mockRejectedValue(new Error('GraphQL Server Error'));
 
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const { result } = renderHook(() => useGroupContent('test-id'));
+
+      await act(async () => {
+        await result.current.handlePublishClick();
+      });
+
+      expect(toast.error).toHaveBeenCalledWith('GraphQL Server Error');
+    });
+
+    it('should map duplicate composition errors returned by the server', async () => {
+      (useOpusById as jest.Mock).mockReturnValue({ data: { opusById: mockFetchedOpus }, loading: false });
+      mockUpdateOpus.mockRejectedValue(new Error('Композиція "Comp 1" вже існує'));
 
       const { result } = renderHook(() => useGroupContent('test-id'));
 
@@ -475,9 +489,29 @@ describe('useGroupContent Hook', () => {
         await result.current.handlePublishClick();
       });
 
-      expect(consoleSpy).toHaveBeenCalled();
-      expect(toast.error).toHaveBeenCalledWith('Помилка при збереженні. Перевірте консоль.');
-      consoleSpy.mockRestore();
+      expect(result.current.errors['compositions.comp-1.name']).toContain('Comp 1');
+      expect(toast.error).toHaveBeenCalledWith('Композиція "Comp 1" вже існує');
+    });
+
+    it('should map required composition-name errors returned by the server', async () => {
+      (useOpusById as jest.Mock).mockReturnValue({ data: { opusById: mockFetchedOpus }, loading: false });
+
+      const { result } = renderHook(() => useGroupContent('test-id'));
+      mockUpdateOpus.mockImplementation(async () => {
+        const composition = result.current.groupData?.compositions[0];
+        if (composition) {
+          composition.name = ' ';
+        }
+        throw new Error('Composition name is required');
+      });
+
+      await act(async () => {
+        await result.current.handlePublishClick();
+      });
+
+      expect(toast.error).toHaveBeenCalledWith('required composition name');
+      expect(result.current.errors['compositions.comp-1.name']).toBe('');
+      expect(result.current.isDirty).toBe(false);
     });
     it('should strip temporary IDs (starting with photo- or containing -) on save', async () => {
       (useOpusById as jest.Mock).mockReturnValue({ data: { opusById: mockFetchedOpus }, loading: false });
@@ -587,7 +621,7 @@ describe('useGroupContent Hook', () => {
 
     it('should return early from handlePublishClick if isSaving is true', async () => {
       (useOpusById as jest.Mock).mockReturnValue({ data: { opusById: mockFetchedOpus }, loading: false });
-      (useUpdateOpusMutation as jest.Mock).mockReturnValue([mockUpdateOpus, { loading: true }]);
+      (useUpdateOpus as jest.Mock).mockReturnValue([updateOpusForTest, { loading: true }]);
 
       const { result } = renderHook(() => useGroupContent('test-id'));
 
@@ -744,6 +778,7 @@ describe('useGroupContent Hook', () => {
         compositions: [
           {
             id: 'c1',
+            name: { uk: 'Test Title', en: 'Test Title' },
             title: { uk: 'Test Title' },
             sheetMusic: [
               { name: '', url: null },
@@ -874,7 +909,7 @@ describe('useGroupContent Hook', () => {
       });
 
       expect(mockDeleteOpus).toHaveBeenCalledWith({ variables: { id: 'test-id' } });
-      expect(toast.error).toHaveBeenCalledWith('Не вдалося видалити групу. Спробуйте ще раз.');
+      expect(toast.error).toHaveBeenCalledWith('GraphQL Error');
       expect(result.current.isDeleteModalOpen).toBe(true);
       expect(mockNavigate).not.toHaveBeenCalled();
 
@@ -1189,6 +1224,81 @@ describe('useGroupContent Hook', () => {
       expect(resultShort.current.currentLanguage).toBe('EN');
     });
 
+    it('should validate Ukrainian and English photo captions that exceed the limit', async () => {
+      (useOpusById as jest.Mock).mockReturnValue({
+        data: {
+          opusById: {
+            ...mockFetchedOpus,
+            gallery: [
+              {
+                id: 'photo-uk-caption',
+                src: 'uk.jpg',
+                description: { uk: 'a'.repeat(251), en: '' },
+                altText: { uk: 'Valid alt', en: 'Valid alt' },
+                crop: null
+              },
+              {
+                id: 'photo-en-caption',
+                src: 'en.jpg',
+                description: { uk: '', en: 'a'.repeat(251) },
+                altText: { uk: 'Valid alt', en: 'Valid alt' },
+                crop: null
+              }
+            ]
+          }
+        },
+        loading: false
+      });
+
+      const { result } = renderHook(() => useGroupContent('test-id'));
+
+      await act(async () => {
+        await result.current.handlePublishClick();
+      });
+
+      expect(result.current.errors['photos[photo-uk-caption].caption.uk']).toBe('captionTooLong');
+      expect(result.current.errors['photos[photo-en-caption].caption.en']).toBe('captionTooLong');
+      expect(result.current.currentLanguage).toBe('EN');
+    });
+
+    it('should block publishing when composition names are duplicated or empty', async () => {
+      (useOpusById as jest.Mock).mockReturnValue({
+        data: {
+          opusById: {
+            ...mockFetchedOpus,
+            compositions: [
+              { id: 'first', name: { uk: 'Same' }, genre: '', year: 1920, audios: [], sheetMusic: [] },
+              { id: 'second', name: { uk: 'same' }, genre: '', year: 1920, audios: [], sheetMusic: [] }
+            ]
+          }
+        },
+        loading: false
+      });
+      const duplicateResult = renderHook(() => useGroupContent('test-id'));
+
+      await act(async () => {
+        await duplicateResult.result.current.handlePublishClick();
+      });
+      expect(toast.error).toHaveBeenCalledWith('duplicate compositions');
+
+      (useOpusById as jest.Mock).mockReturnValue({
+        data: {
+          opusById: {
+            ...mockFetchedOpus,
+            compositions: [{ id: 'empty', name: { uk: ' ' }, genre: '', year: 1920, audios: [], sheetMusic: [] }]
+          }
+        },
+        loading: false
+      });
+      const emptyResult = renderHook(() => useGroupContent('test-id'));
+
+      await act(async () => {
+        await emptyResult.result.current.handlePublishClick();
+      });
+      expect(toast.error).toHaveBeenCalledWith('required composition name');
+      expect(emptyResult.result.current.errors['compositions.empty.name']).toBe('');
+    });
+
     it('should trigger validation error when performance URL is missing but row is not empty', async () => {
       const customOpus = {
         ...mockFetchedOpus,
@@ -1215,6 +1325,116 @@ describe('useGroupContent Hook', () => {
       });
 
       expect(result.current.errors['performances[perf-no-url].url']).toBe('performanceUrl');
+    });
+
+    it('should preserve explicit block order and clear composition errors when compositions change', async () => {
+      (useOpusById as jest.Mock).mockReturnValue({
+        data: {
+          opusById: {
+            ...mockFetchedOpus,
+            blocksOrder: ['works', 'details'],
+            compositions: [
+              { id: 'first', name: { uk: 'Same' }, genre: '', year: 1920, audios: [], sheetMusic: [] },
+              { id: 'second', name: { uk: 'same' }, genre: '', year: 1920, audios: [], sheetMusic: [] }
+            ]
+          }
+        },
+        loading: false
+      });
+      const { result } = renderHook(() => useGroupContent('test-id'));
+
+      await waitFor(() => expect(result.current.groupData?.blocksOrder).toEqual(['works', 'details']));
+      await act(async () => {
+        await result.current.handlePublishClick();
+      });
+      expect(result.current.errors).toEqual({});
+
+      act(() => {
+        result.current.handleFieldChange('compositions', [
+          { id: 'first', name: 'Unique', genre: '', year: '', audios: [], notes: [] }
+        ]);
+      });
+      expect(result.current.errors).toEqual({});
+    });
+
+    it('should map notes without URLs and preserve direct crop coordinates', async () => {
+      (useOpusById as jest.Mock).mockReturnValue({ data: { opusById: mockFetchedOpus }, loading: false });
+      mockUpdateOpus.mockResolvedValue({ data: { updateOpus: { id: 'test-id' } } });
+      const { result } = renderHook(() => useGroupContent('test-id'));
+
+      await waitFor(() => expect(result.current.groupData).not.toBeNull());
+      act(() => {
+        result.current.handleFieldChange('photos', [
+          {
+            id: 'photo-direct-crop',
+            src: 'photo.jpg',
+            caption: { uk: '', en: '' },
+            altText: { uk: 'Alt', en: 'Alt' },
+            crop: { x: 1, y: 2, width: 3, height: 4 }
+          }
+        ]);
+        result.current.handleFieldChange('compositions', [
+          {
+            id: 'composition-note',
+            name: 'Composition',
+            genre: '',
+            year: '',
+            audios: [],
+            notes: [{ id: 'note', name: 'Note', fileUrl: null, publishDate: '' }]
+          }
+        ]);
+      });
+
+      await act(async () => {
+        await result.current.handlePublishClick();
+      });
+
+      const input = mockUpdateOpus.mock.calls[0][0].variables.input;
+      expect(input.compositions[0].notes[0].fileUrl).toBeNull();
+      expect(input.gallery[0].crop).toEqual({ x: 1, y: 2, width: 3, height: 4 });
+    });
+  });
+
+  describe('Composition validation from menu actions', () => {
+    it('should show duplicate-name feedback when publishing from the menu', async () => {
+      (useOpusById as jest.Mock).mockReturnValue({
+        data: {
+          opusById: {
+            ...mockFetchedOpus,
+            compositions: [
+              { id: 'first', name: { uk: 'Same' }, genre: '', year: 1920, audios: [], sheetMusic: [] },
+              { id: 'second', name: { uk: 'same' }, genre: '', year: 1920, audios: [], sheetMusic: [] }
+            ]
+          }
+        },
+        loading: false
+      });
+      const { result } = renderHook(() => useGroupContent('test-id'));
+
+      await act(async () => {
+        await result.current.handleMenuOptionClick('PUBLISH');
+      });
+
+      expect(toast.error).toHaveBeenCalledWith('duplicate compositions');
+    });
+
+    it('should show required-name feedback when publishing an empty composition from the menu', async () => {
+      (useOpusById as jest.Mock).mockReturnValue({
+        data: {
+          opusById: {
+            ...mockFetchedOpus,
+            compositions: [{ id: 'empty', name: { uk: ' ' }, genre: '', year: 1920, audios: [], sheetMusic: [] }]
+          }
+        },
+        loading: false
+      });
+      const { result } = renderHook(() => useGroupContent('test-id'));
+
+      await act(async () => {
+        await result.current.handleMenuOptionClick('PUBLISH');
+      });
+
+      expect(toast.error).toHaveBeenCalledWith('required composition name');
     });
   });
 

--- a/app/shared/hooks/use-group-content/useGroupContent.ts
+++ b/app/shared/hooks/use-group-content/useGroupContent.ts
@@ -6,7 +6,9 @@ import { createCompositionId } from '../use-upsert-opus/useUpsertOpus';
 import { isMediaItemFilled, mapMediaItemFromApi, resolveMediaName } from './compositionMedia';
 import { GroupData, GroupDataField, GroupPhoto } from '~/constants/creativity';
 import {
+  COMPOSITION_DUPLICATE_ERROR,
   COMPOSITION_NAME_REQUIRED_ERROR,
+  COMPOSITION_REQUIRED_FIELDS_ERROR,
   OPUS_FIELD_LIMITS,
   OPUS_MUTATION_RESULTS,
   OPUS_VALIDATION_MESSAGES,
@@ -15,6 +17,7 @@ import {
 import { EditorLanguage } from '~/constants/publications';
 import {
   getDuplicateCompositionError,
+  getDuplicateCompositionIds,
   getInvalidCompositionIds,
   isCompositionNameRequiredError,
   normalizeCompositionName
@@ -378,9 +381,11 @@ export const useGroupContent = (id: string) => {
         const duplicateErrors = Object.fromEntries(
           (groupData.compositions || [])
             .filter((composition) => normalizeCompositionName(composition.name) === duplicateError.name)
-            .map((composition) => [`compositions.${composition.id}.name`, duplicateError.message])
+            .map((composition) => [`compositions.${composition.id}.name`, COMPOSITION_DUPLICATE_ERROR])
         );
         setErrors((previous) => ({ ...previous, ...duplicateErrors }));
+        toast.error(COMPOSITION_DUPLICATE_ERROR);
+        return false;
       }
       if (isCompositionNameRequiredError(error)) {
         setInvalidCompositionIds(getInvalidCompositionIds(groupData.compositions || []));
@@ -448,6 +453,15 @@ export const useGroupContent = (id: string) => {
     const emptyCompositionIds = getInvalidCompositionIds(groupData?.compositions || []);
     setInvalidCompositionIds(emptyCompositionIds);
 
+    const duplicateCompositionIds = getDuplicateCompositionIds(groupData?.compositions || []);
+    if (duplicateCompositionIds.length > 0) {
+      (groupData?.compositions || [])
+        .filter((composition) => duplicateCompositionIds.includes(composition.id))
+        .forEach((composition) => {
+          newErrors[`compositions.${composition.id}.name`] = COMPOSITION_DUPLICATE_ERROR;
+        });
+    }
+
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };
@@ -487,12 +501,17 @@ export const useGroupContent = (id: string) => {
   const handlePublishClick = async () => {
     if (isSaving) return;
     if (!validate()) {
+      if (getDuplicateCompositionIds(groupData?.compositions || []).length > 0) {
+        toast.error(COMPOSITION_DUPLICATE_ERROR);
+        setIsDetailsExpanded(true);
+        return;
+      }
       if (groupData?.compositions.some((composition) => !composition.name.trim())) {
         toast.error(COMPOSITION_NAME_REQUIRED_ERROR);
         setIsDetailsExpanded(true);
         return;
       }
-      toast.error('Заповніть усі обов’язкові поля перед публікацією.');
+      toast.error(COMPOSITION_REQUIRED_FIELDS_ERROR);
       setIsDetailsExpanded(true);
       return;
     }
@@ -522,12 +541,17 @@ export const useGroupContent = (id: string) => {
     }
 
     if (!validate()) {
+      if (getDuplicateCompositionIds(groupData?.compositions || []).length > 0) {
+        toast.error(COMPOSITION_DUPLICATE_ERROR);
+        setIsDetailsExpanded(true);
+        return;
+      }
       if (groupData?.compositions.some((composition) => !composition.name.trim())) {
         toast.error(COMPOSITION_NAME_REQUIRED_ERROR);
         setIsDetailsExpanded(true);
         return;
       }
-      toast.error('Заповніть усі обов’язкові поля перед публікацією.');
+      toast.error(COMPOSITION_REQUIRED_FIELDS_ERROR);
       setIsDetailsExpanded(true);
       return;
     }

--- a/app/shared/hooks/use-group-content/useGroupContent.ts
+++ b/app/shared/hooks/use-group-content/useGroupContent.ts
@@ -482,7 +482,13 @@ export const useGroupContent = (id: string) => {
       );
       if (Array.isArray(value)) {
         const compositions = value as GroupData['compositions'];
-        setInvalidCompositionIds(getInvalidCompositionIds(compositions));
+        setInvalidCompositionIds((previousInvalidIds) =>
+          previousInvalidIds.filter((invalidId) =>
+            compositions.some(
+              (composition) => composition.id === invalidId && !composition.name.trim()
+            )
+          )
+        );
       }
     }
 

--- a/app/shared/hooks/use-group-content/useGroupContent.ts
+++ b/app/shared/hooks/use-group-content/useGroupContent.ts
@@ -7,7 +7,6 @@ import { isMediaItemFilled, mapMediaItemFromApi, resolveMediaName } from './comp
 import { GroupData, GroupDataField, GroupPhoto } from '~/constants/creativity';
 import {
   COMPOSITION_DUPLICATE_ERROR,
-  COMPOSITION_DUPLICATE_INPUT_ERROR,
   COMPOSITION_NAME_REQUIRED_ERROR,
   COMPOSITION_REQUIRED_FIELDS_ERROR,
   OPUS_FIELD_LIMITS,
@@ -24,14 +23,12 @@ import {
   normalizeCompositionName
 } from '~/lib/utils/compositionErrors';
 import { useNavigationGuard } from '~/shared/hooks/use-navigation-guard/useNavigationGuard';
-import { useOpusById } from '~/shared/hooks/use-opuses/useOpuses';
+import { useDeleteOpus, useOpusById, useUpdateOpus } from '~/shared/hooks/use-opuses/useOpuses';
 import { useUnsavedChanges } from '~/shared/hooks/use-unsaved-changes/useUnsavedChanges';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
 import {
   OpusNumberKind,
-  OpusStatus,
-  useDeleteOpusMutation,
-  useUpdateOpusMutation
+  OpusStatus
 } from '~/types/graphql/generated/graphql';
 import { FetchedOpusData } from '~/types/opus';
 
@@ -164,7 +161,6 @@ export const useGroupContent = (id: string) => {
   const [isDirty, setIsDirty] = useState(false);
   const [currentLanguage, setCurrentLanguage] = useState<EditorLanguage>('UA');
   const [errors, setErrors] = useState<Record<string, string>>({});
-  const [invalidCompositionIds, setInvalidCompositionIds] = useState<string[]>([]);
   const [anchors, setAnchors] = useState<MenuAnchor>({
     navigation: null,
     publish: null
@@ -172,9 +168,9 @@ export const useGroupContent = (id: string) => {
   const [publishedTitle, setPublishedTitle] = useState({ uk: '', en: '' });
   const [isDetailsExpanded, setIsDetailsExpanded] = useState(true);
   const [shouldExitAfterSave, setShouldExitAfterSave] = useState(false);
-  const [updateOpus, { loading: isSaving }] = useUpdateOpusMutation();
+  const [updateOpus, { loading: isSaving }] = useUpdateOpus();
 
-  const [deleteOpus, { loading: isDeleting }] = useDeleteOpusMutation();
+  const [deleteOpus, { loading: isDeleting }] = useDeleteOpus();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   useUnsavedChanges(isDirty && !shouldExitAfterSave);
@@ -373,7 +369,7 @@ export const useGroupContent = (id: string) => {
           }))
           .filter((perf) => perf.videoUrl || perf.title.uk || perf.title.en)
       };
-      await updateOpus({ variables: { id, input } });
+      await updateOpus({ id, input });
       toast.success('Групу опубліковано');
       return true;
     } catch (error) {
@@ -382,14 +378,17 @@ export const useGroupContent = (id: string) => {
         const duplicateErrors = Object.fromEntries(
           (groupData.compositions || [])
             .filter((composition) => normalizeCompositionName(composition.name) === duplicateError.name)
-            .map((composition) => [`compositions.${composition.id}.name`, COMPOSITION_DUPLICATE_INPUT_ERROR])
+            .map((composition) => [`compositions.${composition.id}.name`, duplicateError.message])
         );
         setErrors((previous) => ({ ...previous, ...duplicateErrors }));
-        toast.error(COMPOSITION_DUPLICATE_ERROR);
+        toast.error(duplicateError.message);
         return false;
       }
       if (isCompositionNameRequiredError(error)) {
-        setInvalidCompositionIds(getInvalidCompositionIds(groupData.compositions || []));
+        const requiredNameErrors = Object.fromEntries(
+          getInvalidCompositionIds(groupData.compositions || []).map((id) => [`compositions.${id}.name`, ''])
+        );
+        setErrors((previous) => ({ ...previous, ...requiredNameErrors }));
         toast.error(COMPOSITION_NAME_REQUIRED_ERROR);
         return false;
       }
@@ -452,19 +451,14 @@ export const useGroupContent = (id: string) => {
     }
 
     const emptyCompositionIds = getInvalidCompositionIds(groupData?.compositions || []);
-    setInvalidCompositionIds(emptyCompositionIds);
+    emptyCompositionIds.forEach((id) => {
+      newErrors[`compositions.${id}.name`] = '';
+    });
 
-    const duplicateCompositionIds = getDuplicateCompositionIds(groupData?.compositions || []);
-    if (duplicateCompositionIds.length > 0) {
-      (groupData?.compositions || [])
-        .filter((composition) => duplicateCompositionIds.includes(composition.id))
-        .forEach((composition) => {
-          newErrors[`compositions.${composition.id}.name`] = COMPOSITION_DUPLICATE_INPUT_ERROR;
-        });
-    }
+    const hasDuplicateCompositionNames = getDuplicateCompositionIds(groupData?.compositions || []).length > 0;
 
     setErrors(newErrors);
-    return Object.keys(newErrors).length === 0;
+    return Object.keys(newErrors).length === 0 && !hasDuplicateCompositionNames;
   };
 
   const handleFieldChange = (field: GroupDataField | 'blocksOrder', value: unknown, isMultilingual = false) => {
@@ -481,16 +475,6 @@ export const useGroupContent = (id: string) => {
       setErrors((previous) =>
         Object.fromEntries(Object.entries(previous).filter(([key]) => !key.startsWith('compositions.')))
       );
-      if (Array.isArray(value)) {
-        const compositions = value as GroupData['compositions'];
-        setInvalidCompositionIds((previousInvalidIds) =>
-          previousInvalidIds.filter((invalidId) =>
-            compositions.some(
-              (composition) => composition.id === invalidId && !composition.name.trim()
-            )
-          )
-        );
-      }
     }
 
     setGroupData((prev) => {
@@ -531,7 +515,7 @@ export const useGroupContent = (id: string) => {
 
   const handleConfirmDelete = async () => {
     try {
-      await deleteOpus({ variables: { id } });
+      await deleteOpus({ id });
       toast.success(OPUS_MUTATION_RESULTS.deleted);
       setIsDeleteModalOpen(false);
       navigate('/creativity');
@@ -582,7 +566,6 @@ export const useGroupContent = (id: string) => {
     isDirty,
     currentLanguage,
     errors,
-    invalidCompositionIds,
     anchors,
     publishedTitle,
     isDetailsExpanded,

--- a/app/shared/hooks/use-group-content/useGroupContent.ts
+++ b/app/shared/hooks/use-group-content/useGroupContent.ts
@@ -6,12 +6,19 @@ import { createCompositionId } from '../use-upsert-opus/useUpsertOpus';
 import { isMediaItemFilled, mapMediaItemFromApi, resolveMediaName } from './compositionMedia';
 import { GroupData, GroupDataField, GroupPhoto } from '~/constants/creativity';
 import {
+  COMPOSITION_NAME_REQUIRED_ERROR,
   OPUS_FIELD_LIMITS,
   OPUS_MUTATION_RESULTS,
   OPUS_VALIDATION_MESSAGES,
   REQUIRED_FIELD_ERROR
 } from '~/constants/opus';
 import { EditorLanguage } from '~/constants/publications';
+import {
+  getDuplicateCompositionError,
+  getInvalidCompositionIds,
+  isCompositionNameRequiredError,
+  normalizeCompositionName
+} from '~/lib/utils/compositionErrors';
 import { useNavigationGuard } from '~/shared/hooks/use-navigation-guard/useNavigationGuard';
 import { useOpusById } from '~/shared/hooks/use-opuses/useOpuses';
 import { useUnsavedChanges } from '~/shared/hooks/use-unsaved-changes/useUnsavedChanges';
@@ -153,6 +160,7 @@ export const useGroupContent = (id: string) => {
   const [isDirty, setIsDirty] = useState(false);
   const [currentLanguage, setCurrentLanguage] = useState<EditorLanguage>('UA');
   const [errors, setErrors] = useState<Record<string, string>>({});
+  const [invalidCompositionIds, setInvalidCompositionIds] = useState<string[]>([]);
   const [anchors, setAnchors] = useState<MenuAnchor>({
     navigation: null,
     publish: null
@@ -365,8 +373,21 @@ export const useGroupContent = (id: string) => {
       toast.success('Групу опубліковано');
       return true;
     } catch (error) {
-      console.error('Помилка при збереженні контенту групи:', error);
-      toast.error('Помилка при збереженні. Перевірте консоль.');
+      const duplicateError = getDuplicateCompositionError(error);
+      if (duplicateError) {
+        const duplicateErrors = Object.fromEntries(
+          (groupData.compositions || [])
+            .filter((composition) => normalizeCompositionName(composition.name) === duplicateError.name)
+            .map((composition) => [`compositions.${composition.id}.name`, duplicateError.message])
+        );
+        setErrors((previous) => ({ ...previous, ...duplicateErrors }));
+      }
+      if (isCompositionNameRequiredError(error)) {
+        setInvalidCompositionIds(getInvalidCompositionIds(groupData.compositions || []));
+        toast.error(COMPOSITION_NAME_REQUIRED_ERROR);
+        return false;
+      }
+      toast.error(error instanceof Error ? error.message : String(error));
       return false;
     }
   };
@@ -424,6 +445,9 @@ export const useGroupContent = (id: string) => {
       newErrors.creationYear = REQUIRED_FIELD_ERROR;
     }
 
+    const emptyCompositionIds = getInvalidCompositionIds(groupData?.compositions || []);
+    setInvalidCompositionIds(emptyCompositionIds);
+
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };
@@ -436,6 +460,16 @@ export const useGroupContent = (id: string) => {
         delete newErrors[field as string];
         return newErrors;
       });
+    }
+
+    if (field === 'compositions') {
+      setErrors((previous) =>
+        Object.fromEntries(Object.entries(previous).filter(([key]) => !key.startsWith('compositions.')))
+      );
+      if (Array.isArray(value)) {
+        const compositions = value as GroupData['compositions'];
+        setInvalidCompositionIds(getInvalidCompositionIds(compositions));
+      }
     }
 
     setGroupData((prev) => {
@@ -453,6 +487,11 @@ export const useGroupContent = (id: string) => {
   const handlePublishClick = async () => {
     if (isSaving) return;
     if (!validate()) {
+      if (groupData?.compositions.some((composition) => !composition.name.trim())) {
+        toast.error(COMPOSITION_NAME_REQUIRED_ERROR);
+        setIsDetailsExpanded(true);
+        return;
+      }
       toast.error('Заповніть усі обов’язкові поля перед публікацією.');
       setIsDetailsExpanded(true);
       return;
@@ -471,8 +510,7 @@ export const useGroupContent = (id: string) => {
       setIsDeleteModalOpen(false);
       navigate('/creativity');
     } catch (error) {
-      console.error('Помилка при видаленні:', error);
-      toast.error('Не вдалося видалити групу. Спробуйте ще раз.');
+      toast.error(error instanceof Error ? error.message : String(error));
     }
   };
 
@@ -484,18 +522,25 @@ export const useGroupContent = (id: string) => {
     }
 
     if (!validate()) {
+      if (groupData?.compositions.some((composition) => !composition.name.trim())) {
+        toast.error(COMPOSITION_NAME_REQUIRED_ERROR);
+        setIsDetailsExpanded(true);
+        return;
+      }
       toast.error('Заповніть усі обов’язкові поля перед публікацією.');
       setIsDetailsExpanded(true);
       return;
     }
 
     if (optionId === 'PUBLISH') {
-      await handleSave(BaseContentStatuses.Published);
-      setIsDirty(false);
+      const isSuccess = await handleSave(BaseContentStatuses.Published);
+      if (isSuccess) setIsDirty(false);
     } else if (optionId === 'PUBLISH_AND_EXIT') {
-      await handleSave(BaseContentStatuses.Published);
-      setIsDirty(false);
-      setTimeout(() => setShouldExitAfterSave(true), 50);
+      const isSuccess = await handleSave(BaseContentStatuses.Published);
+      if (isSuccess) {
+        setIsDirty(false);
+        setTimeout(() => setShouldExitAfterSave(true), 50);
+      }
     }
   };
 
@@ -506,6 +551,7 @@ export const useGroupContent = (id: string) => {
     isDirty,
     currentLanguage,
     errors,
+    invalidCompositionIds,
     anchors,
     publishedTitle,
     isDetailsExpanded,

--- a/app/shared/hooks/use-group-content/useGroupContent.ts
+++ b/app/shared/hooks/use-group-content/useGroupContent.ts
@@ -7,6 +7,7 @@ import { isMediaItemFilled, mapMediaItemFromApi, resolveMediaName } from './comp
 import { GroupData, GroupDataField, GroupPhoto } from '~/constants/creativity';
 import {
   COMPOSITION_DUPLICATE_ERROR,
+  COMPOSITION_DUPLICATE_INPUT_ERROR,
   COMPOSITION_NAME_REQUIRED_ERROR,
   COMPOSITION_REQUIRED_FIELDS_ERROR,
   OPUS_FIELD_LIMITS,
@@ -381,7 +382,7 @@ export const useGroupContent = (id: string) => {
         const duplicateErrors = Object.fromEntries(
           (groupData.compositions || [])
             .filter((composition) => normalizeCompositionName(composition.name) === duplicateError.name)
-            .map((composition) => [`compositions.${composition.id}.name`, COMPOSITION_DUPLICATE_ERROR])
+            .map((composition) => [`compositions.${composition.id}.name`, COMPOSITION_DUPLICATE_INPUT_ERROR])
         );
         setErrors((previous) => ({ ...previous, ...duplicateErrors }));
         toast.error(COMPOSITION_DUPLICATE_ERROR);
@@ -458,7 +459,7 @@ export const useGroupContent = (id: string) => {
       (groupData?.compositions || [])
         .filter((composition) => duplicateCompositionIds.includes(composition.id))
         .forEach((composition) => {
-          newErrors[`compositions.${composition.id}.name`] = COMPOSITION_DUPLICATE_ERROR;
+          newErrors[`compositions.${composition.id}.name`] = COMPOSITION_DUPLICATE_INPUT_ERROR;
         });
     }
 

--- a/app/shared/hooks/use-upsert-opus/useUpsertOpus.test.ts
+++ b/app/shared/hooks/use-upsert-opus/useUpsertOpus.test.ts
@@ -1,7 +1,12 @@
 import { act, renderHook } from '@testing-library/react';
+import toast from 'react-hot-toast';
 
 import { createCompositionId, toCompositionInput,useUpsertOpus } from './useUpsertOpus';
-import { OPUS_VALIDATION_MESSAGES } from '~/constants/opus';
+import {
+  COMPOSITION_DUPLICATE_ERROR,
+  COMPOSITION_NAME_REQUIRED_ERROR,
+  OPUS_VALIDATION_MESSAGES
+} from '~/constants/opus';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
 import type { FetchedOpusData, OpusCompositionData } from '~/types/opus';
 
@@ -13,6 +18,11 @@ interface OpusByIdResult {
 const mockCreateOpus = jest.fn();
 const mockUpdateOpus = jest.fn();
 let mockOpusByIdResult: OpusByIdResult;
+
+jest.mock('react-hot-toast', () => ({
+  success: jest.fn(),
+  error: jest.fn()
+}));
 
 jest.mock('~/shared/hooks/use-opuses/useOpuses', () => ({
   useCreateOpus: () => [mockCreateOpus],
@@ -205,6 +215,70 @@ describe('useUpsertOpus', () => {
     });
 
     expect(result.current.detailsErrors.name).toBe(OPUS_VALIDATION_MESSAGES.nameTooShort);
+  });
+
+  it('rejects empty and duplicate composition names before mutation', async () => {
+    const { result } = renderHook(() => useUpsertOpus());
+
+    act(() => {
+      result.current.setDetails((prev) => ({
+        ...prev,
+        number: '5',
+        name: 'Соната',
+        creationYear: '1922',
+        compositions: [
+          { id: 'empty', name: '  ', genre: '', year: '', audios: [], notes: [] },
+          { id: 'first', name: ' Соната ', genre: '', year: '', audios: [], notes: [] },
+          { id: 'second', name: 'Соната', genre: '', year: '', audios: [], notes: [] }
+        ]
+      }));
+    });
+
+    await act(async () => {
+      await result.current.handleSave(BaseContentStatuses.Draft);
+    });
+
+    expect(mockCreateOpus).not.toHaveBeenCalled();
+    expect(result.current.compositionErrors).toEqual({ 'compositions.empty.name': '' });
+    expect(toast.error).toHaveBeenCalledWith(COMPOSITION_DUPLICATE_ERROR);
+    expect(toast.error).toHaveBeenCalledWith(COMPOSITION_NAME_REQUIRED_ERROR);
+  });
+
+  it('maps duplicate mutation errors to matching composition fields', async () => {
+    mockCreateOpus.mockRejectedValue(new Error('Композиція " Соната " вже існує'));
+    const { result } = renderHook(() => useUpsertOpus());
+    act(() => {
+      result.current.setDetails((prev) => ({
+        ...prev,
+        number: '5',
+        name: 'Група',
+        creationYear: '1922',
+        compositions: [
+          { id: 'first', name: ' Соната ', genre: '', year: '', audios: [], notes: [] },
+          { id: 'second', name: 'Концерт', genre: '', year: '', audios: [], notes: [] }
+        ]
+      }));
+    });
+
+    await act(async () => {
+      await result.current.handleSave(BaseContentStatuses.Draft);
+    });
+
+    expect(result.current.compositionErrors).toEqual({ 'compositions.first.name': expect.any(String) });
+    expect(result.current.isSaved).toBe(false);
+  });
+
+  it('reports non-composition mutation errors without throwing', async () => {
+    mockCreateOpus.mockRejectedValue(new Error('Network failed'));
+    const { result } = renderHook(() => useUpsertOpus());
+    fillValidDetails(result);
+
+    await act(async () => {
+      await result.current.handleSave(BaseContentStatuses.Draft);
+    });
+
+    expect(toast.error).toHaveBeenCalledWith('Network failed');
+    expect(result.current.isSaved).toBe(false);
   });
 
   it('creates an opus with mapped input when valid', async () => {

--- a/app/shared/hooks/use-upsert-opus/useUpsertOpus.ts
+++ b/app/shared/hooks/use-upsert-opus/useUpsertOpus.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import toast from 'react-hot-toast';
 
 import {
+  COMPOSITION_DUPLICATE_ERROR,
   COMPOSITION_NAME_REQUIRED_ERROR,
   initialOpusDetails,
   initialOpusSeoValue,
@@ -9,7 +10,7 @@ import {
   OPUS_MUTATION_RESULTS,
   OPUS_VALIDATION_MESSAGES
 } from '~/constants/opus';
-import  {getDuplicateCompositionError, getErrorMessage, getInvalidCompositionIds, isCompositionNameRequiredError } from '~/lib/utils/compositionErrors';
+import  {getDuplicateCompositionError, getDuplicateCompositionIds, getErrorMessage, getInvalidCompositionIds, isCompositionNameRequiredError } from '~/lib/utils/compositionErrors';
 import { generateUniqueId } from '~/lib/utils/generateUniqueId';
 import type { SeoBlockValue } from '~/shared/components/forms/seo-metadata-form/seo-metadata-block/SeoMetadataBlock';
 import { useCreateOpus, useOpusById, useUpdateOpus } from '~/shared/hooks/use-opuses/useOpuses';
@@ -293,6 +294,11 @@ export const useUpsertOpus = (
     const invalidIds = getInvalidCompositionIds(value.compositions);
     setInvalidCompositionIds(invalidIds);
 
+    const duplicateIds = getDuplicateCompositionIds(value.compositions);
+    if (duplicateIds.length > 0) {
+      toast.error(COMPOSITION_DUPLICATE_ERROR);
+    }
+
     if (invalidIds.length > 0) {
       toast.error( COMPOSITION_NAME_REQUIRED_ERROR);
     }
@@ -301,7 +307,8 @@ export const useUpsertOpus = (
       !numberError &&
       !nameError &&
       !creationYearError &&
-      invalidIds.length === 0
+      invalidIds.length === 0 &&
+      duplicateIds.length === 0
     );
   };
 

--- a/app/shared/hooks/use-upsert-opus/useUpsertOpus.ts
+++ b/app/shared/hooks/use-upsert-opus/useUpsertOpus.ts
@@ -10,13 +10,23 @@ import {
   OPUS_MUTATION_RESULTS,
   OPUS_VALIDATION_MESSAGES
 } from '~/constants/opus';
-import  {getDuplicateCompositionError, getDuplicateCompositionIds, getErrorMessage, getInvalidCompositionIds, isCompositionNameRequiredError } from '~/lib/utils/compositionErrors';
+import {
+  getDuplicateCompositionError,
+  getDuplicateCompositionIds,
+  getErrorMessage,
+  getInvalidCompositionIds,
+  isCompositionNameRequiredError,
+  normalizeCompositionName
+} from '~/lib/utils/compositionErrors';
 import { generateUniqueId } from '~/lib/utils/generateUniqueId';
 import type { SeoBlockValue } from '~/shared/components/forms/seo-metadata-form/seo-metadata-block/SeoMetadataBlock';
 import { useCreateOpus, useOpusById, useUpdateOpus } from '~/shared/hooks/use-opuses/useOpuses';
 import { CropRect } from '~/types/common';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
-import { OpusNumberKind, OpusStatus } from '~/types/graphql/generated/graphql';
+import {
+  OpusNumberKind,
+  OpusStatus
+} from '~/types/graphql/generated/graphql';
 import type {
   FetchedOpusData,
   OpusCompositionData,
@@ -78,9 +88,7 @@ export type UseUpsertOpusResult = {
 
   detailsErrors: OpusDetailsErrors;
 
-  duplicateCompositionNames: string[];
-  duplicateCompositionErrors?: Record<string, string>;
-  invalidCompositionIds: string[];
+  compositionErrors: Record<string, string>;
 
   seoValue: SeoBlockValue;
   setSeoValue: (
@@ -116,20 +124,7 @@ export const useUpsertOpus = (
     creationYear: ''
   });
 
-  const [
-    duplicateCompositionNames,
-    setDuplicateCompositionNames
-  ] = useState<string[]>([]);
-
-  const [
-    duplicateCompositionErrors,
-    setDuplicateCompositionErrors
-  ] = useState<Record<string, string>>({});
-
-  const [
-    invalidCompositionIds,
-    setInvalidCompositionIds
-  ] = useState<string[]>([]);
+  const [compositionErrors, setCompositionErrors] = useState<Record<string, string>>({});
 
   const [seoValue, setSeoValue] =
     useState<SeoBlockValue>(initialOpusSeoValue);
@@ -141,10 +136,7 @@ export const useUpsertOpus = (
   const latestDataRef = useRef({ details, seoValue, crop });
   const isInitializedRef = useRef(false);
 
-  const clearCompositionServerErrors = useCallback(() => {
-    setDuplicateCompositionNames([]);
-    setDuplicateCompositionErrors({});
-  }, []);
+  const clearCompositionErrors = useCallback(() => setCompositionErrors({}), []);
 
   const changeDetails = useCallback((
     value:
@@ -164,15 +156,7 @@ export const useUpsertOpus = (
     setIsSaved(false);
 
     if (next.compositions !== previousDetails.compositions) {
-      clearCompositionServerErrors();
-
-      setInvalidCompositionIds((previousInvalidIds) =>
-        previousInvalidIds.filter((invalidId) =>
-          next.compositions.some(
-            (composition) => composition.id === invalidId && !composition.name.trim()
-          )
-        )
-      );
+      clearCompositionErrors();
     }
 
 
@@ -181,7 +165,7 @@ export const useUpsertOpus = (
       name: next.name.trim() ? '' : prev.name,
       creationYear: next.creationYear.trim() ? '' : prev.creationYear
     }));
-  }, [clearCompositionServerErrors]);
+  }, [clearCompositionErrors]);
 
   const changeSeoValue = useCallback((value: SeoBlockValue | ((prev: SeoBlockValue) => SeoBlockValue)) => {
     const next = typeof value === 'function' ? value(latestDataRef.current.seoValue) : value;
@@ -294,7 +278,9 @@ export const useUpsertOpus = (
     setDetailsErrors(errors);
 
     const invalidIds = getInvalidCompositionIds(value.compositions);
-    setInvalidCompositionIds(invalidIds);
+    setCompositionErrors(
+      Object.fromEntries(invalidIds.map((id) => [`compositions.${id}.name`, '']))
+    );
 
     const duplicateIds = getDuplicateCompositionIds(value.compositions);
     if (duplicateIds.length > 0) {
@@ -322,10 +308,12 @@ export const useUpsertOpus = (
     const duplicateError = getDuplicateCompositionError(error);
 
     if (duplicateError) {
-      setDuplicateCompositionNames([ duplicateError.name ]);
-      setDuplicateCompositionErrors({
-        [duplicateError.name]: duplicateError.message
-      });
+      const duplicateErrors = Object.fromEntries(
+        latestDataRef.current.details.compositions
+          .filter((composition) => normalizeCompositionName(composition.name) === duplicateError.name)
+          .map((composition) => [`compositions.${composition.id}.name`, duplicateError.message])
+      );
+      setCompositionErrors((previous) => ({ ...previous, ...duplicateErrors }));
 
       toast.error(duplicateError.message);
       return;
@@ -333,7 +321,9 @@ export const useUpsertOpus = (
 
     if (isCompositionNameRequiredError(error)) {
       const invalidIds = getInvalidCompositionIds(latestDataRef.current.details.compositions);
-      setInvalidCompositionIds(invalidIds);
+      setCompositionErrors(
+        Object.fromEntries(invalidIds.map((id) => [`compositions.${id}.name`, '']))
+      );
 
       toast.error(COMPOSITION_NAME_REQUIRED_ERROR);
       return;
@@ -351,8 +341,7 @@ export const useUpsertOpus = (
       return undefined;
     }
 
-    clearCompositionServerErrors();
-    setInvalidCompositionIds([]);
+    clearCompositionErrors();
 
     const { uk: ukMeta, en: enMeta } = currentSeo.meta;
     const opusName = currentDetails.name.trim();
@@ -428,9 +417,7 @@ export const useUpsertOpus = (
     details,
     setDetails: changeDetails,
     detailsErrors,
-    duplicateCompositionNames,
-    duplicateCompositionErrors,
-    invalidCompositionIds,
+    compositionErrors,
     seoValue,
     setSeoValue: changeSeoValue,
     crop,

--- a/app/shared/hooks/use-upsert-opus/useUpsertOpus.ts
+++ b/app/shared/hooks/use-upsert-opus/useUpsertOpus.ts
@@ -42,6 +42,15 @@ export const toCompositionInput = (composition: OpusCompositionData): OpusCompos
     }))
 });
 
+const normalizeCompositionName = (name: string): string => name.trim().toLocaleLowerCase('uk-UA');
+
+const getDuplicateCompositionName = (error: unknown): string | null => {
+  const message = error instanceof Error ? error.message : String(error);
+  if (!message.startsWith('Композиція "')) return null;
+  const match = new RegExp(/"([^"]+)"/).exec(message);
+  return match?.[1] ? normalizeCompositionName(match[1]) : null;
+};
+
 const fileNameFromUrl = (url?: string | null): string => {
   if (!url) {
     return '';
@@ -69,6 +78,7 @@ export const useUpsertOpus = ({ id }: UseUpsertOpusProps = {}) => {
     name: '',
     creationYear: ''
   });
+  const [duplicateCompositionNames, setDuplicateCompositionNames] = useState<string[]>([]);
   const [seoValue, setSeoValue] = useState<SeoBlockValue>(initialOpusSeoValue);
   const [crop, setCrop] = useState<CropRect | null>(null);
   const [forceShowErrors, setForceShowErrors] = useState(false);
@@ -82,6 +92,9 @@ export const useUpsertOpus = ({ id }: UseUpsertOpusProps = {}) => {
     latestDataRef.current.details = next;
     setDetails(next);
     setIsSaved(false);
+    setDuplicateCompositionNames((previous) =>
+      previous.filter((name) => next.compositions.some((composition) => normalizeCompositionName(composition.name) === name))
+    );
 
     setDetailsErrors((prev) => ({
       number: next.number.trim() ? '' : prev.number,
@@ -212,6 +225,8 @@ export const useUpsertOpus = ({ id }: UseUpsertOpusProps = {}) => {
       return undefined;
     }
 
+    setDuplicateCompositionNames([]);
+
     const { uk: ukMeta, en: enMeta } = currentSeo.meta;
     const opusName = currentDetails.name.trim();
     const input = {
@@ -246,25 +261,33 @@ export const useUpsertOpus = ({ id }: UseUpsertOpusProps = {}) => {
     };
 
 
-    if (isEditing && id) {
-      const response = await updateOpus({ id, input });
-      const updatedId = response.data?.updateOpus?.id;
+    try {
+      if (isEditing && id) {
+        const response = await updateOpus({ id, input });
+        const updatedId = response.data?.updateOpus?.id;
 
-      if (updatedId) {
+        if (updatedId) {
+          setIsSaved(true);
+        }
+
+        return updatedId;
+      }
+
+      const response = await createOpus(input);
+      const createdId = response.data?.createOpus?.id;
+
+      if (createdId) {
         setIsSaved(true);
       }
 
-      return updatedId;
+      return createdId;
+    } catch (error) {
+      const duplicateName = getDuplicateCompositionName(error);
+      if (duplicateName) {
+        setDuplicateCompositionNames([duplicateName]);
+      }
+      throw error;
     }
-
-    const response = await createOpus(input);
-    const createdId = response.data?.createOpus?.id;
-
-    if (createdId) {
-      setIsSaved(true);
-    }
-
-    return createdId;
   };
 
   return {
@@ -273,6 +296,7 @@ export const useUpsertOpus = ({ id }: UseUpsertOpusProps = {}) => {
     details,
     setDetails: changeDetails,
     detailsErrors,
+    duplicateCompositionNames,
     seoValue,
     setSeoValue: changeSeoValue,
     crop,

--- a/app/shared/hooks/use-upsert-opus/useUpsertOpus.ts
+++ b/app/shared/hooks/use-upsert-opus/useUpsertOpus.ts
@@ -166,10 +166,12 @@ export const useUpsertOpus = (
     if (next.compositions !== previousDetails.compositions) {
       clearCompositionServerErrors();
 
-      setInvalidCompositionIds(
-        next.compositions
-          .filter((composition) => !composition.name.trim())
-          .map((composition) => composition.id)
+      setInvalidCompositionIds((previousInvalidIds) =>
+        previousInvalidIds.filter((invalidId) =>
+          next.compositions.some(
+            (composition) => composition.id === invalidId && !composition.name.trim()
+          )
+        )
       );
     }
 

--- a/app/shared/hooks/use-upsert-opus/useUpsertOpus.ts
+++ b/app/shared/hooks/use-upsert-opus/useUpsertOpus.ts
@@ -1,11 +1,15 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import toast from 'react-hot-toast';
 
 import {
+  COMPOSITION_NAME_REQUIRED_ERROR,
   initialOpusDetails,
   initialOpusSeoValue,
   OPUS_FIELD_LIMITS,
+  OPUS_MUTATION_RESULTS,
   OPUS_VALIDATION_MESSAGES
 } from '~/constants/opus';
+import  {getDuplicateCompositionError, getErrorMessage, getInvalidCompositionIds, isCompositionNameRequiredError } from '~/lib/utils/compositionErrors';
 import { generateUniqueId } from '~/lib/utils/generateUniqueId';
 import type { SeoBlockValue } from '~/shared/components/forms/seo-metadata-form/seo-metadata-block/SeoMetadataBlock';
 import { useCreateOpus, useOpusById, useUpdateOpus } from '~/shared/hooks/use-opuses/useOpuses';
@@ -22,35 +26,6 @@ import type {
 
 export const createCompositionId = (): string => generateUniqueId();
 
-export const toCompositionInput = (composition: OpusCompositionData): OpusCompositionInput => ({
-  id: composition.id,
-  name: composition.name.trim(),
-  genre: composition.genre.trim() || undefined,
-  year: composition.year.trim() || undefined,
-  audios: composition.audios
-    .filter((audio) => audio.name?.trim() || audio.fileUrl)
-    .map((audio) => ({
-      name: audio.name?.trim() || fileNameFromUrl(audio.fileUrl),
-      fileUrl: audio.fileUrl
-    })),
-  notes: composition.notes
-    .filter((note) => note.name?.trim() || note.fileUrl || note.publishDate?.trim())
-    .map((note) => ({
-      name: note.name?.trim() || fileNameFromUrl(note.fileUrl),
-      fileUrl: note.fileUrl,
-      publishDate: note.publishDate
-    }))
-});
-
-const normalizeCompositionName = (name: string): string => name.trim().toLocaleLowerCase('uk-UA');
-
-const getDuplicateCompositionName = (error: unknown): string | null => {
-  const message = error instanceof Error ? error.message : String(error);
-  if (!message.startsWith('Композиція "')) return null;
-  const match = new RegExp(/"([^"]+)"/).exec(message);
-  return match?.[1] ? normalizeCompositionName(match[1]) : null;
-};
-
 const fileNameFromUrl = (url?: string | null): string => {
   if (!url) {
     return '';
@@ -61,11 +36,72 @@ const fileNameFromUrl = (url?: string | null): string => {
   return decodeURIComponent(segment.split('?')[0]);
 };
 
+export const toCompositionInput = (
+  composition: OpusCompositionData
+): OpusCompositionInput => ({
+  id: composition.id,
+  name: composition.name.trim(),
+  genre: composition.genre.trim() || undefined,
+  year: composition.year.trim() || undefined,
+
+  audios: composition.audios
+    .filter((audio) => audio.name?.trim() || audio.fileUrl)
+    .map((audio) => ({
+      name: audio.name?.trim() || fileNameFromUrl(audio.fileUrl),
+      fileUrl: audio.fileUrl
+    })),
+
+  notes: composition.notes
+    .filter((note) => note.name?.trim() || note.fileUrl || note.publishDate?.trim())
+    .map((note) => ({
+      name: note.name?.trim() || fileNameFromUrl(note.fileUrl),
+      fileUrl: note.fileUrl,
+      publishDate: note.publishDate
+    }))
+});
+
 interface UseUpsertOpusProps {
   id?: string;
 }
 
-export const useUpsertOpus = ({ id }: UseUpsertOpusProps = {}) => {
+export type UseUpsertOpusResult = {
+  isEditing: boolean;
+  isLoading: boolean;
+
+  details: OpusDetailsValue;
+  setDetails: (
+    value:
+      | OpusDetailsValue
+      | ((prev: OpusDetailsValue) => OpusDetailsValue)
+  ) => void;
+
+  detailsErrors: OpusDetailsErrors;
+
+  duplicateCompositionNames: string[];
+  duplicateCompositionErrors?: Record<string, string>;
+  invalidCompositionIds: string[];
+
+  seoValue: SeoBlockValue;
+  setSeoValue: (
+    value:
+      | SeoBlockValue
+      | ((prev: SeoBlockValue) => SeoBlockValue)
+  ) => void;
+
+  crop: CropRect | null;
+  setCrop: (value: CropRect | null) => void;
+
+  forceShowErrors: boolean;
+  isSaved: boolean;
+
+  handleSave: (
+    status: BaseContentStatuses
+  ) => Promise<string | undefined>;
+};
+
+export const useUpsertOpus = (
+  { id }: UseUpsertOpusProps = {}
+): UseUpsertOpusResult => {
   const isEditing = Boolean(id);
   const opusQuery = useOpusById(id ?? '', { skip: !isEditing });
 
@@ -78,8 +114,25 @@ export const useUpsertOpus = ({ id }: UseUpsertOpusProps = {}) => {
     name: '',
     creationYear: ''
   });
-  const [duplicateCompositionNames, setDuplicateCompositionNames] = useState<string[]>([]);
-  const [seoValue, setSeoValue] = useState<SeoBlockValue>(initialOpusSeoValue);
+
+  const [
+    duplicateCompositionNames,
+    setDuplicateCompositionNames
+  ] = useState<string[]>([]);
+
+  const [
+    duplicateCompositionErrors,
+    setDuplicateCompositionErrors
+  ] = useState<Record<string, string>>({});
+
+  const [
+    invalidCompositionIds,
+    setInvalidCompositionIds
+  ] = useState<string[]>([]);
+
+  const [seoValue, setSeoValue] =
+    useState<SeoBlockValue>(initialOpusSeoValue);
+    
   const [crop, setCrop] = useState<CropRect | null>(null);
   const [forceShowErrors, setForceShowErrors] = useState(false);
   const [isSaved, setIsSaved] = useState(isEditing);
@@ -87,34 +140,58 @@ export const useUpsertOpus = ({ id }: UseUpsertOpusProps = {}) => {
   const latestDataRef = useRef({ details, seoValue, crop });
   const isInitializedRef = useRef(false);
 
-  const changeDetails = (value: OpusDetailsValue | ((prev: OpusDetailsValue) => OpusDetailsValue)) => {
-    const next = typeof value === 'function' ? value(latestDataRef.current.details) : value;
+  const clearCompositionServerErrors = useCallback(() => {
+    setDuplicateCompositionNames([]);
+    setDuplicateCompositionErrors({});
+  }, []);
+
+  const changeDetails = useCallback((
+    value:
+      | OpusDetailsValue
+      | ((prev: OpusDetailsValue) => OpusDetailsValue)
+  ) => {
+    const previousDetails = latestDataRef.current.details;
+
+    const next =
+      typeof value === 'function'
+        ? value(previousDetails)
+        : value;
+
     latestDataRef.current.details = next;
+
     setDetails(next);
     setIsSaved(false);
-    setDuplicateCompositionNames((previous) =>
-      previous.filter((name) => next.compositions.some((composition) => normalizeCompositionName(composition.name) === name))
-    );
+
+    if (next.compositions !== previousDetails.compositions) {
+      clearCompositionServerErrors();
+
+      setInvalidCompositionIds(
+        next.compositions
+          .filter((composition) => !composition.name.trim())
+          .map((composition) => composition.id)
+      );
+    }
+
 
     setDetailsErrors((prev) => ({
       number: next.number.trim() ? '' : prev.number,
       name: next.name.trim() ? '' : prev.name,
       creationYear: next.creationYear.trim() ? '' : prev.creationYear
     }));
-  };
+  }, [clearCompositionServerErrors]);
 
-  const changeSeoValue = (value: SeoBlockValue | ((prev: SeoBlockValue) => SeoBlockValue)) => {
+  const changeSeoValue = useCallback((value: SeoBlockValue | ((prev: SeoBlockValue) => SeoBlockValue)) => {
     const next = typeof value === 'function' ? value(latestDataRef.current.seoValue) : value;
     latestDataRef.current.seoValue = next;
     setSeoValue(next);
     setIsSaved(false);
-  };
+  }, []);
 
-  const changeCrop = (value: CropRect | null) => {
+  const changeCrop = useCallback((value: CropRect | null) => {
     latestDataRef.current.crop = value;
     setCrop(value);
     setIsSaved(false);
-  };
+  }, []);
 
   useEffect(() => {
     if (!isEditing || isInitializedRef.current) {
@@ -180,7 +257,7 @@ export const useUpsertOpus = ({ id }: UseUpsertOpusProps = {}) => {
 
     isInitializedRef.current = true;
     setIsSaved(true);
-  }, [isEditing, opusQuery.data]);
+  }, [changeDetails, changeSeoValue, changeCrop, isEditing, opusQuery.data]);
 
   const validate = (value: OpusDetailsValue): boolean => {
     const number = value.number.trim();
@@ -213,7 +290,47 @@ export const useUpsertOpus = ({ id }: UseUpsertOpusProps = {}) => {
 
     setDetailsErrors(errors);
 
-    return !numberError && !nameError && !creationYearError;
+    const invalidIds = getInvalidCompositionIds(value.compositions);
+    setInvalidCompositionIds(invalidIds);
+
+    if (invalidIds.length > 0) {
+      toast.error( COMPOSITION_NAME_REQUIRED_ERROR);
+    }
+
+    return (
+      !numberError &&
+      !nameError &&
+      !creationYearError &&
+      invalidIds.length === 0
+    );
+  };
+
+  const handleMutationError = (
+    error: unknown
+  ): void => {
+    const message = getErrorMessage(error);
+
+    const duplicateError = getDuplicateCompositionError(error);
+
+    if (duplicateError) {
+      setDuplicateCompositionNames([ duplicateError.name ]);
+      setDuplicateCompositionErrors({
+        [duplicateError.name]: duplicateError.message
+      });
+
+      toast.error(duplicateError.message);
+      return;
+    }
+
+    if (isCompositionNameRequiredError(error)) {
+      const invalidIds = getInvalidCompositionIds(latestDataRef.current.details.compositions);
+      setInvalidCompositionIds(invalidIds);
+
+      toast.error(COMPOSITION_NAME_REQUIRED_ERROR);
+      return;
+    }
+
+    toast.error(message);
   };
 
   const handleSave = async (status: BaseContentStatuses): Promise<string | undefined> => {
@@ -225,7 +342,8 @@ export const useUpsertOpus = ({ id }: UseUpsertOpusProps = {}) => {
       return undefined;
     }
 
-    setDuplicateCompositionNames([]);
+    clearCompositionServerErrors();
+    setInvalidCompositionIds([]);
 
     const { uk: ukMeta, en: enMeta } = currentSeo.meta;
     const opusName = currentDetails.name.trim();
@@ -262,31 +380,36 @@ export const useUpsertOpus = ({ id }: UseUpsertOpusProps = {}) => {
 
 
     try {
+      let savedId: string | undefined;
+
       if (isEditing && id) {
         const response = await updateOpus({ id, input });
-        const updatedId = response.data?.updateOpus?.id;
-
-        if (updatedId) {
-          setIsSaved(true);
-        }
-
-        return updatedId;
+        savedId = response.data?.updateOpus?.id;
+      } else {
+        const response = await createOpus(input);
+        savedId = response.data?.createOpus?.id;
       }
 
-      const response = await createOpus(input);
-      const createdId = response.data?.createOpus?.id;
-
-      if (createdId) {
-        setIsSaved(true);
+      if (!savedId) {
+        toast.error(
+          isEditing
+            ? OPUS_MUTATION_RESULTS.updateFailed
+            : OPUS_MUTATION_RESULTS.createFailed
+        );
+        return undefined;
       }
 
-      return createdId;
+      setIsSaved(true);
+
+      toast.success(
+        isEditing
+          ? OPUS_MUTATION_RESULTS.updated
+          : OPUS_MUTATION_RESULTS.created
+      );
+      return savedId;
     } catch (error) {
-      const duplicateName = getDuplicateCompositionName(error);
-      if (duplicateName) {
-        setDuplicateCompositionNames([duplicateName]);
-      }
-      throw error;
+      handleMutationError(error);
+      return undefined;
     }
   };
 
@@ -297,6 +420,8 @@ export const useUpsertOpus = ({ id }: UseUpsertOpusProps = {}) => {
     setDetails: changeDetails,
     detailsErrors,
     duplicateCompositionNames,
+    duplicateCompositionErrors,
+    invalidCompositionIds,
     seoValue,
     setSeoValue: changeSeoValue,
     crop,

--- a/src/constants/errors.ts
+++ b/src/constants/errors.ts
@@ -66,6 +66,7 @@ export const compositionsServiceErrors = {
   COMPOSITION_NOT_FOUND: (id: string) => `Composition with id "${id}" not found`,
   FAILED_TO_DELETE: (id: string) => `Composition with id "${id}" not found or could not be deleted`,
   COMPOSITION_NOT_CREATED: 'Repository failed to create composition record.',
+  COMPOSITION_NAME_TAKEN: (name: string) => `Композиція "${name}" вже існує`,
 };
 
 export const MediaMentionsServiceErrors = {

--- a/src/constants/errors.ts
+++ b/src/constants/errors.ts
@@ -59,7 +59,8 @@ export const opusServiceErrors = {
 
   OPUS_NOT_FOUND: (id: string) => `Opus with id "${id}" not found`,
   FAILED_TO_DELETE: (id: string) => `Opus with id "${id}" not found or could not be deleted`,
-  COMPOSITION_NOT_FOUND_IN_OPUS: 'Composition not found in this opus'
+  COMPOSITION_NOT_FOUND_IN_OPUS: 'Composition not found in this opus',
+  COMPOSITION_NAME_REQUIRED: 'Composition name is required'
 };
 
 export const compositionsServiceErrors = {

--- a/src/domain/repositories/compositionRepository.ts
+++ b/src/domain/repositories/compositionRepository.ts
@@ -14,5 +14,6 @@ export interface ICompositionRepository extends IBaseRepository<Composition, Com
   findByIds(ids: string[]): Promise<Composition[]>;
   findByIdsPaginated(ids: string[], filters?: CompositionFilters): Promise<Composition[]>;
   countByIds(ids: string[], filters?: CompositionFilters): Promise<number>;
+  findByName(name: string): Promise<Composition | null>;
   create(input: CompositionInput): Promise<Composition>;
 }

--- a/src/infrastructure/models/composition.model.ts
+++ b/src/infrastructure/models/composition.model.ts
@@ -35,6 +35,11 @@ const compositionSchema = new Schema(
   { timestamps: true, collection: 'compositions' }
 );
 
+compositionSchema.index(
+  { 'name.uk': 1 },
+  { unique: true, collation: { locale: 'uk', strength: 2 } }
+);
+
 const CompositionModel: Model<Composition> =
   mongoose.models.Composition || mongoose.model<Composition>('Composition', compositionSchema);
 

--- a/src/infrastructure/repositories/compositionRepository/compositionRepository.test.ts
+++ b/src/infrastructure/repositories/compositionRepository/compositionRepository.test.ts
@@ -65,6 +65,7 @@ describe('CompositionRepository', () => {
   const deleteManyMock = jest.fn();
   const saveMock = jest.fn();
   const countDocumentsMock = jest.fn();
+  const findOneMock = jest.fn();
 
   const createChainableQueryMock = (resolvedValue: unknown) => {
     const queryMock: Record<string, jest.Mock> = {};
@@ -85,6 +86,7 @@ describe('CompositionRepository', () => {
     findByIdAndUpdate: jest.Mock;
     deleteMany: jest.Mock;
     countDocuments: jest.Mock;
+    findOne: jest.Mock;
   };
 
   MockModel.find = findMock;
@@ -92,6 +94,7 @@ describe('CompositionRepository', () => {
   MockModel.findByIdAndUpdate = findByIdAndUpdateMock;
   MockModel.deleteMany = deleteManyMock;
   MockModel.countDocuments = countDocumentsMock;
+  MockModel.findOne = findOneMock;
 
   const repository = CompositionRepository({ CompositionModel: MockModel });
 
@@ -108,6 +111,34 @@ describe('CompositionRepository', () => {
 
     expect(saveMock).toHaveBeenCalled();
     expect(result).toHaveLength(1);
+  });
+
+  it('trims localized names before creating and syncing a composition', async (): Promise<void> => {
+    saveMock.mockResolvedValue({ toObject: () => createMockDoc({ name: { uk: ' Соната ', en: ' Sonata ' } }) });
+
+    await repository.create(createCompositionInput());
+    expect(MockModel).toHaveBeenCalledWith(expect.objectContaining({ name: { uk: 'Після бою', en: 'After Battle' } }));
+
+    await repository.syncForOpus([{ ...createCompositionInput(), name: { uk: '  Соната  ', en: '  Sonata  ' } }]);
+    expect(saveMock).toHaveBeenCalledWith();
+    expect(MockModel).toHaveBeenLastCalledWith(expect.objectContaining({ name: { uk: 'Соната', en: 'Sonata' } }));
+  });
+
+  it('findByName trims the search name and maps the matching document', async (): Promise<void> => {
+    const queryChain = createChainableQueryMock(createMockDoc());
+    findOneMock.mockReturnValue(queryChain);
+
+    const result = await repository.findByName('  Соната  ');
+
+    expect(findOneMock).toHaveBeenCalledWith({ 'name.uk': 'Соната' });
+    expect(queryChain.collation).toHaveBeenCalledWith({ locale: 'uk', strength: 2 });
+    expect(result?.id).toBe('c1');
+  });
+
+  it('findByName returns null when no document matches', async (): Promise<void> => {
+    findOneMock.mockReturnValue(createChainableQueryMock(null));
+
+    await expect(repository.findByName('Missing')).resolves.toBeNull();
   });
 
   it('syncForOpus links an existing composition by id instead of duplicating', async (): Promise<void> => {

--- a/src/infrastructure/repositories/compositionRepository/compositionRepository.ts
+++ b/src/infrastructure/repositories/compositionRepository/compositionRepository.ts
@@ -41,6 +41,14 @@ const toEntity = (doc: DbComposition): Composition => ({
   updatedAt: doc.updatedAt
 });
 
+const normalizeInput = (input: CompositionInput): CompositionInput => ({
+  ...input,
+  name: {
+    uk: input.name.uk.trim(),
+    en: input.name.en.trim()
+  }
+});
+
 const buildCompositionQuery = (
   filters?: CompositionFilters,
   extraConditions: FilterQuery<DbComposition>[] = []
@@ -79,7 +87,7 @@ export const CompositionRepository = ({ CompositionModel }: CompositionRepoDeps)
     await dbConnect();
     const results = await Promise.all(
       inputs.map(async (input, index) => {
-        const { id, ...fields } = input;
+        const { id, ...fields } = normalizeInput(input);
         if (id && mongoose.Types.ObjectId.isValid(id)) {
           const updated = await CompositionModel.findByIdAndUpdate(
             id, { ...fields, order: index }, { new: true }
@@ -203,8 +211,8 @@ export const CompositionRepository = ({ CompositionModel }: CompositionRepoDeps)
 
   const create = async (input: CompositionInput): Promise<Composition> => {
     await dbConnect();
-    
-    const newComposition = await new CompositionModel(input).save();
+
+    const newComposition = await new CompositionModel(normalizeInput(input)).save();
     return toEntity(newComposition.toObject() as unknown as DbComposition);
   };
 

--- a/src/infrastructure/repositories/compositionRepository/compositionRepository.ts
+++ b/src/infrastructure/repositories/compositionRepository/compositionRepository.ts
@@ -193,6 +193,14 @@ export const CompositionRepository = ({ CompositionModel }: CompositionRepoDeps)
     return docs.map(toEntity);
   };
 
+  const findByName = async (name: string): Promise<Composition | null> => {
+    await dbConnect();
+    const doc = await CompositionModel.findOne({ 'name.uk': name.trim() })
+      .collation({ locale: 'uk', strength: 2 })
+      .lean<DbComposition>();
+    return doc ? toEntity(doc) : null;
+  };
+
   const create = async (input: CompositionInput): Promise<Composition> => {
     await dbConnect();
     
@@ -207,6 +215,7 @@ export const CompositionRepository = ({ CompositionModel }: CompositionRepoDeps)
     findByIds,
     findByIdsPaginated,
     countByIds,
+    findByName,
     create
   };
 };

--- a/src/interfaces/graphql/resolvers/compositions/compositionNameValidation.test.ts
+++ b/src/interfaces/graphql/resolvers/compositions/compositionNameValidation.test.ts
@@ -1,0 +1,72 @@
+import { GraphQLError } from 'graphql';
+
+import {
+  assertCompositionNameNotTaken,
+  compositionNameTakenError,
+  normalizeCompositionName,
+  throwIfCompositionNameDuplicateKey
+} from './compositionNameValidation';
+import type { Composition } from '~/domain/entities/Composition';
+import type { ICompositionRepository } from '~/domain/repositories/compositionRepository';
+
+const existingComposition: Composition = {
+  id: 'composition-1',
+  name: { uk: 'Соната', en: 'Sonata' },
+  year: null,
+  genre: null,
+  audioAvailable: false,
+  sheetAvailable: false,
+  sheetMusic: [],
+  audios: [],
+  createdAt: '2026-01-01',
+  updatedAt: '2026-01-01'
+};
+
+const repository = (findByName: jest.MockedFunction<ICompositionRepository['findByName']>): ICompositionRepository =>
+  ({ findByName } as unknown as ICompositionRepository);
+
+describe('composition name validation', () => {
+  it('normalizes names and builds a typed duplicate error', () => {
+    expect(normalizeCompositionName('  Соната  ')).toBe('Соната');
+
+    const error = compositionNameTakenError('  Соната  ');
+    expect(error).toBeInstanceOf(GraphQLError);
+    expect(error.message).toBe('Композиція "Соната" вже існує');
+    expect(error.extensions.code).toBe('COMPOSITION_NAME_TAKEN');
+  });
+
+  it('rejects empty names before querying the repository', async () => {
+    const findByName = jest.fn();
+
+    await expect(assertCompositionNameNotTaken(repository(findByName), '   ')).rejects.toMatchObject({
+      message: 'Composition name is required',
+      extensions: { code: 'BAD_USER_INPUT' }
+    });
+    expect(findByName).not.toHaveBeenCalled();
+  });
+
+  it('allows an unused name and the same name for the excluded composition', async () => {
+    const findByName = jest.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(existingComposition);
+
+    await expect(assertCompositionNameNotTaken(repository(findByName), '  New name ')).resolves.toBeUndefined();
+    await expect(assertCompositionNameNotTaken(repository(findByName), ' Sonata ', existingComposition.id)).resolves.toBeUndefined();
+  });
+
+  it('rejects a name owned by another composition', async () => {
+    const findByName = jest.fn().mockResolvedValue(existingComposition);
+
+    await expect(assertCompositionNameNotTaken(repository(findByName), ' Sonata ', 'other-id')).rejects.toMatchObject({
+      message: 'Композиція "Sonata" вже існує',
+      extensions: { code: 'COMPOSITION_NAME_TAKEN' }
+    });
+  });
+
+  it('translates Mongo duplicate-key errors and ignores other errors', () => {
+    expect(() => throwIfCompositionNameDuplicateKey({ code: 11000, keyValue: { 'name.uk': 'Соната' } }, 'fallback'))
+      .toThrow('Композиція "Соната" вже існує');
+    expect(() => throwIfCompositionNameDuplicateKey({ code: 11000 }, ' fallback '))
+      .toThrow('Композиція "fallback" вже існує');
+    expect(() => throwIfCompositionNameDuplicateKey({ code: 1 }, 'fallback')).not.toThrow();
+    expect(() => throwIfCompositionNameDuplicateKey(null, 'fallback')).not.toThrow();
+  });
+});

--- a/src/interfaces/graphql/resolvers/compositions/compositionNameValidation.ts
+++ b/src/interfaces/graphql/resolvers/compositions/compositionNameValidation.ts
@@ -1,0 +1,49 @@
+import { GraphQLError } from 'graphql';
+
+import { compositionsServiceErrors, opusServiceErrors } from '~/back-constants/errors';
+import { ICompositionRepository } from '~/domain/repositories/compositionRepository';
+
+type DuplicateKeyError = {
+  code?: unknown;
+  keyValue?: unknown;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+export const normalizeCompositionName = (name: string): string => name.trim();
+
+export const compositionNameTakenError = (name: string): GraphQLError =>
+  new GraphQLError(compositionsServiceErrors.COMPOSITION_NAME_TAKEN(normalizeCompositionName(name)), {
+    extensions: { code: 'COMPOSITION_NAME_TAKEN' }
+  });
+
+export const assertCompositionNameNotTaken = async (
+  repo: ICompositionRepository,
+  ukName: string,
+  excludeId?: string
+): Promise<void> => {
+  const name = normalizeCompositionName(ukName);
+  if (!name) {
+    throw new GraphQLError(opusServiceErrors.COMPOSITION_NAME_REQUIRED, {
+      extensions: { code: 'BAD_USER_INPUT' }
+    });
+  }
+
+  const existing = await repo.findByName(name);
+
+  if (existing && existing.id !== excludeId) {
+    throw compositionNameTakenError(name);
+  }
+};
+
+export const throwIfCompositionNameDuplicateKey = (error: unknown, fallbackName: string): void => {
+  if (!isRecord(error) || error.code !== 11000) {
+    return;
+  }
+
+  const keyValue = (error as DuplicateKeyError).keyValue;
+  const duplicateName = isRecord(keyValue) ? keyValue['name.uk'] : undefined;
+
+  throw compositionNameTakenError(typeof duplicateName === 'string' ? duplicateName : fallbackName);
+};

--- a/src/interfaces/graphql/resolvers/compositions/compositionsMutation.test.ts
+++ b/src/interfaces/graphql/resolvers/compositions/compositionsMutation.test.ts
@@ -182,6 +182,41 @@ describe('CompositionsMutation', () => {
       expect(result).toEqual(MOCK_COMPOSITION);
     });
 
+    it('should reject an existing name before creating', async () => {
+      const context = createMockContext(MOCK_ADMIN, {
+        findByName: jest.fn().mockResolvedValue(MOCK_COMPOSITION)
+      });
+
+      await expect(
+        CompositionsMutation.createComposition(null, { input: MOCK_INPUT }, context)
+      ).rejects.toMatchObject({
+        message: `Композиція "${MOCK_INPUT.name.uk}" вже існує`,
+        extensions: { code: 'COMPOSITION_NAME_TAKEN' }
+      });
+      expect(context.requestContainer.cradle.compositionsRepository.create).not.toHaveBeenCalled();
+    });
+
+    it('should trim localized names and translate a duplicate-key create error', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      const createMock = jest.fn().mockRejectedValue({ code: 11000, keyValue: { 'name.uk': 'Trimmed' } });
+      const context = createMockContext(MOCK_ADMIN, {
+        findByName: jest.fn().mockResolvedValue(null),
+        create: createMock
+      });
+
+      await expect(
+        CompositionsMutation.createComposition(null, {
+          input: { ...MOCK_INPUT, name: { uk: '  Trimmed  ', en: '  English  ' } }
+        }, context)
+      ).rejects.toMatchObject({
+        message: 'Композиція "Trimmed" вже існує',
+        extensions: { code: 'COMPOSITION_NAME_TAKEN' }
+      });
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Error creating composition:', expect.anything());
+      expect(createMock).toHaveBeenCalledWith(expect.objectContaining({ name: { uk: 'Trimmed', en: 'English' } }));
+      consoleErrorSpy.mockRestore();
+    });
+
     it('should correctly fallback optional fields when input values are missing', async () => {
       const createMock = jest.fn().mockResolvedValue(MOCK_COMPOSITION);
       const moveMock = jest.fn().mockResolvedValue(undefined);
@@ -290,6 +325,44 @@ describe('CompositionsMutation', () => {
       expect(result).toEqual({
         ...MOCK_COMPOSITION,
         ...updateInputFull,
+      });
+    });
+
+    it('should allow updating a composition without changing ownership of its name', async () => {
+      const updateMock = jest.fn().mockResolvedValue(MOCK_COMPOSITION);
+      const context = createMockContext(MOCK_ADMIN, {
+        findById: jest.fn().mockResolvedValue(MOCK_COMPOSITION),
+        findByName: jest.fn().mockResolvedValue(MOCK_COMPOSITION),
+        update: updateMock
+      });
+
+      await CompositionsMutation.updateComposition(
+        null,
+        { id: MOCK_COMPOSITION_ID, input: { name: { uk: '  Соната  ', en: '  Sonata  ' } } },
+        context
+      );
+
+      expect(updateMock).toHaveBeenCalledWith(MOCK_COMPOSITION_ID, {
+        name: { uk: 'Соната', en: 'Sonata' }
+      });
+    });
+
+    it('should translate a duplicate-key update error', async () => {
+      const context = createMockContext(MOCK_ADMIN, {
+        findById: jest.fn().mockResolvedValue(MOCK_COMPOSITION),
+        findByName: jest.fn().mockResolvedValue(null),
+        update: jest.fn().mockRejectedValue({ code: 11000, keyValue: { 'name.uk': 'Taken' } })
+      });
+
+      await expect(
+        CompositionsMutation.updateComposition(
+          null,
+          { id: MOCK_COMPOSITION_ID, input: { name: { uk: 'Taken', en: 'Taken' } } },
+          context
+        )
+      ).rejects.toMatchObject({
+        message: 'Композиція "Taken" вже існує',
+        extensions: { code: 'COMPOSITION_NAME_TAKEN' }
       });
     });
 

--- a/src/interfaces/graphql/resolvers/compositions/compositionsMutation.ts
+++ b/src/interfaces/graphql/resolvers/compositions/compositionsMutation.ts
@@ -1,5 +1,10 @@
 import { GraphQLError } from 'graphql';
 
+import {
+  assertCompositionNameNotTaken,
+  normalizeCompositionName,
+  throwIfCompositionNameDuplicateKey
+} from './compositionNameValidation';
 import type { GraphQLContext } from '~/back-shared/types/container/types';
 import { graphqlErrors } from '~/constants/errors';
 import type { Composition } from '~/domain/entities/Composition';
@@ -18,19 +23,6 @@ const assertAuthenticated = (context: GraphQLContext): void => {
   }
 };
 
-export const assertNameNotTaken = async (
-  repo: ICompositionRepository,
-  ukName: string,
-  excludeId?: string
-): Promise<void> => {
-  const existing = await repo.findByName(ukName.trim());
-  if (existing && existing.id !== excludeId) {
-    throw new GraphQLError(compositionsServiceErrors.COMPOSITION_NAME_TAKEN(ukName), {
-      extensions: { code: 'COMPOSITION_NAME_TAKEN' }
-    });
-  }
-};
-
 async function findExistingComposition(repo: ICompositionRepository, id: string): Promise<Composition> {
   const existing = await repo.findById(id);
   if (!existing) {
@@ -41,8 +33,13 @@ async function findExistingComposition(repo: ICompositionRepository, id: string)
   return existing;
 }
 
+const mapCompositionName = (name: CreateCompositionInput['name']): CompositionInput['name'] => ({
+  uk: normalizeCompositionName(name.uk),
+  en: normalizeCompositionName(name.en)
+});
+
 const mapCompositionInput = (input: CreateCompositionInput): CompositionInput => ({
-  name: input.name,
+  name: mapCompositionName(input.name),
   year: input.year ?? null,
   genre: input.genre ?? null,
   audioAvailable: input.audioAvailable ?? false,
@@ -61,11 +58,18 @@ export const CompositionsMutation = {
 
     const { compositionsRepository: repo, opusRepository: opusRepo } = context.requestContainer.cradle;
 
-    await assertNameNotTaken(repo, input.name.uk);
+    await assertCompositionNameNotTaken(repo, input.name.uk);
 
     const compositionData = mapCompositionInput(input);
 
-    const composition = await repo.create(compositionData);
+    let composition: Composition;
+    try {
+      composition = await repo.create(compositionData);
+    } catch (error) {
+      console.error('Error creating composition:', error);
+      throwIfCompositionNameDuplicateKey(error, compositionData.name.uk);
+      throw error;
+    }
     if (!composition) {
       throw new Error(compositionsServiceErrors.COMPOSITION_NOT_CREATED);
     }
@@ -81,11 +85,11 @@ export const CompositionsMutation = {
 
     await findExistingComposition(repo, id);
     if (input.name != null) {
-      await assertNameNotTaken(repo, input.name.uk, id);
+      await assertCompositionNameNotTaken(repo, input.name.uk, id);
     }
 
     const updateData: CompositionInput = {
-      ...(input.name && { name: input.name }),
+      ...(input.name && { name: mapCompositionName(input.name) }),
       ...(input.year !== undefined && { year: input.year ?? null }),
       ...(input.genre !== undefined && { genre: input.genre }),
       ...(input.audioAvailable !== undefined && { audioAvailable: input.audioAvailable }),
@@ -94,7 +98,13 @@ export const CompositionsMutation = {
       ...(input.audios !== undefined && { audios: input.audios })
     };
 
-    const updatedComposition = await repo.update(id, updateData);
+    let updatedComposition: Composition | null;
+    try {
+      updatedComposition = await repo.update(id, updateData);
+    } catch (error) {
+      throwIfCompositionNameDuplicateKey(error, input.name?.uk ?? '');
+      throw error;
+    }
 
     if (!updatedComposition) {
       throw new GraphQLError(`Failed to update composition with id ${id}`, {

--- a/src/interfaces/graphql/resolvers/compositions/compositionsMutation.ts
+++ b/src/interfaces/graphql/resolvers/compositions/compositionsMutation.ts
@@ -18,6 +18,19 @@ const assertAuthenticated = (context: GraphQLContext): void => {
   }
 };
 
+export const assertNameNotTaken = async (
+  repo: ICompositionRepository,
+  ukName: string,
+  excludeId?: string
+): Promise<void> => {
+  const existing = await repo.findByName(ukName.trim());
+  if (existing && existing.id !== excludeId) {
+    throw new GraphQLError(compositionsServiceErrors.COMPOSITION_NAME_TAKEN(ukName), {
+      extensions: { code: 'COMPOSITION_NAME_TAKEN' }
+    });
+  }
+};
+
 async function findExistingComposition(repo: ICompositionRepository, id: string): Promise<Composition> {
   const existing = await repo.findById(id);
   if (!existing) {
@@ -46,10 +59,9 @@ export const CompositionsMutation = {
   ): Promise<Composition> => {
     assertAuthenticated(context);
 
-    const { 
-      compositionsRepository: repo, 
-      opusRepository: opusRepo 
-    } = context.requestContainer.cradle;
+    const { compositionsRepository: repo, opusRepository: opusRepo } = context.requestContainer.cradle;
+
+    await assertNameNotTaken(repo, input.name.uk);
 
     const compositionData = mapCompositionInput(input);
 
@@ -68,6 +80,7 @@ export const CompositionsMutation = {
     const repo = context.requestContainer.cradle.compositionsRepository;
 
     await findExistingComposition(repo, id);
+    await assertNameNotTaken(repo, input.name.uk, id);
 
     const updateData: CompositionInput = {
       ...(input.name && { name: input.name }),

--- a/src/interfaces/graphql/resolvers/compositions/compositionsMutation.ts
+++ b/src/interfaces/graphql/resolvers/compositions/compositionsMutation.ts
@@ -80,7 +80,9 @@ export const CompositionsMutation = {
     const repo = context.requestContainer.cradle.compositionsRepository;
 
     await findExistingComposition(repo, id);
-    await assertNameNotTaken(repo, input.name.uk, id);
+    if (input.name != null) {
+      await assertNameNotTaken(repo, input.name.uk, id);
+    }
 
     const updateData: CompositionInput = {
       ...(input.name && { name: input.name }),

--- a/src/interfaces/graphql/resolvers/opus/opusMutation.test.ts
+++ b/src/interfaces/graphql/resolvers/opus/opusMutation.test.ts
@@ -266,6 +266,51 @@ describe('OpusMutation Resolvers', () => {
       expect(result).toEqual({ ...MOCK_OPUS_ENTITY, compositions: [MOCK_COMPOSITION_1] });
     });
 
+    it('should reject an empty composition name before syncing', async () => {
+      mockOpusRepo.findByNumber.mockResolvedValue(null);
+
+      await expect(
+        OpusMutation.createOpus(
+          {},
+          { input: { ...BASE_CREATE_INPUT, compositions: [{ name: '   ' }] } },
+          adminContext
+        )
+      ).rejects.toMatchObject({
+        message: 'Composition name is required',
+        extensions: { code: 'BAD_USER_INPUT' }
+      });
+      expect(mockCompositionsRepo.syncForOpus).not.toHaveBeenCalled();
+    });
+
+    it('should reject duplicate names submitted in one opus', async () => {
+      mockOpusRepo.findByNumber.mockResolvedValue(null);
+
+      await expect(
+        OpusMutation.createOpus(
+          {},
+          { input: { ...BASE_CREATE_INPUT, compositions: [{ name: 'Sonata' }, { name: ' sonata ' }] } },
+          adminContext
+        )
+      ).rejects.toMatchObject({ extensions: { code: 'COMPOSITION_NAME_TAKEN' } });
+    });
+
+    it('should translate a duplicate-key error from composition synchronization', async () => {
+      mockOpusRepo.findByNumber.mockResolvedValue(null);
+      mockedGenerateUniqueSlug.mockResolvedValue(SLUG_VALUE);
+      mockCompositionsRepo.syncForOpus.mockRejectedValue({ code: 11000, keyValue: { 'name.uk': 'Sonata' } });
+
+      await expect(
+        OpusMutation.createOpus(
+          {},
+          { input: { ...BASE_CREATE_INPUT, compositions: [{ name: 'Sonata' }] } },
+          adminContext
+        )
+      ).rejects.toMatchObject({
+        message: 'Композиція "Sonata" вже існує',
+        extensions: { code: 'COMPOSITION_NAME_TAKEN' }
+      });
+    });
+
     it('should trim name.uk when generating slug and set status from input', async () => {
       mockOpusRepo.findByNumber.mockResolvedValue(null);
       mockedGenerateUniqueSlug.mockResolvedValue(SLUG_VALUE);
@@ -597,6 +642,20 @@ describe('OpusMutation Resolvers', () => {
       expect(mockedProcessSlugUpdate).toHaveBeenCalledWith(OPUS_ID, nameInput, mockOpusRepo, expect.any(Object));
       expect(mockOpusRepo.removeCompositionsFromCompositionsOpus).toHaveBeenCalledWith([COMPOSITION_ID_3]);
       expect(mockOpusRepo.moveCompositionsToCompositionsOpus).toHaveBeenCalledWith([COMPOSITION_ID_1]);
+    });
+
+    it('should reject a composition name already used by another composition on update', async () => {
+      mockOpusRepo.findById.mockResolvedValue(MOCK_OPUS_ENTITY);
+      mockCompositionsRepo.findByName.mockResolvedValue({ ...MOCK_COMPOSITION_1, id: OTHER_OPUS_ID });
+
+      await expect(
+        OpusMutation.updateOpus(
+          {},
+          { id: OPUS_ID, input: { ...BASE_UPDATE_INPUT, compositions: [{ name: 'Taken' }] } },
+          adminContext
+        )
+      ).rejects.toMatchObject({ extensions: { code: 'COMPOSITION_NAME_TAKEN' } });
+      expect(mockCompositionsRepo.syncForOpus).not.toHaveBeenCalled();
     });
 
     it('should throw OPUS_NOT_FOUND when update returns null', async () => {

--- a/src/interfaces/graphql/resolvers/opus/opusMutation.test.ts
+++ b/src/interfaces/graphql/resolvers/opus/opusMutation.test.ts
@@ -95,7 +95,9 @@ describe('OpusMutation Resolvers', () => {
     const compositionsRepo = {
       findByOpusId: jest.fn(),
       findByOpusIds: jest.fn(),
+      findByNumber: jest.fn(),
       findByIds: jest.fn(),
+      findByName: jest.fn(),
       syncForOpus: jest.fn().mockResolvedValue([]),
       deleteByOpusId: jest.fn(),
       searchByTitle: jest.fn()

--- a/src/interfaces/graphql/resolvers/opus/opusMutation.ts
+++ b/src/interfaces/graphql/resolvers/opus/opusMutation.ts
@@ -1,5 +1,6 @@
 import { GraphQLError } from 'graphql';
 
+import { assertNameNotTaken } from '../compositions/compositionsMutation';
 import { markImagesAsUsed, processSlugUpdate, syncImagesCrops } from '../helpers';
 import { orderCompositionsByIds } from './tab-handlers/tabHandlersHelpers';
 import { opusServiceErrors } from '~/back-constants/errors';
@@ -81,6 +82,17 @@ const parseYear = (value: string | undefined): number | null => {
   const year = Number.parseInt(trimmed, 10);
   return Number.isFinite(year) ? year : null;
 };
+
+async function assertCompositionsNamesNotTaken(
+  compositionsRepo: ICompositionRepository,
+  compositions: GQLComposition[]
+): Promise<void> {
+  for (const composition of compositions) {
+    const name = composition.name?.trim();
+    if (!name) continue;
+    await assertNameNotTaken(compositionsRepo, name, composition.id);
+  }
+}
 
 const mapComposition = (composition: GQLComposition): CompositionInput => {
   const notesWithFiles = (composition.notes ?? []).filter((note) => note.fileUrl);
@@ -335,7 +347,6 @@ export const OpusMutation = {
 
     const repo = context.requestContainer.cradle.opusRepository;
     const compositionsRepo = context.requestContainer.cradle.compositionsRepository;
-
     const number = input.number;
     const existingByNumber = await repo.findByNumber(number);
     if (existingByNumber) {
@@ -343,11 +354,12 @@ export const OpusMutation = {
         extensions: { code: 'DUPLICATE_OPUS_NUMBER' }
       });
     }
-
     const nameForSlug = input.name.uk?.trim();
     const slug = await generateUniqueSlug(nameForSlug, {
-      checkExists: async (candidate: string) => (await repo.findBySlug(candidate)) !== null
+      checkExists: async (candidate) => (await repo.findBySlug(candidate)) !== null
     });
+
+    await assertCompositionsNamesNotTaken(compositionsRepo, input.compositions ?? []);
 
     const compositions = await compositionsRepo.syncForOpus((input.compositions ?? []).map(mapComposition));
     const compositionIds = compositions.map((c) => c.id);
@@ -441,6 +453,10 @@ export const OpusMutation = {
     const existingOpus = await findExistingOpus(repo, id);
 
     await ensureUniqueOpusNumber(repo, id, input.number);
+
+    if (input.compositions !== undefined) {
+      await assertCompositionsNamesNotTaken(compositionsRepo, input.compositions);
+    }
 
     const compositions = await handleCompositionsSync(compositionsRepo, repo, existingOpus, input.compositions);
 

--- a/src/interfaces/graphql/resolvers/opus/opusMutation.ts
+++ b/src/interfaces/graphql/resolvers/opus/opusMutation.ts
@@ -1,6 +1,10 @@
 import { GraphQLError } from 'graphql';
 
-import { assertNameNotTaken } from '../compositions/compositionsMutation';
+import {
+  assertCompositionNameNotTaken,
+  compositionNameTakenError,
+  throwIfCompositionNameDuplicateKey
+} from '../compositions/compositionNameValidation';
 import { markImagesAsUsed, processSlugUpdate, syncImagesCrops } from '../helpers';
 import { orderCompositionsByIds } from './tab-handlers/tabHandlersHelpers';
 import { opusServiceErrors } from '~/back-constants/errors';
@@ -87,6 +91,8 @@ async function assertCompositionsNamesNotTaken(
   compositionsRepo: ICompositionRepository,
   compositions: GQLComposition[]
 ): Promise<void> {
+  const submittedNames = new Set<string>();
+
   for (const composition of compositions) {
     const name = composition.name?.trim();
     if (!name) {
@@ -94,7 +100,14 @@ async function assertCompositionsNamesNotTaken(
         extensions: { code: 'BAD_USER_INPUT' }
       });
     }
-    await assertNameNotTaken(compositionsRepo, name, composition.id);
+
+    const normalizedName = name.toLocaleLowerCase('uk');
+    if (submittedNames.has(normalizedName)) {
+      throw compositionNameTakenError(name);
+    }
+    submittedNames.add(normalizedName);
+
+    await assertCompositionNameNotTaken(compositionsRepo, name, composition.id);
   }
 }
 
@@ -282,7 +295,13 @@ async function handleCompositionsSync(
     return orderCompositionsByIds(compositionIds, await compositionsRepo.findByIds(compositionIds));
   }
 
-  const compositions = await compositionsRepo.syncForOpus(inputCompositions.map(mapComposition));
+  let compositions;
+  try {
+    compositions = await compositionsRepo.syncForOpus(inputCompositions.map(mapComposition));
+  } catch (error) {
+    throwIfCompositionNameDuplicateKey(error, inputCompositions[0]?.name ?? '');
+    throw error;
+  }
   const oldCompositionIds = (existingOpus.compositions ?? []).map((cid) => cid.toString());
   const newCompositionIds = compositions.map((c) => c.id);
 
@@ -365,7 +384,13 @@ export const OpusMutation = {
 
     await assertCompositionsNamesNotTaken(compositionsRepo, input.compositions ?? []);
 
-    const compositions = await compositionsRepo.syncForOpus((input.compositions ?? []).map(mapComposition));
+    let compositions;
+    try {
+      compositions = await compositionsRepo.syncForOpus((input.compositions ?? []).map(mapComposition));
+    } catch (error) {
+      throwIfCompositionNameDuplicateKey(error, input.compositions?.[0]?.name ?? '');
+      throw error;
+    }
     const compositionIds = compositions.map((c) => c.id);
 
     const opusData: CreateOpusInput = {

--- a/src/interfaces/graphql/resolvers/opus/opusMutation.ts
+++ b/src/interfaces/graphql/resolvers/opus/opusMutation.ts
@@ -89,7 +89,11 @@ async function assertCompositionsNamesNotTaken(
 ): Promise<void> {
   for (const composition of compositions) {
     const name = composition.name?.trim();
-    if (!name) continue;
+    if (!name) {
+      throw new GraphQLError(opusServiceErrors.COMPOSITION_NAME_REQUIRED, {
+        extensions: { code: 'BAD_USER_INPUT' }
+      });
+    }
     await assertNameNotTaken(compositionsRepo, name, composition.id);
   }
 }
@@ -100,7 +104,7 @@ const mapComposition = (composition: GQLComposition): CompositionInput => {
 
   return {
     id: composition.id,
-    name: { uk: composition.name, en: composition.name },
+    name: { uk: composition.name.trim(), en: composition.name.trim() },
     year: parseYear(composition.year ?? undefined),
     genre: composition.genre ?? null,
     audioAvailable: audios.length > 0,

--- a/src/interfaces/graphql/resolvers/opus/opusQuery.test.ts
+++ b/src/interfaces/graphql/resolvers/opus/opusQuery.test.ts
@@ -119,6 +119,7 @@ describe('OpusQuery Resolvers', () => {
       count: jest.fn(),
       findByIdsPaginated: jest.fn(),
       countByIds: jest.fn(),
+      findByName: jest.fn(),
       findBySlug: jest.fn(),
       findPaginated: jest.fn(),
     } as jest.Mocked<ICompositionRepository>;


### PR DESCRIPTION
## Description

Implements duplicate composition-name validation across standalone composition and opus workflows.

Names are normalized before comparison and persistence, and validation errors are propagated to the relevant composition fields so users receive clear and actionable feedback.

Database-level uniqueness constraints and duplicate-key handling provide an additional safeguard against concurrent duplicate creation.

Now validates empty composition names, duplicate names within an opus, and duplicate composition names within the `compositions` collection.

Hide the selected suggested composition from the suggestion list.

### What was changed

* Added empty-name and duplicate-name validation for composition creation, updates, and opus composition synchronization.
* Added normalized, case-insensitive name checks with support for excluding the composition currently being edited.
* Added repository-level name lookup, trimmed localized names before persistence, and introduced a unique index for Ukrainian composition names.
* Added structured GraphQL errors for required and duplicate names, including MongoDB duplicate-key error translation.
* Propagated backend and client-side validation errors to composition inputs in opus and group editing flows.
* Updated tests for composition actions, group content, works sections, and title inputs.

## Type of change

* [ ] New feature
* [x] Bug fix
* [ ] Documentation update
* [x] Refactoring / Tech debt
* [ ] CI/CD improvement
* [ ] Other

## How to test

1. Check out this branch.
2. Navigate to the Creativity opus create or edit page.
3. Add compositions with empty or duplicate names and attempt to save.
4. Verify that saving is blocked and the affected composition fields display validation errors.
5. Verify that compositions with unique names save successfully.
6. Verify that an existing composition can retain its current name while being edited.
7. Run the affected Jest suites with coverage and verify that all tests pass.

## Video / Screenshots

### How it works now

https://github.com/user-attachments/assets/1271a6cf-3062-482e-8dfe-28052d557486

https://github.com/user-attachments/assets/4f8ba685-895a-4ea1-a0f5-d1297a87cc1c

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---

Closes #766 
