### PR TITLE
 feat: add transactions to opus and composition flows

### DIFF
--- a/src/domain/repositories/baseRepository.ts
+++ b/src/domain/repositories/baseRepository.ts
@@ -1,3 +1,5 @@
+import { ClientSession } from 'mongoose';
+
 import {SortByDate, SortOrder} from '~/types/enums/common.enums';
 
 export type SortCriteria = {
@@ -27,15 +29,16 @@ export type BaseEntity = {
 };
 
 export interface IBaseRepository<TEntity extends BaseEntity, TFilters extends FiltersInput = FiltersInput> {
-    findById(id: string): Promise<TEntity | null>;
-    findBySlug(slug: string): Promise<TEntity | null>;
-    findAll(filters?: TFilters): Promise<TEntity[]>;
-    update(id: string, input: Partial<Omit<TEntity, keyof BaseEntity>>): Promise<TEntity | null>;
-    delete(id: string): Promise<boolean>;
-    count(filters?: QueryFilters<TFilters>): Promise<number>;
+    findById(id: string, session?: ClientSession): Promise<TEntity | null>;
+    findBySlug(slug: string, session?: ClientSession): Promise<TEntity | null>;
+    findAll(filters?: TFilters, session?: ClientSession): Promise<TEntity[]>;
+    update(id: string, input: Partial<Omit<TEntity, keyof BaseEntity>>, session?: ClientSession): Promise<TEntity | null>;
+    delete(id: string, session?: ClientSession): Promise<boolean>;
+    count(filters?: QueryFilters<TFilters>, session?: ClientSession): Promise<number>;
     findPaginated(
         page: number,
         limit: number,
-        filters?: Omit<TFilters, keyof PaginationFilters>
+        filters?: Omit<TFilters, keyof PaginationFilters>,
+        session?: ClientSession
     ): Promise<{ items: TEntity[]; total: number; page: number; totalPages: number }>;
 }

--- a/src/domain/repositories/compositionRepository.ts
+++ b/src/domain/repositories/compositionRepository.ts
@@ -1,3 +1,4 @@
+import { ClientSession } from 'mongoose';
 
 import { Composition } from '~/domain/entities/Composition';
 import { FiltersInput, IBaseRepository } from '~/domain/repositories/baseRepository';
@@ -9,10 +10,10 @@ export type CompositionFilters = FiltersInput & {
 export type CompositionInput = Omit<Composition, 'id' | 'createdAt' | 'updatedAt'> & { id?: string };
 
 export interface ICompositionRepository extends IBaseRepository<Composition, CompositionFilters> {
-  syncForOpus( inputs: CompositionInput[]): Promise<Composition[]>;
-  searchByTitle(search: string, ids?: string[]): Promise<Composition[]>;
-  findByIds(ids: string[]): Promise<Composition[]>;
-  findByIdsPaginated(ids: string[], filters?: CompositionFilters): Promise<Composition[]>;
-  countByIds(ids: string[], filters?: CompositionFilters): Promise<number>;
-  create(input: CompositionInput): Promise<Composition>;
+  syncForOpus(inputs: CompositionInput[], session?: ClientSession): Promise<Composition[]>;
+  searchByTitle(search: string, ids?: string[], session?: ClientSession): Promise<Composition[]>;
+  findByIds(ids: string[], session?: ClientSession): Promise<Composition[]>;
+  findByIdsPaginated(ids: string[], filters?: CompositionFilters, session?: ClientSession): Promise<Composition[]>;
+  countByIds(ids: string[], filters?: CompositionFilters, session?: ClientSession): Promise<number>;
+  create(input: CompositionInput, session?: ClientSession): Promise<Composition>;
 }

--- a/src/domain/repositories/opusRepository.ts
+++ b/src/domain/repositories/opusRepository.ts
@@ -1,3 +1,5 @@
+import { ClientSession } from 'mongoose';
+
 import { Opus, OpusNumberKind } from '~/domain/entities/Opus';
 import { FiltersInput, IBaseRepository } from '~/domain/repositories/baseRepository';
 import { OpusStatus } from '~/types/enums/common.enums';
@@ -16,9 +18,9 @@ export type OpusFilters = FiltersInput & {
 };
 
 export interface IOpusRepository extends IBaseRepository<Opus, OpusFilters> {
-  create(input: CreateOpusInput): Promise<Opus>;
-  findByNumber(number: number): Promise<Opus | null>;
-  unlink(opusId: string): Promise<void>;
-  moveCompositionsToCompositionsOpus(compositionIds: string[]): Promise<void>;
-  removeCompositionsFromCompositionsOpus(compositionIds: string[]): Promise<void>;
+  create(input: CreateOpusInput, session?: ClientSession): Promise<Opus>;
+  findByNumber(number: number, session?: ClientSession): Promise<Opus | null>;
+  unlink(opusId: string, session?: ClientSession): Promise<void>;
+  moveCompositionsToCompositionsOpus(compositionIds: string[], session?: ClientSession ): Promise<void>;
+  removeCompositionsFromCompositionsOpus(compositionIds: string[], session?: ClientSession ): Promise<void>;
 }

--- a/src/infrastructure/repositories/assetRepository/assetRepository.test.ts
+++ b/src/infrastructure/repositories/assetRepository/assetRepository.test.ts
@@ -623,7 +623,8 @@ describe('AssetRepository', () => {
 
         expect(mockAssetModel.findOneAndUpdate).toHaveBeenCalledWith(
           { url: 'https://example.com/photo.jpg' },
-          { $addToSet: { usageRefs: { pageId: 'about', blockId: 'hero' } } }
+          { $addToSet: { usageRefs: { pageId: 'about', blockId: 'hero' } } },
+          { session: undefined }
         );
       });
     });

--- a/src/infrastructure/repositories/assetRepository/assetRepository.ts
+++ b/src/infrastructure/repositories/assetRepository/assetRepository.ts
@@ -1,4 +1,4 @@
-import { FilterQuery, Model, Types } from 'mongoose';
+import { ClientSession, FilterQuery, Model, Types } from 'mongoose';
 
 import { config } from '../../../config';
 import { UPLOAD_ERRORS } from '../../../uploads/errors';
@@ -316,8 +316,8 @@ export const AssetRepository = ({ AssetModel }: AssetRepoDeps) => {
     return true;
   };
 
-  const addUsageRef = async (url: string, ref: AssetUsageRef): Promise<void> => {
-    await AssetModel.findOneAndUpdate({ url }, { $addToSet: { usageRefs: ref } });
+  const addUsageRef = async (url: string, ref: AssetUsageRef, session?: ClientSession): Promise<void> => {
+    await AssetModel.findOneAndUpdate({ url }, { $addToSet: { usageRefs: ref } }, { session });
   };
 
   return {

--- a/src/infrastructure/repositories/baseRepository/baseRepository.test.ts
+++ b/src/infrastructure/repositories/baseRepository/baseRepository.test.ts
@@ -39,6 +39,7 @@ describe('createBaseRepository', () => {
   let toEntity: (doc: TestDbDoc) => TestEntity;
 
   const createMockQueryBuilder = (resolvedValue: TestDbDoc[] | TestDbDoc | null) => ({
+    session: jest.fn().mockReturnThis(),
     sort: jest.fn().mockReturnThis(),
     skip: jest.fn().mockReturnThis(),
     limit: jest.fn().mockReturnThis(),
@@ -99,6 +100,17 @@ describe('createBaseRepository', () => {
       const nullResult = await repository.findById(validId);
       expect(nullResult).toBeNull();
     });
+
+    it('should apply the provided session to the query', async () => {
+      const session = {} as never;
+      const mockQueryBuilder = createMockQueryBuilder(createMockDoc());
+      (mockModel.findById as jest.Mock).mockReturnValue(mockQueryBuilder);
+
+      const repository = createBaseRepository<TestEntity, TestDbDoc, TestFilters>({ model: mockModel, toEntity });
+      await repository.findById('507f1f77bcf86cd799439011', session);
+
+      expect(mockQueryBuilder.session).toHaveBeenCalledWith(session);
+    });
   });
 
   describe('findBySlug', () => {
@@ -123,6 +135,17 @@ describe('createBaseRepository', () => {
       (mockModel.findOne as jest.Mock).mockReturnValue(createMockQueryBuilder(null));
       const nullResult = await repository.findBySlug('non-existent-slug');
       expect(nullResult).toBeNull();
+    });
+
+    it('should apply the provided session to the query', async () => {
+      const session = {} as never;
+      const mockQueryBuilder = createMockQueryBuilder(createMockDoc());
+      (mockModel.findOne as jest.Mock).mockReturnValue(mockQueryBuilder);
+
+      const repository = createBaseRepository<TestEntity, TestDbDoc, TestFilters>({ model: mockModel, toEntity });
+      await repository.findBySlug('valid-slug', session);
+
+      expect(mockQueryBuilder.session).toHaveBeenCalledWith(session);
     });
   });
 
@@ -166,6 +189,21 @@ describe('createBaseRepository', () => {
 
       expect(result).toBeNull();
     });
+
+    it('should pass the provided session to the update operation', async () => {
+      const session = {} as never;
+      const leanMock = jest.fn().mockResolvedValue(createMockDoc());
+      (mockModel.findByIdAndUpdate as jest.Mock).mockReturnValue({ lean: leanMock });
+
+      const repository = createBaseRepository<TestEntity, TestDbDoc, TestFilters>({ model: mockModel, toEntity });
+      await repository.update('507f1f77bcf86cd799439011', { name: 'Updated' }, session);
+
+      expect(mockModel.findByIdAndUpdate).toHaveBeenCalledWith(
+        '507f1f77bcf86cd799439011',
+        expect.any(Object),
+        expect.objectContaining({ new: true, runValidators: true, session })
+      );
+    });
   });
 
   describe('delete', () => {
@@ -188,6 +226,16 @@ describe('createBaseRepository', () => {
       (mockModel.findByIdAndDelete as jest.Mock).mockResolvedValue(null);
       const falseResult = await repository.delete(mockId);
       expect(falseResult).toBe(false);
+    });
+
+    it('should pass the provided session to the delete operation', async () => {
+      const session = {} as never;
+      (mockModel.findByIdAndDelete as jest.Mock).mockResolvedValue(createMockDoc());
+
+      const repository = createBaseRepository<TestEntity, TestDbDoc, TestFilters>({ model: mockModel, toEntity });
+      await repository.delete('507f1f77bcf86cd799439011', session);
+
+      expect(mockModel.findByIdAndDelete).toHaveBeenCalledWith('507f1f77bcf86cd799439011', { session });
     });
   });
 
@@ -260,6 +308,19 @@ describe('createBaseRepository', () => {
         name: 1,
         createdAt: -1
       });
+    });
+
+    it('should apply the provided session and pagination options', async () => {
+      const session = {} as never;
+      const mockQueryBuilder = createMockQueryBuilder([]);
+      (mockModel.find as jest.Mock).mockReturnValue(mockQueryBuilder);
+
+      const repository = createBaseRepository<TestEntity, TestDbDoc, TestFilters>({ model: mockModel, toEntity });
+      await repository.findAll({ skip: 2, limit: 5 }, session);
+
+      expect(mockQueryBuilder.session).toHaveBeenCalledWith(session);
+      expect(mockQueryBuilder.skip).toHaveBeenCalledWith(2);
+      expect(mockQueryBuilder.limit).toHaveBeenCalledWith(5);
     });
   });
 
@@ -347,6 +408,17 @@ describe('createBaseRepository', () => {
 
       expect(mockModel.countDocuments).toHaveBeenCalledWith({ name: 'John' });
       expect(result).toBe(10);
+    });
+
+    it('should pass the provided session to countDocuments', async () => {
+      const session = {} as never;
+      (mockModel.countDocuments as jest.Mock).mockResolvedValue(7);
+
+      const repository = createBaseRepository<TestEntity, TestDbDoc, TestFilters>({ model: mockModel, toEntity });
+      const result = await repository.count({ name: 'John' }, session);
+
+      expect(mockModel.countDocuments).toHaveBeenCalledWith({}, { session });
+      expect(result).toBe(7);
     });
   });
 });

--- a/src/infrastructure/repositories/baseRepository/baseRepository.ts
+++ b/src/infrastructure/repositories/baseRepository/baseRepository.ts
@@ -1,18 +1,19 @@
-import { FilterQuery, Model, Types, UpdateQuery } from 'mongoose';
+import { ClientSession, FilterQuery, Model, Types, UpdateQuery } from 'mongoose';
 
 import {
   BaseEntity,
   FiltersInput,
-  IBaseRepository, PaginationFilters,
+  IBaseRepository,
+  PaginationFilters,
   QueryFilters,
   SortCriteria
 } from '~/domain/repositories/baseRepository';
 import dbConnect from '~/infrastructure/db/connect';
 
 export const createBaseRepository = <
-    TEntity extends BaseEntity,
-    TDbDoc,
-    TFilters extends FiltersInput
+  TEntity extends BaseEntity,
+  TDbDoc,
+  TFilters extends FiltersInput
 >(options: {
   model: Model<TDbDoc>;
   toEntity: (doc: TDbDoc) => TEntity;
@@ -30,29 +31,34 @@ export const createBaseRepository = <
   };
 
   const repository = {
-    findById: async (id: string): Promise<TEntity | null> => {
+    findById: async (id: string, session?: ClientSession): Promise<TEntity | null> => {
       await dbConnect();
 
       if (!Types.ObjectId.isValid(id)) {
         return null;
       }
 
-      const doc = await model.findById(id).lean<TDbDoc>();
+      const query = model.findById(id);
+      if (session) query.session(session);
+      const doc = await query.lean<TDbDoc>();
       return doc ? toEntity(doc) : null;
     },
 
-    findBySlug: async (slug: string): Promise<TEntity | null> => {
+    findBySlug: async (slug: string, session?: ClientSession): Promise<TEntity | null> => {
       await dbConnect();
 
       if (!slug) {
         return null;
       }
 
-      const doc = await model.findOne({ slug } as FilterQuery<TDbDoc>).lean<TDbDoc>();
+      const query = model.findOne({ slug } as FilterQuery<TDbDoc>);
+      if (session) query.session(session);
+      const doc = await query.lean<TDbDoc>();
+
       return doc ? toEntity(doc) : null;
     },
 
-    findAll: async (filters?: TFilters): Promise<TEntity[]> => {
+    findAll: async (filters?: TFilters, session?: ClientSession): Promise<TEntity[]> => {
       await dbConnect();
 
       const queryFilters = extractQueryFilters(filters);
@@ -71,6 +77,7 @@ export const createBaseRepository = <
       }
 
       const queryBuilder = model.find(query).sort(sort);
+      if (session) queryBuilder.session(session);
 
       if (filters?.skip) {
         queryBuilder.skip(filters.skip);
@@ -87,7 +94,8 @@ export const createBaseRepository = <
     findPaginated: async (
       page: number = 1,
       limit: number = 10,
-      filters?: Omit<TFilters, keyof PaginationFilters>
+      filters?: Omit<TFilters, keyof PaginationFilters>,
+      session?: ClientSession
     ): Promise<{ items: TEntity[]; total: number; page: number; totalPages: number }> => {
       await dbConnect();
 
@@ -99,12 +107,11 @@ export const createBaseRepository = <
         skip
       } as TFilters;
 
-       
       const countFilters = extractQueryFilters(queryFilters);
 
       const [items, total] = await Promise.all([
-        repository.findAll(queryFilters),
-        repository.count(countFilters)
+        repository.findAll(queryFilters, session),
+        repository.count(countFilters, session)
       ]);
 
       return {
@@ -115,7 +122,11 @@ export const createBaseRepository = <
       };
     },
 
-    update: async (id: string, input: Partial<Omit<TEntity, keyof BaseEntity>>): Promise<TEntity | null> => {
+    update: async (
+      id: string,
+      input: Partial<Omit<TEntity, keyof BaseEntity>>,
+      session?: ClientSession
+    ): Promise<TEntity | null> => {
       await dbConnect();
 
       if (!Types.ObjectId.isValid(id)) {
@@ -130,29 +141,34 @@ export const createBaseRepository = <
       const updated = await model
         .findByIdAndUpdate(id, dataWithTimestamp as unknown as UpdateQuery<TDbDoc>, {
           new: true,
-          runValidators: true
+          runValidators: true,
+          ...(session ? { session } : {})
         })
         .lean<TDbDoc>();
 
       return updated ? toEntity(updated) : null;
     },
 
-    delete: async (id: string): Promise<boolean> => {
+    delete: async (id: string, session?: ClientSession): Promise<boolean> => {
       await dbConnect();
 
       if (!Types.ObjectId.isValid(id)) {
         return false;
       }
 
-      const result = await model.findByIdAndDelete(id);
+      const result = session
+        ? await model.findByIdAndDelete(id, { session })
+        : await model.findByIdAndDelete(id);
       return result !== null;
     },
 
-    count: async (filters?: QueryFilters<TFilters>): Promise<number> => {
+    count: async (filters?: QueryFilters<TFilters>, session?: ClientSession): Promise<number> => {
       await dbConnect();
 
       const query = buildQuery ? buildQuery(filters) : {};
-      return model.countDocuments(query);
+      return session
+        ? model.countDocuments(query, { session })
+        : model.countDocuments(query);
     }
   };
 

--- a/src/infrastructure/repositories/compositionRepository/compositionRepository.test.ts
+++ b/src/infrastructure/repositories/compositionRepository/compositionRepository.test.ts
@@ -74,6 +74,7 @@ describe('CompositionRepository', () => {
     queryMock.limit = jest.fn().mockReturnValue(queryMock);
     queryMock.skip = jest.fn().mockReturnValue(queryMock);
     queryMock.sort = jest.fn().mockReturnValue(queryMock);
+    queryMock.session = jest.fn().mockReturnValue(queryMock);
     queryMock.then = jest.fn((resolve: (val: unknown) => void) => resolve(resolvedValue));
 
     return queryMock;
@@ -110,13 +111,24 @@ describe('CompositionRepository', () => {
     expect(result).toHaveLength(1);
   });
 
+  it('create saves a composition with the provided session', async (): Promise<void> => {
+    const session = {} as never;
+    saveMock.mockResolvedValue({ toObject: () => createMockDoc() });
+
+    const result = await repository.create(createCompositionInput(), session);
+
+    expect(saveMock).toHaveBeenCalledWith({ session });
+    expect(result.id).toBe('c1');
+  });
+
   it('syncForOpus links an existing composition by id instead of duplicating', async (): Promise<void> => {
     findByIdAndUpdateMock.mockReturnValue({ lean: jest.fn().mockResolvedValue(createMockDoc()) });
 
     const result = await repository.syncForOpus([createCompositionInput(EXISTING_COMPOSITION_ID)]);
 
     expect(findByIdAndUpdateMock).toHaveBeenCalledWith(EXISTING_COMPOSITION_ID, expect.any(Object), {
-      new: true
+      new: true,
+      session: undefined
     });
     expect(saveMock).not.toHaveBeenCalled();
     expect(result).toHaveLength(1);

--- a/src/infrastructure/repositories/compositionRepository/compositionRepository.ts
+++ b/src/infrastructure/repositories/compositionRepository/compositionRepository.ts
@@ -1,4 +1,4 @@
-import mongoose, { FilterQuery, Model } from 'mongoose';
+import mongoose, { ClientSession, FilterQuery, Model } from 'mongoose';
 
 import { createBaseRepository } from '../baseRepository/baseRepository';
 import { buildBaseQuery, combineConditions, fieldCondition, getBaseSort } from '../helpers';
@@ -75,21 +75,21 @@ export const CompositionRepository = ({ CompositionModel }: CompositionRepoDeps)
     ids.filter((id) => mongoose.Types.ObjectId.isValid(id)).map((id) => new mongoose.Types.ObjectId(id));
 
 
-  const syncForOpus = async (inputs: CompositionInput[]): Promise<Composition[]> => {
+  const syncForOpus = async (inputs: CompositionInput[], session?: ClientSession): Promise<Composition[]> => {
     await dbConnect();
-    const results = await Promise.all(
-      inputs.map(async (input, index) => {
-        const { id, ...fields } = input;
-        if (id && mongoose.Types.ObjectId.isValid(id)) {
-          const updated = await CompositionModel.findByIdAndUpdate(
-            id, { ...fields, order: index }, { new: true }
-          ).lean<DbComposition>();
-          return updated ? toEntity(updated) : null;
-        }
-        const created = await new CompositionModel({ ...fields, order: index }).save();
-        return toEntity(created.toObject() as unknown as DbComposition);
-      })
-    );
+    const results: Array<Composition | null> = [];
+    for (const [index, input] of inputs.entries()) {
+      const { id, ...fields } = input;
+      if (id && mongoose.Types.ObjectId.isValid(id)) {
+        const updated = await CompositionModel.findByIdAndUpdate(
+          id, { ...fields, order: index }, { new: true, session }
+        ).lean<DbComposition>();
+        results.push(updated ? toEntity(updated) : null);
+      } else {
+        const created = await new CompositionModel({ ...fields, order: index }).save({ session });
+        results.push(toEntity(created.toObject() as unknown as DbComposition));
+      }
+    }
     return results.filter((r): r is Composition => r !== null);
   };
 
@@ -133,7 +133,7 @@ export const CompositionRepository = ({ CompositionModel }: CompositionRepoDeps)
   };
 
 
-  const findByIds = async (ids: string[]): Promise<Composition[]> => {
+  const findByIds = async (ids: string[], session?: ClientSession): Promise<Composition[]> => {
     await dbConnect();
 
     const validIds = ids
@@ -146,12 +146,13 @@ export const CompositionRepository = ({ CompositionModel }: CompositionRepoDeps)
 
     const docs = await CompositionModel.find({ _id: { $in: validIds } })
       .sort({ order: 1, _id: 1 })
+      .session(session ?? null)
       .lean<DbComposition[]>();
 
     return docs.map(toEntity);
   };
 
-  const countByIds = async (ids: string[], filters?: CompositionFilters): Promise<number> => {
+  const countByIds = async (ids: string[], filters?: CompositionFilters, session?: ClientSession): Promise<number> => {
     await dbConnect();
 
     const validIds = toValidObjectIds(ids);
@@ -162,12 +163,13 @@ export const CompositionRepository = ({ CompositionModel }: CompositionRepoDeps)
     const query = buildCompositionQuery(filters, [
       { _id: { $in: validIds } }
     ]);
-    return CompositionModel.countDocuments(query);
+    return CompositionModel.countDocuments(query, { session });
   };
 
   const findByIdsPaginated = async (
     ids: string[],
-    filters?: CompositionFilters
+    filters?: CompositionFilters,
+    session?: ClientSession
   ): Promise<Composition[]> => {
     await dbConnect();
 
@@ -184,6 +186,7 @@ export const CompositionRepository = ({ CompositionModel }: CompositionRepoDeps)
 
     const queryBuilder = CompositionModel.find(query)
       .sort(sort)
+      .session(session ?? null)
       .collation({ locale: 'uk', numericOrdering: true });
 
     if (filters?.skip) queryBuilder.skip(filters.skip);
@@ -193,10 +196,10 @@ export const CompositionRepository = ({ CompositionModel }: CompositionRepoDeps)
     return docs.map(toEntity);
   };
 
-  const create = async (input: CompositionInput): Promise<Composition> => {
+  const create = async (input: CompositionInput, session?: ClientSession): Promise<Composition> => {
     await dbConnect();
     
-    const newComposition = await new CompositionModel(input).save();
+    const newComposition = await new CompositionModel(input).save({ session });
     return toEntity(newComposition.toObject() as unknown as DbComposition);
   };
 

--- a/src/infrastructure/repositories/helpers.test.ts
+++ b/src/infrastructure/repositories/helpers.test.ts
@@ -1,8 +1,42 @@
-import { buildBaseQuery, combineConditions, createToEntity, fieldCondition, getBaseSort } from './helpers';
+import { buildBaseQuery, combineConditions, createToEntity, fieldCondition, getBaseSort, withTransaction } from './helpers';
 import { BaseEntity } from '~/domain/repositories/baseRepository';
 import { SortByDate, SortOrder } from '~/types/enums/common.enums';
 
+jest.mock('~/infrastructure/db/connect', () => jest.fn().mockResolvedValue(undefined));
+jest.mock('mongoose', () => ({ startSession: jest.fn() }));
+
+import { startSession } from 'mongoose';
+
+const mockedStartSession = startSession as jest.MockedFunction<typeof startSession>;
+
 describe('Repository Helpers', () => {
+
+  describe('withTransaction', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it('runs the callback in a session and ends the session after success', async () => {
+      const session = {
+        withTransaction: jest.fn(async (callback: (session: unknown) => Promise<void>) => callback(session)),
+        endSession: jest.fn().mockResolvedValue(undefined)
+      } as unknown as Awaited<ReturnType<typeof startSession>>;
+      mockedStartSession.mockResolvedValue(session);
+
+      await expect(withTransaction(async (activeSession) => activeSession)).resolves.toBe(session);
+      expect(session.withTransaction).toHaveBeenCalledTimes(1);
+      expect(session.endSession).toHaveBeenCalledTimes(1);
+    });
+
+    it('ends the session and propagates callback failures', async () => {
+      const session = {
+        withTransaction: jest.fn().mockRejectedValue(new Error('transaction failed')),
+        endSession: jest.fn().mockResolvedValue(undefined)
+      } as unknown as Awaited<ReturnType<typeof startSession>>;
+      mockedStartSession.mockResolvedValue(session);
+
+      await expect(withTransaction(async () => 'result')).rejects.toThrow('transaction failed');
+      expect(session.endSession).toHaveBeenCalledTimes(1);
+    });
+  });
 
   describe('createToEntity', () => {
         interface TestEntity extends BaseEntity {
@@ -60,6 +94,18 @@ describe('Repository Helpers', () => {
           expect(result).toEqual({ status: { $in: ['published'] } });
         });
 
+        it('should include ids in the query when provided', () => {
+          const filters = { ids: ['id-1', 'id-2'] };
+          const result = buildBaseQuery<MockDbModel>(filters);
+
+          expect(result).toEqual({
+            $and: [
+              { _id: { $in: ['id-1', 'id-2'] } },
+              { _id: { $in: ['id-1', 'id-2'] } }
+            ]
+          });
+        });
+
         it('should include slug in query if provided', () => {
           const filters = { slug: 'some-slug' };
           const result = buildBaseQuery<MockDbModel>(filters);
@@ -95,6 +141,10 @@ describe('Repository Helpers', () => {
             ]
           });
         });
+
+        it('should skip search when no search fields are configured', () => {
+          expect(buildBaseQuery<MockDbModel>({ search: 'festival' }, [])).toEqual({});
+        });
   });
 
   describe('getBaseSort', () => {
@@ -118,6 +168,15 @@ describe('Repository Helpers', () => {
       };
       const result = getBaseSort(filters);
       expect(result).toEqual({ adminTitle: -1 });
+    });
+
+    it('should use a mapped sort field when provided', () => {
+      const result = getBaseSort(
+        { sort: [{ sortBy: SortByDate.CreatedAt, sortOrder: SortOrder.Asc }] },
+        { [SortByDate.CreatedAt]: 'publishedAt' }
+      );
+
+      expect(result).toEqual({ publishedAt: 1 });
     });
 
     it('should only use the first sort criteria if multiple are provided', () => {
@@ -164,6 +223,8 @@ describe('getLanguageCondition and language filtering', () => {
   it('should ignore unknown languages (returning null) and empty language arrays', () => {
     const result = buildBaseQuery({ languages: [] });
     expect(result).toEqual({});
+
+    expect(buildBaseQuery({ languages: ['unknown' as never] })).toEqual({});
   });
 
   it('should combine multiple valid languages with $or', () => {

--- a/src/infrastructure/repositories/helpers.ts
+++ b/src/infrastructure/repositories/helpers.ts
@@ -1,5 +1,6 @@
-import { FilterQuery } from 'mongoose';
+import { ClientSession, FilterQuery, startSession } from 'mongoose';
 
+import dbConnect from '../db/connect';
 import { BaseEntity, FiltersInput } from '~/domain/repositories/baseRepository';
 
 const NON_EMPTY_STRING_QUERY = { $nin: ['', null] } as const;
@@ -165,4 +166,22 @@ export const combineConditions = <TDb>(
   return { $and: nonEmpty } as FilterQuery<TDb>;
 };
 
+export async function withTransaction<T>(
+  callback: (session: ClientSession) => Promise<T>,
+): Promise<T> {
+  await dbConnect();
 
+  const session = await startSession();
+
+  try {
+    let result!: T;
+
+    await session.withTransaction(async () => {
+      result = await callback(session);
+    });
+
+    return result;
+  } finally {
+    await session.endSession();
+  }
+}

--- a/src/infrastructure/repositories/newsRepository/newsRepository.test.ts
+++ b/src/infrastructure/repositories/newsRepository/newsRepository.test.ts
@@ -22,6 +22,7 @@ interface DbNewsMock extends Omit<News, 'id'> {
 }
 
 interface MockQuery {
+  session: jest.Mock;
   sort: jest.Mock;
   skip: jest.Mock;
   limit: jest.Mock;
@@ -60,6 +61,7 @@ describe('NewsRepository - Advanced Filtering Logic', () => {
   const setupAdvancedMock = (data: DbNews[]) => {
     const queryBuilder = {
       state: { data: [...data], sort: {} as Record<string, number> },
+      session: jest.fn().mockReturnThis(),
       sort: jest.fn().mockImplementation(function (this: typeof queryBuilder, sortObj: Record<string, number>) {
         this.state.sort = sortObj;
         return this;
@@ -262,6 +264,7 @@ describe('NewsRepository Comprehensive Tests', () => {
   describe('Filtering and Sorting', () => {
     const setupChainMock = (data: DbNewsMock[]): MockQuery => {
       const query: MockQuery = {
+        session: jest.fn().mockReturnThis(),
         sort: jest.fn().mockReturnThis(),
         skip: jest.fn().mockReturnThis(),
         limit: jest.fn().mockReturnThis(),
@@ -326,6 +329,7 @@ describe('NewsRepository Comprehensive Tests', () => {
 
       const items = [createMockNewsDoc({ slug: 'n1' }), createMockNewsDoc({ slug: 'n2' })];
       findMock.mockReturnValue({
+        session: jest.fn().mockReturnThis(),
         sort: jest.fn().mockReturnThis(),
         skip: jest.fn().mockReturnThis(),
         limit: jest.fn().mockReturnThis(),
@@ -345,6 +349,7 @@ describe('NewsRepository Comprehensive Tests', () => {
   describe('Base Operations', () => {
     it('should find news by slug', async () => {
       findOneMock.mockReturnValue({
+        session: jest.fn().mockReturnThis(),
         lean: jest.fn().mockResolvedValue(createMockNewsDoc({ slug: 'unique-slug' }))
       });
 
@@ -377,6 +382,7 @@ describe('NewsRepository Comprehensive Tests', () => {
 
     it('should return null if findById finds nothing', async () => {
       findByIdMock.mockReturnValue({
+        session: jest.fn().mockReturnThis(),
         lean: jest.fn().mockResolvedValue(null)
       });
 

--- a/src/infrastructure/repositories/opusRepository/opusRepository.test.ts
+++ b/src/infrastructure/repositories/opusRepository/opusRepository.test.ts
@@ -43,6 +43,11 @@ const MOCK_YOUTUBE_URL_1 = 'https://youtube.com/watch?v=1';
 const MOCK_YOUTUBE_URL_2 = 'https://youtube.com/watch?v=2';
 const LOOSE_OPUS_ID = 'loose-opus-id';
 
+const createQueryMock = (value: unknown) => ({
+  session: jest.fn().mockReturnThis(),
+  lean: jest.fn().mockResolvedValue(value)
+});
+
 const createMockOpusDoc = (overrides: Partial<DbOpus> = {}): DbOpus => ({
   _id: { toString: (): string => MOCK_ID },
   number: OPUS_NUMBER_1,
@@ -74,6 +79,7 @@ describe('OpusRepository', () => {
   const findMock = jest.fn();
   const countDocumentsMock = jest.fn();
   const saveMock = jest.fn();
+  const createMock = jest.fn();
   const updateOneMock = jest.fn();
   const findByIdMock = jest.fn();
   const findOneAndUpdateMock = jest.fn();
@@ -87,6 +93,7 @@ describe('OpusRepository', () => {
     updateOne: jest.Mock;
     findById: jest.Mock;
     findOneAndUpdate: jest.Mock;
+    create: jest.Mock;
   };
 
   MockModel.findOne = findOneMock;
@@ -95,6 +102,7 @@ describe('OpusRepository', () => {
   MockModel.updateOne = updateOneMock;
   MockModel.findById = findByIdMock;
   MockModel.findOneAndUpdate = findOneAndUpdateMock;
+  MockModel.create = createMock;
 
   let repository: IOpusRepository;
 
@@ -122,7 +130,7 @@ describe('OpusRepository', () => {
 
   describe('findByNumber', () => {
     it('returns the opus when found', async () => {
-      findOneMock.mockReturnValue({ lean: jest.fn().mockResolvedValue(createMockOpusDoc()) });
+      findOneMock.mockReturnValue(createQueryMock(createMockOpusDoc()));
       const result = await repository.findByNumber(OPUS_NUMBER_1);
       expect(findOneMock).toHaveBeenCalledWith({ number: OPUS_NUMBER_1 });
       expect(result?.number).toBe(OPUS_NUMBER_1);
@@ -135,7 +143,7 @@ describe('OpusRepository', () => {
     });
 
     it('looks up number 0 instead of treating it as empty', async () => {
-      findOneMock.mockReturnValue({ lean: jest.fn().mockResolvedValue(createMockOpusDoc({ number: 0 })) });
+      findOneMock.mockReturnValue(createQueryMock(createMockOpusDoc({ number: 0 })));
       const result = await repository.findByNumber(0);
       expect(findOneMock).toHaveBeenCalledWith({ number: 0 });
       expect(result?.number).toBe(0);
@@ -144,17 +152,17 @@ describe('OpusRepository', () => {
 
   describe('create', () => {
     it('creates a new opus when the number is unique', async () => {
-      findOneMock.mockReturnValue({ lean: jest.fn().mockResolvedValue(null) });
-      saveMock.mockResolvedValue({ toObject: (): DbOpus => createMockOpusDoc({ number: OPUS_NUMBER_1 }) });
+      findOneMock.mockReturnValue(createQueryMock(null));
+      createMock.mockResolvedValue([{ toObject: (): DbOpus => createMockOpusDoc({ number: OPUS_NUMBER_1 }) }]);
 
       const result = await repository.create(createInput);
 
       expect(result.number).toBe(OPUS_NUMBER_1);
-      expect(saveMock).toHaveBeenCalled();
+      expect(createMock).toHaveBeenCalledWith([expect.objectContaining({ number: OPUS_NUMBER_1 })], { session: undefined });
     });
 
     it('throws when the number already exists', async () => {
-      findOneMock.mockReturnValue({ lean: jest.fn().mockResolvedValue(createMockOpusDoc()) });
+      findOneMock.mockReturnValue(createQueryMock(createMockOpusDoc()));
 
       await expect(repository.create(createInput)).rejects.toThrow(`Opus with number "${OPUS_NUMBER_1}" already exists`);
       expect(saveMock).not.toHaveBeenCalled();
@@ -166,12 +174,15 @@ describe('OpusRepository', () => {
         title: { uk: MOCK_TITLE_UK, en: MOCK_TITLE_EN },
         status: OpusStatus.Draft as unknown as CreateOpusInput['status'],
       };
-      findOneMock.mockReturnValue({ lean: jest.fn().mockResolvedValue(null) });
-      saveMock.mockResolvedValue({ toObject: (): DbOpus => createMockOpusDoc({ number: OPUS_NUMBER_2 }) });
+      findOneMock.mockReturnValue(createQueryMock(null));
+      createMock.mockResolvedValue([{ toObject: (): DbOpus => createMockOpusDoc({ number: OPUS_NUMBER_2 }) }]);
 
       const result = await repository.create(inputWithoutMeta);
 
-      expect(MockModel).toHaveBeenCalledWith(expect.objectContaining({ meta: { views: 0 } }));
+      expect(createMock).toHaveBeenCalledWith(
+        [expect.objectContaining({ meta: { views: 0 } })],
+        { session: undefined }
+      );
       expect(result.number).toBe(OPUS_NUMBER_2);
     });
   });
@@ -197,7 +208,7 @@ describe('OpusRepository', () => {
         datesNote: 'Нотатка про дати',
         publishedAt: MOCK_PUBLISHED_DATE
       });
-      findOneMock.mockReturnValue({ lean: jest.fn().mockResolvedValue(doc) });
+      findOneMock.mockReturnValue(createQueryMock(doc));
 
       const result = await repository.findByNumber(OPUS_NUMBER_1);
 
@@ -222,7 +233,7 @@ describe('OpusRepository', () => {
 
     it('keeps provided optional values instead of applying fallbacks', async (): Promise<void> => {
       const doc = createMockOpusDoc({ numberKind: 'sineop', meta: { views: 42 } });
-      findOneMock.mockReturnValue({ lean: jest.fn().mockResolvedValue(doc) });
+      findOneMock.mockReturnValue(createQueryMock(doc));
 
       const result = await repository.findByNumber(OPUS_NUMBER_1);
 
@@ -266,7 +277,7 @@ describe('OpusRepository', () => {
         ]
       });
 
-      findOneMock.mockReturnValue({ lean: jest.fn().mockResolvedValue(doc) });
+      findOneMock.mockReturnValue(createQueryMock(doc));
 
       const result = await repository.findByNumber(OPUS_NUMBER_1);
 
@@ -305,7 +316,7 @@ describe('OpusRepository', () => {
           }
         ]
       });
-      findOneMock.mockReturnValue({ lean: jest.fn().mockResolvedValue(doc) });
+      findOneMock.mockReturnValue(createQueryMock(doc));
 
       const result = await repository.findByNumber(OPUS_NUMBER_1);
 
@@ -321,6 +332,7 @@ describe('OpusRepository', () => {
   describe('findAll', () => {
     const mockChain = () => ({
       sort: jest.fn().mockReturnThis(),
+      session: jest.fn().mockReturnThis(),
       skip: jest.fn().mockReturnThis(),
       limit: jest.fn().mockReturnThis(),
       lean: jest.fn().mockResolvedValue([createMockOpusDoc()])
@@ -382,7 +394,7 @@ describe('OpusRepository', () => {
     });
     it('applies fallback for missing creationYear', async () => {
       const doc = createMockOpusDoc({ creationYear: '' });
-      findOneMock.mockReturnValue({ lean: jest.fn().mockResolvedValue(doc) });
+      findOneMock.mockReturnValue(createQueryMock(doc));
 
       const result = await repository.findByNumber(OPUS_NUMBER_1);
 
@@ -412,7 +424,7 @@ describe('OpusRepository', () => {
     
     it('falls back numberKind to "op" when nullish', async (): Promise<void> => {
       const doc = createMockOpusDoc({ numberKind: undefined });
-      findOneMock.mockReturnValue({ lean: jest.fn().mockResolvedValue(doc) });
+      findOneMock.mockReturnValue(createQueryMock(doc));
 
       const result = await repository.findByNumber(OPUS_NUMBER_1);
 
@@ -423,7 +435,7 @@ describe('OpusRepository', () => {
       const doc = createMockOpusDoc({
         name: 'Просто рядкова назва' as unknown as DbOpus['name']
       });
-      findOneMock.mockReturnValue({ lean: jest.fn().mockResolvedValue(doc) });
+      findOneMock.mockReturnValue(createQueryMock(doc));
 
       const result = await repository.findByNumber(OPUS_NUMBER_1);
 
@@ -438,7 +450,7 @@ describe('OpusRepository', () => {
         introDescription: null,
         parts: undefined
       });
-      findOneMock.mockReturnValue({ lean: jest.fn().mockResolvedValue(doc) });
+      findOneMock.mockReturnValue(createQueryMock(doc));
 
       const result = await repository.findByNumber(OPUS_NUMBER_1);
 
@@ -451,7 +463,7 @@ describe('OpusRepository', () => {
         introDescription: { uk: 'Вступ', en: 'Intro' },
         parts: { uk: 'Частини', en: 'Parts' }
       });
-      findOneMock.mockReturnValue({ lean: jest.fn().mockResolvedValue(doc) });
+      findOneMock.mockReturnValue(createQueryMock(doc));
 
       const result = await repository.findByNumber(OPUS_NUMBER_1);
 
@@ -483,23 +495,25 @@ describe('OpusRepository', () => {
             compositions: []
           })
         },
-        { upsert: true, new: true }
+        { upsert: true, new: true, session: undefined }
       );
       expect(updateOneMock).toHaveBeenCalledWith(
         { _id: LOOSE_OPUS_ID },
-        { $addToSet: { compositions: { $each: ['comp1', 'comp2'] } } }
+        { $addToSet: { compositions: { $each: ['comp1', 'comp2'] } } },
+        { session: undefined }
       );
     });
 
     it('updates loose opus using $addToSet if it already exists during moveCompositionsToCompositionsOpus', async () => {
-      findOneMock.mockReturnValue({ lean: jest.fn().mockResolvedValue({ _id: LOOSE_OPUS_ID }) });
+      findOneMock.mockReturnValue(createQueryMock({ _id: LOOSE_OPUS_ID }));
       updateOneMock.mockResolvedValue({});
 
       await repository.moveCompositionsToCompositionsOpus(['comp1', 'comp2']);
 
       expect(updateOneMock).toHaveBeenCalledWith(
         { _id: LOOSE_OPUS_ID },
-        { $addToSet: { compositions: { $each: ['comp1', 'comp2'] } } }
+        { $addToSet: { compositions: { $each: ['comp1', 'comp2'] } } },
+        { session: undefined }
       );
     });
 
@@ -509,7 +523,7 @@ describe('OpusRepository', () => {
     });
 
     it('does nothing in removeCompositionsFromCompositionsOpus when loose opus does not exist', async () => {
-      findOneMock.mockReturnValue({ lean: jest.fn().mockResolvedValue(null) });
+      findOneMock.mockReturnValue(createQueryMock(null));
 
       await repository.removeCompositionsFromCompositionsOpus(['comp1']);
 
@@ -517,19 +531,20 @@ describe('OpusRepository', () => {
     });
 
     it('removes compositions from loose opus if it exists during removeCompositionsFromCompositionsOpus', async () => {
-      findOneMock.mockReturnValue({ lean: jest.fn().mockResolvedValue({ _id: LOOSE_OPUS_ID }) });
+      findOneMock.mockReturnValue(createQueryMock({ _id: LOOSE_OPUS_ID }));
       updateOneMock.mockResolvedValue({});
 
       await repository.removeCompositionsFromCompositionsOpus(['comp1']);
 
       expect(updateOneMock).toHaveBeenCalledWith(
         { _id: LOOSE_OPUS_ID },
-        { $pull: { compositions: { $in: ['comp1'] } } }
+        { $pull: { compositions: { $in: ['comp1'] } } },
+        { session: undefined }
       );
     });
 
     it('unlinks opus by finding it and moving its compositions', async () => {
-      findByIdMock.mockReturnValue({ lean: jest.fn().mockResolvedValue({ compositions: ['comp-to-move'] }) });
+      findByIdMock.mockReturnValue(createQueryMock({ compositions: ['comp-to-move'] }));
       findOneAndUpdateMock.mockReturnValue({
         lean: jest.fn().mockResolvedValue({ _id: LOOSE_OPUS_ID })
       });
@@ -541,7 +556,8 @@ describe('OpusRepository', () => {
       expect(findOneAndUpdateMock).toHaveBeenCalled();
       expect(updateOneMock).toHaveBeenCalledWith(
         { _id: LOOSE_OPUS_ID },
-        { $addToSet: { compositions: { $each: ['comp-to-move'] } } }
+        { $addToSet: { compositions: { $each: ['comp-to-move'] } } },
+        { session: undefined }
       );
     });
   });

--- a/src/infrastructure/repositories/opusRepository/opusRepository.ts
+++ b/src/infrastructure/repositories/opusRepository/opusRepository.ts
@@ -1,4 +1,4 @@
-import { Model } from 'mongoose';
+import { ClientSession, Model } from 'mongoose';
 
 import { createBaseRepository } from '../baseRepository/baseRepository';
 import { opusServiceErrors } from '~/back-constants/errors';
@@ -124,18 +124,23 @@ export const OpusRepository = ({ OpusModel }: OpusRepoDeps): IOpusRepository => 
     getDefaultSort: getBaseSort
   });
 
-  const findByNumber = async (number: number): Promise<Opus | null> => {
+  const findByNumber = async (number: number, session?: ClientSession): Promise<Opus | null> => {
     await dbConnect();
 
     if (number === undefined || number === null) {
       return null;
     }
 
-    const doc = await OpusModel.findOne({ number }).lean<DbOpus>();
+    const doc = await OpusModel.findOne({ number })
+      .session(session ?? null)
+      .lean<DbOpus>();
+
     return doc ? toEntity(doc) : null;
   };
 
-  const getOrCreateCompositionsOpus = async (): Promise<{ _id: string }> => {
+  const getOrCreateCompositionsOpus = async (
+    session?: ClientSession 
+  ): Promise<{ _id: string }> => {
     return OpusModel.findOneAndUpdate(
       { numberKind: 'compositions' },
       {
@@ -148,53 +153,70 @@ export const OpusRepository = ({ OpusModel }: OpusRepoDeps): IOpusRepository => 
           compositions: []
         }
       },
-      { upsert: true, new: true }
+      { 
+        upsert: true, 
+        new: true, 
+        session: session
+      }
     ).lean<{ _id: string }>();
   };
 
   const moveCompositionsToCompositionsOpus = async (
     compositionIds: string[],
+    session?: ClientSession
   ): Promise<void> => {
     if (compositionIds.length === 0) {
       return;
     }
-    const compOpus = await getOrCreateCompositionsOpus();
+
+    const compOpus = await getOrCreateCompositionsOpus(session);
+
     await OpusModel.updateOne(
       { _id: compOpus._id },
       { $addToSet: { compositions: { $each: compositionIds } } },
+      { session }
     );
   };
 
   const removeCompositionsFromCompositionsOpus = async (
     compositionIds: string[],
+    session?: ClientSession
   ): Promise<void> => {
     if (compositionIds.length === 0) {
       return;
     }
+
     const compOpus = await OpusModel.findOne({ numberKind: 'compositions' })
+      .session(session ?? null)
       .lean<{ _id: string }>();
+
     if (!compOpus) {
       return;
     }
+
     await OpusModel.updateOne(
       { _id: compOpus._id },
       { $pull: { compositions: { $in: compositionIds } } },
+      { session } 
     );
   };
 
-  const unlink = async (opusId: string): Promise<void> => {
+  const unlink = async (opusId: string, session?: ClientSession): Promise<void> => {
     await dbConnect();
-    const opus = await OpusModel.findById(opusId).lean<{ compositions?: string[] }>();
-    await moveCompositionsToCompositionsOpus(opus?.compositions ?? []);
+    const opus = await OpusModel.findById(opusId)
+      .session(session ?? null)
+      .lean<{ compositions?: string[] }>();
+
+    await moveCompositionsToCompositionsOpus(opus?.compositions ?? [], session);
   };
 
   return {
     ...baseRepo,
     findByNumber,
-    create: async (input: CreateOpusInput): Promise<Opus> => {
+    create: async (input: CreateOpusInput, session?: ClientSession): Promise<Opus> => {
       await dbConnect();
 
-      const existing = await findByNumber(input.number);
+      const existing = await findByNumber(input.number, session);
 
       if (existing) {
         throw new Error(opusServiceErrors.NUMBER_ALREADY_EXISTS(input.number));
@@ -205,7 +227,7 @@ export const OpusRepository = ({ OpusModel }: OpusRepoDeps): IOpusRepository => 
         meta: { views: input.meta?.views ?? 0 }
       };
 
-      const newOpus = await new OpusModel(opusData).save();
+      const [newOpus] = await OpusModel.create([opusData], { session });
       return toEntity(newOpus.toObject() as unknown as DbOpus);
     },
     unlink,

--- a/src/interfaces/graphql/resolvers/compositions/compositionsMutation.test.ts
+++ b/src/interfaces/graphql/resolvers/compositions/compositionsMutation.test.ts
@@ -13,6 +13,10 @@ import type {
   UpdateCompositionInput
 } from '~/types/graphql/generated/graphql';
 
+jest.mock('~/src/infrastructure/repositories/helpers', () => ({
+  withTransaction: jest.fn(async (callback: (session: object) => Promise<unknown>) => callback({}))
+}));
+
 type AdminContextType = NonNullable<GraphQLContext['admin']>;
 
 type MockCompositionsRepository = {
@@ -177,8 +181,8 @@ describe('CompositionsMutation', () => {
 
       const result = await CompositionsMutation.createComposition(null, { input: MOCK_INPUT }, context);
 
-      expect(createMock).toHaveBeenCalledWith(MOCK_MAPPED_INPUT);
-      expect(moveMock).toHaveBeenCalledWith([MOCK_COMPOSITION_ID]);
+      expect(createMock).toHaveBeenCalledWith(MOCK_MAPPED_INPUT, expect.anything());
+      expect(moveMock).toHaveBeenCalledWith([MOCK_COMPOSITION_ID], expect.anything());
       expect(result).toEqual(MOCK_COMPOSITION);
     });
 
@@ -193,7 +197,7 @@ describe('CompositionsMutation', () => {
 
       await CompositionsMutation.createComposition(null, { input: MOCK_INPUT_PARTIAL }, context);
 
-      expect(createMock).toHaveBeenCalledWith(MOCK_MAPPED_INPUT_PARTIAL);
+      expect(createMock).toHaveBeenCalledWith(MOCK_MAPPED_INPUT_PARTIAL, expect.anything());
     });
   });
 
@@ -365,8 +369,8 @@ describe('CompositionsMutation', () => {
         context
       );
 
-      expect(removeMock).toHaveBeenCalledWith([MOCK_COMPOSITION_ID]);
-      expect(deleteMock).toHaveBeenCalledWith(MOCK_COMPOSITION_ID);
+      expect(removeMock).toHaveBeenCalledWith([MOCK_COMPOSITION_ID], expect.anything());
+      expect(deleteMock).toHaveBeenCalledWith(MOCK_COMPOSITION_ID, expect.anything());
       expect(result).toBe(true);
     });
   });

--- a/src/interfaces/graphql/resolvers/compositions/compositionsMutation.ts
+++ b/src/interfaces/graphql/resolvers/compositions/compositionsMutation.ts
@@ -5,6 +5,7 @@ import { graphqlErrors } from '~/constants/errors';
 import type { Composition } from '~/domain/entities/Composition';
 import { compositionsServiceErrors } from '~/src/constants/errors';
 import { CompositionInput, ICompositionRepository } from '~/src/domain/repositories/compositionRepository';
+import { withTransaction } from '~/src/infrastructure/repositories/helpers';
 import { CreateCompositionInput, UpdateCompositionInput } from '~/types/graphql/generated/graphql';
 
 type CreateCompositionArgs = { input: CreateCompositionInput };
@@ -53,14 +54,16 @@ export const CompositionsMutation = {
 
     const compositionData = mapCompositionInput(input);
 
-    const composition = await repo.create(compositionData);
-    if (!composition) {
-      throw new Error(compositionsServiceErrors.COMPOSITION_NOT_CREATED);
-    }
+    return withTransaction(async (session) => {
+      const composition = await repo.create(compositionData, session );
+      if (!composition) {
+        throw new Error(compositionsServiceErrors.COMPOSITION_NOT_CREATED);
+      }
 
-    await opusRepo.moveCompositionsToCompositionsOpus([composition.id]);
+      await opusRepo.moveCompositionsToCompositionsOpus([composition.id], session);
 
-    return composition;
+      return composition;
+    });
   },
 
   updateComposition: async (_: unknown, { id, input }: UpdateCompositionArgs, context: GraphQLContext): Promise<Composition> => {
@@ -94,10 +97,12 @@ export const CompositionsMutation = {
     assertAuthenticated(context);
     const repo = context.requestContainer.cradle.compositionsRepository;
     await findExistingComposition(repo, id);
-	
-    const opusRepo = context.requestContainer.cradle.opusRepository;
-    await opusRepo.removeCompositionsFromCompositionsOpus([id]);
 
-    return repo.delete(id);
+    const opusRepo = context.requestContainer.cradle.opusRepository;
+
+    return withTransaction(async (session) => {
+      await opusRepo.removeCompositionsFromCompositionsOpus([id], session);
+      return repo.delete(id, session);
+    });
   }
 };

--- a/src/interfaces/graphql/resolvers/helpers.ts
+++ b/src/interfaces/graphql/resolvers/helpers.ts
@@ -1,4 +1,5 @@
 import { GraphQLError } from 'graphql';
+import type { ClientSession } from 'mongoose';
 
 import {extractImagesWithMetadata} from '~/application/use-cases/extractImageSrc/extractImageSrc';
 import type { GraphQLContext } from '~/back-shared/types/container/types';
@@ -82,19 +83,20 @@ export const extractTitleForSlug = (title: unknown): string => {
 };
 
 export const processSlugUpdate = async <
-    TRepo extends { findBySlug: (slug: string) => Promise<BaseEntity | null> }
+    TRepo extends { findBySlug: (slug: string, session?: ClientSession) => Promise<BaseEntity | null> }
 >(
   id: string | null,
   title: unknown,
   repo: TRepo,
-  updateData: { slug?: string }
+  updateData: { slug?: string },
+  session?: ClientSession
 ): Promise<void> => {
   const titleForSlug = extractTitleForSlug(title);
 
   if (titleForSlug) {
     updateData.slug = await generateUniqueSlug(titleForSlug, {
       checkExists: async (slug: string) => {
-        const existing = await repo.findBySlug(slug);
+        const existing = await repo.findBySlug(slug, session);
         return existing !== null && (id ? existing.id !== id : true);
       }
     });

--- a/src/interfaces/graphql/resolvers/opus/opusMutation.test.ts
+++ b/src/interfaces/graphql/resolvers/opus/opusMutation.test.ts
@@ -16,6 +16,9 @@ import { OpusStatus } from '~/types/graphql/generated/graphql';
 jest.mock('../helpers');
 jest.mock('./tab-handlers/tabHandlersHelpers');
 jest.mock('~/src/shared/utils/slugGenerator/slugGenerator');
+jest.mock('~/src/infrastructure/repositories/helpers', () => ({
+  withTransaction: jest.fn(async (callback: (session: object) => Promise<unknown>) => callback({}))
+}));
 
 const mockedSyncImagesCrops = syncImagesCrops as jest.MockedFunction<typeof syncImagesCrops>;
 const mockedMarkImagesAsUsed = markImagesAsUsed as jest.MockedFunction<typeof markImagesAsUsed>;
@@ -225,7 +228,7 @@ describe('OpusMutation Resolvers', () => {
             { name: 'Audio 2', url: null }
           ]
         }
-      ]);
+      ], expect.anything());
       expect(mockOpusRepo.create).toHaveBeenCalledWith({
         number: OPUS_NUMBER,
         numberKind: 'op',
@@ -249,8 +252,8 @@ describe('OpusMutation Resolvers', () => {
         meta: { views: 0 },
         compositions: [COMPOSITION_ID_1],
         blocksOrder: null
-      });
-      expect(mockOpusRepo.removeCompositionsFromCompositionsOpus).toHaveBeenCalledWith([COMPOSITION_ID_1]);
+      }, expect.anything());
+      expect(mockOpusRepo.removeCompositionsFromCompositionsOpus).toHaveBeenCalledWith([COMPOSITION_ID_1], expect.anything());
       expect(mockedSyncImagesCrops).toHaveBeenCalledWith(OPUS_ID, coverImage, {
         isCoverImage: true
       });
@@ -286,7 +289,8 @@ describe('OpusMutation Resolvers', () => {
       expect(mockOpusRepo.create).toHaveBeenCalledWith(
         expect.objectContaining({
           status: OpusStatus.Published
-        })
+        }),
+        expect.anything()
       );
       expect(mockedSyncImagesCrops).not.toHaveBeenCalled();
       expect(mockedMarkImagesAsUsed).not.toHaveBeenCalled();
@@ -556,7 +560,7 @@ describe('OpusMutation Resolvers', () => {
         adminContext
       );
 
-      expect(mockCompositionsRepo.findByIds).toHaveBeenCalledWith([COMPOSITION_ID_1, COMPOSITION_ID_2]);
+      expect(mockCompositionsRepo.findByIds).toHaveBeenCalledWith([COMPOSITION_ID_1, COMPOSITION_ID_2], expect.anything());
       expect(mockedOrderCompositionsByIds).toHaveBeenCalledWith(
         [COMPOSITION_ID_1, COMPOSITION_ID_2],
         [MOCK_COMPOSITION_1, MOCK_COMPOSITION_2]
@@ -568,7 +572,7 @@ describe('OpusMutation Resolvers', () => {
         creationYear: CREATION_YEAR,
         title: { uk: 'Нев', en: 'New' },
         compositions: [COMPOSITION_ID_1, COMPOSITION_ID_2]
-      });
+      }, expect.anything());
       expect(result).toEqual({ ...MOCK_OPUS_ENTITY, compositions: [MOCK_COMPOSITION_1, MOCK_COMPOSITION_2] });
     });
 
@@ -592,9 +596,9 @@ describe('OpusMutation Resolvers', () => {
         adminContext
       );
 
-      expect(mockedProcessSlugUpdate).toHaveBeenCalledWith(OPUS_ID, nameInput, mockOpusRepo, expect.any(Object));
-      expect(mockOpusRepo.removeCompositionsFromCompositionsOpus).toHaveBeenCalledWith([COMPOSITION_ID_3]);
-      expect(mockOpusRepo.moveCompositionsToCompositionsOpus).toHaveBeenCalledWith([COMPOSITION_ID_1]);
+      expect(mockedProcessSlugUpdate).toHaveBeenCalledWith(OPUS_ID, nameInput, mockOpusRepo, expect.any(Object), expect.anything());
+      expect(mockOpusRepo.removeCompositionsFromCompositionsOpus).toHaveBeenCalledWith([COMPOSITION_ID_3], expect.anything());
+      expect(mockOpusRepo.moveCompositionsToCompositionsOpus).toHaveBeenCalledWith([COMPOSITION_ID_1], expect.anything());
     });
 
     it('should throw OPUS_NOT_FOUND when update returns null', async () => {
@@ -651,7 +655,7 @@ describe('OpusMutation Resolvers', () => {
         adminContext
       );
 
-      expect(mockOpusRepo.update).toHaveBeenCalledWith(OPUS_ID, expect.objectContaining({ performances }));
+      expect(mockOpusRepo.update).toHaveBeenCalledWith(OPUS_ID, expect.objectContaining({ performances }), expect.anything());
     });
 
     describe('Field Validations (updateOpus)', () => {
@@ -777,7 +781,7 @@ describe('OpusMutation Resolvers', () => {
             sheetMusic: [],
             audios: []
           })
-        ]);
+        ], expect.anything());
       });
 
       it('should skip gallery item validation if src is empty', async () => {
@@ -812,8 +816,8 @@ describe('OpusMutation Resolvers', () => {
 
       const result = await OpusMutation.deleteOpus({}, { id: OPUS_ID }, adminContext);
 
-      expect(mockOpusRepo.unlink).toHaveBeenCalledWith(OPUS_ID);
-      expect(mockOpusRepo.delete).toHaveBeenCalledWith(OPUS_ID);
+      expect(mockOpusRepo.unlink).toHaveBeenCalledWith(OPUS_ID, expect.anything());
+      expect(mockOpusRepo.delete).toHaveBeenCalledWith(OPUS_ID, expect.anything());
       expect(result).toBe(true);
     });
   });
@@ -882,9 +886,9 @@ describe('OpusMutation Resolvers', () => {
       expect(mockOpusRepo.findById).toHaveBeenCalledWith(OPUS_ID);
       expect(mockOpusRepo.update).toHaveBeenCalledWith(OPUS_ID, {
         compositions: [COMPOSITION_ID_2]
-      });
-      expect(mockOpusRepo.moveCompositionsToCompositionsOpus).toHaveBeenCalledWith([COMPOSITION_ID_1]);
-      expect(mockCompositionsRepo.findByIds).toHaveBeenCalledWith([COMPOSITION_ID_2]);
+      }, expect.anything());
+      expect(mockOpusRepo.moveCompositionsToCompositionsOpus).toHaveBeenCalledWith([COMPOSITION_ID_1], expect.anything());
+      expect(mockCompositionsRepo.findByIds).toHaveBeenCalledWith([COMPOSITION_ID_2], expect.anything());
       expect(mockedOrderCompositionsByIds).toHaveBeenCalledWith([COMPOSITION_ID_2], [MOCK_COMPOSITION_2]);
       expect(result).toEqual({ ...updatedOpusEntity, compositions: [MOCK_COMPOSITION_2] });
     });

--- a/src/interfaces/graphql/resolvers/opus/opusMutation.ts
+++ b/src/interfaces/graphql/resolvers/opus/opusMutation.ts
@@ -1,4 +1,5 @@
 import { GraphQLError } from 'graphql';
+import { ClientSession } from 'mongoose';
 
 import { markImagesAsUsed, processSlugUpdate, syncImagesCrops } from '../helpers';
 import { orderCompositionsByIds } from './tab-handlers/tabHandlersHelpers';
@@ -16,6 +17,7 @@ import type {
 } from '~/domain/entities/Opus';
 import { CompositionInput, ICompositionRepository } from '~/domain/repositories/compositionRepository';
 import { CreateOpusInput, IOpusRepository, UpdateOpusInput } from '~/domain/repositories/opusRepository';
+import { withTransaction } from '~/src/infrastructure/repositories/helpers';
 import { generateUniqueSlug } from '~/src/shared/utils/slugGenerator/slugGenerator';
 import { OpusGalleryItemInput, OpusStatus, UpdateOpusStatusPayload } from '~/types/graphql/generated/graphql';
 
@@ -259,14 +261,18 @@ async function handleCompositionsSync(
   compositionsRepo: ICompositionRepository,
   repo: IOpusRepository,
   existingOpus: Opus,
-  inputCompositions: GQLComposition[] | undefined
+  inputCompositions: GQLComposition[] | undefined,
+  session?: ClientSession
 ) {
   if (inputCompositions === undefined) {
     const compositionIds = existingOpus.compositions ?? [];
-    return orderCompositionsByIds(compositionIds, await compositionsRepo.findByIds(compositionIds));
+    return orderCompositionsByIds(compositionIds, await compositionsRepo.findByIds(compositionIds, session));
   }
 
-  const compositions = await compositionsRepo.syncForOpus(inputCompositions.map(mapComposition));
+  const compositions = await compositionsRepo.syncForOpus(
+    inputCompositions.map(mapComposition),
+    session
+  );
   const oldCompositionIds = (existingOpus.compositions ?? []).map((cid) => cid.toString());
   const newCompositionIds = compositions.map((c) => c.id);
 
@@ -276,17 +282,17 @@ async function handleCompositionsSync(
   const removed = oldCompositionIds.filter((cid) => !newSet.has(cid));
 
   if (added.length > 0) {
-    await repo.removeCompositionsFromCompositionsOpus(added);
+    await repo.removeCompositionsFromCompositionsOpus(added, session);
   }
   if (removed.length > 0) {
-    await repo.moveCompositionsToCompositionsOpus(removed);
+    await repo.moveCompositionsToCompositionsOpus(removed, session);
   }
 
   return compositions;
 }
 
-async function updateAndVerifyOpus(repo: IOpusRepository, id: string, updateData: UpdateOpusInput): Promise<Opus> {
-  const opus = await repo.update(id, updateData);
+async function updateAndVerifyOpus(repo: IOpusRepository, id: string, updateData: UpdateOpusInput, session?: ClientSession ): Promise<Opus> {
+  const opus = await repo.update(id, updateData, session);
   if (!opus) {
     throw new GraphQLError(opusServiceErrors.OPUS_NOT_FOUND(id), {
       extensions: { code: 'OPUS_NOT_FOUND' }
@@ -335,6 +341,7 @@ export const OpusMutation = {
 
     const repo = context.requestContainer.cradle.opusRepository;
     const compositionsRepo = context.requestContainer.cradle.compositionsRepository;
+    const assetsRepo = context.requestContainer.cradle.assetsRepository;
 
     const number = input.number;
     const existingByNumber = await repo.findByNumber(number);
@@ -349,45 +356,51 @@ export const OpusMutation = {
       checkExists: async (candidate: string) => (await repo.findBySlug(candidate)) !== null
     });
 
-    const compositions = await compositionsRepo.syncForOpus((input.compositions ?? []).map(mapComposition));
-    const compositionIds = compositions.map((c) => c.id);
+    const { opus, compositions } = await withTransaction(async (session) => {
+      const syncedCompositions = await compositionsRepo.syncForOpus(
+        (input.compositions ?? []).map(mapComposition),
+        session
+      );
+      const compositionIds = syncedCompositions.map((c) => c.id);
 
-    const opusData: CreateOpusInput = {
-      number: input.number,
-      numberKind: input.numberKind,
-      title: input.title,
-      name: input.name,
-      description: input.description,
-      additionalText: input.additionalText ?? null,
-      creationYear: input.creationYear,
-      endYear: input.endYear ?? null,
-      datesNote: input.datesNote ?? null,
-      genre: input.genre ?? null,
-      adminTitle: input.adminTitle ?? null,
-      slug,
-      introDescription: input.introDescription ?? null,
-      parts: input.parts ?? null,
-      keywords: input.keywords ?? null,
-      allowIndexation: input.allowIndexation ?? null,
-      coverImage: input.coverImage ?? null,
-      status: input.status || OpusStatus.Draft,
-      publishedAt: input.publishedAt ?? null,
-      meta: { views: 0 },
-      compositions: compositionIds,
-      gallery: input.gallery,
-      performancesTitle: input.performancesTitle,
-      performances: input.performances,
-      blocksOrder: input.blocksOrder ?? null
-    };
+      const opusData: CreateOpusInput = {
+        number: input.number,
+        numberKind: input.numberKind,
+        title: input.title,
+        name: input.name,
+        description: input.description,
+        additionalText: input.additionalText ?? null,
+        creationYear: input.creationYear,
+        endYear: input.endYear ?? null,
+        datesNote: input.datesNote ?? null,
+        genre: input.genre ?? null,
+        adminTitle: input.adminTitle ?? null,
+        slug,
+        introDescription: input.introDescription ?? null,
+        parts: input.parts ?? null,
+        keywords: input.keywords ?? null,
+        allowIndexation: input.allowIndexation ?? null,
+        coverImage: input.coverImage ?? null,
+        status: input.status || OpusStatus.Draft,
+        publishedAt: input.publishedAt ?? null,
+        meta: { views: 0 },
+        compositions: compositionIds,
+        gallery: input.gallery,
+        performancesTitle: input.performancesTitle,
+        performances: input.performances,
+        blocksOrder: input.blocksOrder ?? null
+      };
 
-    const opus = await repo.create(opusData);
-    await repo.removeCompositionsFromCompositionsOpus(compositionIds);
+      const newOpus = await repo.create(opusData, session);
+      await repo.removeCompositionsFromCompositionsOpus(compositionIds, session);
+
+      return { opus: newOpus, compositions: syncedCompositions };
+    });
 
     if (input.coverImage?.crop) {
       await syncImagesCrops(opus.id, input.coverImage, { isCoverImage: true });
     }
     if (input.coverImage) {
-      const assetsRepo = context.requestContainer.cradle.assetsRepository;
       await markImagesAsUsed(assetsRepo, null, input.coverImage, 'opus', opus.id);
     }
 
@@ -442,16 +455,27 @@ export const OpusMutation = {
 
     await ensureUniqueOpusNumber(repo, id, input.number);
 
-    const compositions = await handleCompositionsSync(compositionsRepo, repo, existingOpus, input.compositions);
+    const { opus, compositions } = await withTransaction(async (session) => {
+      const syncedCompositions = await handleCompositionsSync(
+        compositionsRepo,
+        repo,
+        existingOpus,
+        input.compositions,
+        session
+      );
 
-    const updateData = buildOpusUpdateData(
-      input,
-      compositions.map((c) => c.id)
-    );
+      const updateData = buildOpusUpdateData(
+        input,
+        syncedCompositions.map((c) => c.id)
+      );
 
-    await processSlugUpdate(id, input.name, repo, updateData);
+      await processSlugUpdate(id, input.name, repo, updateData, session);
 
-    const opus = await updateAndVerifyOpus(repo, id, updateData);
+      const opus = await updateAndVerifyOpus(repo, id, updateData, session);
+
+
+      return { opus, compositions: syncedCompositions };
+    });
 
     if (input.coverImage?.crop) {
       await syncImagesCrops(opus.id, input.coverImage, { isCoverImage: true });
@@ -466,8 +490,10 @@ export const OpusMutation = {
   deleteOpus: async (_: unknown, { id }: { id: string }, context: GraphQLContext): Promise<boolean> => {
     assertAuthenticated(context);
     const repo = context.requestContainer.cradle.opusRepository;
-    await repo.unlink(id);
-    return repo.delete(id);
+    return withTransaction(async (session) => {
+      await repo.unlink(id, session);
+      return repo.delete(id, session);
+    });
   },
 
   unlinkComposition: async (_: unknown, { opusId, compositionId }: UnlinkCompositionArgs, context: GraphQLContext): Promise<OpusFull> => {
@@ -492,15 +518,17 @@ export const OpusMutation = {
 
     const updatedCompositionIds = currentCompositions.filter((id) => id !== compositionId);
 
-    const updatedOpus = await updateAndVerifyOpus(repo, opusId, {
-      compositions: updatedCompositionIds
+    return withTransaction(async (session) => {
+      const updatedOpus = await updateAndVerifyOpus(repo, opusId, {
+        compositions: updatedCompositionIds
+      }, session);
+
+      await repo.moveCompositionsToCompositionsOpus([compositionId], session);
+
+      const compositions = await compositionsRepo.findByIds(updatedCompositionIds, session);
+      const orderedCompositions = orderCompositionsByIds(updatedCompositionIds, compositions);
+
+      return { ...updatedOpus, compositions: orderedCompositions };
     });
-
-    await repo.moveCompositionsToCompositionsOpus([compositionId]);
-
-    const compositions = await compositionsRepo.findByIds(updatedCompositionIds);
-    const orderedCompositions = orderCompositionsByIds(updatedCompositionIds, compositions);
-
-    return { ...updatedOpus, compositions: orderedCompositions };
   },
 };


### PR DESCRIPTION
  ## Description

  Implements atomic database transactions for opus and composition workflows.

  ### What was changed

  - Added session propagation across opus and composition repositories.
  - Wrapped multi-write create, update, delete, sync, and unlink flows in transactions.
  - Ensured composition synchronization participates in the active transaction.
  - Preserved non-transactional behavior for shared image.
  - Added transaction-aware repository mocks and updated affected tests.

  ## Type of change

  - [x] New feature
  - [ ] Bug fix
  - [ ] Documentation update
  - [ ] Refactoring / Tech debt
  - [ ] CI/CD improvement
  - [ ] Other:

# How to test

1. Check out this branch.
2. Make sure your local MongoDB instance is configured to use a Replica Set.
3. Verify the following **Opus** and **Composition** flows:
* Create
* Update
* Delete

## Configure MongoDB Replica Set locally

1. Make sure MongoDB is running and available:

```bash
net start MongoDB
```

2. Start MongoDB with Replica Set support:

```bash
mongod --replSet rs0
```

3. Open the MongoDB shell:

```bash
mongosh
```

4. Initialize the Replica Set:

```javascript
rs.initiate()
```

5. Verify that the MongoDB configuration file:

```text
C:\Program Files\MongoDB\Server\<version>\bin\mongod.cfg
```

contains:

```yaml
replication:
  replSetName: rs0
```

6. If you updated `mongod.cfg`, restart the MongoDB service to apply the changes.

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
 Closes #759
