### PR TITLE
fix: min length alt text validation

### DIFF
--- a/app/shared/components/forms/seo-metadata-form/SeoMetadataForm.test.tsx
+++ b/app/shared/components/forms/seo-metadata-form/SeoMetadataForm.test.tsx
@@ -16,13 +16,19 @@ jest.mock('~/shared/components/design-system/photo-block/PhotoBlock', () => ({
     onChangeImage,
     showAlternativeText,
     altText,
-    onChangeAltText
+    onChangeAltText,
+    onBlurAltText,
+    altTextError,
+    altTextErrorState
   }: {
     imageUrl?: string;
     onChangeImage: (url: string, crop?: MockCropResult | null) => void;
     showAlternativeText?: boolean;
     altText?: string;
     onChangeAltText?: (value: string) => void;
+    onBlurAltText?: () => void;
+    altTextError?: string;
+    altTextErrorState?: boolean;
   }) => (
     <div data-testid="photo-block" data-imageurl={imageUrl}>
       <button data-testid="photo-block-trigger" onClick={() => onChangeImage('https://example.com/mock-image.png')}>
@@ -44,11 +50,15 @@ jest.mock('~/shared/components/design-system/photo-block/PhotoBlock', () => ({
         PhotoBlock Query URL
       </button>
       {showAlternativeText && (
-        <input
-          aria-label="Alt текст зображення"
-          value={altText || ''}
-          onChange={(e) => onChangeAltText?.(e.target.value)}
-        />
+        <>
+          <input
+            aria-label="Alt текст зображення"
+            value={altText || ''}
+            onChange={(e) => onChangeAltText?.(e.target.value)}
+            onBlur={onBlurAltText}
+          />
+          {altTextErrorState && altTextError && <span data-testid="alt-text-error">{altTextError}</span>}
+        </>
       )}
     </div>
   )
@@ -618,5 +628,61 @@ describe('SeoMetadataForm', () => {
 
     const photoBlock = screen.getByTestId('photo-block');
     expect(photoBlock).toHaveAttribute('data-imageurl', 'https://example.com/valid.png');
+  });
+
+  const renderWithStateAndAltText = () => {
+    const Wrapper = () => {
+      const [value, setValue] = React.useState<SeoMetadataFormProps['value']>(defaultProps.value);
+      return (
+        <SeoMetadataForm {...defaultProps} value={value} onChange={setValue} showAlternativeText={true} />
+      );
+    };
+
+    return render(<Wrapper />);
+  };
+
+  it('shows no alt text error when the field is left empty (alt text is optional)', async () => {
+    renderWithStateAndAltText();
+    const altInput = screen.getByLabelText(/alt текст/i);
+ 
+    await user.click(altInput);
+    await user.tab();
+ 
+    expect(screen.queryByTestId('alt-text-error')).not.toBeInTheDocument();
+  });
+ 
+  it('shows minLength error when alt text has 1 character on blur', async () => {
+    renderWithStateAndAltText();
+    const altInput = screen.getByLabelText(/alt текст/i);
+ 
+    await user.type(altInput, 'T');
+    await user.tab();
+ 
+    expect(await screen.findByTestId('alt-text-error')).toHaveTextContent(/мінімум 2 символа/i);
+  });
+ 
+  it('clears alt text error once 2+ characters are entered', async () => {
+    renderWithStateAndAltText();
+    const altInput = screen.getByLabelText(/alt текст/i);
+ 
+    await user.type(altInput, 'T');
+    await user.tab();
+    expect(await screen.findByTestId('alt-text-error')).toBeInTheDocument();
+ 
+    await user.type(altInput, 'e');
+    expect(screen.queryByTestId('alt-text-error')).not.toBeInTheDocument();
+  });
+ 
+  it('shows alt text error via forceShowErrors when showAlternativeText is enabled', () => {
+    render(
+      <SeoMetadataForm
+        {...defaultProps}
+        showAlternativeText={true}
+        forceShowErrors={true}
+        value={{ ...defaultProps.value, altText: { uk: 'T', en: 'T' } }}
+      />
+    );
+ 
+    expect(screen.getByTestId('alt-text-error')).toBeInTheDocument();
   });
 });

--- a/app/shared/components/forms/seo-metadata-form/SeoMetadataForm.tsx
+++ b/app/shared/components/forms/seo-metadata-form/SeoMetadataForm.tsx
@@ -49,6 +49,8 @@ export interface SeoMetadataFormProps {
   };
 }
 
+const ALT_TEXT_MIN_LENGTH = 2;
+
 const getFileNameFromUrl = (url: string | null): string | undefined =>
   url ? url.split('/').pop()?.split('?')[0] : undefined;
 
@@ -87,6 +89,9 @@ export default function SeoMetadataForm({
   const [touched, setTouched] = useState<Partial<Record<keyof LocalizedMeta, boolean>>>({});
   const [errors, setErrors] = useState<Partial<Record<keyof LocalizedMeta, string>>>({});
 
+  const [altTextTouched, setAltTextTouched] = useState(false);
+  const [altTextError, setAltTextError] = useState('');
+
   const translationErrors = seoFormErrors[locale];
 
   useEffect(() => {
@@ -107,6 +112,11 @@ export default function SeoMetadataForm({
       title: validateField('title', value.title),
       description: validateField('description', value.description)
     }));
+
+    if (showAlternativeText) {
+      setAltTextTouched(true);
+      setAltTextError(validateAltText(value.altText?.[locale] ?? ''));
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [forceShowErrors]);
 
@@ -136,6 +146,12 @@ export default function SeoMetadataForm({
     }
   };
 
+  const validateAltText = (val: string) => {
+    const length = val.trim().length;
+    if (length > 0 && length < ALT_TEXT_MIN_LENGTH) return translationErrors.minLength;
+    return '';
+  };
+
   const handleBlur = (field: keyof LocalizedMeta) => {
     setTouched((prev) => ({ ...prev, [field]: true }));
     const fieldValue = typeof value[field] === 'string' ? value[field] : '';
@@ -145,6 +161,22 @@ export default function SeoMetadataForm({
   const handleFieldChange = (field: keyof LocalizedMeta, val: string) => {
     onChange({ ...value, [field]: val });
     if (touched[field]) setErrors((prev) => ({ ...prev, [field]: validateField(field, val) }));
+  };
+
+  const handleAltTextBlur = () => {
+    setAltTextTouched(true);
+    setAltTextError(validateAltText(value.altText?.[locale] ?? ''));
+  };
+
+  const handleAltTextChange = (alt: string) => {
+    onChange({
+      ...value,
+      altText: {
+        uk: locale === 'uk' ? alt : (value.altText?.uk ?? ''),
+        en: locale === 'en' ? alt : (value.altText?.en ?? '')
+      }
+    });
+    if (altTextTouched) setAltTextError(validateAltText(alt));
   };
 
   const handleImageChange = async (url: string, crop: CropResult | null | undefined) => {
@@ -183,15 +215,10 @@ export default function SeoMetadataForm({
         initialCrop={crop ? { rect: crop } : null}
         showAlternativeText={showAlternativeText}
         altText={value.altText?.[locale] ?? ''}
-        onChangeAltText={(alt) =>
-          onChange({
-            ...value,
-            altText: {
-              uk: locale === 'uk' ? alt : (value.altText?.uk ?? ''),
-              en: locale === 'en' ? alt : (value.altText?.en ?? '')
-            }
-          })
-        }
+        onChangeAltText={handleAltTextChange}
+        onBlurAltText={handleAltTextBlur}
+        altTextError={altTextError}
+        altTextErrorState={Boolean(altTextError) && altTextTouched}
         locale={locale}
       />
       <Typography variant="textMd" sx={styles.ogImageHint}>

--- a/src/constants/errors.ts
+++ b/src/constants/errors.ts
@@ -34,7 +34,8 @@ export const newsServiceErrors = {
   TITLE_REQUIRED_FOR_SLUG: 'Title is required to generate a slug',
   TITLE_TOO_SHORT_FOR_SLUG: 'Title must be at least 2 characters long to generate a slug',
   TITLE_TOO_LONG_FOR_SLUG: 'Title must not exceed 150 characters',
-  DESCRIPTION_LENGTH_INVALID: 'Description must contain from 2 to 250 characters'
+  DESCRIPTION_LENGTH_INVALID: 'Description must contain from 2 to 250 characters',
+  ALT_TEXT_TOO_SHORT: 'Alt text must contain at least 2 characters'
 };
 
 export const opusServiceErrors = {

--- a/src/interfaces/graphql/resolvers/news/newsMutation.test.ts
+++ b/src/interfaces/graphql/resolvers/news/newsMutation.test.ts
@@ -456,7 +456,6 @@ describe('NewsMutation Resolvers', () => {
   ])(
     'should throw GraphQLError with BAD_USER_INPUT if coverImage.alt.$lang has fewer than 2 characters',
     async ({ lang, otherLang }) => {
-      expect.assertions(5);
       const invalidInput = {
         ...baseInput,
         coverImage: {
@@ -464,16 +463,15 @@ describe('NewsMutation Resolvers', () => {
           alt: { [lang]: 'T', [otherLang]: '' } as LocalizedString
         }
       };
- 
-      try {
-        await NewsMutation.createNews({}, { input: invalidInput }, adminContext);
-      } catch (error) {
-        expect(error).toBeInstanceOf(GraphQLError);
-        expect((error as GraphQLError).message).toBe(newsServiceErrors.ALT_TEXT_TOO_SHORT);
-        expect((error as GraphQLError).extensions.code).toBe('BAD_USER_INPUT');
-        expect((error as GraphQLError).extensions.fields).toEqual([`altText.${lang}`]);
-      }
- 
+
+      await expect(NewsMutation.createNews({}, { input: invalidInput }, adminContext)).rejects.toMatchObject({
+        message: newsServiceErrors.ALT_TEXT_TOO_SHORT,
+        extensions: {
+          code: 'BAD_USER_INPUT',
+          fields: [`altText.${lang}`]
+        }
+      });
+
       expect(mockRepo.create).not.toHaveBeenCalled();
     }
   );
@@ -507,21 +505,21 @@ describe('NewsMutation Resolvers', () => {
   });
  
   it('should throw GraphQLError with BAD_USER_INPUT if updated coverImage.alt has fewer than 2 characters', async () => {
-    expect.assertions(5);
     mockAction('findById', createMockNews({ id }));
- 
-    try {
-      await NewsMutation.updateNews(
+
+    await expect(
+      NewsMutation.updateNews(
         {},
         { id, input: { coverImage: { ...baseInput.coverImage, alt: { uk: 'T', en: '' } } } },
         adminContext
-      );
-    } catch (error) {
-      expect(error).toBeInstanceOf(GraphQLError);
-      expect((error as GraphQLError).message).toBe(newsServiceErrors.ALT_TEXT_TOO_SHORT);
-      expect((error as GraphQLError).extensions.code).toBe('BAD_USER_INPUT');
-      expect((error as GraphQLError).extensions.fields).toEqual(['altText.uk']);
-    }
+      )
+    ).rejects.toMatchObject({
+      message: newsServiceErrors.ALT_TEXT_TOO_SHORT,
+      extensions: {
+        code: 'BAD_USER_INPUT',
+        fields: ['altText.uk']
+      }
+    });
  
     expect(mockRepo.update).not.toHaveBeenCalled();
   });

--- a/src/interfaces/graphql/resolvers/news/newsMutation.test.ts
+++ b/src/interfaces/graphql/resolvers/news/newsMutation.test.ts
@@ -442,4 +442,96 @@ describe('NewsMutation Resolvers', () => {
       expect(result!.meta.views).toBe(5);
     });
   });
+  it('should allow createNews when coverImage.alt is empty (alt text is optional)', async () => {
+    mockAction('findBySlug', null);
+    mockAction('create', createMockNews({ id: 'new-id' }));
+ 
+    await expect(NewsMutation.createNews({}, { input: baseInput }, adminContext)).resolves.toBeDefined();
+    expect(mockRepo.create).toHaveBeenCalled();
+  });
+ 
+  it.each([
+    { lang: 'uk' as const, otherLang: 'en' as const },
+    { lang: 'en' as const, otherLang: 'uk' as const }
+  ])(
+    'should throw GraphQLError with BAD_USER_INPUT if coverImage.alt.$lang has fewer than 2 characters',
+    async ({ lang, otherLang }) => {
+      expect.assertions(5);
+      const invalidInput = {
+        ...baseInput,
+        coverImage: {
+          ...baseInput.coverImage,
+          alt: { [lang]: 'T', [otherLang]: '' } as LocalizedString
+        }
+      };
+ 
+      try {
+        await NewsMutation.createNews({}, { input: invalidInput }, adminContext);
+      } catch (error) {
+        expect(error).toBeInstanceOf(GraphQLError);
+        expect((error as GraphQLError).message).toBe(newsServiceErrors.ALT_TEXT_TOO_SHORT);
+        expect((error as GraphQLError).extensions.code).toBe('BAD_USER_INPUT');
+        expect((error as GraphQLError).extensions.fields).toEqual([`altText.${lang}`]);
+      }
+ 
+      expect(mockRepo.create).not.toHaveBeenCalled();
+    }
+  );
+ 
+  it('should accept coverImage.alt with exactly 2 characters', async () => {
+    mockAction('findBySlug', null);
+    mockAction('create', createMockNews({ id: 'new-id' }));
+ 
+    const validInput = {
+      ...baseInput,
+      coverImage: { ...baseInput.coverImage, alt: { uk: 'Ко', en: 'Al' } }
+    };
+ 
+    await expect(NewsMutation.createNews({}, { input: validInput }, adminContext)).resolves.toBeDefined();
+    expect(mockRepo.create).toHaveBeenCalled();
+  });
+ 
+  it('should trim coverImage.alt before persisting', async () => {
+    mockAction('findBySlug', null);
+    mockAction('create', createMockNews({ id: 'new-id' }));
+ 
+    const validInput = {
+      ...baseInput,
+      coverImage: { ...baseInput.coverImage, alt: { uk: '  Валідний альт  ', en: 'Valid alt' } }
+    };
+ 
+    await NewsMutation.createNews({}, { input: validInput }, adminContext);
+ 
+    const createCallArg = (mockRepo.create as jest.Mock).mock.calls[0][0];
+    expect(createCallArg.coverImage.alt.uk).toBe('Валідний альт');
+  });
+ 
+  it('should throw GraphQLError with BAD_USER_INPUT if updated coverImage.alt has fewer than 2 characters', async () => {
+    expect.assertions(5);
+    mockAction('findById', createMockNews({ id }));
+ 
+    try {
+      await NewsMutation.updateNews(
+        {},
+        { id, input: { coverImage: { ...baseInput.coverImage, alt: { uk: 'T', en: '' } } } },
+        adminContext
+      );
+    } catch (error) {
+      expect(error).toBeInstanceOf(GraphQLError);
+      expect((error as GraphQLError).message).toBe(newsServiceErrors.ALT_TEXT_TOO_SHORT);
+      expect((error as GraphQLError).extensions.code).toBe('BAD_USER_INPUT');
+      expect((error as GraphQLError).extensions.fields).toEqual(['altText.uk']);
+    }
+ 
+    expect(mockRepo.update).not.toHaveBeenCalled();
+  });
+ 
+  it('should allow updateNews when coverImage is omitted entirely (no alt validation triggered)', async () => {
+    mockAction('findById', createMockNews({ id }));
+    mockAction('update', createMockNews({ id }));
+ 
+    await NewsMutation.updateNews({}, { id, input: { description: { uk: 'New', en: 'New' } } }, adminContext);
+ 
+    expect(mockRepo.update).toHaveBeenCalled();
+  });
 });

--- a/src/interfaces/graphql/resolvers/news/newsMutation.ts
+++ b/src/interfaces/graphql/resolvers/news/newsMutation.ts
@@ -63,8 +63,10 @@ const TITLE_MAX_LENGTH = 150;
 const DESCRIPTION_MIN_LENGTH = 2;
 const DESCRIPTION_MAX_LENGTH = 250;
 
+const ALT_TEXT_MIN_LENGTH = 2;
+
 type LocalizedLengthValidationOptions = {
-  fieldName: 'title' | 'description';
+  fieldName: 'title' | 'description' | 'altText';
   minLength?: number;
   maxLength?: number;
 };
@@ -122,6 +124,24 @@ const validateTitleMaxLength = (title: LocalizedString | undefined): void => {
   throwBadUserInput(newsServiceErrors.TITLE_TOO_LONG_FOR_SLUG, invalidFields);
 };
 
+const validateAltTextMinLength = (coverImage: LocalizedImage | undefined): void => {
+  if (!coverImage?.alt) return;
+
+  const { alt } = coverImage;
+
+  const invalidFields = (['uk', 'en'] as const)
+    .filter((lang) => {
+      const localizedValue = alt[lang];
+      if (typeof localizedValue !== 'string') return false;
+
+      const length = localizedValue.trim().length;
+      return length > 0 && length < ALT_TEXT_MIN_LENGTH;
+    })
+    .map((lang) => `altText.${lang}`);
+
+  throwBadUserInput(newsServiceErrors.ALT_TEXT_TOO_SHORT, invalidFields);
+};
+
 const trimLocalizedString = (value: LocalizedString | undefined): LocalizedString | undefined => {
   if (!value) return value;
 
@@ -136,6 +156,15 @@ const trimLocalizedString = (value: LocalizedString | undefined): LocalizedStrin
   });
 
   return trimmed;
+};
+
+const trimLocalizedImageAlt = (coverImage: LocalizedImage | undefined): LocalizedImage | undefined => {
+  if (!coverImage?.alt) return coverImage;
+
+  return {
+    ...coverImage,
+    alt: trimLocalizedString(coverImage.alt) ?? coverImage.alt
+  };
 };
 
 const endpointHandler = endpointRepositoryHandler('newsRepository');
@@ -153,7 +182,8 @@ export const NewsMutation = {
     const trimmedInput = {
       ...input,
       title: trimLocalizedString(input.title) ?? input.title,
-      description: trimLocalizedString(input.description) ?? input.description
+      description: trimLocalizedString(input.description) ?? input.description,
+      coverImage: trimLocalizedImageAlt(input.coverImage) ?? input.coverImage
     };
 
     const titleForSlug = extractTitleForSlug(trimmedInput.title);
@@ -166,6 +196,7 @@ export const NewsMutation = {
 
     validateTitleMaxLength(trimmedInput.title);
     validateDescriptionLength(trimmedInput.description);
+    validateAltTextMinLength(trimmedInput.coverImage);
 
     const slug = await generateUniqueSlug(titleForSlug, {
       checkExists: async (slug: string) => {
@@ -225,10 +256,14 @@ export const NewsMutation = {
     const trimmedInput = {
       ...input,
       title: trimLocalizedString(input.title) ?? input.title,
-      description: trimLocalizedString(input.description) ?? input.description
+      description: trimLocalizedString(input.description) ?? input.description,
+      coverImage: trimLocalizedImageAlt(input.coverImage) ?? input.coverImage
     };
 
     validateDescriptionLength(trimmedInput.description);
+    if (input.coverImage) {
+      validateAltTextMinLength(trimmedInput.coverImage);
+    }
 
     if (input.content || input.description || input.coverImage) {
       await processContentFields(trimmedInput, updateData);


### PR DESCRIPTION
## Description

Enforce a 2-character minimum on the news cover image alt text (uk/en), client and server side.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Open a news item, set cover image alt text to 1 character, blur the field → error shown, save blocked.
2. Empty alt text still allowed (optional field).

## Video / Screenshots

Before:
<img width="2468" height="1540" alt="image" src="https://github.com/user-attachments/assets/ee6ce42a-9d9b-4184-bdf0-da69ee180bdd" />

After:

https://github.com/user-attachments/assets/4074318c-84d6-41c2-aae7-15218cd5c984


## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [ ] No Sonar issues
- [x] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

### Closes: https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/583

---

