### PR TITLE
fix: add validation for title on createNews/updateNews

### DIFF
--- a/src/constants/errors.ts
+++ b/src/constants/errors.ts
@@ -34,7 +34,8 @@ export const newsServiceErrors = {
   TITLE_REQUIRED_FOR_SLUG: 'Title is required to generate a slug',
   TITLE_TOO_SHORT_FOR_SLUG: 'Title must be at least 2 characters long to generate a slug',
   TITLE_TOO_LONG_FOR_SLUG: 'Title must not exceed 150 characters',
-  DESCRIPTION_LENGTH_INVALID: 'Description must contain from 2 to 250 characters'
+  DESCRIPTION_LENGTH_INVALID: 'Description must contain from 2 to 250 characters',
+  TITLE_LENGTH_INVALID: 'Title must contain from 2 to 150 characters'
 };
 
 export const opusServiceErrors = {
@@ -67,7 +68,7 @@ export const compositionsServiceErrors = {
   COMPOSITION_NOT_FOUND: (id: string) => `Composition with id "${id}" not found`,
   FAILED_TO_DELETE: (id: string) => `Composition with id "${id}" not found or could not be deleted`,
   COMPOSITION_NOT_CREATED: 'Repository failed to create composition record.',
-  COMPOSITION_NAME_TAKEN: (name: string) => `Композиція "${name}" вже існує`,
+  COMPOSITION_NAME_TAKEN: (name: string) => `Композиція "${name}" вже існує`
 };
 
 export const MediaMentionsServiceErrors = {

--- a/src/interfaces/graphql/resolvers/news/newsMutation.test.ts
+++ b/src/interfaces/graphql/resolvers/news/newsMutation.test.ts
@@ -103,10 +103,10 @@ describe('NewsMutation Resolvers', () => {
       );
     });
 
-    it('should throw TITLE_TOO_SHORT_FOR_SLUG if title has fewer than 2 characters', async () => {
+    it('should throw TITLE_LENGTH_INVALID if title has fewer than 2 characters', async () => {
       const invalidInput = { ...baseInput, title: { uk: 'Т', en: 'T' } };
       await expect(NewsMutation.createNews({}, { input: invalidInput }, adminContext)).rejects.toThrow(
-        newsServiceErrors.TITLE_TOO_SHORT_FOR_SLUG
+        newsServiceErrors.TITLE_LENGTH_INVALID
       );
     });
 
@@ -118,7 +118,7 @@ describe('NewsMutation Resolvers', () => {
         await NewsMutation.createNews({}, { input: invalidInput }, adminContext);
       } catch (error) {
         expect(error).toBeInstanceOf(GraphQLError);
-        expect((error as GraphQLError).message).toBe(newsServiceErrors.TITLE_TOO_LONG_FOR_SLUG);
+        expect((error as GraphQLError).message).toBe(newsServiceErrors.TITLE_LENGTH_INVALID);
         expect((error as GraphQLError).extensions.code).toBe('BAD_USER_INPUT');
       }
     });
@@ -131,7 +131,7 @@ describe('NewsMutation Resolvers', () => {
         await NewsMutation.createNews({}, { input: invalidInput }, adminContext);
       } catch (error) {
         expect(error).toBeInstanceOf(GraphQLError);
-        expect((error as GraphQLError).message).toBe(newsServiceErrors.TITLE_TOO_LONG_FOR_SLUG);
+        expect((error as GraphQLError).message).toBe(newsServiceErrors.TITLE_LENGTH_INVALID);
         expect((error as GraphQLError).extensions.code).toBe('BAD_USER_INPUT');
       }
     });
@@ -301,12 +301,12 @@ describe('NewsMutation Resolvers', () => {
       expect(mockRepo.update).not.toHaveBeenCalled();
     });
 
-    it('should throw TITLE_TOO_SHORT_FOR_SLUG if updated title has fewer than 2 characters', async () => {
+    it('should throw TITLE_LENGTH_INVALID if updated title has fewer than 2 characters', async () => {
       mockAction('findById', createMockNews({ id }));
 
       await expect(
         NewsMutation.updateNews({}, { id, input: { title: { uk: 'Т', en: 'T' } } }, adminContext)
-      ).rejects.toThrow(newsServiceErrors.TITLE_TOO_SHORT_FOR_SLUG);
+      ).rejects.toThrow(newsServiceErrors.TITLE_LENGTH_INVALID);
 
       expect(mockRepo.update).not.toHaveBeenCalled();
     });
@@ -323,7 +323,7 @@ describe('NewsMutation Resolvers', () => {
         );
       } catch (error) {
         expect(error).toBeInstanceOf(GraphQLError);
-        expect((error as GraphQLError).message).toBe(newsServiceErrors.TITLE_TOO_LONG_FOR_SLUG);
+        expect((error as GraphQLError).message).toBe(newsServiceErrors.TITLE_LENGTH_INVALID);
         expect((error as GraphQLError).extensions.code).toBe('BAD_USER_INPUT');
       }
 

--- a/src/interfaces/graphql/resolvers/news/newsMutation.test.ts
+++ b/src/interfaces/graphql/resolvers/news/newsMutation.test.ts
@@ -89,17 +89,17 @@ describe('NewsMutation Resolvers', () => {
   beforeEach(() => jest.clearAllMocks());
 
   describe('Security & Validation', () => {
-    it('should throw TITLE_REQUIRED_FOR_SLUG if title is empty', async () => {
+    it('should throw TITLE_LENGTH_INVALID if title is empty', async () => {
       const invalidInput = { ...baseInput, title: { uk: '', en: '' } };
       await expect(NewsMutation.createNews({}, { input: invalidInput }, adminContext)).rejects.toThrow(
-        newsServiceErrors.TITLE_REQUIRED_FOR_SLUG
+        newsServiceErrors.TITLE_LENGTH_INVALID
       );
     });
 
-    it('should throw TITLE_REQUIRED_FOR_SLUG if title uk is missing (via partial object)', async () => {
+    it('should throw TITLE_LENGTH_INVALID if title uk is missing (via partial object)', async () => {
       const invalidInput = { ...baseInput, title: { uk: '' } } as unknown as CreateNewsGQLInput;
       await expect(NewsMutation.createNews({}, { input: invalidInput }, adminContext)).rejects.toThrow(
-        newsServiceErrors.TITLE_REQUIRED_FOR_SLUG
+        newsServiceErrors.TITLE_LENGTH_INVALID
       );
     });
 
@@ -291,12 +291,12 @@ describe('NewsMutation Resolvers', () => {
       expect(mockRepo.update).toHaveBeenCalled();
     });
 
-    it('should throw TITLE_REQUIRED_FOR_SLUG if updated title is empty', async () => {
+    it('should throw TITLE_LENGTH_INVALID if updated title is empty', async () => {
       mockAction('findById', createMockNews({ id }));
 
       await expect(
         NewsMutation.updateNews({}, { id, input: { title: { uk: '', en: '' } } }, adminContext)
-      ).rejects.toThrow(newsServiceErrors.TITLE_REQUIRED_FOR_SLUG);
+      ).rejects.toThrow(newsServiceErrors.TITLE_LENGTH_INVALID);
 
       expect(mockRepo.update).not.toHaveBeenCalled();
     });

--- a/src/interfaces/graphql/resolvers/news/newsMutation.ts
+++ b/src/interfaces/graphql/resolvers/news/newsMutation.ts
@@ -58,6 +58,7 @@ const processContentFields = async (input: UpdateNewsGQLInput, updateData: Updat
   }
 };
 
+const TITLE_MIN_LENGTH = 2;
 const TITLE_MAX_LENGTH = 150;
 
 const DESCRIPTION_MIN_LENGTH = 2;
@@ -113,13 +114,14 @@ const validateDescriptionLength = (description: LocalizedString | undefined): vo
   throwBadUserInput(newsServiceErrors.DESCRIPTION_LENGTH_INVALID, invalidFields);
 };
 
-const validateTitleMaxLength = (title: LocalizedString | undefined): void => {
+const validateTitleLength = (title: LocalizedString | undefined): void => {
   const invalidFields = getInvalidLocalizedLengthFields(title, {
     fieldName: 'title',
-    maxLength: TITLE_MAX_LENGTH
+    maxLength: TITLE_MAX_LENGTH,
+    minLength: TITLE_MIN_LENGTH
   });
 
-  throwBadUserInput(newsServiceErrors.TITLE_TOO_LONG_FOR_SLUG, invalidFields);
+  throwBadUserInput(newsServiceErrors.TITLE_LENGTH_INVALID, invalidFields);
 };
 
 const trimLocalizedString = (value: LocalizedString | undefined): LocalizedString | undefined => {
@@ -160,11 +162,9 @@ export const NewsMutation = {
 
     if (!titleForSlug) {
       throw new Error(newsServiceErrors.TITLE_REQUIRED_FOR_SLUG);
-    } else if (titleForSlug.trim().length < 2) {
-      throw new Error(newsServiceErrors.TITLE_TOO_SHORT_FOR_SLUG);
     }
 
-    validateTitleMaxLength(trimmedInput.title);
+    validateTitleLength(trimmedInput.title);
     validateDescriptionLength(trimmedInput.description);
 
     const slug = await generateUniqueSlug(titleForSlug, {
@@ -238,11 +238,9 @@ export const NewsMutation = {
       const titleForSlug = extractTitleForSlug(trimmedInput.title);
       if (!titleForSlug) {
         throw new Error(newsServiceErrors.TITLE_REQUIRED_FOR_SLUG);
-      } else if (titleForSlug.trim().length < 2) {
-        throw new Error(newsServiceErrors.TITLE_TOO_SHORT_FOR_SLUG);
       }
 
-      validateTitleMaxLength(trimmedInput.title);
+      validateTitleLength(trimmedInput.title);
 
       await processSlugUpdate(id, trimmedInput.title, repo, updateData);
       updateData.title = trimmedInput.title;

--- a/src/interfaces/graphql/resolvers/news/newsMutation.ts
+++ b/src/interfaces/graphql/resolvers/news/newsMutation.ts
@@ -160,10 +160,6 @@ export const NewsMutation = {
 
     const titleForSlug = extractTitleForSlug(trimmedInput.title);
 
-    if (!titleForSlug) {
-      throw new Error(newsServiceErrors.TITLE_REQUIRED_FOR_SLUG);
-    }
-
     validateTitleLength(trimmedInput.title);
     validateDescriptionLength(trimmedInput.description);
 
@@ -235,11 +231,6 @@ export const NewsMutation = {
     }
 
     if (trimmedInput.title) {
-      const titleForSlug = extractTitleForSlug(trimmedInput.title);
-      if (!titleForSlug) {
-        throw new Error(newsServiceErrors.TITLE_REQUIRED_FOR_SLUG);
-      }
-
       validateTitleLength(trimmedInput.title);
 
       await processSlugUpdate(id, trimmedInput.title, repo, updateData);


### PR DESCRIPTION
## Description

Fixes validation for the English SEO title in the Create News mutation.

Previously, a title with only 1 character could be accepted, which could lead to an invalid publication being created. The validation now correctly handles the minimum title length.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. Execute the Login request in Postman.
2. Verify that authorization data is successfully saved in Postman variables.
3. Open the GraphQL request Mutations/Create News.
4. In GraphQL Variables, set title.en to 1 character while keeping all other required fields valid:
```
{
  "input": {
    "adminTitle": "Test Yana",
    "title": {
      "uk": "Це тестовий заголовок meta новини українською мовою",
      "en": "A"
    }
  }
}
```
5. Send the request.
6. Check the API response.
7. Open the created publication on the website/client side.

## Video / Screenshots
<img width="1363" height="973" alt="Screenshot 2026-08-11 at 18 56 35" src="https://github.com/user-attachments/assets/dd85d552-ac68-4a37-9423-b78b7e72a1a6" />

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

 Closes: [#580](https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/580)
---
