### PR TITLE
bugfix: restore audio and PDF filtering in MediaModal galleries

### DIFF
--- a/app/shared/components/media-modal/flow/MediaModalFlow.test.tsx
+++ b/app/shared/components/media-modal/flow/MediaModalFlow.test.tsx
@@ -387,6 +387,21 @@ describe('MediaModalFlow', () => {
     expect(screen.queryByTestId('MediaModal')).not.toBeInTheDocument();
   });
 
+  it('should not render media content while the modal is closed', () => {
+    const gallery = jest.fn(() => <div data-testid="GalleryView" />);
+
+    render(
+      <MediaModalFlow
+        open={false}
+        onClose={jest.fn()}
+        onApply={jest.fn()}
+        renderers={{ ...createRenderers(), gallery }}
+      />
+    );
+
+    expect(gallery).not.toHaveBeenCalled();
+  });
+
   it('should apply non-image upload without crop step', async () => {
     const onClose = jest.fn();
     const onApply = jest.fn().mockResolvedValue(undefined);

--- a/app/shared/components/media-modal/flow/MediaModalFlow.tsx
+++ b/app/shared/components/media-modal/flow/MediaModalFlow.tsx
@@ -316,7 +316,7 @@ export function MediaModalFlow({
       footerLeft={footerLeft}
       footerRight={footerRight}
     >
-      {renderBody()}
+      {open ? renderBody() : null}
     </MediaModalContainer>
   );
 }

--- a/app/shared/components/media-modal/views/gallery-view/GalleryView.test.tsx
+++ b/app/shared/components/media-modal/views/gallery-view/GalleryView.test.tsx
@@ -298,6 +298,103 @@ describe('GalleryView', () => {
     expect(screen.queryByText('cover.jpg')).not.toBeInTheDocument();
   });
 
+  it.each([
+    ['audio', 'recording.mp3', 'audio/mpeg', 'AUDIO'],
+    ['pdf', 'score.pdf', 'application/pdf', 'PDF']
+  ] as const)('should use Asset MIME metadata for generic R2 listings in the %s gallery', (mediaKind, filename, mimeType, assetType) => {
+    const url = `https://example.com/${filename}`;
+
+    (useGalleryFiles as jest.Mock).mockReturnValue({
+      files: [
+        {
+          filename,
+          originalName: filename,
+          mimeType: 'application/octet-stream',
+          size: 1,
+          createdAt: '2024-01-01T00:00:00.000Z',
+          url
+        }
+      ],
+      isLoading: false,
+      error: null
+    });
+    (useAllAssetsQuery as jest.Mock).mockReturnValue({
+      data: {
+        allAssets: [{
+          id: `asset-${mediaKind}`,
+          type: assetType,
+          mimeType,
+          url,
+          filename,
+          originalname: filename,
+          isStarred: false,
+          tags: [],
+          usageRefs: []
+        }]
+      },
+      loading: false
+    });
+
+    render(
+      <GalleryView
+        selected={null}
+        onPick={mockOnPick}
+        filters={mockFilters}
+        onFiltersChange={mockOnFiltersChange}
+        mediaKind={mediaKind}
+      />
+    );
+
+    expect(screen.getByText(filename)).toBeInTheDocument();
+  });
+
+  it.each([
+    ['audio', 'recording.mp3', 'image/jpeg'],
+    ['pdf', 'score.pdf', 'audio/mpeg']
+  ] as const)('should reject a %s file when Asset MIME metadata conflicts', (mediaKind, filename, mimeType) => {
+    const url = `https://example.com/${filename}`;
+
+    (useGalleryFiles as jest.Mock).mockReturnValue({
+      files: [{
+        filename,
+        originalName: filename,
+        mimeType: 'application/octet-stream',
+        size: 1,
+        createdAt: '2024-01-01T00:00:00.000Z',
+        url
+      }],
+      isLoading: false,
+      error: null
+    });
+    (useAllAssetsQuery as jest.Mock).mockReturnValue({
+      data: {
+        allAssets: [{
+          id: `asset-${mediaKind}-conflict`,
+          type: 'IMAGE',
+          mimeType,
+          url,
+          filename,
+          isStarred: false,
+          tags: [],
+          usageRefs: []
+        }]
+      },
+      loading: false
+    });
+
+    render(
+      <GalleryView
+        selected={null}
+        onPick={mockOnPick}
+        filters={mockFilters}
+        onFiltersChange={mockOnFiltersChange}
+        mediaKind={mediaKind}
+      />
+    );
+
+    expect(screen.queryByText(filename)).not.toBeInTheDocument();
+  });
+
   it('should match items by usage page from asset usageRefs', () => {
     (useAllAssetsQuery as jest.Mock).mockReturnValue({
       data: {

--- a/app/shared/components/media-modal/views/gallery-view/GalleryView.tsx
+++ b/app/shared/components/media-modal/views/gallery-view/GalleryView.tsx
@@ -111,6 +111,7 @@ export function GalleryView({ selected: _selected, onPick, filters, onFiltersCha
 
   type AssetMeta = {
     id: string;
+    mimeType: string;
     filename: string;
     originalname?: string;
     isStarred: boolean;
@@ -129,10 +130,15 @@ export function GalleryView({ selected: _selected, onPick, filters, onFiltersCha
   const galleryItems = useMemo((): GalleryItem[] => {
     return r2Files
       .filter((file): file is GalleryFile & { url: string } => Boolean(file.url))
-      .filter((file) => !config.matchesFile || config.matchesFile(file.mimeType ?? '', file.filename ?? ''))
-      .map((file) => {
+      .flatMap((file): GalleryItem[] => {
         const asset = assetByUrl[file.url];
-        return {
+        const mimeType = asset?.mimeType || file.mimeType || '';
+
+        if (config.matchesFile && !config.matchesFile(mimeType, file.filename ?? '')) {
+          return [];
+        }
+
+        return [{
           id: asset?.id ?? file.path ?? file.filename,
           filename: asset?.filename ?? file.filename,
           originalname: asset?.originalname ?? undefined,
@@ -141,7 +147,7 @@ export function GalleryView({ selected: _selected, onPick, filters, onFiltersCha
           tags: asset?.tags ?? [],
           usageRefs: asset?.usageRefs ?? [],
           createdAt: file.createdAt
-        };
+        }];
       });
   }, [r2Files, assetByUrl, config]);
 


### PR DESCRIPTION
## Description
Restores reliable selection of existing audio and PDF files in MediaModal galleries. R2 file listings do not include the stored ContentType, so listed files use application/octet-stream. The gallery now uses the matching Asset MIME type when available before applying media filters.

  ### What was changed

- Use the matching Asset MIME type for gallery files when available.
- Fall back to the R2 MIME type when no matching Asset exists.
- Keep existing audio, PDF, and image filtering behavior.
- Render MediaModal content only while the modal is open.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Check out this branch.
2. Open a composition and open the audio gallery.
3. Verify that an existing audio Asset appears in the gallery.
4. Open the PDF gallery and verify that an existing PDF Asset appears.
5. Select and save the items, then verify that they remain linked to the composition after saving.

## Video / Screenshots

https://github.com/user-attachments/assets/16ad9620-9072-4c21-a03b-62ffd4459088

## Checklist

- [ ] Code compiles and runs correctly
- [ ] Tests pass successfully
- [ ] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [ ] Linked issue/task included
- [ ] Task moved to the review column on the board

---
Closes #785 