### PR TITLE
feat: add gallery modal empty state

### DIFF
--- a/app/shared/components/media-modal/views/gallery-view/GalleryView.test.tsx
+++ b/app/shared/components/media-modal/views/gallery-view/GalleryView.test.tsx
@@ -6,7 +6,6 @@ import type { GalleryFilters } from '../../flow/MediaModalFlowState';
 import { MockMediaGrid, MockSearchButton } from '../../test-utils/sharedMocks';
 import { GalleryView } from './GalleryView';
 import { useGalleryFiles } from '~/shared/hooks/use-galllery-photo/useGallery';
-import { useStore } from '~/store';
 import { useAllAssetsQuery } from '~/types/graphql/generated/graphql';
 
 jest.mock('../../components/search-button/SearchButton', () => ({
@@ -113,7 +112,6 @@ describe('GalleryView', () => {
     mockOnFiltersChange.mockClear();
     (useGalleryFiles as jest.Mock).mockReturnValue({ files: mockFiles, isLoading: false, error: null });
     (useAllAssetsQuery as jest.Mock).mockReturnValue({ data: undefined, loading: false });
-    useStore.getState().setLocale('uk');
   });
 
   it('should render gallery view with title', () => {
@@ -222,13 +220,20 @@ describe('GalleryView', () => {
     expect(screen.queryByTestId('mocked-media-grid')).not.toBeInTheDocument();
   });
 
-  it('should render empty state text in English when locale is en', () => {
-    useStore.getState().setLocale('en');
+  it('should render media-kind specific empty state for pdf gallery', () => {
     (useGalleryFiles as jest.Mock).mockReturnValue({ files: [], isLoading: false, error: null });
 
-    renderGalleryView();
+    render(
+      <GalleryView
+        selected={null}
+        onPick={mockOnPick}
+        filters={mockFilters}
+        onFiltersChange={mockOnFiltersChange}
+        mediaKind="pdf"
+      />
+    );
 
-    expect(screen.getByText('No images found. Try adding images to the media library.')).toBeInTheDocument();
+    expect(screen.getByText('Файлів не знайдено. Спробуйте додати файли до медіатеки.')).toBeInTheDocument();
   });
 
   it('should render media-kind specific empty state for audio gallery', () => {

--- a/app/shared/components/media-modal/views/gallery-view/GalleryView.test.tsx
+++ b/app/shared/components/media-modal/views/gallery-view/GalleryView.test.tsx
@@ -6,6 +6,7 @@ import type { GalleryFilters } from '../../flow/MediaModalFlowState';
 import { MockMediaGrid, MockSearchButton } from '../../test-utils/sharedMocks';
 import { GalleryView } from './GalleryView';
 import { useGalleryFiles } from '~/shared/hooks/use-galllery-photo/useGallery';
+import { useStore } from '~/store';
 import { useAllAssetsQuery } from '~/types/graphql/generated/graphql';
 
 jest.mock('../../components/search-button/SearchButton', () => ({
@@ -112,6 +113,7 @@ describe('GalleryView', () => {
     mockOnFiltersChange.mockClear();
     (useGalleryFiles as jest.Mock).mockReturnValue({ files: mockFiles, isLoading: false, error: null });
     (useAllAssetsQuery as jest.Mock).mockReturnValue({ data: undefined, loading: false });
+    useStore.getState().setLocale('uk');
   });
 
   it('should render gallery view with title', () => {
@@ -201,6 +203,48 @@ describe('GalleryView', () => {
     renderGalleryView();
 
     expect(screen.getByText('Завантаження...')).toBeInTheDocument();
+  });
+
+  it('should render empty state when image array is empty after loading', () => {
+    (useGalleryFiles as jest.Mock).mockReturnValue({ files: [], isLoading: false, error: null });
+
+    renderGalleryView();
+
+    expect(screen.getByTestId('GalleryView-emptyState')).toBeInTheDocument();
+    expect(screen.getByText('Зображень не знайдено. Спробуйте додати зображення до медіатеки.')).toBeInTheDocument();
+    expect(screen.queryByTestId('mocked-media-grid')).not.toBeInTheDocument();
+  });
+
+  it('should render empty state when search returns no gallery items', () => {
+    renderGalleryView({ search: 'missing-image' });
+
+    expect(screen.getByTestId('GalleryView-emptyState')).toBeInTheDocument();
+    expect(screen.queryByTestId('mocked-media-grid')).not.toBeInTheDocument();
+  });
+
+  it('should render empty state text in English when locale is en', () => {
+    useStore.getState().setLocale('en');
+    (useGalleryFiles as jest.Mock).mockReturnValue({ files: [], isLoading: false, error: null });
+
+    renderGalleryView();
+
+    expect(screen.getByText('No images found. Try adding images to the media library.')).toBeInTheDocument();
+  });
+
+  it('should render media-kind specific empty state for audio gallery', () => {
+    (useGalleryFiles as jest.Mock).mockReturnValue({ files: [], isLoading: false, error: null });
+
+    render(
+      <GalleryView
+        selected={null}
+        onPick={mockOnPick}
+        filters={mockFilters}
+        onFiltersChange={mockOnFiltersChange}
+        mediaKind="audio"
+      />
+    );
+
+    expect(screen.getByText('Аудіофайлів не знайдено. Спробуйте додати аудіофайли до медіатеки.')).toBeInTheDocument();
   });
 
   it('should filter out non-starred items when favorites filter is starred', () => {

--- a/app/shared/components/media-modal/views/gallery-view/GalleryView.tsx
+++ b/app/shared/components/media-modal/views/gallery-view/GalleryView.tsx
@@ -190,6 +190,41 @@ export function GalleryView({ selected: _selected, onPick, filters, onFiltersCha
   const loading = r2Loading || assetsLoading;
   const shouldShowEmptyState = !loading && filteredAndSortedItems.length === 0;
 
+  const renderGalleryContent = () => {
+    if (loading) {
+      return <Box sx={sharedViewStyles.gridContainer}>Завантаження...</Box>;
+    }
+
+    if (shouldShowEmptyState) {
+      return (
+        <Box sx={sharedViewStyles.emptyState} data-testid="GalleryView-emptyState">
+          <Typography variant="body1" sx={sharedViewStyles.emptyStateText}>
+            {config.emptyStateText[currentLocale]}
+          </Typography>
+        </Box>
+      );
+    }
+
+    return (
+      <MediaGrid
+        items={filteredAndSortedItems}
+        sx={sharedViewStyles.gridContainer}
+        renderCard={(item) => (
+          <GalleryCard
+            src={item.url}
+            iconSrc={config.iconSrc}
+            fileName={item.originalname || item.filename}
+            isStarred={item.isStarred}
+            usageLocations={getPageNames(item.usageRefs)}
+            onClick={() => handleCardClick(item)}
+            testId={`GalleryCard-${item.id}`}
+          />
+        )}
+        testIdPrefix="GalleryView"
+      />
+    );
+  };
+
   return (
     <Box data-testid="GalleryView" sx={sharedViewStyles.container}>
       <Box sx={sharedViewStyles.header}>
@@ -221,32 +256,7 @@ export function GalleryView({ selected: _selected, onPick, filters, onFiltersCha
         </Box>
       </Box>
 
-      {loading ? (
-        <Box sx={sharedViewStyles.gridContainer}>Завантаження...</Box>
-      ) : shouldShowEmptyState ? (
-        <Box sx={sharedViewStyles.emptyState} data-testid="GalleryView-emptyState">
-          <Typography variant="body1" sx={sharedViewStyles.emptyStateText}>
-            {config.emptyStateText[currentLocale]}
-          </Typography>
-        </Box>
-      ) : (
-        <MediaGrid
-          items={filteredAndSortedItems}
-          sx={sharedViewStyles.gridContainer}
-          renderCard={(item) => (
-            <GalleryCard
-              src={item.url}
-              iconSrc={config.iconSrc}
-              fileName={item.originalname || item.filename}
-              isStarred={item.isStarred}
-              usageLocations={getPageNames(item.usageRefs)}
-              onClick={() => handleCardClick(item)}
-              testId={`GalleryCard-${item.id}`}
-            />
-          )}
-          testIdPrefix="GalleryView"
-        />
-      )}
+      {renderGalleryContent()}
     </Box>
   );
 }

--- a/app/shared/components/media-modal/views/gallery-view/GalleryView.tsx
+++ b/app/shared/components/media-modal/views/gallery-view/GalleryView.tsx
@@ -8,28 +8,42 @@ import { GalleryCard } from '../../components/gallery-card/GalleryCard';
 import { MediaGrid } from '../../components/media-grid/MediaGrid';
 import { SearchButton } from '../../components/search-button/SearchButton';
 import type { GalleryFilters } from '../../flow/MediaModalFlowState';
-import type { GalleryMedia, MediaKind } from '../../MediaModal.types';
+import type { GalleryMedia, Locale, MediaKind } from '../../MediaModal.types';
 import { matchesAudio, matchesPdf } from '../../MediaModal.utils';
 import { sharedViewStyles } from '../shared-view.styles';
 import { useDebounce } from '~/hooks/use-debounce/useDebounce';
 import { matchesSearch, sortByDateAndName } from '~/lib/utils/filterHelpers';
 import { type GalleryFile, useGalleryFiles } from '~/shared/hooks/use-galllery-photo/useGallery';
+import { useStore } from '~/store';
 import { AssetType, useAllAssetsQuery } from '~/types/graphql/generated/graphql';
 
 type MediaKindConfig = {
   folder: string;
   assetType: AssetType;
   title: string;
+  emptyStateText: Record<Locale, string>;
   iconSrc?: string;
   matchesFile?: (mimeType: string, filename: string) => boolean;
 };
 
 const MEDIA_KIND_CONFIG: Record<MediaKind, MediaKindConfig> = {
-  image: { folder: 'photos', assetType: AssetType.Image, title: 'Усі зображення' },
+  image: {
+    folder: 'photos',
+    assetType: AssetType.Image,
+    title: 'Усі зображення',
+    emptyStateText: {
+      uk: 'Зображень не знайдено. Спробуйте додати зображення до медіатеки.',
+      en: 'No images found. Try adding images to the media library.'
+    }
+  },
   audio: {
     folder: 'compositions',
     assetType: AssetType.Audio,
     title: 'Усі аудіо',
+    emptyStateText: {
+      uk: 'Аудіофайлів не знайдено. Спробуйте додати аудіофайли до медіатеки.',
+      en: 'No audio files found. Try adding audio files to the media library.'
+    },
     iconSrc: '/icons/audio.svg',
     matchesFile: matchesAudio
   },
@@ -37,6 +51,10 @@ const MEDIA_KIND_CONFIG: Record<MediaKind, MediaKindConfig> = {
     folder: 'uploads',
     assetType: AssetType.Pdf,
     title: 'Усі файли',
+    emptyStateText: {
+      uk: 'Файлів не знайдено. Спробуйте додати файли до медіатеки.',
+      en: 'No files found. Try adding files to the media library.'
+    },
     iconSrc: '/icons/pdf.svg',
     matchesFile: matchesPdf
   }
@@ -100,6 +118,7 @@ const matchesUsageFilter = (item: GalleryItem, filter: string): boolean => {
 
 export function GalleryView({ selected: _selected, onPick, filters, onFiltersChange, mediaKind = 'image' }: Props) {
   const config = MEDIA_KIND_CONFIG[mediaKind];
+  const currentLocale = useStore((state) => state.locale);
   const { files: r2Files, isLoading: r2Loading } = useGalleryFiles(config.folder);
 
   const { data: assetsData, loading: assetsLoading } = useAllAssetsQuery({
@@ -169,6 +188,7 @@ export function GalleryView({ selected: _selected, onPick, filters, onFiltersCha
   };
 
   const loading = r2Loading || assetsLoading;
+  const shouldShowEmptyState = !loading && filteredAndSortedItems.length === 0;
 
   return (
     <Box data-testid="GalleryView" sx={sharedViewStyles.container}>
@@ -203,6 +223,12 @@ export function GalleryView({ selected: _selected, onPick, filters, onFiltersCha
 
       {loading ? (
         <Box sx={sharedViewStyles.gridContainer}>Завантаження...</Box>
+      ) : shouldShowEmptyState ? (
+        <Box sx={sharedViewStyles.emptyState} data-testid="GalleryView-emptyState">
+          <Typography variant="body1" sx={sharedViewStyles.emptyStateText}>
+            {config.emptyStateText[currentLocale]}
+          </Typography>
+        </Box>
       ) : (
         <MediaGrid
           items={filteredAndSortedItems}

--- a/app/shared/components/media-modal/views/gallery-view/GalleryView.tsx
+++ b/app/shared/components/media-modal/views/gallery-view/GalleryView.tsx
@@ -8,20 +8,19 @@ import { GalleryCard } from '../../components/gallery-card/GalleryCard';
 import { MediaGrid } from '../../components/media-grid/MediaGrid';
 import { SearchButton } from '../../components/search-button/SearchButton';
 import type { GalleryFilters } from '../../flow/MediaModalFlowState';
-import type { GalleryMedia, Locale, MediaKind } from '../../MediaModal.types';
+import type { GalleryMedia, MediaKind } from '../../MediaModal.types';
 import { matchesAudio, matchesPdf } from '../../MediaModal.utils';
 import { sharedViewStyles } from '../shared-view.styles';
 import { useDebounce } from '~/hooks/use-debounce/useDebounce';
 import { matchesSearch, sortByDateAndName } from '~/lib/utils/filterHelpers';
 import { type GalleryFile, useGalleryFiles } from '~/shared/hooks/use-galllery-photo/useGallery';
-import { useStore } from '~/store';
 import { AssetType, useAllAssetsQuery } from '~/types/graphql/generated/graphql';
 
 type MediaKindConfig = {
   folder: string;
   assetType: AssetType;
   title: string;
-  emptyStateText: Record<Locale, string>;
+  emptyStateText: string;
   iconSrc?: string;
   matchesFile?: (mimeType: string, filename: string) => boolean;
 };
@@ -31,19 +30,13 @@ const MEDIA_KIND_CONFIG: Record<MediaKind, MediaKindConfig> = {
     folder: 'photos',
     assetType: AssetType.Image,
     title: 'Усі зображення',
-    emptyStateText: {
-      uk: 'Зображень не знайдено. Спробуйте додати зображення до медіатеки.',
-      en: 'No images found. Try adding images to the media library.'
-    }
+    emptyStateText: 'Зображень не знайдено. Спробуйте додати зображення до медіатеки.'
   },
   audio: {
     folder: 'compositions',
     assetType: AssetType.Audio,
     title: 'Усі аудіо',
-    emptyStateText: {
-      uk: 'Аудіофайлів не знайдено. Спробуйте додати аудіофайли до медіатеки.',
-      en: 'No audio files found. Try adding audio files to the media library.'
-    },
+    emptyStateText: 'Аудіофайлів не знайдено. Спробуйте додати аудіофайли до медіатеки.',
     iconSrc: '/icons/audio.svg',
     matchesFile: matchesAudio
   },
@@ -51,10 +44,7 @@ const MEDIA_KIND_CONFIG: Record<MediaKind, MediaKindConfig> = {
     folder: 'uploads',
     assetType: AssetType.Pdf,
     title: 'Усі файли',
-    emptyStateText: {
-      uk: 'Файлів не знайдено. Спробуйте додати файли до медіатеки.',
-      en: 'No files found. Try adding files to the media library.'
-    },
+    emptyStateText: 'Файлів не знайдено. Спробуйте додати файли до медіатеки.',
     iconSrc: '/icons/pdf.svg',
     matchesFile: matchesPdf
   }
@@ -118,7 +108,6 @@ const matchesUsageFilter = (item: GalleryItem, filter: string): boolean => {
 
 export function GalleryView({ selected: _selected, onPick, filters, onFiltersChange, mediaKind = 'image' }: Props) {
   const config = MEDIA_KIND_CONFIG[mediaKind];
-  const currentLocale = useStore((state) => state.locale);
   const { files: r2Files, isLoading: r2Loading } = useGalleryFiles(config.folder);
 
   const { data: assetsData, loading: assetsLoading } = useAllAssetsQuery({
@@ -199,7 +188,7 @@ export function GalleryView({ selected: _selected, onPick, filters, onFiltersCha
       return (
         <Box sx={sharedViewStyles.emptyState} data-testid="GalleryView-emptyState">
           <Typography variant="body1" sx={sharedViewStyles.emptyStateText}>
-            {config.emptyStateText[currentLocale]}
+            {config.emptyStateText}
           </Typography>
         </Box>
       );

--- a/app/shared/components/media-modal/views/shared-view.styles.ts
+++ b/app/shared/components/media-modal/views/shared-view.styles.ts
@@ -56,5 +56,19 @@ export const sharedViewStyles = {
     },
     scrollbarWidth: 'none',
     msOverflowStyle: 'none'
+  } as SxProps<Theme>,
+  emptyState: {
+    flex: 1,
+    minHeight: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    textAlign: 'center',
+    px: '24px'
+  } as SxProps<Theme>,
+
+  emptyStateText: {
+    color: 'white',
+    maxWidth: '420px'
   } as SxProps<Theme>
 };


### PR DESCRIPTION
## Description

Adds an empty state message to the media gallery modal when no items are available or when search/filtering returns no results.

The empty state uses Ukrainian text for the admin UI and supports image, audio, and PDF gallery modes.

Closes Liatoshynsky-Foundation/lf-admin#667

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other:

## How to test

1. Run `npm run dev`.
2. Open `/about-us`.
3. Open the media gallery modal.
4. Search for a value that returns no results, for example `qwerty-no-image-test`.
5. Confirm that the empty state message is shown in the gallery area.

Also checked:

- `npx eslint app/shared/components/media-modal/views/gallery-view/GalleryView.tsx app/shared/components/media-modal/views/gallery-view/GalleryView.test.tsx app/shared/components/media-modal/views/shared-view.styles.ts`
- `npx prettier --check app/shared/components/media-modal/views/gallery-view/GalleryView.tsx app/shared/components/media-modal/views/gallery-view/GalleryView.test.tsx app/shared/components/media-modal/views/shared-view.styles.ts`
- `npm test -- --runTestsByPath app/shared/components/media-modal/views/gallery-view/GalleryView.test.tsx --runInBand --coverage=false`

## Video / Screenshots

<img width="1408" height="758" alt="image" src="https://github.com/user-attachments/assets/faadb5c4-a57e-4ab6-a6f9-9e92b33a062b" />

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board