### PR TITLE
feat: archive filter according to design

### DIFF
--- a/app/(logged_in)/archive/(components)/ArchivePageContent.test.tsx
+++ b/app/(logged_in)/archive/(components)/ArchivePageContent.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, within } from '@testing-library/react';
 
 import type { FondsTableProps } from './archive-fonds-table/ArchiveFondsTable';
 import { ArchivePageContent } from './ArchivePageContent';
-import { ARCHIVE_STATUS_FILTER_OPTIONS, ARCHIVE_TABS } from '~/constants/archive';
+import { ARCHIVE_TABS } from '~/constants/archive';
 
 jest.mock('../(temp)/archive.mock', () => ({
   __esModule: true,
@@ -84,7 +84,7 @@ const mockStatusFilterProps = {
   label: 'Status Label',
   options: [],
   onChange: jest.fn(),
-  value: ['all'],
+  value: [],
 };
 
 const defaultMockReturnValue = {
@@ -176,7 +176,7 @@ describe('ArchivePageContent', () => {
   });
 
   describe('hasActiveStatusFilter prop', () => {
-    it(`should be false when filterValues are ['${ARCHIVE_STATUS_FILTER_OPTIONS[0].value}']`, () => {
+    it('should be false when filterValues are empty (all values)', () => {
       render(<ArchivePageContent activeTab="all" />);
 
       expect(screen.getByTestId('fonds-table-has-active-status-filter')).toHaveTextContent('false');

--- a/app/(logged_in)/archive/(components)/ArchivePageContent.test.tsx
+++ b/app/(logged_in)/archive/(components)/ArchivePageContent.test.tsx
@@ -42,9 +42,10 @@ jest.mock('../(temp)/archive.mock', () => ({
 
 jest.mock('./archive-fonds-table/ArchiveFondsTable', () => ({
   __esModule: true,
-  FondsTable: ({ fonds, hasActiveCriteria }: FondsTableProps) => (
+  FondsTable: ({ fonds, hasActiveSearch, hasActiveStatusFilter }: FondsTableProps) => (
     <div data-testid="fonds-table">
-      <div data-testid="fonds-table-has-active-criteria">{JSON.stringify(hasActiveCriteria)}</div>
+      <div data-testid="fonds-table-has-active-search">{JSON.stringify(hasActiveSearch)}</div>
+      <div data-testid="fonds-table-has-active-status-filter">{JSON.stringify(hasActiveStatusFilter)}</div>
       <div data-testid="fonds-table-fonds">
         {fonds.map((fond) => (
           <div key={fond.id} data-testid={`fonds-table-item-${fond.id}`}>
@@ -152,7 +153,7 @@ describe('ArchivePageContent', () => {
     expect(screen.getByTestId('fonds-table')).toBeInTheDocument();
   });
 
-  describe('hasActiveCriteria prop', () => {
+  describe('hasActiveSearch prop', () => {
     it('should be false when search is an empty string', () => {
       mockUseArchiveFiltering.mockReturnValue({
         ...defaultMockReturnValue,
@@ -164,33 +165,32 @@ describe('ArchivePageContent', () => {
 
       render(<ArchivePageContent activeTab="all" />);
 
-      expect(screen.getByTestId('fonds-table-has-active-criteria')).toHaveTextContent('false');
+      expect(screen.getByTestId('fonds-table-has-active-search')).toHaveTextContent('false');
     });
 
-    it('should be true when search has a value & filterValues too', () => {
-      mockUseArchiveFiltering.mockReturnValue({
-        ...defaultMockReturnValue,
-        statusFilterProps: {
-          ...defaultMockReturnValue.statusFilterProps,
-          value: ['other value from all'],
-        },
-      });
+    it('should be true when search has a value', () => {
       render(<ArchivePageContent activeTab="all" />);
 
-      expect(screen.getByTestId('fonds-table-has-active-criteria')).toHaveTextContent('true');
+      expect(screen.getByTestId('fonds-table-has-active-search')).toHaveTextContent('true');
     });
-    it(`should be false when filterValues are ['${ARCHIVE_STATUS_FILTER_OPTIONS[0].value}'] and search is an empty string`, () => {
+  });
+
+  describe('hasActiveStatusFilter prop', () => {
+    it(`should be false when filterValues are ['${ARCHIVE_STATUS_FILTER_OPTIONS[0].value}']`, () => {
+      render(<ArchivePageContent activeTab="all" />);
+
+      expect(screen.getByTestId('fonds-table-has-active-status-filter')).toHaveTextContent('false');
+    });
+
+    it('should be true when a specific status is selected', () => {
       mockUseArchiveFiltering.mockReturnValue({
         ...defaultMockReturnValue,
-        searchProps: {
-          ...defaultMockReturnValue.searchProps,
-          search: '',
-        },
+        statusFilterProps: { ...defaultMockReturnValue.statusFilterProps, value: ['published'] }
       });
 
       render(<ArchivePageContent activeTab="all" />);
 
-      expect(screen.getByTestId('fonds-table-has-active-criteria')).toHaveTextContent('false');
+      expect(screen.getByTestId('fonds-table-has-active-status-filter')).toHaveTextContent('true');
     });
   });
 
@@ -231,6 +231,7 @@ describe('ArchivePageContent', () => {
     it('should pass empty array when filter status does not match any variant', () => {
       mockUseArchiveFiltering.mockReturnValue({
         ...defaultMockReturnValue,
+        searchProps: { ...defaultMockReturnValue.searchProps, search: '' },
         statusFilterProps: {
           ...defaultMockReturnValue.statusFilterProps,
           value: ['other'],
@@ -241,6 +242,20 @@ describe('ArchivePageContent', () => {
 
       const fondsContainer = screen.getByTestId('fonds-table-fonds');
       expect(fondsContainer.children).toHaveLength(0);
+    });
+
+    it('should combine search and status filter conditions with AND', () => {
+      mockUseArchiveFiltering.mockReturnValue({
+        ...defaultMockReturnValue,
+        searchProps: { ...defaultMockReturnValue.searchProps, search: 'same part' },
+        statusFilterProps: { ...defaultMockReturnValue.statusFilterProps, value: ['hidden'] }
+      });
+
+      render(<ArchivePageContent activeTab="all" />);
+
+      const items = screen.getAllByTestId(/^fonds-table-item-/);
+      expect(items).toHaveLength(1);
+      expect(items[0]).toHaveTextContent('A Fond same part');
     });
 
     it('should pass an array with matched values when search query matches any variants', () => {

--- a/app/(logged_in)/archive/(components)/ArchivePageContent.tsx
+++ b/app/(logged_in)/archive/(components)/ArchivePageContent.tsx
@@ -11,7 +11,7 @@ import { normalizeSearch } from '~/lib/utils/normalizeSearch';
 import { PageHeader } from '~/shared/components/page-header/PageHeader';
 import { SearchStatusToolbar } from '~/shared/components/search-status-toolbar/SearchStatusToolbar';
 
-interface ArchivePageContentProps { activeTab: ArchiveTabValue }
+interface ArchivePageContentProps { activeTab: ArchiveTabValue}
 
 export const ArchivePageContent = ({ activeTab }: ArchivePageContentProps) => {
   const { searchProps, statusFilterProps } = useArchiveFiltering();
@@ -20,8 +20,10 @@ export const ArchivePageContent = ({ activeTab }: ArchivePageContentProps) => {
   const normalizedSearch = normalizeSearch(searchValue);
   const filterValues = statusFilterProps.value;
 
+  const isAllStatus = filterValues.includes(ARCHIVE_STATUS_FILTER_OPTIONS[0].value);
+
   const visibleFonds = ARCHIVE_FONDS_MOCK_DATA.filter((fond) => {
-    const matchesStatus = filterValues.includes(ARCHIVE_STATUS_FILTER_OPTIONS[0].value) ? true : filterValues.includes(fond.status);
+    const matchesStatus = isAllStatus ? true : filterValues.includes(fond.status);
 
     const normalizedFondName = normalizeSearch(fond.name);
     const matchesName = normalizedFondName.includes(normalizedSearch);
@@ -31,7 +33,8 @@ export const ArchivePageContent = ({ activeTab }: ArchivePageContentProps) => {
 
   const ascSortedVisibleFonds = visibleFonds.toSorted((a, b) => Number(a.fondNumber) - Number(b.fondNumber));
 
-  const hasActiveCriteria = Boolean(searchProps.search) || !filterValues.includes(ARCHIVE_STATUS_FILTER_OPTIONS[0].value);
+  const hasActiveSearch = Boolean(searchValue);
+  const hasActiveStatusFilter = !isAllStatus;
 
   return (
     <Box sx={styles.pageContainer}>
@@ -43,7 +46,7 @@ export const ArchivePageContent = ({ activeTab }: ArchivePageContentProps) => {
       />
       <SearchStatusToolbar dataTestId='archive-control-panel' searchProps={searchProps} statusFilterProps={statusFilterProps} />
 
-      <FondsTable fonds={ascSortedVisibleFonds} hasActiveCriteria={hasActiveCriteria} />
+      <FondsTable fonds={ascSortedVisibleFonds} hasActiveSearch={hasActiveSearch} hasActiveStatusFilter={hasActiveStatusFilter}  />
     </Box >
   );
 };

--- a/app/(logged_in)/archive/(components)/ArchivePageContent.tsx
+++ b/app/(logged_in)/archive/(components)/ArchivePageContent.tsx
@@ -6,12 +6,18 @@ import { ARCHIVE_FONDS_MOCK_DATA } from '../(temp)/archive.mock';
 import { FondsTable } from './archive-fonds-table/ArchiveFondsTable';
 import { ArchiveCreateAction } from './ArchiveCreateAction';
 import { styles } from './ArchivePageContent.styles';
-import { ARCHIVE_PAGE_TITLE, ARCHIVE_STATUS_FILTER_OPTIONS, ARCHIVE_TABS, type ArchiveTabValue } from '~/constants/archive';
+import {
+  ARCHIVE_PAGE_TITLE,
+  ARCHIVE_TABS,
+  type ArchiveTabValue
+} from '~/constants/archive';
 import { normalizeSearch } from '~/lib/utils/normalizeSearch';
 import { PageHeader } from '~/shared/components/page-header/PageHeader';
 import { SearchStatusToolbar } from '~/shared/components/search-status-toolbar/SearchStatusToolbar';
 
-interface ArchivePageContentProps { activeTab: ArchiveTabValue}
+interface ArchivePageContentProps {
+  activeTab: ArchiveTabValue;
+}
 
 export const ArchivePageContent = ({ activeTab }: ArchivePageContentProps) => {
   const { searchProps, statusFilterProps } = useArchiveFiltering();
@@ -20,7 +26,7 @@ export const ArchivePageContent = ({ activeTab }: ArchivePageContentProps) => {
   const normalizedSearch = normalizeSearch(searchValue);
   const filterValues = statusFilterProps.value;
 
-  const isAllStatus = filterValues.includes(ARCHIVE_STATUS_FILTER_OPTIONS[0].value);
+  const isAllStatus = filterValues.length === 0;
 
   const visibleFonds = ARCHIVE_FONDS_MOCK_DATA.filter((fond) => {
     const matchesStatus = isAllStatus ? true : filterValues.includes(fond.status);
@@ -44,9 +50,17 @@ export const ArchivePageContent = ({ activeTab }: ArchivePageContentProps) => {
         tabs={ARCHIVE_TABS}
         action={<ArchiveCreateAction />}
       />
-      <SearchStatusToolbar dataTestId='archive-control-panel' searchProps={searchProps} statusFilterProps={statusFilterProps} />
+      <SearchStatusToolbar
+        dataTestId="archive-control-panel"
+        searchProps={searchProps}
+        statusFilterProps={statusFilterProps}
+      />
 
-      <FondsTable fonds={ascSortedVisibleFonds} hasActiveSearch={hasActiveSearch} hasActiveStatusFilter={hasActiveStatusFilter}  />
-    </Box >
+      <FondsTable
+        fonds={ascSortedVisibleFonds}
+        hasActiveSearch={hasActiveSearch}
+        hasActiveStatusFilter={hasActiveStatusFilter}
+      />
+    </Box>
   );
 };

--- a/app/(logged_in)/archive/(components)/archive-fonds-table/ArchiveFondsTable.test.tsx
+++ b/app/(logged_in)/archive/(components)/archive-fonds-table/ArchiveFondsTable.test.tsx
@@ -5,6 +5,7 @@ import {
   ARCHIVE_EMPTY_STATE_DESCRIPTION,
   ARCHIVE_EMPTY_STATE_NO_RESULTS_DESCRIPTION,
   ARCHIVE_EMPTY_STATE_NO_RESULTS_TITLE,
+  ARCHIVE_EMPTY_STATE_NO_STATUS_MATCH_TITLE,
   ARCHIVE_EMPTY_STATE_TITLE,
   ARCHIVE_FONDS_TABLE_HEADERS,
 } from '~/constants/archive';
@@ -13,7 +14,7 @@ import { BaseContentStatuses } from '~/types/enums/common.enums';
 
 type EmptyStateProps = {
   title: string;
-  description: string;
+  description?: string;
 };
 
 type TableLayoutProps<TGroup, TSub, TPlain> = {
@@ -74,7 +75,8 @@ const defaultProps: FondsTableProps = {
       updatedAt: '2023-01-01',
     },
   ],
-  hasActiveCriteria: false,
+  hasActiveSearch: false,
+  hasActiveStatusFilter: false,
 };
 
 const renderComponent = (overrides?: Partial<FondsTableProps>) => {
@@ -131,20 +133,37 @@ describe('ArchiveFondsTable', () => {
       expect(screen.getByTestId(`mock-cell-${cell}`)).toBeInTheDocument();
     }
   });
+
   describe('should render state UIs', () => {
-    it('should render the no search results fallback if rows.length is 0 and hasActiveCriteria is true', () => {
-      renderComponent({ hasActiveCriteria: true, fonds: [] });
+    it('should render the "not created yet" fallback when there are no fonds and no active criteria', () => {
+      renderComponent({ fonds: [], hasActiveSearch: false, hasActiveStatusFilter: false });
+
+      expect(screen.getByTestId('mock-empty-state')).toBeInTheDocument();
+      expect(screen.getByTestId('mock-empty-state-title')).toHaveTextContent(ARCHIVE_EMPTY_STATE_TITLE);
+      expect(screen.getByTestId('mock-empty-state-description')).toHaveTextContent(ARCHIVE_EMPTY_STATE_DESCRIPTION);
+    });
+
+    it('should render the no search results fallback when search is active (with or without status filter)', () => {
+      renderComponent({ fonds: [], hasActiveSearch: true, hasActiveStatusFilter: false });
 
       expect(screen.getByTestId('mock-empty-state')).toBeInTheDocument();
       expect(screen.getByTestId('mock-empty-state-title')).toHaveTextContent(ARCHIVE_EMPTY_STATE_NO_RESULTS_TITLE);
       expect(screen.getByTestId('mock-empty-state-description')).toHaveTextContent(ARCHIVE_EMPTY_STATE_NO_RESULTS_DESCRIPTION);
     });
-    it('should render the not fond fallback if rows.length is 0 and hasActiveCriteria is false', () => {
-      renderComponent({ fonds: [] });
+
+    it('should render the no search results fallback when both search and status filter are active', () => {
+      renderComponent({ fonds: [], hasActiveSearch: true, hasActiveStatusFilter: true });
 
       expect(screen.getByTestId('mock-empty-state')).toBeInTheDocument();
-      expect(screen.getByTestId('mock-empty-state-title')).toHaveTextContent(ARCHIVE_EMPTY_STATE_TITLE);
-      expect(screen.getByTestId('mock-empty-state-description')).toHaveTextContent(ARCHIVE_EMPTY_STATE_DESCRIPTION);
+      expect(screen.getByTestId('mock-empty-state-title')).toHaveTextContent(ARCHIVE_EMPTY_STATE_NO_RESULTS_TITLE);
+      expect(screen.getByTestId('mock-empty-state-description')).toHaveTextContent(ARCHIVE_EMPTY_STATE_NO_RESULTS_DESCRIPTION);
+    });
+
+    it('should render the status-only fallback when only the status filter is active', () => {
+      renderComponent({ fonds: [], hasActiveSearch: false, hasActiveStatusFilter: true });
+
+      expect(screen.getByTestId('mock-empty-state')).toBeInTheDocument();
+      expect(screen.getByTestId('mock-empty-state-title')).toHaveTextContent(ARCHIVE_EMPTY_STATE_NO_STATUS_MATCH_TITLE);
     });
   });
 });

--- a/app/(logged_in)/archive/(components)/archive-fonds-table/ArchiveFondsTable.tsx
+++ b/app/(logged_in)/archive/(components)/archive-fonds-table/ArchiveFondsTable.tsx
@@ -5,6 +5,7 @@ import {
   ARCHIVE_EMPTY_STATE_DESCRIPTION,
   ARCHIVE_EMPTY_STATE_NO_RESULTS_DESCRIPTION,
   ARCHIVE_EMPTY_STATE_NO_RESULTS_TITLE,
+  ARCHIVE_EMPTY_STATE_NO_STATUS_MATCH_TITLE,
   ARCHIVE_EMPTY_STATE_TITLE,
   ARCHIVE_FONDS_TABLE_HEADERS,
 } from '~/constants/archive';
@@ -23,10 +24,11 @@ export type FondRow = Fond & {
 
 export interface FondsTableProps {
   fonds: Fond[];
-  hasActiveCriteria: boolean;
+  hasActiveSearch: boolean;
+  hasActiveStatusFilter: boolean;
 }
 
-export const FondsTable = ({ fonds, hasActiveCriteria }: FondsTableProps) => {
+export const FondsTable = ({ fonds, hasActiveSearch, hasActiveStatusFilter }: FondsTableProps) => {
   const rows = fonds.map((fond) => ({
     type: 'individual' as const,
     id: fond.id,
@@ -107,10 +109,30 @@ export const FondsTable = ({ fonds, hasActiveCriteria }: FondsTableProps) => {
   ];
  
   if (rows.length === 0) {
+    const hasActiveCriteria = hasActiveSearch || hasActiveStatusFilter;
+
+    if (!hasActiveCriteria) {
+      return (
+        <EmptyState
+          title={ARCHIVE_EMPTY_STATE_TITLE}
+          description={ARCHIVE_EMPTY_STATE_DESCRIPTION}
+        />
+      );
+    }
+
+    if (hasActiveStatusFilter && !hasActiveSearch) {
+      return (
+        <EmptyState
+          title={ARCHIVE_EMPTY_STATE_NO_STATUS_MATCH_TITLE}
+          description=""
+        />
+      );
+    }
+
     return (
       <EmptyState
-        title={hasActiveCriteria ? ARCHIVE_EMPTY_STATE_NO_RESULTS_TITLE : ARCHIVE_EMPTY_STATE_TITLE}
-        description={hasActiveCriteria ? ARCHIVE_EMPTY_STATE_NO_RESULTS_DESCRIPTION : ARCHIVE_EMPTY_STATE_DESCRIPTION}
+        title={ARCHIVE_EMPTY_STATE_NO_RESULTS_TITLE}
+        description={ARCHIVE_EMPTY_STATE_NO_RESULTS_DESCRIPTION}
       />
     );
   }

--- a/app/(logged_in)/archive/(hooks)/useArchiveFiltering.test.tsx
+++ b/app/(logged_in)/archive/(hooks)/useArchiveFiltering.test.tsx
@@ -22,6 +22,8 @@ describe('useArchiveFiltering', () => {
         value: [ARCHIVE_STATUS_FILTER_OPTIONS[0].value],
         maxSelections: 1,
         hideClearAction: true,
+        menuAlign: 'right',
+        persistLabel: true,
         onChange: expect.any(Function)
       },
     });
@@ -47,5 +49,21 @@ describe('useArchiveFiltering', () => {
 
     expect(result.current.statusFilterProps.value).toStrictEqual(expectedNewValue);
     expect(result.current.activeStatusFilters).toEqual(expectedNewValue);
+  });
+
+  it('should reset to "all" when onChange is called with an empty array', () => {
+    const { result } = renderHook(() => useArchiveFiltering());
+
+    act(() => {
+      result.current.statusFilterProps.onChange!(['published']);
+    });
+    expect(result.current.statusFilterProps.value).toStrictEqual(['published']);
+
+    act(() => {
+      result.current.statusFilterProps.onChange!([]);
+    });
+
+    expect(result.current.statusFilterProps.value).toStrictEqual([ARCHIVE_STATUS_FILTER_OPTIONS[0].value]);
+    expect(result.current.activeStatusFilters).toEqual([ARCHIVE_STATUS_FILTER_OPTIONS[0].value]);
   });
 });

--- a/app/(logged_in)/archive/(hooks)/useArchiveFiltering.test.tsx
+++ b/app/(logged_in)/archive/(hooks)/useArchiveFiltering.test.tsx
@@ -8,7 +8,7 @@ describe('useArchiveFiltering', () => {
     const { result } = renderHook(() => useArchiveFiltering());
 
     expect(result.current).toStrictEqual({
-      activeStatusFilters: [ARCHIVE_STATUS_FILTER_OPTIONS[0].value],
+      activeStatusFilters: [],
       searchProps: {
         search: '',
         options: [],
@@ -19,7 +19,7 @@ describe('useArchiveFiltering', () => {
       statusFilterProps: {
         label: 'Статус',
         options: ARCHIVE_STATUS_FILTER_OPTIONS,
-        value: [ARCHIVE_STATUS_FILTER_OPTIONS[0].value],
+        value: [],
         maxSelections: 1,
         hideClearAction: true,
         menuAlign: 'right',
@@ -51,7 +51,7 @@ describe('useArchiveFiltering', () => {
     expect(result.current.activeStatusFilters).toEqual(expectedNewValue);
   });
 
-  it('should reset to "all" when onChange is called with an empty array', () => {
+  it('should set filters to an empty array when onChange is called with an empty array', () => {
     const { result } = renderHook(() => useArchiveFiltering());
 
     act(() => {
@@ -63,7 +63,7 @@ describe('useArchiveFiltering', () => {
       result.current.statusFilterProps.onChange!([]);
     });
 
-    expect(result.current.statusFilterProps.value).toStrictEqual([ARCHIVE_STATUS_FILTER_OPTIONS[0].value]);
-    expect(result.current.activeStatusFilters).toEqual([ARCHIVE_STATUS_FILTER_OPTIONS[0].value]);
+    expect(result.current.statusFilterProps.value).toStrictEqual([]);
+    expect(result.current.activeStatusFilters).toEqual([]);
   });
 });

--- a/app/(logged_in)/archive/(hooks)/useArchiveFiltering.tsx
+++ b/app/(logged_in)/archive/(hooks)/useArchiveFiltering.tsx
@@ -28,9 +28,11 @@ export const useArchiveFiltering = (): {
       label: 'Статус',
       options: ARCHIVE_STATUS_FILTER_OPTIONS,
       value: statusFilters,
-      onChange: (value) => setStatusFilters(value),
+      onChange: (value) => setStatusFilters(value.length === 0 ? [ARCHIVE_STATUS_FILTER_OPTIONS[0].value] : value),
       maxSelections: 1,
       hideClearAction: true,
+      menuAlign: 'right',
+      persistLabel: true
     }
   };
 };

--- a/app/(logged_in)/archive/(hooks)/useArchiveFiltering.tsx
+++ b/app/(logged_in)/archive/(hooks)/useArchiveFiltering.tsx
@@ -11,7 +11,7 @@ export const useArchiveFiltering = (): {
   statusFilterProps: Omit<FilterSelectProps, 'value'> & { value: string[] }
 } => {
   const [search, setSearch] = useState<string>('');
-  const [statusFilters, setStatusFilters] = useState<string[]>([ARCHIVE_STATUS_FILTER_OPTIONS[0].value]);
+  const [statusFilters, setStatusFilters] = useState<string[]>([]);
 
   const activeStatusFilters = statusFilters;
 
@@ -28,7 +28,7 @@ export const useArchiveFiltering = (): {
       label: 'Статус',
       options: ARCHIVE_STATUS_FILTER_OPTIONS,
       value: statusFilters,
-      onChange: (value) => setStatusFilters(value.length === 0 ? [ARCHIVE_STATUS_FILTER_OPTIONS[0].value] : value),
+      onChange: (value) => setStatusFilters(value),
       maxSelections: 1,
       hideClearAction: true,
       menuAlign: 'right',

--- a/app/constants/archive.ts
+++ b/app/constants/archive.ts
@@ -23,7 +23,6 @@ export const ARCHIVE_STATUSES = [
 ] as const;
 
 export const ARCHIVE_STATUS_FILTER_OPTIONS: ReadonlyArray<FilterOption> = [
-  { value: 'all', label: 'Усі' },
   { value: BaseContentStatuses.Hidden, label: 'Приховано' },
   { value: BaseContentStatuses.Published, label: 'Опубліковано' },
 ];

--- a/app/constants/archive.ts
+++ b/app/constants/archive.ts
@@ -63,6 +63,7 @@ export const ARCHIVE_EMPTY_STATE_DESCRIPTION =
   'Натисніть «Додати фонд», щоб створити перший.';
 export const ARCHIVE_EMPTY_STATE_NO_RESULTS_TITLE = 'Нічого не знайдено';
 export const ARCHIVE_EMPTY_STATE_NO_RESULTS_DESCRIPTION = 'Спробуйте змінити параметри пошуку або фільтрів.';
+export const ARCHIVE_EMPTY_STATE_NO_STATUS_MATCH_TITLE = 'Немає фондів із вибраним статусом';
 
 export const ARCHIVE_FONDS_TABLE_HEADERS = {
   fond: 'Фонд',

--- a/app/shared/components/selector/FilterSelect.test.tsx
+++ b/app/shared/components/selector/FilterSelect.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import { FilterSelect } from './FilterSelect';
 import { filterSelectStyles } from './FilterSelect.styles';
+import { BaseContentStatuses } from '~/types/enums/common.enums';
 
 const mockOptions = [
   { label: 'First', value: 'first' },
@@ -296,5 +297,14 @@ describe('FilterSelect', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'No Transition' }));
     expect(mockUseMenuScrollClose).toHaveBeenCalled();
+  });
+
+  it('should render Badge icon for badgeable statuses', () => {
+    const badgeableOptions = [
+      { label: 'Published', value: BaseContentStatuses.Published },
+      { label: 'Hidden', value: BaseContentStatuses.Hidden }
+    ];
+    render(<FilterSelect label="Badgeable Select" options={badgeableOptions} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Badgeable Select' }));
   });
 });

--- a/app/shared/components/selector/FilterSelect.test.tsx
+++ b/app/shared/components/selector/FilterSelect.test.tsx
@@ -306,5 +306,7 @@ describe('FilterSelect', () => {
     ];
     render(<FilterSelect label="Badgeable Select" options={badgeableOptions} />);
     fireEvent.click(screen.getByRole('button', { name: 'Badgeable Select' }));
+    expect(screen.getByTestId('item-Published')).toBeInTheDocument();
+    expect(screen.getByTestId('item-Hidden')).toBeInTheDocument();
   });
 });

--- a/app/shared/components/selector/FilterSelect.tsx
+++ b/app/shared/components/selector/FilterSelect.tsx
@@ -2,18 +2,21 @@
 
 import { Box, Chip, Divider, Typography } from '@mui/material';
 import { ChevronDown } from 'lucide-react';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 
 import Button from '../design-system/button/Button';
 import DropdownMenu from '../dropdown-menu/DropdownMenu';
 import { filterSelectStyles } from './FilterSelect.styles';
 import FilterSelectItem from './FilterSelectItem/FilterSelectItem';
 import CloseIcon from '~/public/icons/close.svg';
+import Badge from '~/shared/components/badge/Badge';
 import { useMenuScrollClose } from '~/shared/hooks/use-menu-scroll-close/useMenuScrollClose';
+import { BaseContentStatuses } from '~/types/enums/common.enums';
 
 export interface FilterOption {
   value: string;
   label: string;
+  icon?: ReactNode;
 }
 
 export interface FilterSelectProps {
@@ -29,6 +32,8 @@ export interface FilterSelectProps {
   hideClearAction?: boolean;
   menuMinWidth?: number;
   clearLabel?: string;
+  persistLabel?: boolean;
+  menuAlign?: 'left' | 'right';
   onChange?: (allSelected: string[]) => void;
   onAdd?: (value: string, label: string, allSelected: string[]) => void;
   onRemove?: (value: string, label: string, allSelected: string[]) => void;
@@ -47,6 +52,8 @@ export const FilterSelect: React.FC<FilterSelectProps> = ({
   hideClearAction = false,
   menuMinWidth,
   clearLabel = 'Очистити',
+  persistLabel = false,
+  menuAlign = 'left',
   onChange,
   onAdd,
   onRemove
@@ -117,13 +124,18 @@ export const FilterSelect: React.FC<FilterSelectProps> = ({
     });
   };
 
-  const isMaxReached = maxSelections ? selectedValues.length >= maxSelections : false;
+  const isMaxReached = maxSelections && maxSelections > 1 ? selectedValues.length >= maxSelections : false;
   const selectedOptionsCount = selectedValues.length;
   const selectedOptionsLabel = useMemo(() => {
     return selectedValues.map((val) => options.find((opt) => opt.value === val)?.label ?? val).join(', ');
   }, [options, selectedValues]);
 
   const triggerAriaLabel = selectedOptionsCount > 0 && !hideCounterChip ? `${label}: ${selectedOptionsLabel}` : label;
+
+  const isBadgeableStatus = (
+    value: string
+  ): value is typeof BaseContentStatuses.Published | typeof BaseContentStatuses.Hidden =>
+    value === BaseContentStatuses.Published || value === BaseContentStatuses.Hidden;
 
   return (
     <Box>
@@ -137,7 +149,7 @@ export const FilterSelect: React.FC<FilterSelectProps> = ({
         aria-expanded={Boolean(anchorEl)}
         aria-label={triggerAriaLabel}
       >
-        {(selectedOptionsCount === 0 || hideCounterChip) && (
+        {(selectedOptionsCount === 0 || hideCounterChip || persistLabel) && (
           <Typography variant="textMd" sx={filterSelectStyles.label(disabled)}>
             {label}
           </Typography>
@@ -166,8 +178,8 @@ export const FilterSelect: React.FC<FilterSelectProps> = ({
         open={Boolean(anchorEl)}
         onClose={handleClose}
         sx={filterSelectStyles.dropdownMenu(menuMinWidth)}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+        anchorOrigin={{ vertical: 'bottom', horizontal: menuAlign }}
+        transformOrigin={{ vertical: 'top', horizontal: menuAlign }}
         maxHeight={300}
         transitionDuration={disableTransition ? 0 : undefined}
         menuList={
@@ -181,6 +193,7 @@ export const FilterSelect: React.FC<FilterSelectProps> = ({
                   <FilterSelectItem
                     key={option.value}
                     label={option.label}
+                    icon={isBadgeableStatus(option.value) ? <Badge variant={option.value} /> : undefined}
                     onClick={() => handleOptionClick(option)}
                     selected={isSelected}
                     disabled={optionDisabled}

--- a/app/shared/components/selector/FilterSelectItem/FilterSelectItem.styles.tsx
+++ b/app/shared/components/selector/FilterSelectItem/FilterSelectItem.styles.tsx
@@ -21,5 +21,13 @@ export const styles = {
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center'
-  }
+  },
+
+  startIcon: {
+    width: 20,
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+  
 };

--- a/app/shared/components/selector/FilterSelectItem/FilterSelectItem.tsx
+++ b/app/shared/components/selector/FilterSelectItem/FilterSelectItem.tsx
@@ -6,12 +6,14 @@ import { styles } from './FilterSelectItem.styles';
 
 export interface FilterSelectItemProps extends MenuItemProps {
   label: string;
+  icon?: React.ReactNode;
 }
 
-const FilterSelectItem = ({ label, sx, selected, ...props }: FilterSelectItemProps) => {
+const FilterSelectItem = ({ label, icon, sx, selected, ...props }: FilterSelectItemProps) => {
   return (
     <MenuItem selected={selected} sx={[styles.menuItem, ...(Array.isArray(sx) ? sx : [sx])]} {...props}>
       <Box sx={styles.content}>
+        {icon && <Box sx={styles.startIcon}>{icon}</Box>}
         <Typography variant="textMd" sx={styles.label}>
           {label}
         </Typography>


### PR DESCRIPTION
## Description

Refined the UI/UX logic and empty states for the Fonds publication status filter, according to design system. 

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Navigate to the Archive admin panel and open the Fonds table.
2. Open the status filter dropdown and verify that the "Published" and "Hidden" options display the correct colored badges.
3. Select a status and then try to clear it-verify that the filter safely falls back to the default `Усі` option.
4. Filter by a status that yields no results and verify the empty state says `Немає фондів із вибраним статусом`.

## Video / Screenshots

before:

<img width="278" height="245" alt="image" src="https://github.com/user-attachments/assets/e06042ab-6ce4-4170-bc31-0736fb4263ed" />

requirements:

<img width="1217" height="332" alt="image" src="https://github.com/user-attachments/assets/b4ea6330-b32d-4502-95aa-1756d253f07f" />

after:

https://github.com/user-attachments/assets/58d3b4b3-6fcb-4bdb-920a-ff3e314cb08b

<img width="711" height="245" alt="image" src="https://github.com/user-attachments/assets/5932881d-29ae-433d-aaa0-a9a22149f438" />


## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [x] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
