### PR TITLE
fix: align about foundation image buttons

### DIFF
--- a/app/shared/components/about-us/our-mission/OurMission.styles.ts
+++ b/app/shared/components/about-us/our-mission/OurMission.styles.ts
@@ -16,6 +16,7 @@ export const styles = {
 
   imageBlockWrapper: {
     display: 'flex',
-    flexDirection: 'column'
+    flexDirection: 'column',
+    gap: '16px'
   }
 };

--- a/app/shared/components/about-us/our-mission/OurMission.test.tsx
+++ b/app/shared/components/about-us/our-mission/OurMission.test.tsx
@@ -6,10 +6,12 @@ import { createDocNode } from '~/__mocks__/utils';
 import { BLOCK_IDS, PAGE_IDS } from '~/constants/pageBlocks';
 import { MissionListItemWithId } from '~/types/store/pages/about-us/blocks/missionBlock';
 
-
 interface MockImagePreviewBlockProps {
   readonly title: string;
   readonly imageUrl: string;
+  readonly previewWidth?: number;
+  readonly previewHeight?: number;
+  readonly alignActionsToPreviewBottom?: boolean;
   readonly altText?: string;
   readonly onChangeImage: (url: string, crop?: unknown) => void;
   readonly onChangeAltText?: (value: string) => void;
@@ -20,8 +22,20 @@ const toggleBlockVisibilityMock = jest.fn();
 const setFieldValidityMock = jest.fn();
 const usePageBlockMock = jest.fn();
 jest.mock('~/store', () => ({
-  useStore: (selector: (state: { readonly locale: 'uk'; readonly setField: typeof setFieldMock; readonly toggleBlockVisibility: typeof toggleBlockVisibilityMock; readonly setFieldValidity: typeof setFieldValidityMock }) => unknown) =>
-    selector({ locale: 'uk', setField: setFieldMock, toggleBlockVisibility: toggleBlockVisibilityMock, setFieldValidity: setFieldValidityMock })
+  useStore: (
+    selector: (state: {
+      readonly locale: 'uk';
+      readonly setField: typeof setFieldMock;
+      readonly toggleBlockVisibility: typeof toggleBlockVisibilityMock;
+      readonly setFieldValidity: typeof setFieldValidityMock;
+    }) => unknown
+  ) =>
+    selector({
+      locale: 'uk',
+      setField: setFieldMock,
+      toggleBlockVisibility: toggleBlockVisibilityMock,
+      setFieldValidity: setFieldValidityMock
+    })
 }));
 jest.mock('~/shared/hooks/use-page-block/usePageBlock', () => ({
   usePageBlock: () => usePageBlockMock()
@@ -33,9 +47,20 @@ jest.mock('../../sortable-list/SortableList');
 
 jest.mock('~/ds-components/photo-block/PhotoBlock', () => ({
   __esModule: true,
-  ImagePreviewBlock: ({ title, imageUrl, altText, onChangeImage, onChangeAltText }: MockImagePreviewBlockProps) => (
+  ImagePreviewBlock: ({
+    title,
+    imageUrl,
+    previewWidth,
+    previewHeight,
+    alignActionsToPreviewBottom,
+    altText,
+    onChangeImage,
+    onChangeAltText
+  }: MockImagePreviewBlockProps) => (
     <div data-testid={`image-block-${title}`}>
       <span data-testid={`image-url-${title}`}>{imageUrl}</span>
+      <span data-testid={`preview-size-${title}`}>{`${previewWidth}x${previewHeight}`}</span>
+      <span data-testid={`align-bottom-${title}`}>{String(alignActionsToPreviewBottom)}</span>
       <span data-testid={`alt-text-${title}`}>{altText}</span>
       <button data-testid={`upload-${title}`} onClick={() => onChangeImage('new-image-path.jpg')}>
         Upload
@@ -116,6 +141,15 @@ describe('OurMission', () => {
     expect(screen.getByTestId(`alt-text-${keys.bigUpload}`)).toHaveTextContent('legacy alt text');
   });
 
+  it('should pass mission image preview layout settings', () => {
+    runSimulation();
+
+    expect(screen.getByTestId(`preview-size-${keys.upload}`)).toHaveTextContent('188x224');
+    expect(screen.getByTestId(`preview-size-${keys.bigUpload}`)).toHaveTextContent('395x224');
+    expect(screen.getByTestId(`align-bottom-${keys.upload}`)).toHaveTextContent('true');
+    expect(screen.getByTestId(`align-bottom-${keys.bigUpload}`)).toHaveTextContent('true');
+  });
+
   it('should render skeleton when no block exists', () => {
     usePageBlockMock.mockReturnValue({ block: null });
 
@@ -153,19 +187,12 @@ describe('OurMission', () => {
         expect.objectContaining({ id: 'uuid-1', uk: { type: 'doc', content: [] }, en: { type: 'doc', content: [] } })
       ])
     ],
-    [
-      'triggering item drop action rows',
-      `delete-${TARGET_ID}`,
-      'list',
-      []
-    ],
+    ['triggering item drop action rows', `delete-${TARGET_ID}`, 'list', []],
     [
       'updating standard list point rich-text trees',
       `trigger-change-${keys.item}`,
       'list',
-      expect.arrayContaining([
-        expect.objectContaining({ id: TARGET_ID, uk: createDocNode(`Updated ${keys.item}`) })
-      ])
+      expect.arrayContaining([expect.objectContaining({ id: TARGET_ID, uk: createDocNode(`Updated ${keys.item}`) })])
     ],
     [
       'editing layout image configuration captions',
@@ -207,19 +234,11 @@ describe('OurMission', () => {
       'bigImage',
       expect.objectContaining({ alt: expect.objectContaining({ uk: 'Updated alt text' }) })
     ]
-  ])(
-    'should correctly invoke setField upon %s',
-    (_scenario, triggerId, storeKey, expectedPayload) => {
-      runSimulation(triggerId);
+  ])('should correctly invoke setField upon %s', (_scenario, triggerId, storeKey, expectedPayload) => {
+    runSimulation(triggerId);
 
-      expect(setFieldMock).toHaveBeenCalledWith(
-        PAGE_IDS.ABOUT_US,
-        BLOCK_IDS.OUR_MISSION,
-        storeKey,
-        expectedPayload
-      );
-    }
-  );
+    expect(setFieldMock).toHaveBeenCalledWith(PAGE_IDS.ABOUT_US, BLOCK_IDS.OUR_MISSION, storeKey, expectedPayload);
+  });
 
   it('should call toggleBlockVisibility with pageId and blockId when the visibility toggle is clicked', () => {
     runSimulation('collapsible-block-toggle-visibility');
@@ -262,12 +281,10 @@ describe('OurMission', () => {
 
     fireEvent.click(screen.getByTestId('mock-sortable-list'));
 
-    expect(setFieldMock).toHaveBeenCalledWith(
-      PAGE_IDS.ABOUT_US,
-      BLOCK_IDS.OUR_MISSION,
-      'list',
-      [doubleMockBlock.list[1], doubleMockBlock.list[0]]
-    );
+    expect(setFieldMock).toHaveBeenCalledWith(PAGE_IDS.ABOUT_US, BLOCK_IDS.OUR_MISSION, 'list', [
+      doubleMockBlock.list[1],
+      doubleMockBlock.list[0]
+    ]);
   });
 
   it('should leave unrelated mission points untouched when updating a single point in a multi-point list', () => {
@@ -285,15 +302,10 @@ describe('OurMission', () => {
     render(<OurMission />);
     fireEvent.click(screen.getAllByTestId(`trigger-change-${keys.item}`)[0]);
 
-    expect(setFieldMock).toHaveBeenCalledWith(
-      PAGE_IDS.ABOUT_US,
-      BLOCK_IDS.OUR_MISSION,
-      'list',
-      [
-        expect.objectContaining({ id: '1', uk: createDocNode(`Updated ${keys.item}`) }),
-        doubleMockBlock.list[1]
-      ]
-    );
+    expect(setFieldMock).toHaveBeenCalledWith(PAGE_IDS.ABOUT_US, BLOCK_IDS.OUR_MISSION, 'list', [
+      expect.objectContaining({ id: '1', uk: createDocNode(`Updated ${keys.item}`) }),
+      doubleMockBlock.list[1]
+    ]);
   });
 
   it('should propagate a provided crop through onChangeImage instead of falling back to null', () => {
@@ -303,7 +315,11 @@ describe('OurMission', () => {
       PAGE_IDS.ABOUT_US,
       BLOCK_IDS.OUR_MISSION,
       'smallImage',
-      expect.objectContaining({ src: 'new-image-path.jpg', isTmp: false, crop: { rect: { x: 0, y: 0, width: 10, height: 10 } } })
+      expect.objectContaining({
+        src: 'new-image-path.jpg',
+        isTmp: false,
+        crop: { rect: { x: 0, y: 0, width: 10, height: 10 } }
+      })
     );
   });
 
@@ -353,9 +369,9 @@ describe('OurMission', () => {
     usePageBlockMock.mockReturnValue({
       block: { ...mockBlock, title: undefined }
     });
-    
+
     render(<OurMission />);
-    
+
     expect(screen.getByTestId('collapsible-block')).toBeInTheDocument();
   });
 });

--- a/app/shared/components/about-us/our-mission/OurMission.tsx
+++ b/app/shared/components/about-us/our-mission/OurMission.tsx
@@ -38,25 +38,51 @@ export type MissionImage = {
   crop?: CropResult | null;
 };
 
+const MISSION_SMALL_IMAGE_PREVIEW_SIZE = {
+  width: 188,
+  height: 224
+};
+
+const MISSION_BIG_IMAGE_PREVIEW_SIZE = {
+  width: 395,
+  height: 224
+};
+
 type MissionImageBlockProps = {
   image: MissionImage;
   locale: 'uk' | 'en';
   title: string;
   aspectRatio?: number;
+  previewWidth: number;
+  previewHeight: number;
   imageAlt?: string;
   onChangeCaption: (value: JSONContent) => void;
   onChangeImage: (url: string, crop?: CropResult | null) => void;
   onAltChange?: (val: string) => void;
 };
 
-const MissionImageBlock = ({ image, locale, title, aspectRatio, imageAlt, onChangeCaption, onChangeImage, onAltChange}: MissionImageBlockProps) => (
+const MissionImageBlock = ({
+  image,
+  locale,
+  title,
+  aspectRatio,
+  previewWidth,
+  previewHeight,
+  imageAlt,
+  onChangeCaption,
+  onChangeImage,
+  onAltChange
+}: MissionImageBlockProps) => (
   <Box sx={styles.imageBlockWrapper}>
     <ImagePreviewBlock
       imageUrl={getImageUrl(image)}
       title={title}
       fileName={image.src || ''}
       initialCrop={image.crop}
-      aspectRatio = {aspectRatio}
+      aspectRatio={aspectRatio}
+      previewWidth={previewWidth}
+      previewHeight={previewHeight}
+      alignActionsToPreviewBottom
       onChangeImage={onChangeImage}
       showAlternativeText
       altText={imageAlt}
@@ -91,7 +117,6 @@ const OurMission = () => {
   };
 
   if (!block) return <EditBlockSkeleton />;
-
 
   const missionPoints: MissionPoint[] = missionList.map((item) => ({
     id: item.id,
@@ -180,11 +205,7 @@ const OurMission = () => {
           <Typography variant="subtitle1" component="h4" sx={styles.pointHeader}>
             Текст секції:
           </Typography>
-          <SortableList
-            id="mission points"
-            items={missionPoints.map((p) => p.id as string)}
-            onDragEnd={handleDragEnd}
-          >
+          <SortableList id="mission points" items={missionPoints.map((p) => p.id as string)} onDragEnd={handleDragEnd}>
             <ConfigurableList<MissionPoint>
               items={missionPoints}
               addBtnLabel="Додати пункт"
@@ -216,6 +237,8 @@ const OurMission = () => {
           locale={currentLocale}
           title="Перше зображення секції"
           aspectRatio={CROP_RATIOS.FUNDATION_PROFILE_SMALL}
+          previewWidth={MISSION_SMALL_IMAGE_PREVIEW_SIZE.width}
+          previewHeight={MISSION_SMALL_IMAGE_PREVIEW_SIZE.height}
           onChangeCaption={(value) => handleCaptionChange('smallImage', value)}
           onChangeImage={(url, crop) => handleImageChange('smallImage', url, crop)}
           imageAlt={resolveLocalizedText(block.smallImage.alt?.[currentLocale])}
@@ -229,6 +252,8 @@ const OurMission = () => {
           locale={currentLocale}
           title="Друге зображення секції"
           aspectRatio={CROP_RATIOS.FUNDATION_PROFILE_BIG}
+          previewWidth={MISSION_BIG_IMAGE_PREVIEW_SIZE.width}
+          previewHeight={MISSION_BIG_IMAGE_PREVIEW_SIZE.height}
           onChangeCaption={(value) => handleCaptionChange('bigImage', value)}
           onChangeImage={(url, crop) => handleImageChange('bigImage', url, crop)}
           imageAlt={resolveLocalizedText(block.bigImage.alt?.[currentLocale])}

--- a/app/shared/components/design-system/photo-block/PhotoBlock.styles.ts
+++ b/app/shared/components/design-system/photo-block/PhotoBlock.styles.ts
@@ -1,4 +1,3 @@
-
 export const PREVIEW_W = 196;
 export const PREVIEW_H = 120;
 
@@ -67,11 +66,11 @@ export const styles = {
   },
 
   editButton: {
-    width: '127px',
+    width: '127px'
   },
 
   changeButton: {
-    width: '190px',
+    width: '190px'
   },
 
   fileNameText: {

--- a/app/shared/components/design-system/photo-block/PhotoBlock.test.tsx
+++ b/app/shared/components/design-system/photo-block/PhotoBlock.test.tsx
@@ -23,16 +23,14 @@ jest.mock('~/public/icons/pencil.svg', () => ({
 }));
 
 const useImageMetadataMock = jest.fn();
+const useCroppedImageMock = jest.fn();
 
 jest.mock('~/shared/hooks/use-image-metadata/useImageMetadata', () => ({
   useImageMetadata: (...args: unknown[]) => useImageMetadataMock(...args)
 }));
 
 jest.mock('~/hooks/use-cropped-image/use-cropped-image', () => ({
-  useCroppedImage: () => ({
-    styles: { container: {}, image: {} },
-    onLoad: jest.fn()
-  })
+  useCroppedImage: (...args: unknown[]) => useCroppedImageMock(...args)
 }));
 
 type MediaModalProps = {
@@ -127,6 +125,10 @@ describe('ImagePreviewBlock', () => {
       dimensions: { width: 1024, height: 768 },
       fileName: 'test.jpg'
     });
+    useCroppedImageMock.mockReturnValue({
+      styles: { container: {}, image: {} },
+      onLoad: jest.fn()
+    });
   });
 
   it('should render correctly with initial image', () => {
@@ -205,6 +207,12 @@ describe('ImagePreviewBlock', () => {
 
     expect(screen.getByTestId('cloud-upload-icon')).toBeInTheDocument();
     expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+
+  it('passes custom preview size to cropped image hook', () => {
+    renderComponent({ previewWidth: 188, previewHeight: 224 });
+
+    expect(useCroppedImageMock).toHaveBeenCalledWith(null, 188, 224);
   });
 
   it('disables "Редагувати" but keeps "Змінити зображення" enabled when there is no image', () => {

--- a/app/shared/components/design-system/photo-block/PhotoBlock.tsx
+++ b/app/shared/components/design-system/photo-block/PhotoBlock.tsx
@@ -34,6 +34,9 @@ interface ImagePreviewBlockProps extends StackProps {
   disabled?: boolean;
   locale?: 'uk' | 'en';
   aspectRatio?: number;
+  previewWidth?: number;
+  previewHeight?: number;
+  alignActionsToPreviewBottom?: boolean;
 }
 
 export const ImagePreviewBlock = ({
@@ -55,7 +58,10 @@ export const ImagePreviewBlock = ({
   onBlurAltText,
   disabled = false,
   locale = 'uk',
-  aspectRatio
+  aspectRatio,
+  previewWidth = PREVIEW_W,
+  previewHeight = PREVIEW_H,
+  alignActionsToPreviewBottom = false
 }: ImagePreviewBlockProps) => {
   const [previewImage, setPreviewImage] = useState<string>(imageUrl);
 
@@ -75,7 +81,29 @@ export const ImagePreviewBlock = ({
   const displayedFileName =
     finalFileName && finalFileName.length > 15 ? `${finalFileName.slice(0, 15)}...` : finalFileName;
 
-  const { styles: cropStyles, onLoad: onImgLoad } = useCroppedImage(savedCrop, PREVIEW_W, PREVIEW_H);
+  const { styles: cropStyles, onLoad: onImgLoad } = useCroppedImage(savedCrop, previewWidth, previewHeight);
+
+  const previewStyles = useMemo(
+    () => ({
+      ...styles.imagePreview,
+      width: `${previewWidth}px`,
+      height: `${previewHeight}px`
+    }),
+    [previewWidth, previewHeight]
+  );
+
+  const rightBlockStyles = useMemo(() => {
+    if (!alignActionsToPreviewBottom) return styles.rightBlock;
+
+    return {
+      ...styles.rightBlock,
+      gap: 0,
+      minHeight: `${previewHeight}px`,
+      justifyContent: 'space-between'
+    };
+  }, [alignActionsToPreviewBottom, previewHeight]);
+
+  const rightBlockSpacing = alignActionsToPreviewBottom ? 0 : stackSpacing;
 
   const openEditCrop = () => {
     setMediaInitial({
@@ -123,7 +151,7 @@ export const ImagePreviewBlock = ({
   const renderPreviewContent = useMemo(() => {
     if (!previewImage) {
       return (
-        <Box sx={styles.imagePreview}>
+        <Box sx={previewStyles}>
           <CloudUpload data-testid="cloud-upload-icon" size={76} strokeWidth={1.5} />
         </Box>
       );
@@ -138,7 +166,73 @@ export const ImagePreviewBlock = ({
         <Box component="img" src={previewImage} alt={title || 'Selected'} onLoad={onImgLoad} sx={cropStyles.image} />
       </Box>
     );
-  }, [previewImage, oval, title, cropStyles, onImgLoad]);
+  }, [previewImage, oval, title, cropStyles, onImgLoad, previewStyles]);
+
+  const renderTextContent = (
+    <>
+      <Stack spacing={typographySpacing} sx={styles.textStack}>
+        <Box sx={styles.fileNameContainer}>
+          <Typography variant="body1" sx={{ ...styles.fileNameText, flexShrink: 0 }}>
+            Назва файлу
+          </Typography>
+          <Typography variant="body1" sx={styles.fileNameText}>
+            {displayedFileName}
+          </Typography>
+        </Box>
+
+        {dimensions ? (
+          <Typography variant="body2" color="text.secondary" sx={styles.imageSizeText}>
+            Розмір: {dimensions.width} × {dimensions.height}
+          </Typography>
+        ) : null}
+      </Stack>
+
+      {showAlternativeText && (
+        <TextField
+          label="Alt текст зображення"
+          value={altText || ''}
+          onChange={(e) => onChangeAltText?.(e.target.value)}
+          onBlur={onBlurAltText}
+          fullWidth
+          margin="none"
+          multiline
+          maxRows={4}
+          disabled={!previewImage}
+          error={altTextErrorState}
+          helperText={altTextError}
+          slotProps={{ htmlInput: { maxLength: 250 } }}
+        />
+      )}
+    </>
+  );
+
+  const renderActionButtons = (
+    <Stack direction={direction} spacing={buttonSpacing}>
+      <Button
+        startIcon={<PencilIcon />}
+        variant="outlined"
+        color="primary"
+        size="small"
+        onClick={openEditCrop}
+        sx={[styles.imageActionButton, styles.editButton]}
+        disabled={disabled || !previewImage}
+      >
+        Редагувати
+      </Button>
+
+      <Button
+        startIcon={<ImageIcon />}
+        variant="outlined"
+        color="primary"
+        size="small"
+        onClick={openChangeImage}
+        sx={[styles.imageActionButton, styles.changeButton]}
+        disabled={disabled}
+      >
+        Змінити зображення
+      </Button>
+    </Stack>
+  );
 
   return (
     <Box sx={styles.container}>
@@ -151,68 +245,9 @@ export const ImagePreviewBlock = ({
       <Box sx={styles.imageBlock}>
         {renderPreviewContent}
 
-        <Stack spacing={stackSpacing} sx={styles.rightBlock}>
-          <Stack spacing={typographySpacing} sx={styles.textStack}>
-            <Box sx={styles.fileNameContainer}>
-              <Typography variant="body1" sx={{ ...styles.fileNameText, flexShrink: 0 }}>
-                Назва файлу
-              </Typography>
-              <Typography variant="body1" sx={styles.fileNameText}>
-                {displayedFileName}
-              </Typography>
-            </Box>
-
-            {dimensions ? (
-              <Typography variant="body2" color="text.secondary" sx={styles.imageSizeText}>
-                Розмір: {dimensions.width} × {dimensions.height}
-              </Typography>
-            ) : null}
-          </Stack>
-
-          {showAlternativeText && (
-            <TextField
-              label="Alt текст зображення"
-              value={altText || ''}
-              onChange={(e) => onChangeAltText?.(e.target.value)}
-              onBlur={onBlurAltText}
-              fullWidth
-              margin="none"
-              multiline
-              maxRows={4}
-              disabled={!previewImage}
-              error={altTextErrorState}
-              helperText={altTextError}
-              inputProps={{ maxLength: 250 }}
-            />
-          )}
-
-          <Stack direction={direction} spacing={buttonSpacing}>
-            <Button
-              startIcon={
-                <PencilIcon />
-              }
-              variant="outlined"
-              color="primary"
-              size="small"
-              onClick={openEditCrop}
-              sx={[styles.imageActionButton, styles.editButton]}
-              disabled={disabled || !previewImage}
-            >
-              Редагувати
-            </Button>
-
-            <Button
-              startIcon={<ImageIcon />}
-              variant="outlined"
-              color="primary"
-              size="small"
-              onClick={openChangeImage}
-              sx={[styles.imageActionButton, styles.changeButton]}
-              disabled={disabled}
-            >
-              Змінити зображення
-            </Button>
-          </Stack>
+        <Stack spacing={rightBlockSpacing} sx={rightBlockStyles}>
+          {alignActionsToPreviewBottom ? <Stack spacing={stackSpacing}>{renderTextContent}</Stack> : renderTextContent}
+          {renderActionButtons}
         </Stack>
       </Box>
 


### PR DESCRIPTION
## Description

Fixes the positioning of the "Редагувати" and "Змінити зображення" buttons in the About Foundation image blocks.

The image, text content, and action buttons are now aligned according to the mockup: the buttons are placed in the same image block area and aligned near the bottom edge of the image.

Closes Liatoshynsky-Foundation/lf-manual-tests#512

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other:

## How to test

1. Run `npm run dev`.
2. Open `http://localhost:3001/about-us`.
3. Open `Про Фундацію`.
4. Open the `Наша місія` section.
5. Check that the `Редагувати` and `Змінити зображення` buttons are positioned at the image level and match the mockup.

## Video / Screenshots

<img width="1106" height="747" alt="image" src="https://github.com/user-attachments/assets/a3d2233f-0f9f-4fab-a18f-9e499f5c82ee" />

## Checklist

- [x] Code compiles and runs correctly
- [ ] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [ ] Task moved to the review column on the board
