### PR TITLE
feat: support optional opus metadata and centralize SEO validation

### DIFF
--- a/app/(logged_in)/creativity/group/create/OpusView.test.tsx
+++ b/app/(logged_in)/creativity/group/create/OpusView.test.tsx
@@ -11,6 +11,7 @@ interface MockSeoMetadataBlockProps {
       uk: { x: number; y: number; width: number; height: number } | null;
     } | null
   ) => void;
+  required?: boolean;
 }
 
 const mockPush = jest.fn();
@@ -18,21 +19,26 @@ jest.mock('next/navigation', () => ({
   useRouter: jest.fn(() => ({ push: mockPush }))
 }));
 
+const mockSeoMetadataRequired = jest.fn();
+
 jest.mock('~/shared/components/forms/seo-metadata-form/seo-metadata-block/SeoMetadataBlock', () => ({
   __esModule: true,
-  default: ({ onChangeCrop }: MockSeoMetadataBlockProps) => (
-    <div data-testid="mock-seo-metadata-block">
-      <button
-        data-testid="mock-change-crop-btn"
-        onClick={() => onChangeCrop({ uk: { x: 0, y: 0, width: 100, height: 100 } })}
-      >
+  default: ({ onChangeCrop, required }: MockSeoMetadataBlockProps) => {
+    mockSeoMetadataRequired(required);
+    return (
+      <div data-testid="mock-seo-metadata-block">
+        <button
+          data-testid="mock-change-crop-btn"
+          onClick={() => onChangeCrop({ uk: { x: 0, y: 0, width: 100, height: 100 } })}
+        >
         Change Crop
-      </button>
-      <button data-testid="mock-change-crop-null-btn" onClick={() => onChangeCrop(null)}>
+        </button>
+        <button data-testid="mock-change-crop-null-btn" onClick={() => onChangeCrop(null)}>
         Change Crop Null
-      </button>
-    </div>
-  )
+        </button>
+      </div>
+    );
+  }
 }));
 
 jest.mock('~/shared/components/media-modal/MediaModal', () => ({
@@ -77,6 +83,12 @@ describe('OpusView Component', () => {
     expect(screen.getByText('Створення опусу')).toBeInTheDocument();
     expect(screen.getByText('Деталі')).toBeInTheDocument();
     expect(screen.getByLabelText('Назва опусу *')).toBeInTheDocument();
+  });
+
+  it('makes SEO metadata optional for opus create and edit forms', () => {
+    render(<OpusView data={createMockData()} mode="create" />);
+
+    expect(mockSeoMetadataRequired).toHaveBeenCalledWith(false);
   });
 
   it('renders the edit title in edit mode', () => {

--- a/app/(logged_in)/creativity/group/create/OpusView.tsx
+++ b/app/(logged_in)/creativity/group/create/OpusView.tsx
@@ -89,6 +89,7 @@ export default function OpusView({ data, mode = 'create' }: Readonly<OpusViewPro
         <Box sx={styles.seoWrapper}>
           <SeoMetadataBlock
             showAlternativeText
+            required={false}
             forceShowErrors={forceShowErrors}
             value={seoValue}
             onChange={setSeoValue}

--- a/app/constants/errors.ts
+++ b/app/constants/errors.ts
@@ -150,6 +150,9 @@ export const MediaMentionsErrors = {
 
 export const seoFormErrors = {
   uk: {
+    descriptionMaxLength: 'Максимум 250 символів',
+    keywordsMaxLength: 'Максимум 250 символів',
+    altTextMaxLength: 'Максимум 250 символів',
     minLength: 'Мінімум 2 символа',
     maxLength: 'Максимум 150 символів',
     required: 'Обовʼязкове поле',
@@ -157,6 +160,9 @@ export const seoFormErrors = {
     keywords: 'Ключові слова мають бути через кому, без порожніх значень'
   },
   en: {
+    descriptionMaxLength: 'Maximum 250 characters',
+    keywordsMaxLength: 'Maximum 250 characters',
+    altTextMaxLength: 'Maximum 250 characters',
     minLength: 'Minimum 2 characters',
     maxLength: 'Maximum 150 characters',
     required: 'Required field',

--- a/app/constants/publications.ts
+++ b/app/constants/publications.ts
@@ -273,7 +273,22 @@ export const ADMIN_TITLE_LABELS: Record<PublicationsItemType, string> = {
   media: 'Назва публікації в адмінці'
 } as const;
 
-export const META_TITLE_MAX_LENGTH = 150;
+export const META_TITLE_LENGTH = {
+  min: 2,
+  max: 150
+};
+export const META_DESCRIPTION_LENGTH = {
+  min: 2,
+  max: 250
+};
+export const META_KEYWORDS_LENGTH = {
+  min: 2,
+  max: 250
+};
+export const META_ALT_TEXT_LENGTH = {
+  min: 2,
+  max: 250
+};
 
 export const CROP_RATIOS = {
   HERO_BANNER: 816 / 300,

--- a/app/shared/components/design-system/photo-block/PhotoBlock.styles.ts
+++ b/app/shared/components/design-system/photo-block/PhotoBlock.styles.ts
@@ -1,6 +1,6 @@
 
-export const PREVIEW_W = 196;
-export const PREVIEW_H = 120;
+export const PREVIEW_W = 177;
+export const PREVIEW_H = 135;
 
 export const styles = {
   container: {

--- a/app/shared/components/design-system/photo-block/PhotoBlock.test.tsx
+++ b/app/shared/components/design-system/photo-block/PhotoBlock.test.tsx
@@ -136,7 +136,7 @@ describe('ImagePreviewBlock', () => {
     expect(screen.getByAltText('Основне зображення')).toHaveAttribute('src', 'test.jpg');
     expect(screen.getByText(/Назва файлу/)).toBeInTheDocument();
     expect(screen.getByText(/test\.jpg/)).toBeInTheDocument();
-    expect(screen.getByText(/1024 × 768/)).toBeInTheDocument();
+    expect(screen.getByText(/1024×768/)).toBeInTheDocument();
   });
 
   it('should open MediaModal on "Редагувати" click', async () => {
@@ -237,6 +237,26 @@ describe('ImagePreviewBlock', () => {
 
     await user.type(input, '!');
     expect(onChangeAltText).toHaveBeenCalled();
+  });
+
+  it('reports alt text blur and displays its validation error', async () => {
+    const user = userEvent.setup();
+    const onBlurAltText = jest.fn();
+
+    renderComponent({
+      showAlternativeText: true,
+      altText: 'alt text',
+      onBlurAltText,
+      altTextErrorState: true,
+      altTextError: 'Alt text is required'
+    });
+
+    const input = screen.getByRole('textbox', { name: /^Alt/i });
+    await user.click(input);
+    await user.tab();
+
+    expect(onBlurAltText).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('Alt text is required')).toBeInTheDocument();
   });
 
   it('disables buttons when disabled prop is true', () => {

--- a/app/shared/components/design-system/photo-block/PhotoBlock.tsx
+++ b/app/shared/components/design-system/photo-block/PhotoBlock.tsx
@@ -164,7 +164,7 @@ export const ImagePreviewBlock = ({
 
             {dimensions ? (
               <Typography variant="body2" color="text.secondary" sx={styles.imageSizeText}>
-                Розмір: {dimensions.width} × {dimensions.height}
+                Розмір: {dimensions.width}×{dimensions.height} px.
               </Typography>
             ) : null}
           </Stack>
@@ -178,7 +178,7 @@ export const ImagePreviewBlock = ({
               fullWidth
               margin="none"
               multiline
-              maxRows={4}
+              maxRows={2}
               disabled={!previewImage}
               error={altTextErrorState}
               helperText={altTextError}
@@ -188,9 +188,7 @@ export const ImagePreviewBlock = ({
 
           <Stack direction={direction} spacing={buttonSpacing}>
             <Button
-              startIcon={
-                <PencilIcon />
-              }
+              startIcon={<PencilIcon />}
               variant="outlined"
               color="primary"
               size="small"

--- a/app/shared/components/forms/seo-metadata-form/SeoMetadataForm.test.tsx
+++ b/app/shared/components/forms/seo-metadata-form/SeoMetadataForm.test.tsx
@@ -1,10 +1,16 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { SeoCanonicalUrlField } from './seo-canonicalurl-field/SeoCanonicalUrlField';
 import SeoMetadataForm, { LocalizedMeta, SeoMetadataFormProps } from './SeoMetadataForm';
-import { META_TITLE_MAX_LENGTH } from '~/constants/publications';
+import { seoFormErrors } from '~/constants/errors';
+import {
+  META_ALT_TEXT_LENGTH,
+  META_DESCRIPTION_LENGTH,
+  META_KEYWORDS_LENGTH,
+  META_TITLE_LENGTH
+} from '~/constants/publications';
 
 interface MockCropResult {
   rect: unknown;
@@ -16,13 +22,17 @@ jest.mock('~/shared/components/design-system/photo-block/PhotoBlock', () => ({
     onChangeImage,
     showAlternativeText,
     altText,
-    onChangeAltText
+    onChangeAltText,
+    onBlurAltText,
+    altTextError
   }: {
     imageUrl?: string;
     onChangeImage: (url: string, crop?: MockCropResult | null) => void;
     showAlternativeText?: boolean;
     altText?: string;
     onChangeAltText?: (value: string) => void;
+    onBlurAltText?: () => void;
+    altTextError?: string;
   }) => (
     <div data-testid="photo-block" data-imageurl={imageUrl}>
       <button data-testid="photo-block-trigger" onClick={() => onChangeImage('https://example.com/mock-image.png')}>
@@ -48,8 +58,10 @@ jest.mock('~/shared/components/design-system/photo-block/PhotoBlock', () => ({
           aria-label="Alt текст зображення"
           value={altText || ''}
           onChange={(e) => onChangeAltText?.(e.target.value)}
+          onBlur={onBlurAltText}
         />
       )}
+      {altTextError && <span>{altTextError}</span>}
     </div>
   )
 }));
@@ -59,12 +71,14 @@ jest.mock('./seo-base-fields/SeoBaseFields', () => ({
     onBlur,
     onFieldChange,
     showKeywords,
+    value,
     errors,
     touched
   }: {
     onBlur: (field: keyof LocalizedMeta) => void;
     onFieldChange: (field: keyof LocalizedMeta, val: string) => void;
     showKeywords?: boolean;
+    value: LocalizedMeta;
     errors: Partial<Record<keyof LocalizedMeta, string>>;
     touched: Partial<Record<keyof LocalizedMeta, boolean>>;
   }) => (
@@ -101,6 +115,7 @@ jest.mock('./seo-base-fields/SeoBaseFields', () => ({
       <label htmlFor="meta-title-input">Meta title</label>
       <input
         id="meta-title-input"
+        value={value.title}
         onBlur={() => onBlur('title')}
         onChange={(e) => onFieldChange('title', e.target.value)}
       />
@@ -109,6 +124,7 @@ jest.mock('./seo-base-fields/SeoBaseFields', () => ({
       <label htmlFor="meta-description-input">Meta description</label>
       <input
         id="meta-description-input"
+        value={value.description}
         onBlur={() => onBlur('description')}
         onChange={(e) => onFieldChange('description', e.target.value)}
       />
@@ -119,6 +135,7 @@ jest.mock('./seo-base-fields/SeoBaseFields', () => ({
           <label htmlFor="meta-keywords-input">Meta keywords</label>
           <input
             id="meta-keywords-input"
+            value={value.keywords}
             onBlur={() => onBlur('keywords')}
             onChange={(e) => onFieldChange('keywords', e.target.value)}
           />
@@ -210,12 +227,14 @@ describe('SeoMetadataForm', () => {
   });
 
   it('rejects title longer than the maximum length on blur, respects input maxLength attribute', async () => {
-    renderWithState();
-    const input = screen.getByLabelText(/meta title/i) as HTMLInputElement;
-
-    fireEvent.change(input, { target: { value: 'a'.repeat(META_TITLE_MAX_LENGTH + 1) } });
-    fireEvent.blur(input);
-    expect(await screen.findByText(/максимум 150 символів/i)).toBeInTheDocument();
+    render(
+      <SeoMetadataForm
+        {...defaultProps}
+        forceShowErrors={true}
+        value={{ ...defaultProps.value, title: 'a'.repeat(META_TITLE_LENGTH.max + 1) }}
+      />
+    );
+    expect(await screen.findByText(seoFormErrors.uk.maxLength)).toBeInTheDocument();
   });
 
   it('accepts title within the allowed length range', async () => {
@@ -237,7 +256,7 @@ describe('SeoMetadataForm', () => {
 
     await user.type(input, 'Some description');
     fireEvent.blur(input);
-    expect(screen.queryByText(/обовʼязкове поле/i)).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText(/обовʼязкове поле/i)).not.toBeInTheDocument());
   });
 
   it('validates canonicalUrl: empty, valid, invalid', async () => {
@@ -266,6 +285,17 @@ describe('SeoMetadataForm', () => {
     expect(await screen.findByText(/некоректний url/i)).toBeInTheDocument();
   });
 
+  it('validates description minimum and maximum lengths', async () => {
+    render(
+      <SeoMetadataForm
+        {...defaultProps}
+        forceShowErrors={true}
+        value={{ ...defaultProps.value, description: 'a'.repeat(META_DESCRIPTION_LENGTH.max + 1) }}
+      />
+    );
+    expect(await screen.findByText(seoFormErrors.uk.descriptionMaxLength)).toBeInTheDocument();
+  });
+
   it('validates keywords: empty, valid, invalid', async () => {
     renderWithState();
     const input = screen.getByLabelText(/meta keywords/i);
@@ -278,6 +308,27 @@ describe('SeoMetadataForm', () => {
     await user.type(input, 'one, ,two');
     fireEvent.blur(input);
     expect(await screen.findByText(/Ключові слова мають бути через кому/i)).toBeInTheDocument();
+  });
+
+  it('validates keywords minimum and maximum lengths', async () => {
+    render(
+      <SeoMetadataForm
+        {...defaultProps}
+        forceShowErrors={true}
+        value={{ ...defaultProps.value, keywords: 'a'.repeat(META_KEYWORDS_LENGTH.max + 1) }}
+      />
+    );
+    expect(await screen.findByText(seoFormErrors.uk.keywordsMaxLength)).toBeInTheDocument();
+  });
+
+  it('does not require title or description when the form is optional', async () => {
+    render(<SeoMetadataForm {...defaultProps} required={false} />);
+
+    fireEvent.blur(screen.getByLabelText(/meta title/i));
+    fireEvent.blur(screen.getByLabelText(/meta description/i));
+
+    expect(screen.queryByText(seoFormErrors.uk.minLength)).not.toBeInTheDocument();
+    expect(screen.queryByText(seoFormErrors.uk.required)).not.toBeInTheDocument();
   });
 
   it('does not render canonicalUrl without extraFields', () => {
@@ -311,6 +362,72 @@ describe('SeoMetadataForm', () => {
     const altInput = screen.getByLabelText(/alt текст/i);
     await user.type(altInput, 'alt text');
     expect(onChange).toHaveBeenCalled();
+  });
+
+  it('requires alt text when an OG image is present', async () => {
+    render(
+      <SeoMetadataForm
+        {...defaultProps}
+        ogImage="https://example.com/image.png"
+        showAlternativeText={true}
+        value={{ ...defaultProps.value, altText: { uk: '', en: '' } }}
+      />
+    );
+
+    fireEvent.blur(screen.getByRole('textbox', { name: /^Alt/i }));
+
+    expect(await screen.findByText(seoFormErrors.uk.required)).toBeInTheDocument();
+  });
+
+  it('validates alt text changes after the field has been touched', async () => {
+    const onChange = jest.fn();
+    render(
+      <SeoMetadataForm
+        {...defaultProps}
+        onChange={onChange}
+        ogImage="https://example.com/image.png"
+        showAlternativeText={true}
+        value={{ ...defaultProps.value, altText: { uk: '', en: '' } }}
+      />
+    );
+
+    const altInput = screen.getByRole('textbox', { name: /^Alt/i });
+    fireEvent.blur(altInput);
+    fireEvent.change(altInput, { target: { value: 'valid alt text' } });
+
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ altText: { uk: 'valid alt text', en: '' } })
+    );
+    await waitFor(() => expect(screen.queryByText(seoFormErrors.uk.required)).not.toBeInTheDocument());
+  });
+
+  it('uses an empty value when blurring an undefined alt text field', async () => {
+    render(
+      <SeoMetadataForm
+        {...defaultProps}
+        ogImage="https://example.com/image.png"
+        showAlternativeText={true}
+        value={{ ...defaultProps.value }}
+      />
+    );
+
+    fireEvent.blur(screen.getByRole('textbox', { name: /^Alt/i }));
+
+    expect(await screen.findByText(seoFormErrors.uk.required)).toBeInTheDocument();
+  });
+
+  it('validates alt text maximum length', async () => {
+    render(
+      <SeoMetadataForm
+        {...defaultProps}
+        forceShowErrors={true}
+        ogImage="https://example.com/image.png"
+        showAlternativeText={true}
+        value={{ ...defaultProps.value, altText: { uk: 'a'.repeat(META_ALT_TEXT_LENGTH.max + 1), en: '' } }}
+      />
+    );
+
+    expect(await screen.findByText(seoFormErrors.uk.altTextMaxLength)).toBeInTheDocument();
   });
 
   it('renders keywords field as multiline text field when extraFieldsBeforeKeywords is true', async () => {
@@ -521,7 +638,7 @@ describe('SeoMetadataForm', () => {
     expect(screen.getAllByText(/обовʼязкове поле/i).length).toBeGreaterThan(0);
   });
 
-  it('covers forceShowErrors effect completely on mount and rerender', () => {
+  it('covers forceShowErrors effect completely on mount and rerender', async () => {
     const { rerender } = render(<SeoMetadataForm {...defaultProps} forceShowErrors={true} />);
 
     expect(screen.getAllByText(/обовʼязкове поле/i).length).toBeGreaterThan(0);
@@ -536,7 +653,7 @@ describe('SeoMetadataForm', () => {
       />
     );
 
-    expect(screen.queryByText(/обовʼязкове поле/i)).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText(/обовʼязкове поле/i)).not.toBeInTheDocument());
   });
 
   it('covers valid canonicalUrl and default case branches in validateField', async () => {

--- a/app/shared/components/forms/seo-metadata-form/SeoMetadataForm.tsx
+++ b/app/shared/components/forms/seo-metadata-form/SeoMetadataForm.tsx
@@ -4,10 +4,11 @@ import 'dayjs/locale/uk';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { Box, Checkbox, Divider, FormControlLabel, Stack, TextField, Typography } from '@mui/material';
 import type { ReactNode } from 'react';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { SeoBaseFields } from './seo-base-fields/SeoBaseFields';
 import { styles } from './SeoMetadataForm.styles';
+import { SeoField, SeoFieldValidationError, validateSeoField } from './validateSeoField';
 import { seoFormErrors } from '~/constants/errors';
 import { CROP_RATIOS } from '~/constants/publications';
 import { ImagePreviewBlock as PhotoBlock } from '~/shared/components/design-system/photo-block/PhotoBlock';
@@ -34,6 +35,7 @@ export interface SeoMetadataFormProps {
   readonly onIndexingChange: (val: boolean) => void;
   readonly showAlternativeText?: boolean;
   readonly extraFieldsBeforeKeywords?: boolean;
+  readonly required?: boolean;
   readonly forceShowErrors?: boolean;
   readonly extraFields?: (value: LocalizedMeta, onChange: (val: LocalizedMeta) => void) => ReactNode;
   readonly crop?: CropRect | null;
@@ -73,6 +75,7 @@ export default function SeoMetadataForm({
   onIndexingChange,
   showAlternativeText = false,
   extraFieldsBeforeKeywords = false,
+  required = true,
   forceShowErrors = false,
   crop,
   onChangeCrop,
@@ -89,6 +92,14 @@ export default function SeoMetadataForm({
 
   const translationErrors = seoFormErrors[locale];
 
+  const isFieldRequired = useCallback(
+    (field: keyof LocalizedMeta, fieldValue = value): boolean => {
+      if (field === 'altText') return Boolean(ogImage);
+      return required || Boolean(typeof fieldValue[field] === 'string' && fieldValue[field].trim());
+    },
+    [ogImage, required, value]
+  );
+
   useEffect(() => {
     if (isValidHttpUrl(ogImage)) {
       setOgImagePreview(ogImage);
@@ -99,52 +110,76 @@ export default function SeoMetadataForm({
     }
   }, [ogImage]);
 
+  const validateField = useCallback(
+    (field: keyof LocalizedMeta, val: string, fieldRequired = isFieldRequired(field)) => {
+      if (!['title', 'description', 'keywords', 'canonicalUrl', 'altText'].includes(field)) return '';
+
+      const validationError = validateSeoField(field as SeoField, val, { required: fieldRequired });
+      const errorMessages: Record<SeoFieldValidationError, string> = {
+        '': '',
+        required: translationErrors.required,
+        minLength: translationErrors.minLength,
+        maxLength: translationErrors.maxLength,
+        descriptionMaxLength: translationErrors.descriptionMaxLength,
+        keywordsMaxLength: translationErrors.keywordsMaxLength,
+        altTextMaxLength: translationErrors.altTextMaxLength,
+        invalidUrl: translationErrors.invalidUrl,
+        keywords: translationErrors.keywords
+      };
+
+      return errorMessages[validationError];
+    },
+    [isFieldRequired, translationErrors]
+  );
+
   useEffect(() => {
     if (!forceShowErrors) return;
-    setTouched((prev) => ({ ...prev, title: true, description: true }));
+    setTouched((prev) => ({ ...prev, title: true, description: true, keywords: true, altText: true }));
     setErrors((prev) => ({
       ...prev,
       title: validateField('title', value.title),
-      description: validateField('description', value.description)
+      description: validateField('description', value.description),
+      keywords: validateField('keywords', value.keywords),
+      altText: validateField('altText', value.altText?.[locale] ?? '')
     }));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [forceShowErrors]);
-
-  const validateField = (field: keyof LocalizedMeta, val: string) => {
-    switch (field) {
-    case 'title': {
-      const length = val.trim().length;
-      if (length < 2) return translationErrors.minLength;
-      if (length > 150) return translationErrors.maxLength;
-      return '';
-    }
-    case 'description':
-      return val.trim() ? '' : translationErrors.required;
-    case 'canonicalUrl':
-      if (!val) return '';
-      try {
-        new URL(val);
-        return '';
-      } catch {
-        return translationErrors.invalidUrl;
-      }
-    case 'keywords':
-      if (!val) return '';
-      return val.split(',').some((word) => !word.trim()) ? translationErrors.keywords : '';
-    default:
-      return '';
-    }
-  };
+  }, [forceShowErrors, locale, validateField, value.altText, value.description, value.keywords, value.title]);
 
   const handleBlur = (field: keyof LocalizedMeta) => {
     setTouched((prev) => ({ ...prev, [field]: true }));
-    const fieldValue = typeof value[field] === 'string' ? value[field] : '';
-    setErrors((prev) => ({ ...prev, [field]: validateField(field, fieldValue) }));
+
+    let fieldValue = '';
+
+    if (field === 'altText') {
+      fieldValue = value.altText?.[locale] ?? '';
+    } else if (typeof value[field] === 'string') {
+      fieldValue = value[field];
+    }
+
+    setErrors((prev) => ({
+      ...prev,
+      [field]: validateField(field, fieldValue)
+    }));
   };
 
   const handleFieldChange = (field: keyof LocalizedMeta, val: string) => {
-    onChange({ ...value, [field]: val });
-    if (touched[field]) setErrors((prev) => ({ ...prev, [field]: validateField(field, val) }));
+    const nextValue = { ...value, [field]: val };
+    const nextFieldRequired = isFieldRequired(field, nextValue);
+
+    onChange(nextValue);
+    if (touched[field]) setErrors((prev) => ({ ...prev, [field]: validateField(field, val, nextFieldRequired) }));
+  };
+
+  const handleAltTextChange = (val: string) => {
+    const nextValue = {
+      ...value,
+      altText: {
+        uk: locale === 'uk' ? val : (value.altText?.uk ?? ''),
+        en: locale === 'en' ? val : (value.altText?.en ?? '')
+      }
+    };
+
+    onChange(nextValue);
+    if (touched.altText) setErrors((prev) => ({ ...prev, altText: validateField('altText', val) }));
   };
 
   const handleImageChange = async (url: string, crop: CropResult | null | undefined) => {
@@ -162,12 +197,9 @@ export default function SeoMetadataForm({
   const renderPhotoBlock = () => (
     <Stack sx={styles.photoBlock}>
       <Box sx={styles.photoBlockHeader}>
-        <Typography variant="subtitle1" sx={styles.photoBlockTitle}>
+        <Typography variant="subtitle2" sx={styles.photoBlockTitle}>
           {'Зображення для соцмереж'}
         </Typography>
-        <TooltipCustom title={'Зображення для соцмереж'}>
-          <InfoOutlinedIcon sx={styles.infoIcon} />
-        </TooltipCustom>
         <Divider sx={styles.photoBlockHeaderDivider} />
       </Box>
       <PhotoBlock
@@ -183,15 +215,10 @@ export default function SeoMetadataForm({
         initialCrop={crop ? { rect: crop } : null}
         showAlternativeText={showAlternativeText}
         altText={value.altText?.[locale] ?? ''}
-        onChangeAltText={(alt) =>
-          onChange({
-            ...value,
-            altText: {
-              uk: locale === 'uk' ? alt : (value.altText?.uk ?? ''),
-              en: locale === 'en' ? alt : (value.altText?.en ?? '')
-            }
-          })
-        }
+        onChangeAltText={handleAltTextChange}
+        onBlurAltText={() => handleBlur('altText')}
+        altTextErrorState={Boolean(errors.altText && touched.altText)}
+        altTextError={errors.altText && touched.altText ? errors.altText : ''}
         locale={locale}
       />
       <Typography variant="textMd" sx={styles.ogImageHint}>
@@ -213,6 +240,7 @@ export default function SeoMetadataForm({
           onFieldChange={handleFieldChange}
           onBlur={handleBlur}
           showKeywords={!extraFieldsBeforeKeywords}
+          required={required}
           labels={labels}
         />
         {extraFields?.(value, onChange)}

--- a/app/shared/components/forms/seo-metadata-form/seo-base-fields/SeoBaseFields.test.tsx
+++ b/app/shared/components/forms/seo-metadata-form/seo-base-fields/SeoBaseFields.test.tsx
@@ -123,4 +123,24 @@ describe('SeoBaseFields', () => {
     expect(screen.getByLabelText('Meta keywords')).toHaveAttribute('data-multiline', 'true');
     expect(screen.getByLabelText('Meta title')).not.toHaveAttribute('data-multiline');
   });
+
+  it('allows title and description to be optional when required is false', () => {
+    render(<SeoBaseFields {...baseProps} required={false} />);
+
+    expect(screen.getByLabelText('Meta title')).not.toHaveAttribute('aria-required', 'true');
+    expect(screen.getByLabelText('Meta description')).not.toHaveAttribute('aria-required', 'true');
+  });
+
+  it('makes title and description optional when required is false', () => {
+    render(<SeoBaseFields {...baseProps} required={false} />);
+
+    expect(screen.getByLabelText('Meta title')).not.toHaveAttribute('aria-required', 'true');
+    expect(screen.getByLabelText('Meta description')).not.toHaveAttribute('aria-required', 'true');
+  });
+
+  it('omits keywords when configured to hide them', () => {
+    render(<SeoBaseFields {...baseProps} showKeywords={false} />);
+
+    expect(screen.queryByLabelText('Meta keywords')).not.toBeInTheDocument();
+  });
 });

--- a/app/shared/components/forms/seo-metadata-form/seo-base-fields/SeoBaseFields.tsx
+++ b/app/shared/components/forms/seo-metadata-form/seo-base-fields/SeoBaseFields.tsx
@@ -2,7 +2,7 @@ import { Stack, TextField } from '@mui/material';
 
 import type { LocalizedMeta } from '../SeoMetadataForm';
 import { styles } from '../SeoMetadataForm.styles';
-import { META_TITLE_MAX_LENGTH } from '~/constants/publications';
+import { META_DESCRIPTION_LENGTH, META_KEYWORDS_LENGTH, META_TITLE_LENGTH } from '~/constants/publications';
 
 interface SeoBaseFieldsProps {
   readonly value: LocalizedMeta;
@@ -11,6 +11,7 @@ interface SeoBaseFieldsProps {
   readonly onFieldChange: (field: keyof LocalizedMeta, val: string) => void;
   readonly onBlur: (field: keyof LocalizedMeta) => void;
   readonly showKeywords?: boolean;
+  readonly required?: boolean;
   readonly labels?: {
     readonly metaTitle?: string;
     readonly metaDescription?: string;
@@ -18,23 +19,49 @@ interface SeoBaseFieldsProps {
   };
 }
 
-export function SeoBaseFields({ value, errors, touched, onFieldChange, onBlur, showKeywords = true, labels = {} }: SeoBaseFieldsProps) {
+export function SeoBaseFields({
+  value,
+  errors,
+  touched,
+  onFieldChange,
+  onBlur,
+  showKeywords = true,
+  required = true,
+  labels = {}
+}: SeoBaseFieldsProps) {
   const fields = [
-    { key: 'title' as const, label: labels.metaTitle || 'Meta title', required: true, maxLength: META_TITLE_MAX_LENGTH },
+    {
+      key: 'title' as const,
+      label: labels.metaTitle || 'Meta title',
+      required,
+      maxLength: META_TITLE_LENGTH.max
+    },
     {
       key: 'description' as const,
       label: labels.metaDescription || 'Meta description',
-      required: true,
+      required,
+      maxLength: META_DESCRIPTION_LENGTH.max,
       multiline: true,
       minRows: 3,
       maxRows: 3
     },
-    ...(showKeywords ? [{ key: 'keywords' as const, label: labels.metaKeywords || 'Meta keywords', multiline: true, minRows: 2, maxRows: 2 }] : [])
+    ...(showKeywords
+      ? [
+        {
+          key: 'keywords' as const,
+          label: labels.metaKeywords || 'Meta keywords',
+          multiline: true,
+          minRows: 2,
+          maxRows: 2,
+          maxLength: META_KEYWORDS_LENGTH.max
+        }
+      ]
+      : [])
   ];
 
   return (
     <Stack direction="column" spacing={2.5} sx={styles.formFieldsContainer}>
-      {fields.map(({ key, label, required, multiline, minRows, maxRows, maxLength }) => (
+      {fields.map(({ key, label, required: fieldRequired, multiline, minRows, maxRows, maxLength }) => (
         <TextField
           key={key}
           label={label}
@@ -45,7 +72,7 @@ export function SeoBaseFields({ value, errors, touched, onFieldChange, onBlur, s
           helperText={errors[key] && touched[key] ? errors[key] : ''}
           fullWidth
           sx={styles.textField}
-          required={required}
+          required={fieldRequired}
           multiline={multiline}
           minRows={minRows}
           maxRows={maxRows}

--- a/app/shared/components/forms/seo-metadata-form/seo-metadata-block/SeoMetadataBlock.test.tsx
+++ b/app/shared/components/forms/seo-metadata-form/seo-metadata-block/SeoMetadataBlock.test.tsx
@@ -16,7 +16,8 @@ jest.mock('../SeoMetadataForm', () => ({
     onImageChange,
     onIndexingChange,
     onChangeCrop,
-    extraFields
+    extraFields,
+    required
   }: {
     locale: string;
     value: { title: string; description: string; keywords: string };
@@ -27,12 +28,14 @@ jest.mock('../SeoMetadataForm', () => ({
     onIndexingChange: (val: boolean) => void;
     onChangeCrop?: (crop: object | null) => void;
     extraFields?: (value: object, onChange: (val: object) => void) => React.ReactNode;
+    required?: boolean;
   }) => (
     <div>
       <span data-testid={`locale-${locale}`}>{locale}</span>
       <span data-testid={`title-${locale}`}>{value?.title}</span>
       <span data-testid={`og-image-${locale}`}>{ogImage ? 'has-image' : 'no-image'}</span>
       <span data-testid={`indexing-${locale}`}>{String(allowIndexing)}</span>
+      <span data-testid={`required-${locale}`}>{String(required ?? true)}</span>
       <button onClick={() => onChange({ title: 'test', description: 'desc', keywords: 'kw' })}>change-{locale}</button>
       <button onClick={() => onImageChange('https://example.com/test.png')}>image-{locale}</button>
       <button onClick={() => onIndexingChange(false)}>indexing-{locale}</button>
@@ -61,6 +64,14 @@ describe('SeoMetadataBlock', () => {
     renderBlock();
     locales.forEach((locale) => {
       expect(screen.getByTestId(`locale-${locale}`)).toBeInTheDocument();
+    });
+  });
+
+  it('passes optional validation mode to both locale forms', () => {
+    renderBlock({ required: false });
+
+    locales.forEach((locale) => {
+      expect(screen.getByTestId(`required-${locale}`)).toHaveTextContent('false');
     });
   });
 

--- a/app/shared/components/forms/seo-metadata-form/seo-metadata-block/SeoMetadataBlock.tsx
+++ b/app/shared/components/forms/seo-metadata-form/seo-metadata-block/SeoMetadataBlock.tsx
@@ -30,6 +30,7 @@ export interface SeoMetadataBlockProps {
   readonly showAlternativeText?: boolean;
   readonly showTicketUrl?: boolean;
   readonly extraFieldsBeforeKeywords?: boolean;
+  readonly required?: boolean;
   readonly forceShowErrors?: boolean;
   readonly value?: SeoBlockValue;
   readonly crop?: LocalizedCropRect | null;
@@ -46,6 +47,7 @@ export default function SeoMetadataBlock({
   showAlternativeText = false,
   showTicketUrl = false,
   extraFieldsBeforeKeywords = false,
+  required = true,
   forceShowErrors = false,
   value: externalValue,
   crop,
@@ -138,6 +140,7 @@ export default function SeoMetadataBlock({
         onIndexingChange={(val) => handleChange({ ...value, allowIndexing: { ...value.allowIndexing, uk: val } })}
         showAlternativeText={showAlternativeText}
         extraFieldsBeforeKeywords={extraFieldsBeforeKeywords}
+        required={required}
         forceShowErrors={forceShowErrors}
         crop={crop?.uk ?? null}
         onChangeCrop={(newUkCrop) => onChangeCrop?.({ uk: newUkCrop, en: crop?.en ?? null })}
@@ -157,6 +160,7 @@ export default function SeoMetadataBlock({
         onIndexingChange={(val) => handleChange({ ...value, allowIndexing: { ...value.allowIndexing, en: val } })}
         showAlternativeText={showAlternativeText}
         extraFieldsBeforeKeywords={extraFieldsBeforeKeywords}
+        required={required}
         forceShowErrors={forceShowErrors}
         crop={crop?.en ?? null}
         onChangeCrop={(newEnCrop) => onChangeCrop?.({ uk: crop?.uk ?? null, en: newEnCrop })}

--- a/app/shared/components/forms/seo-metadata-form/validateSeoField.test.ts
+++ b/app/shared/components/forms/seo-metadata-form/validateSeoField.test.ts
@@ -1,0 +1,39 @@
+import { validateSeoField } from './validateSeoField';
+import {
+  META_ALT_TEXT_LENGTH,
+  META_DESCRIPTION_LENGTH,
+  META_KEYWORDS_LENGTH,
+  META_TITLE_LENGTH
+} from '~/constants/publications';
+
+describe('validateSeoField', () => {
+  test.each([
+    ['title', META_TITLE_LENGTH],
+    ['description', META_DESCRIPTION_LENGTH],
+    ['keywords', META_KEYWORDS_LENGTH],
+    ['altText', META_ALT_TEXT_LENGTH]
+  ] as const)('accepts %s at its configured boundaries', (field, limits) => {
+    expect(validateSeoField(field, 'a'.repeat(limits.min))).toBe('');
+    expect(validateSeoField(field, 'a'.repeat(limits.max))).toBe('');
+    expect(validateSeoField(field, 'a'.repeat(limits.max + 1))).toMatch(/MaxLength|maxLength/);
+  });
+
+  it('allows empty optional fields but reports required fields', () => {
+    expect(validateSeoField('title', '', { required: false })).toBe('');
+    expect(validateSeoField('description', '', { required: false })).toBe('');
+    expect(validateSeoField('title', '', { required: true })).toBe('minLength');
+    expect(validateSeoField('description', '', { required: true })).toBe('required');
+    expect(validateSeoField('altText', '', { required: true })).toBe('required');
+  });
+
+  it('validates keyword formatting after length validation', () => {
+    expect(validateSeoField('keywords', 'one, ,two')).toBe('keywords');
+    expect(validateSeoField('keywords', 'one, two')).toBe('');
+  });
+
+  it('validates canonical URLs and allows an empty value', () => {
+    expect(validateSeoField('canonicalUrl', '')).toBe('');
+    expect(validateSeoField('canonicalUrl', 'https://example.com/page')).toBe('');
+    expect(validateSeoField('canonicalUrl', 'not-a-url')).toBe('invalidUrl');
+  });
+});

--- a/app/shared/components/forms/seo-metadata-form/validateSeoField.test.ts
+++ b/app/shared/components/forms/seo-metadata-form/validateSeoField.test.ts
@@ -21,6 +21,8 @@ describe('validateSeoField', () => {
   it('allows empty optional fields but reports required fields', () => {
     expect(validateSeoField('title', '', { required: false })).toBe('');
     expect(validateSeoField('description', '', { required: false })).toBe('');
+    expect(validateSeoField('altText', '   ', { required: false })).toBe('');
+    expect(validateSeoField('keywords', '', { required: true })).toBe('');
     expect(validateSeoField('title', '', { required: true })).toBe('minLength');
     expect(validateSeoField('description', '', { required: true })).toBe('required');
     expect(validateSeoField('altText', '', { required: true })).toBe('required');
@@ -29,6 +31,7 @@ describe('validateSeoField', () => {
   it('validates keyword formatting after length validation', () => {
     expect(validateSeoField('keywords', 'one, ,two')).toBe('keywords');
     expect(validateSeoField('keywords', 'one, two')).toBe('');
+    expect(validateSeoField('keywords', 'one,two,')).toBe('keywords');
   });
 
   it('validates canonical URLs and allows an empty value', () => {

--- a/app/shared/components/forms/seo-metadata-form/validateSeoField.ts
+++ b/app/shared/components/forms/seo-metadata-form/validateSeoField.ts
@@ -19,28 +19,51 @@ export type SeoFieldValidationError =
   | 'keywords';
 
 type LengthLimit = { min: number; max: number };
+type SeoLengthField = Exclude<SeoField, 'canonicalUrl'>;
 
-const lengthLimits: Partial<Record<SeoField, LengthLimit>> = {
+const lengthLimits: Record<SeoLengthField, LengthLimit> = {
   title: META_TITLE_LENGTH,
   description: META_DESCRIPTION_LENGTH,
   keywords: META_KEYWORDS_LENGTH,
   altText: META_ALT_TEXT_LENGTH
 };
 
-const maxLengthErrors: Partial<Record<SeoField, SeoFieldValidationError>> = {
+const maxLengthErrors: Record<SeoLengthField, SeoFieldValidationError> = {
   title: 'maxLength',
   description: 'descriptionMaxLength',
   keywords: 'keywordsMaxLength',
   altText: 'altTextMaxLength'
 };
 
-const validateLength = (field: SeoField, value: string): SeoFieldValidationError => {
+const validateLength = (field: SeoLengthField, value: string): SeoFieldValidationError => {
   const limits = lengthLimits[field];
-  if (!limits) return '';
   if (value.length < limits.min) return 'minLength';
-  if (value.length > limits.max) return maxLengthErrors[field] ?? 'maxLength';
+  if (value.length > limits.max) return maxLengthErrors[field];
   return '';
 };
+
+const validateCanonicalUrl = (value: string): SeoFieldValidationError => {
+  if (!value) return '';
+
+  try {
+    new URL(value);
+    return '';
+  } catch {
+    return 'invalidUrl';
+  }
+};
+
+const validateEmptyValue = (
+  field: SeoField,
+  required: boolean
+): SeoFieldValidationError => {
+  if (field === 'keywords') return '';
+  if (field === 'title' && required) return 'minLength';
+  return required ? 'required' : '';
+};
+
+const validateKeywords = (value: string): SeoFieldValidationError =>
+  value.split(',').some((word) => !word.trim()) ? 'keywords' : '';
 
 export interface SeoFieldValidationOptions {
   readonly required?: boolean;
@@ -51,27 +74,15 @@ export const validateSeoField = (
   value: string,
   { required = false }: SeoFieldValidationOptions = {}
 ): SeoFieldValidationError => {
-  if (field === 'canonicalUrl') {
-    if (!value) return '';
-    try {
-      new URL(value);
-      return '';
-    } catch {
-      return 'invalidUrl';
-    }
-  }
+  if (field === 'canonicalUrl') return validateCanonicalUrl(value);
 
   const trimmed = value.trim();
-  if (!trimmed) {
-    if (field === 'keywords') return '';
-    if (field === 'title' && required) return 'minLength';
-    return required ? 'required' : '';
-  }
+  if (!trimmed) return validateEmptyValue(field, required);
 
   const lengthError = validateLength(field, trimmed);
   if (lengthError) return lengthError;
 
-  if (field === 'keywords' && trimmed.split(',').some((word) => !word.trim())) return 'keywords';
+  if (field === 'keywords') return validateKeywords(trimmed);
 
   return '';
 };

--- a/app/shared/components/forms/seo-metadata-form/validateSeoField.ts
+++ b/app/shared/components/forms/seo-metadata-form/validateSeoField.ts
@@ -1,0 +1,77 @@
+import {
+  META_ALT_TEXT_LENGTH,
+  META_DESCRIPTION_LENGTH,
+  META_KEYWORDS_LENGTH,
+  META_TITLE_LENGTH
+} from '~/constants/publications';
+
+export type SeoField = 'title' | 'description' | 'keywords' | 'canonicalUrl' | 'altText';
+
+export type SeoFieldValidationError =
+  | ''
+  | 'required'
+  | 'minLength'
+  | 'maxLength'
+  | 'descriptionMaxLength'
+  | 'keywordsMaxLength'
+  | 'altTextMaxLength'
+  | 'invalidUrl'
+  | 'keywords';
+
+type LengthLimit = { min: number; max: number };
+
+const lengthLimits: Partial<Record<SeoField, LengthLimit>> = {
+  title: META_TITLE_LENGTH,
+  description: META_DESCRIPTION_LENGTH,
+  keywords: META_KEYWORDS_LENGTH,
+  altText: META_ALT_TEXT_LENGTH
+};
+
+const maxLengthErrors: Partial<Record<SeoField, SeoFieldValidationError>> = {
+  title: 'maxLength',
+  description: 'descriptionMaxLength',
+  keywords: 'keywordsMaxLength',
+  altText: 'altTextMaxLength'
+};
+
+const validateLength = (field: SeoField, value: string): SeoFieldValidationError => {
+  const limits = lengthLimits[field];
+  if (!limits) return '';
+  if (value.length < limits.min) return 'minLength';
+  if (value.length > limits.max) return maxLengthErrors[field] ?? 'maxLength';
+  return '';
+};
+
+export interface SeoFieldValidationOptions {
+  readonly required?: boolean;
+}
+
+export const validateSeoField = (
+  field: SeoField,
+  value: string,
+  { required = false }: SeoFieldValidationOptions = {}
+): SeoFieldValidationError => {
+  if (field === 'canonicalUrl') {
+    if (!value) return '';
+    try {
+      new URL(value);
+      return '';
+    } catch {
+      return 'invalidUrl';
+    }
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    if (field === 'keywords') return '';
+    if (field === 'title' && required) return 'minLength';
+    return required ? 'required' : '';
+  }
+
+  const lengthError = validateLength(field, trimmed);
+  if (lengthError) return lengthError;
+
+  if (field === 'keywords' && trimmed.split(',').some((word) => !word.trim())) return 'keywords';
+
+  return '';
+};

--- a/app/shared/hooks/use-upsert-opus/useUpsertOpus.test.ts
+++ b/app/shared/hooks/use-upsert-opus/useUpsertOpus.test.ts
@@ -7,6 +7,12 @@ import {
   COMPOSITION_NAME_REQUIRED_ERROR,
   OPUS_VALIDATION_MESSAGES
 } from '~/constants/opus';
+import {
+  META_ALT_TEXT_LENGTH,
+  META_DESCRIPTION_LENGTH,
+  META_KEYWORDS_LENGTH,
+  META_TITLE_LENGTH
+} from '~/constants/publications';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
 import type { FetchedOpusData, OpusCompositionData } from '~/types/opus';
 
@@ -268,6 +274,30 @@ describe('useUpsertOpus', () => {
     expect(result.current.isSaved).toBe(false);
   });
 
+  it('marks invalid compositions when the mutation reports a required name error', async () => {
+    mockCreateOpus.mockRejectedValue(new Error('Composition name is required'));
+    const { result } = renderHook(() => useUpsertOpus());
+    act(() => {
+      result.current.setDetails((prev) => ({
+        ...prev,
+        number: '5',
+        name: 'Р“СЂСѓРїР°',
+        creationYear: '1922',
+        compositions: [
+          { id: 'valid', name: 'РўРІС–СЂ', genre: '', year: '', audios: [], notes: [] }
+        ]
+      }));
+    });
+
+    await act(async () => {
+      await result.current.handleSave(BaseContentStatuses.Draft);
+    });
+
+    expect(result.current.compositionErrors).toEqual({});
+    expect(toast.error).toHaveBeenCalledWith(COMPOSITION_NAME_REQUIRED_ERROR);
+    expect(result.current.isSaved).toBe(false);
+  });
+
   it('reports non-composition mutation errors without throwing', async () => {
     mockCreateOpus.mockRejectedValue(new Error('Network failed'));
     const { result } = renderHook(() => useUpsertOpus());
@@ -375,7 +405,7 @@ describe('useUpsertOpus', () => {
     expect(composition.notes).toEqual([{ name: 'Ноти', fileUrl: 'notes-url', publishDate: '' }]);
   });
 
-  it('sets publishedAt and maps SEO fallbacks when publishing', async () => {
+  it('sets publishedAt and maps cover-image fallbacks when publishing', async () => {
     mockCreateOpus.mockResolvedValue({ data: { createOpus: { id: 'opus-101' } } });
 
     const { result } = renderHook(() => useUpsertOpus());
@@ -391,10 +421,116 @@ describe('useUpsertOpus', () => {
 
     const payload = mockCreateOpus.mock.calls[0][0];
     expect(typeof payload.publishedAt).toBe('string');
-    expect(payload.title).toEqual({ uk: 'Соната', en: 'Соната' });
+    expect(payload.title).toEqual({ uk: '', en: '' });
     expect(payload.coverImage.src).toBe('Соната');
     expect(payload.coverImage.alt).toEqual({ uk: 'Соната', en: 'Соната' });
     expect(payload.coverImage.crop).toEqual({ x: 10, y: 20, width: 30, height: 40 });
+  });
+
+  test.each([
+    ['title', 'a'],
+    ['title', 'a'.repeat(META_TITLE_LENGTH.max + 1)],
+    ['description', 'a'],
+    ['description', 'a'.repeat(META_DESCRIPTION_LENGTH.max + 1)],
+    ['keywords', 'a'],
+    ['keywords', 'a'.repeat(META_KEYWORDS_LENGTH.max + 1)],
+    ['keywords', 'one, ,two']
+  ] as const)('rejects invalid optional SEO %s values before mutation', async (field, fieldValue) => {
+    const { result } = renderHook(() => useUpsertOpus());
+    fillValidDetails(result);
+
+    act(() => {
+      result.current.setSeoValue((prev) => ({
+        ...prev,
+        meta: {
+          ...prev.meta,
+          uk: { ...prev.meta.uk, [field]: fieldValue }
+        }
+      }));
+    });
+
+    await act(async () => {
+      await result.current.handleSave(BaseContentStatuses.Draft);
+    });
+
+    expect(mockCreateOpus).not.toHaveBeenCalled();
+    expect(result.current.forceShowErrors).toBe(true);
+  });
+
+  it('validates SEO metadata independently for the English locale', async () => {
+    const { result } = renderHook(() => useUpsertOpus());
+    fillValidDetails(result);
+
+    act(() => {
+      result.current.setSeoValue((prev) => ({
+        ...prev,
+        meta: {
+          ...prev.meta,
+          en: { ...prev.meta.en, description: 'a' }
+        }
+      }));
+    });
+
+    await act(async () => {
+      await result.current.handleSave(BaseContentStatuses.Draft);
+    });
+
+    expect(mockCreateOpus).not.toHaveBeenCalled();
+    expect(result.current.forceShowErrors).toBe(true);
+  });
+
+  it('requires alt text in both locales only when a preview image is selected', async () => {
+    const { result } = renderHook(() => useUpsertOpus());
+    fillValidDetails(result);
+
+    act(() => {
+      result.current.setSeoValue((prev) => ({
+        ...prev,
+        ogImage: 'https://example.com/image.png'
+      }));
+    });
+
+    await act(async () => {
+      await result.current.handleSave(BaseContentStatuses.Draft);
+    });
+
+    expect(mockCreateOpus).not.toHaveBeenCalled();
+    expect(result.current.forceShowErrors).toBe(true);
+  });
+
+  it('accepts valid SEO values at the configured maximum lengths', async () => {
+    mockCreateOpus.mockResolvedValue({ data: { createOpus: { id: 'opus-seo-valid' } } });
+    const { result } = renderHook(() => useUpsertOpus());
+    fillValidDetails(result);
+
+    act(() => {
+      result.current.setSeoValue((prev) => ({
+        ...prev,
+        ogImage: 'https://example.com/image.png',
+        meta: {
+          uk: {
+            ...prev.meta.uk,
+            title: 'a'.repeat(META_TITLE_LENGTH.max),
+            description: 'a'.repeat(META_DESCRIPTION_LENGTH.max),
+            keywords: 'a'.repeat(META_KEYWORDS_LENGTH.max),
+            altText: { uk: 'a'.repeat(META_ALT_TEXT_LENGTH.max), en: prev.meta.uk.altText?.en ?? '' }
+          },
+          en: {
+            ...prev.meta.en,
+            title: 'a'.repeat(META_TITLE_LENGTH.max),
+            description: 'a'.repeat(META_DESCRIPTION_LENGTH.max),
+            keywords: 'a'.repeat(META_KEYWORDS_LENGTH.max),
+            altText: { uk: prev.meta.en.altText?.uk ?? '', en: 'a'.repeat(META_ALT_TEXT_LENGTH.max) }
+          }
+        }
+      }));
+    });
+
+    await act(async () => {
+      await result.current.handleSave(BaseContentStatuses.Draft);
+    });
+
+    expect(mockCreateOpus).toHaveBeenCalledTimes(1);
   });
 
   it('keeps isSaved false when create returns no id', async () => {

--- a/app/shared/hooks/use-upsert-opus/useUpsertOpus.ts
+++ b/app/shared/hooks/use-upsert-opus/useUpsertOpus.ts
@@ -20,6 +20,7 @@ import {
 } from '~/lib/utils/compositionErrors';
 import { generateUniqueId } from '~/lib/utils/generateUniqueId';
 import type { SeoBlockValue } from '~/shared/components/forms/seo-metadata-form/seo-metadata-block/SeoMetadataBlock';
+import { validateSeoField } from '~/shared/components/forms/seo-metadata-form/validateSeoField';
 import { useCreateOpus, useOpusById, useUpdateOpus } from '~/shared/hooks/use-opuses/useOpuses';
 import { CropRect } from '~/types/common';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
@@ -45,6 +46,29 @@ const fileNameFromUrl = (url?: string | null): string => {
   const segment = url.split('/').pop() ?? url;
 
   return decodeURIComponent(segment.split('?')[0]);
+};
+
+const isSeoMetaInvalid = (
+  meta: SeoBlockValue['meta']['uk'],
+  altLocale: 'uk' | 'en',
+  hasPreviewImage: boolean
+): boolean => {
+  return (
+    Boolean(validateSeoField('title', meta.title)) ||
+    Boolean(validateSeoField('description', meta.description)) ||
+    Boolean(validateSeoField('keywords', meta.keywords)) ||
+    (hasPreviewImage && Boolean(validateSeoField('altText', meta.altText?.[altLocale] ?? '', { required: true })))
+  );
+};
+
+const getAltText = (
+  altText: string | undefined,
+  hasOgImage: boolean,
+  fallback: string
+): string => {
+  const trimmedAlt = altText?.trim();
+
+  return hasOgImage ? (trimmedAlt ?? '') : (trimmedAlt || fallback);
 };
 
 export const toCompositionInput = (
@@ -345,6 +369,16 @@ export const useUpsertOpus = (
 
     const { uk: ukMeta, en: enMeta } = currentSeo.meta;
     const opusName = currentDetails.name.trim();
+    const hasOgImage = Boolean(currentSeo.ogImage);
+
+    if (
+      isSeoMetaInvalid(ukMeta, 'uk', Boolean(currentSeo.ogImage)) ||
+      isSeoMetaInvalid(enMeta, 'en', Boolean(currentSeo.ogImage))
+    ) {
+      setForceShowErrors(true);
+      return undefined;
+    }
+
     const input = {
       numberKind: currentDetails.numberKind as unknown as OpusNumberKind,
       number: Number(currentDetails.number.trim()),
@@ -362,13 +396,16 @@ export const useUpsertOpus = (
       },
       compositions: currentDetails.compositions.map(toCompositionInput),
       adminTitle: opusName,
-      title: { uk: ukMeta.title.trim() || opusName, en: enMeta.title.trim() || opusName },
+      title: { uk: ukMeta.title.trim(), en: enMeta.title.trim() },
       description: { uk: ukMeta.description.trim(), en: enMeta.description.trim() },
       keywords: { uk: ukMeta.keywords.trim(), en: enMeta.keywords.trim() },
       allowIndexation: { uk: currentSeo.allowIndexing.uk, en: currentSeo.allowIndexing.en },
       coverImage: {
         src: currentSeo.ogImage || opusName,
-        alt: { uk: ukMeta.altText?.uk || opusName, en: enMeta.altText?.en || opusName },
+        alt: {
+          uk: getAltText(ukMeta.altText?.uk, hasOgImage, opusName),
+          en: getAltText(enMeta.altText?.en, hasOgImage, opusName),
+        },
         caption: { uk: opusName, en: opusName },
         ...(currentCrop && { crop: currentCrop })
       },

--- a/src/infrastructure/models/opus.model.ts
+++ b/src/infrastructure/models/opus.model.ts
@@ -26,7 +26,7 @@ const opusSchema = new Schema(
       type: Number, required: true, 
       set: (v: unknown) => (v != null ? Number(v) : v) 
     },
-    title: { type: translatedFieldSchema, required: true },
+    title: { type: translatedFieldUnrequiredSchema, required: false, default: undefined },
     numberKind: { type: String, enum: ['op', 'sineop', 'compositions'], default: 'op' },
     name: { type: translatedFieldSchema, default: { uk: '', en: '' } },
     additionalText: { 

--- a/src/interfaces/graphql/resolvers/opus/opusMutation.test.ts
+++ b/src/interfaces/graphql/resolvers/opus/opusMutation.test.ts
@@ -177,6 +177,21 @@ describe('OpusMutation Resolvers', () => {
       );
     });
 
+    it('creates an opus when optional SEO title and description are omitted', async () => {
+      mockOpusRepo.findByComplexKey.mockResolvedValue(null);
+      mockedGenerateUniqueSlug.mockResolvedValue(SLUG_VALUE);
+      mockOpusRepo.create.mockResolvedValue(MOCK_OPUS_ENTITY);
+
+      const { title: _title, description: _description, ...inputWithoutSeo } = BASE_CREATE_INPUT;
+
+      await OpusMutation.createOpus({}, { input: inputWithoutSeo }, adminContext);
+
+      expect(mockOpusRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ title: undefined, description: undefined }),
+        expect.anything()
+      );
+    });
+
     it('should create opus with default parameters and sync compositions/images', async () => {
       mockOpusRepo.findByComplexKey.mockResolvedValue(null);
       mockedGenerateUniqueSlug.mockImplementation(async (_, options) => {

--- a/src/interfaces/graphql/resolvers/opus/opusMutation.ts
+++ b/src/interfaces/graphql/resolvers/opus/opusMutation.ts
@@ -50,8 +50,8 @@ export type CreateOpusGQLInput = {
   genre?: LocalizedString;
   compositions?: GQLComposition[];
   adminTitle?: string;
-  title: LocalizedString;
-  description: OpusDescription;
+  title?: LocalizedString;
+  description?: OpusDescription;
   introDescription?: OpusDescription;
   parts?: OpusDescription;
   gallery?: OpusGalleryItem[];

--- a/src/interfaces/graphql/schemas/opus.graphql
+++ b/src/interfaces/graphql/schemas/opus.graphql
@@ -43,7 +43,7 @@ type Opus {
   number: Float!
   blocksOrder: [String]
   numberKind: OpusNumberKind!
-  title: LocalizedString!
+  title: LocalizedString
   name: LocalizedString!
   additionalText: String
   creationYear: String!
@@ -113,8 +113,8 @@ input CreateOpusInput {
   genre: JSON
   compositions: JSON
   adminTitle: String
-  title: JSON!
-  description: JSON!
+  title: JSON
+  description: JSON
   introDescription: JSON
   parts: JSON
   gallery: [OpusGalleryItemInput!]


### PR DESCRIPTION
## Description

Implements optional opus title and description metadata across the UI, GraphQL schema, mutation input, and persistence model for opus. SEO validation is centralized and shared between the metadata form and opus upsert flow, ensuring consistent validation for lengths, keywords, and alternative text. The fields validation also works now in news components that use SeoMetadataBlock.

### What was changed

- Made opus title and description metadata optional.
- Centralized SEO field validation in `validateSeoField`.
- Updated metadata length limits and localized validation messages.
- Added image-dependent alternative text validation.
- Updated photo preview, GraphQL, persistence, and related component behavior of opuses.
- Improve the UI according to the design
- Сropped meta image display
- Added and updated tests.

## Type of change

- [x] New feature
- [x] Bug fix
- [ ] Documentation update
- [x] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Check out this branch.
2. Open the opus creation or editing page.
3. Verify title and description can be left empty.
4. Verify SEO validation for length limits, keywords, and alternative text.
5. Verify alternative text is required only when a preview image exists.
6. Run the test suites.

## Video / Screenshots

https://github.com/user-attachments/assets/d5985a23-71ad-4b4e-b1ee-c596db45f39d

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [ ] Task moved to the review column on the board

---
Closes #780

Related bugs:
Closes https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/595
Closes https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/596
Closes https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/582
