### PR TITLE
bugfix: improve gallery selection and composition audio handling

### DIFF
--- a/app/(logged_in)/creativity/useWorksFiltering.ts
+++ b/app/(logged_in)/creativity/useWorksFiltering.ts
@@ -20,7 +20,6 @@ import type { FilteringToolbarProps, SortSelectProps } from '~/shared/components
 import { useDebounce } from '~/shared/hooks/use-debounce/useDebounce';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
 import {
-  ContentLanguage,
   OpusStatus,
   SortOrder,
   type WorksFiltersInput,
@@ -55,16 +54,6 @@ const mapWorksStatus = (status: WorksStatusValue): OpusStatus => {
     return OpusStatus.Published;
   }
   return OpusStatus.Draft;
-};
-
-const mapWorksLanguage = (language: WorksLanguageValue): ContentLanguage => {
-  if (language === 'bilingual') {
-    return ContentLanguage.Bilingual;
-  }
-  if (language === 'en') {
-    return ContentLanguage.En;
-  }
-  return ContentLanguage.Uk;
 };
 
 const mapWorksSort = (sortValue: FilesSortValue): WorksSortOptions[] => {
@@ -195,11 +184,10 @@ export function useWorksFiltering(): Readonly<{
   const requestFilters = useMemo<Omit<WorksFiltersInput, 'limit' | 'skip'>>(
     () => ({
       search: debouncedSearch || undefined,
-      languages: languageFilters.length ? languageFilters.map(mapWorksLanguage) : undefined,
       statuses: statusFilters.length ? statusFilters.map(mapWorksStatus) : undefined,
       sort: mapWorksSort(sortValue)
     }),
-    [languageFilters, debouncedSearch, statusFilters, sortValue]
+    [debouncedSearch, statusFilters, sortValue]
   );
 
   return {

--- a/app/(logged_in)/research/useResearchWorksFiltering.test.ts
+++ b/app/(logged_in)/research/useResearchWorksFiltering.test.ts
@@ -1,6 +1,7 @@
 import { act, renderHook } from '@testing-library/react';
 
 import { useResearchWorksFiltering } from './useResearchWorksFiltering';
+import { RESEARCH_STATUS_OPTIONS, SORT_STORAGE_KEY } from '~/constants/research';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
 
 jest.mock('~/constants/sort', () => ({
@@ -19,8 +20,6 @@ jest.mock('~/constants/sort', () => ({
     { value: 'name_desc', label: 'Назва (Я-А)' }
   ]
 }));
-
-const SORT_STORAGE_KEY = 'research_works_sort';
 
 describe('useResearchWorksFiltering', () => {
   beforeEach(() => {
@@ -44,10 +43,7 @@ describe('useResearchWorksFiltering', () => {
       expect(result.current.statusFilterProps.label).toBe('Статус');
       expect(result.current.statusFilterProps.value).toEqual([]);
       expect(result.current.statusFilterProps.hideClearAction).toBe(true);
-      expect(result.current.statusFilterProps.options).toEqual([
-        { value: BaseContentStatuses.Published, label: 'Опубліковано' },
-        { value: BaseContentStatuses.Hidden, label: 'Приховано' }
-      ]);
+      expect(result.current.statusFilterProps.options).toEqual(RESEARCH_STATUS_OPTIONS);
     });
 
     it('sets sortProps triggerLabel to the label of the default sort option', () => {

--- a/app/constants/creativity.ts
+++ b/app/constants/creativity.ts
@@ -58,11 +58,6 @@ export const WORKS_TABS: ReadonlyArray<WorksTabConfig> = [
   { value: WORKS_TABS_NAMES.WORKS, label: 'Твори', href: `${WORKS_BASE_PATH}/compositions` }
 ];
 
-const WORKS_LANGUAGE_FILTER_OPTIONS: ReadonlyArray<FilterOption> = [
-  { value: 'uk', label: 'Українська' },
-  { value: 'en', label: 'Англійська' },
-  { value: 'bilingual', label: 'Двомовна' }
-];
 
 const WORKS_STATUS_FILTER_OPTIONS: ReadonlyArray<FilterOption> = [
   {
@@ -81,12 +76,6 @@ export const WORKS_FILTERS: ReadonlyArray<WorksFilterConfig> = [
     label: 'Статус',
     options: WORKS_STATUS_FILTER_OPTIONS,
     menuMinWidth: 150
-  },
-  {
-    id: 'language',
-    label: 'Мова',
-    options: WORKS_LANGUAGE_FILTER_OPTIONS,
-    menuMinWidth: 205
   }
 ];
 

--- a/app/shared/components/forms/opus-details-block/composition-modal/CompositionModal.test.tsx
+++ b/app/shared/components/forms/opus-details-block/composition-modal/CompositionModal.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { ReactElement } from 'react';
 
 import CompositionModal from './CompositionModal';
-import { COMPOSITION_MODAL_TEXTS } from '~/constants/opus';
+import { COMPOSITION_MODAL_LABELS, COMPOSITION_MODAL_TEXTS } from '~/constants/opus';
 import type { MediaModalResult } from '~/shared/components/media-modal/MediaModal.types';
 import type { OpusCompositionData } from '~/types/opus';
 
@@ -48,6 +48,18 @@ const baseProps = {
   onSubmit: jest.fn()
 };
 
+const INITIAL_COMPOSITION_VALUE: OpusCompositionData = {
+  id: 'c1',
+  name: 'Твір',
+  genre: '',
+  year: '',
+  audios: [{ id: 'a1', name: 'Запис', fileUrl: 'https://files/rec.mp3' }],
+  notes: [
+    { id: 'n1', name: 'Ноти 1', fileUrl: 'https://files/sheet.pdf', publishDate: '2020' },
+    { id: 'n2', name: 'Ноти 2' }
+  ]
+};
+
 describe('CompositionModal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -63,7 +75,7 @@ describe('CompositionModal', () => {
 
   it('renders the edit heading and prefilled title', () => {
     const initialValue: OpusCompositionData = {
-      id: 'c1',
+      ...INITIAL_COMPOSITION_VALUE,
       name: 'Існуючий твір',
       genre: 'Соната',
       year: '1920',
@@ -136,7 +148,7 @@ describe('CompositionModal', () => {
 
   it('clears the title with the adornment button', () => {
     const initialValue: OpusCompositionData = {
-      id: 'c1',
+      ...INITIAL_COMPOSITION_VALUE,
       name: 'Твір',
       genre: '',
       year: '',
@@ -254,18 +266,10 @@ describe('CompositionModal', () => {
 
   it('renders prefilled audios and notes and hides the empty notice', () => {
     const initialValue: OpusCompositionData = {
-      id: 'c1',
-      name: 'Твір',
+      ...INITIAL_COMPOSITION_VALUE,
       genre: 'Соната',
       year: '1900',
-      audios: [
-        { id: 'a1', name: 'Запис', fileUrl: 'https://files/rec.mp3' },
-        { id: 'a2', name: '', fileUrl: 'https://files/second.mp3?token=123' }
-      ],
-      notes: [
-        { id: 'n1', name: 'Ноти 1', fileUrl: 'https://files/sheet.pdf', publishDate: '2020' },
-        { id: 'n2', name: 'Ноти 2' }
-      ]
+      audios: [...INITIAL_COMPOSITION_VALUE.audios, { id: 'a2', name: '', fileUrl: 'https://files/second.mp3?token=123' }]
     };
     render(<CompositionModal {...baseProps} mode="edit" initialValue={initialValue} />);
 
@@ -275,20 +279,11 @@ describe('CompositionModal', () => {
     expect(screen.getByDisplayValue('Ноти 1')).toBeInTheDocument();
     expect(screen.getByDisplayValue('2020')).toBeInTheDocument();
     expect(screen.queryByText(/Додайте файли/)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: COMPOSITION_MODAL_LABELS.addAudio })).toBeDisabled();
   });
 
   it('edits, clears and removes prefilled media', () => {
-    const initialValue: OpusCompositionData = {
-      id: 'c1',
-      name: 'Твір',
-      genre: '',
-      year: '',
-      audios: [
-        { id: 'a1', name: 'Запис', fileUrl: 'https://files/rec.mp3' },
-        { id: 'a2', name: 'Другий запис', fileUrl: 'https://files/second.mp3' }
-      ],
-      notes: [{ id: 'n1', name: 'Ноти 1', fileUrl: 'https://files/sheet.pdf', publishDate: '2020' }]
-    };
+    const initialValue: OpusCompositionData = { ...INITIAL_COMPOSITION_VALUE };
     render(<CompositionModal {...baseProps} mode="edit" initialValue={initialValue} />);
 
     fireEvent.change(screen.getByDisplayValue('Ноти 1'), { target: { value: 'Оновлені ноти' } });
@@ -373,7 +368,7 @@ describe('CompositionModal', () => {
   it('submits the composition with a trimmed title in edit mode', () => {
     const onSubmit = jest.fn();
     const initialValue: OpusCompositionData = {
-      id: 'c1',
+      ...INITIAL_COMPOSITION_VALUE,
       name: 'Початковий твір',
       genre: 'Соната',
       year: '1920',

--- a/app/shared/components/forms/opus-details-block/composition-modal/CompositionModal.tsx
+++ b/app/shared/components/forms/opus-details-block/composition-modal/CompositionModal.tsx
@@ -245,7 +245,13 @@ export default function CompositionModal({
           <Box sx={styles.mediaHeader}>
             <Typography sx={styles.mediaTitle}>{COMPOSITION_MODAL_LABELS.audio}</Typography>
             <Box sx={styles.mediaDivider} />
-            <Button variant="filled" size="small" color="primary" onClick={() => setMediaTarget({ field: 'audios' })}>
+            <Button
+              variant="filled"
+              size="small"
+              color="primary"
+              disabled={composition.audios.length > 0}
+              onClick={() => setMediaTarget({ field: 'audios' })}
+            >
               {COMPOSITION_MODAL_LABELS.addAudio}
             </Button>
           </Box>

--- a/app/shared/components/media-modal/components/gallery-card/GalleryCard.test.tsx
+++ b/app/shared/components/media-modal/components/gallery-card/GalleryCard.test.tsx
@@ -16,52 +16,61 @@ jest.mock('~/public/icons/star.svg', () => ({
 describe('GalleryCard', () => {
   const mockOnClick = jest.fn();
 
+  const DEFAULT_GALLERY_CARD_PROPS = {
+    src: '/test.jpg',
+    fileName: 'test.jpg',
+    isStarred: false,
+    onClick: mockOnClick
+  };
+  const GALLERY_CARD_VALUES = {
+    selectedTestId: 'selected-gallery-card',
+    customTestId: 'custom-gallery-card'
+  };
+  const SELECTED_GALLERY_CARD_PROPS = {
+    ...DEFAULT_GALLERY_CARD_PROPS,
+    isSelected: true,
+    testId: GALLERY_CARD_VALUES.selectedTestId
+  };
+  const SELECTED_GALLERY_CARD_OPACITY = '0.65';
+
   beforeEach(() => {
     mockOnClick.mockClear();
   });
 
-  it('should render image with correct src and fileName', () => {
-    render(<GalleryCard src="/test.jpg" fileName="test-image.jpg" isStarred={false} onClick={mockOnClick} />);
+  it('should render media with correct src and fileName', () => {
+    render(<GalleryCard {...DEFAULT_GALLERY_CARD_PROPS} />);
 
-    expect(screen.getByAltText('test-image.jpg')).toHaveAttribute('src', '/test.jpg');
-    expect(screen.getByText('test-image.jpg')).toBeInTheDocument();
+    expect(screen.getByAltText(DEFAULT_GALLERY_CARD_PROPS.fileName)).toHaveAttribute(
+      'src',
+      DEFAULT_GALLERY_CARD_PROPS.src
+    );
+    expect(screen.getByText(DEFAULT_GALLERY_CARD_PROPS.fileName)).toBeInTheDocument();
   });
 
   it('should call onClick when clicked', async () => {
     const user = userEvent.setup();
-    render(
-      <GalleryCard src="/test.jpg" fileName="test.jpg" isStarred={false} onClick={mockOnClick} testId="gallery-card" />
-    );
+    render(<GalleryCard {...DEFAULT_GALLERY_CARD_PROPS} testId="gallery-card" />);
 
-    const image = screen.getByAltText('test.jpg');
-    await user.click(image);
+    await user.click(screen.getByAltText(DEFAULT_GALLERY_CARD_PROPS.fileName));
     expect(mockOnClick).toHaveBeenCalledTimes(1);
   });
 
   it('should render with custom testId', () => {
-    render(
-      <GalleryCard
-        src="/test.jpg"
-        fileName="test.jpg"
-        isStarred={false}
-        onClick={mockOnClick}
-        testId="custom-gallery-card"
-      />
-    );
+    render(<GalleryCard {...DEFAULT_GALLERY_CARD_PROPS} testId={GALLERY_CARD_VALUES.customTestId} />);
 
-    expect(screen.getByTestId('custom-gallery-card')).toBeInTheDocument();
+    expect(screen.getByTestId(GALLERY_CARD_VALUES.customTestId)).toBeInTheDocument();
   });
 
   it('should render without icons when not starred and no usage locations', () => {
-    render(<GalleryCard src="/test.jpg" fileName="test.jpg" isStarred={false} onClick={mockOnClick} />);
+    render(<GalleryCard {...DEFAULT_GALLERY_CARD_PROPS} />);
 
-    expect(screen.getByText('test.jpg')).toBeInTheDocument();
+    expect(screen.getByText(DEFAULT_GALLERY_CARD_PROPS.fileName)).toBeInTheDocument();
   });
 
   it('should render with starred state', () => {
-    render(<GalleryCard src="/test.jpg" fileName="test.jpg" isStarred={true} onClick={mockOnClick} />);
+    render(<GalleryCard {...DEFAULT_GALLERY_CARD_PROPS} isStarred />);
 
-    expect(screen.getByText('test.jpg')).toBeInTheDocument();
+    expect(screen.getByText(DEFAULT_GALLERY_CARD_PROPS.fileName)).toBeInTheDocument();
   });
 
   it('should render with usage locations', () => {
@@ -75,6 +84,14 @@ describe('GalleryCard', () => {
       />
     );
 
-    expect(screen.getByText('test.jpg')).toBeInTheDocument();
+    expect(screen.getByText(DEFAULT_GALLERY_CARD_PROPS.fileName)).toBeInTheDocument();
+  });
+
+  it('should apply selected styling to the media container', () => {
+    render(<GalleryCard {...SELECTED_GALLERY_CARD_PROPS} />);
+
+    expect(screen.getByTestId(SELECTED_GALLERY_CARD_PROPS.testId).firstElementChild).toHaveStyle({
+      opacity: SELECTED_GALLERY_CARD_OPACITY
+    });
   });
 });

--- a/app/shared/components/media-modal/components/gallery-card/GalleryCard.tsx
+++ b/app/shared/components/media-modal/components/gallery-card/GalleryCard.tsx
@@ -15,6 +15,7 @@ type GalleryCardProps = Readonly<{
   usageLocations?: string[];
   onClick: () => void;
   iconSrc?: string;
+  isSelected?: boolean;
   testId?: string;
 }>;
 
@@ -25,6 +26,7 @@ export function GalleryCard({
   usageLocations = [],
   onClick,
   iconSrc,
+  isSelected = false,
   testId
 }: GalleryCardProps) {
   const isUsed = usageLocations.length > 0;
@@ -71,6 +73,7 @@ export function GalleryCard({
       alt={fileName}
       onClick={onClick}
       iconSrc={iconSrc}
+      isSelected={isSelected}
       topRightContent={topRightContent}
       bottomContent={fileName}
       testId={testId}

--- a/app/shared/components/media-modal/components/media-card/MediaCard.styles.ts
+++ b/app/shared/components/media-modal/components/media-card/MediaCard.styles.ts
@@ -28,6 +28,10 @@ export const mediaCardStyles = {
     }
   } as SxProps<Theme>,
 
+  selectedImageContainer: {
+    opacity: 0.65
+  } as SxProps<Theme>,
+
   image: {
     width: '100%',
     height: '100%',

--- a/app/shared/components/media-modal/components/media-card/MediaCard.test.tsx
+++ b/app/shared/components/media-modal/components/media-card/MediaCard.test.tsx
@@ -3,40 +3,64 @@ import userEvent from '@testing-library/user-event';
 
 import { MediaCard } from './MediaCard';
 
+const DEFAULT_MEDIA_CARD_PROPS = {
+  src: '/test.jpg',
+  alt: 'Test media'
+};
+const MEDIA_CARD_CONTENT = {
+  bottom: 'filename.jpg',
+  topLeft: 'Left content',
+  topRight: 'Right content'
+};
+const ICON_MEDIA_CARD_PROPS = {
+  ...DEFAULT_MEDIA_CARD_PROPS,
+  alt: 'Icon media',
+  iconSrc: '/icon.svg'
+};
+const CUSTOM_MEDIA_CARD_PROPS = {
+  ...DEFAULT_MEDIA_CARD_PROPS,
+  testId: 'custom-card'
+};
+const SELECTED_MEDIA_CARD_PROPS = {
+  ...DEFAULT_MEDIA_CARD_PROPS,
+  isSelected: true
+};
+
+const SELECTED_MEDIA_CARD_OPACITY = '0.65';
+
 describe('MediaCard', () => {
-  it('should render image with src and alt', () => {
-    render(<MediaCard src="/test.jpg" alt="Test image" />);
+  it('should render media with src and alt', () => {
+    render(<MediaCard {...DEFAULT_MEDIA_CARD_PROPS} />);
 
     const img = screen.getByRole('img');
-    expect(img).toHaveAttribute('src', '/test.jpg');
-    expect(img).toHaveAttribute('alt', 'Test image');
+    expect(img).toHaveAttribute('src', DEFAULT_MEDIA_CARD_PROPS.src);
+    expect(img).toHaveAttribute('alt', DEFAULT_MEDIA_CARD_PROPS.alt);
   });
 
   it('should render bottom content when provided', () => {
-    render(<MediaCard src="/test.jpg" alt="Test" bottomContent="filename.jpg" />);
+    render(<MediaCard {...DEFAULT_MEDIA_CARD_PROPS} bottomContent={MEDIA_CARD_CONTENT.bottom} />);
 
-    expect(screen.getByText('filename.jpg')).toBeInTheDocument();
+    expect(screen.getByText(MEDIA_CARD_CONTENT.bottom)).toBeInTheDocument();
   });
 
   it('should render top-left and top-right content when provided', () => {
     render(
       <MediaCard
-        src="/test.jpg"
-        alt="Test"
-        topLeftContent={<div>Left content</div>}
-        topRightContent={<div>Right content</div>}
+        {...DEFAULT_MEDIA_CARD_PROPS}
+        topLeftContent={<div>{MEDIA_CARD_CONTENT.topLeft}</div>}
+        topRightContent={<div>{MEDIA_CARD_CONTENT.topRight}</div>}
       />
     );
 
-    expect(screen.getByText('Left content')).toBeInTheDocument();
-    expect(screen.getByText('Right content')).toBeInTheDocument();
+    expect(screen.getByText(MEDIA_CARD_CONTENT.topLeft)).toBeInTheDocument();
+    expect(screen.getByText(MEDIA_CARD_CONTENT.topRight)).toBeInTheDocument();
   });
 
   it('should call onClick when card is clicked', async () => {
     const user = userEvent.setup();
     const handleClick = jest.fn();
 
-    render(<MediaCard src="/test.jpg" alt="Test" onClick={handleClick} />);
+    render(<MediaCard {...DEFAULT_MEDIA_CARD_PROPS} onClick={handleClick} />);
 
     const card = screen.getByRole('img').parentElement!;
     await user.click(card);
@@ -45,16 +69,22 @@ describe('MediaCard', () => {
   });
 
   it('should apply custom testId', () => {
-    render(<MediaCard src="/test.jpg" alt="Test" testId="custom-card" />);
+    render(<MediaCard {...CUSTOM_MEDIA_CARD_PROPS} />);
 
-    expect(screen.getByTestId('custom-card')).toBeInTheDocument();
+    expect(screen.getByTestId(CUSTOM_MEDIA_CARD_PROPS.testId)).toBeInTheDocument();
   });
 
-  it('should render icon instead of standard image when iconSrc is provided', () => {
-    render(<MediaCard src="/test.jpg" alt="Icon alt text" iconSrc="/icon.svg" />);
+  it('should render icon media when iconSrc is provided', () => {
+    render(<MediaCard {...ICON_MEDIA_CARD_PROPS} />);
 
     const img = screen.getByRole('img');
-    expect(img).toHaveAttribute('src', '/icon.svg');
-    expect(img).toHaveAttribute('alt', 'Icon alt text');
+    expect(img).toHaveAttribute('src', ICON_MEDIA_CARD_PROPS.iconSrc);
+    expect(img).toHaveAttribute('alt', ICON_MEDIA_CARD_PROPS.alt);
+  });
+
+  it('should apply selected styling to the media container', () => {
+    render(<MediaCard {...SELECTED_MEDIA_CARD_PROPS} />);
+
+    expect(screen.getByRole('img').parentElement).toHaveStyle({ opacity: SELECTED_MEDIA_CARD_OPACITY });
   });
 });

--- a/app/shared/components/media-modal/components/media-card/MediaCard.tsx
+++ b/app/shared/components/media-modal/components/media-card/MediaCard.tsx
@@ -4,6 +4,7 @@ import { Box } from '@mui/material';
 import { ReactNode } from 'react';
 
 import { mediaCardStyles } from './MediaCard.styles';
+import { sxToArray } from '~/lib/utils/sxToArray';
 
 type MediaCardProps = Readonly<{
   src: string;
@@ -13,6 +14,7 @@ type MediaCardProps = Readonly<{
   topLeftContent?: ReactNode;
   topRightContent?: ReactNode;
   bottomContent?: ReactNode;
+  isSelected?: boolean;
   testId?: string;
 }>;
 
@@ -24,11 +26,15 @@ export function MediaCard({
   topLeftContent,
   topRightContent,
   bottomContent,
+  isSelected = false,
   testId
 }: MediaCardProps) {
   return (
     <Box sx={mediaCardStyles.wrapper} data-testid={testId}>
-      <Box sx={mediaCardStyles.imageContainer} onClick={onClick}>
+      <Box
+        sx={[mediaCardStyles.imageContainer, ...sxToArray(isSelected ? mediaCardStyles.selectedImageContainer : undefined)]}
+        onClick={onClick}
+      >
         {iconSrc ? (
           <Box sx={{ width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
             <Box component="img" src={iconSrc} alt={alt} sx={{ width: 56, height: 56 }} />

--- a/app/shared/components/media-modal/views/gallery-view/GalleryView.tsx
+++ b/app/shared/components/media-modal/views/gallery-view/GalleryView.tsx
@@ -106,7 +106,7 @@ const matchesUsageFilter = (item: GalleryItem, filter: string): boolean => {
   return item.usageRefs.some((ref) => ref.pageId === filter);
 };
 
-export function GalleryView({ selected: _selected, onPick, filters, onFiltersChange, mediaKind = 'image' }: Props) {
+export function GalleryView({ selected, onPick, filters, onFiltersChange, mediaKind = 'image' }: Props) {
   const config = MEDIA_KIND_CONFIG[mediaKind];
   const { files: r2Files, isLoading: r2Loading } = useGalleryFiles(config.folder);
 
@@ -146,16 +146,18 @@ export function GalleryView({ selected: _selected, onPick, filters, onFiltersCha
           return [];
         }
 
-        return [{
-          id: asset?.id ?? file.path ?? file.filename,
-          filename: asset?.filename ?? file.filename,
-          originalname: asset?.originalname ?? undefined,
-          url: file.url,
-          isStarred: asset?.isStarred ?? false,
-          tags: asset?.tags ?? [],
-          usageRefs: asset?.usageRefs ?? [],
-          createdAt: file.createdAt
-        }];
+        return [
+          {
+            id: asset?.id ?? file.path ?? file.filename,
+            filename: asset?.filename ?? file.filename,
+            originalname: asset?.originalname ?? undefined,
+            url: file.url,
+            isStarred: asset?.isStarred ?? false,
+            tags: asset?.tags ?? [],
+            usageRefs: asset?.usageRefs ?? [],
+            createdAt: file.createdAt
+          }
+        ];
       });
   }, [r2Files, assetByUrl, config]);
 
@@ -213,6 +215,7 @@ export function GalleryView({ selected: _selected, onPick, filters, onFiltersCha
             usageLocations={getPageNames(item.usageRefs)}
             onClick={() => handleCardClick(item)}
             testId={`GalleryCard-${item.id}`}
+            isSelected={selected?.id === item.id}
           />
         )}
         testIdPrefix="GalleryView"

--- a/app/shared/components/side-navigation/SideNavigation.consts.ts
+++ b/app/shared/components/side-navigation/SideNavigation.consts.ts
@@ -15,7 +15,6 @@ export const NAVIGATION_DATA = {
       element: { title: 'Каталоги', iconSrc: 'book-marked' },
       collapseElements: [
         { title: 'Твори', href: '/creativity' },
-        { title: 'Опуси', href: '/creativity/opus' },
         { title: 'Дослідження та наукові праці', href: '/research' },
         { title: 'Архів кабінету-музею', href: '/archive' }
       ]

--- a/app/shared/components/side-navigation/list-element/ListElement.test.tsx
+++ b/app/shared/components/side-navigation/list-element/ListElement.test.tsx
@@ -3,89 +3,106 @@ import userEvent from '@testing-library/user-event';
 
 import { ListElement } from './ListElement';
 
-let mockedPathname = '/test';
+const TEST_PATHS = {
+  default: '/test',
+  nestedFiles: '/files/image',
+  partialFiles: '/files-other',
+  unconfiguredOpus: '/creativity/opus'
+} as const;
+
+const DEFAULT_ELEMENT = {
+  title: 'TestTitle',
+  iconSrc: 'icon.svg',
+  href: TEST_PATHS.default
+} as const;
+
+const FILES_ELEMENT = {
+  title: 'Файли',
+  iconSrc: 'folder-open',
+  href: '/files'
+} as const;
+
+const CREATIVITY_ELEMENT = {
+  title: 'Твори',
+  href: '/creativity'
+} as const;
+
+let mockedPathname: string = TEST_PATHS.default;
 
 jest.mock('next/navigation', () => ({
   usePathname: () => mockedPathname
 }));
 
 describe('List Element', () => {
-  const element = { title: 'TestTitle', iconSrc: 'icon.svg', href: '/test' };
-
   beforeEach(() => {
-    mockedPathname = '/test';
+    mockedPathname = TEST_PATHS.default;
   });
 
   it('should render the element', () => {
-    render(<ListElement element={element} open />);
-    expect(screen.getByText('TestTitle')).toBeInTheDocument();
-    expect(screen.getByAltText('TestTitle')).toBeInTheDocument();
+    render(<ListElement element={DEFAULT_ELEMENT} open />);
+    expect(screen.getByText(DEFAULT_ELEMENT.title)).toBeInTheDocument();
+    expect(screen.getByAltText(DEFAULT_ELEMENT.title)).toBeInTheDocument();
   });
 
   it('should render the element without the icon', () => {
-    const testElement = { ...element, iconSrc: undefined };
+    const testElement = { ...DEFAULT_ELEMENT, iconSrc: undefined };
     render(<ListElement element={testElement} open />);
     expect(screen.queryByRole('img')).not.toBeInTheDocument();
   });
   it('should work with handleClick', () => {
     const mockClick = jest.fn();
-    render(<ListElement element={element} open handleClick={mockClick} />);
+    render(<ListElement element={DEFAULT_ELEMENT} open handleClick={mockClick} />);
     fireEvent.click(screen.getByRole('button'));
     expect(mockClick).toHaveBeenCalled();
   });
   it('should be selected if the path matches', () => {
-    render(<ListElement element={element} open={true} />);
+    render(<ListElement element={DEFAULT_ELEMENT} open />);
     expect(screen.getByRole('button')).toHaveClass('Mui-selected');
   });
 
   it('should be selected for nested routes', () => {
-    mockedPathname = '/files/image';
+    mockedPathname = TEST_PATHS.nestedFiles;
 
-    render(<ListElement element={{ title: 'Файли', iconSrc: 'folder-open', href: '/files' }} open={true} />);
+    render(<ListElement element={FILES_ELEMENT} open />);
 
     expect(screen.getByRole('button')).toHaveClass('Mui-selected');
   });
 
   it('should not be selected for partial prefix matches', () => {
-    mockedPathname = '/files-other';
+    mockedPathname = TEST_PATHS.partialFiles;
 
-    render(<ListElement element={{ title: 'Файли', iconSrc: 'folder-open', href: '/files' }} open={true} />);
-
-    expect(screen.getByRole('button')).not.toHaveClass('Mui-selected');
-  });
-
-  it('should not select a parent route when a deeper sibling route matches', () => {
-    mockedPathname = '/creativity/opus';
-
-    render(<ListElement element={{ title: 'Твори', href: '/creativity' }} open={true} />);
+    render(<ListElement element={FILES_ELEMENT} open />);
 
     expect(screen.getByRole('button')).not.toHaveClass('Mui-selected');
   });
 
-  it('should select the most specific route', () => {
-    mockedPathname = '/creativity/opus';
+  it('should select the parent route when the deeper route is not configured', () => {
+    mockedPathname = TEST_PATHS.unconfiguredOpus;
 
-    render(<ListElement element={{ title: 'Опуси', href: '/creativity/opus' }} open={true} />);
+    render(<ListElement element={CREATIVITY_ELEMENT} open />);
 
     expect(screen.getByRole('button')).toHaveClass('Mui-selected');
   });
 
   it('should render children', () => {
     render(
-      <ListElement element={element} open={true}>
+      <ListElement element={DEFAULT_ELEMENT} open>
         <div>TestChildren</div>
       </ListElement>
     );
     expect(screen.getByText('TestChildren')).toBeInTheDocument();
   });
+
   it('should work with default handleClick fallback', async () => {
     const user = userEvent.setup();
-    render(<ListElement element={element} open />);
+    render(<ListElement element={DEFAULT_ELEMENT} open />);
     await user.click(screen.getByRole('button'));
+
+    expect(screen.getByRole('button')).toHaveClass('Mui-selected');
   });
 
   it('should apply disabled styles and accept sxItem as an array', () => {
-    const disabledElement = { ...element, disabled: true };
+    const disabledElement = { ...DEFAULT_ELEMENT, disabled: true };
     render(<ListElement element={disabledElement} open sxItem={[{ margin: '10px' }]} />);
 
     const button = screen.getByRole('button');


### PR DESCRIPTION
## Description

Implements gallery selection feedback, composition audio limits, and related opus UI cleanup.

### What was changed

  - Added selected-state styling to media cards and gallery cards.
  - Disabled adding another audio file when a composition already contains audio.
  - Removed the separate “Опуси” navigation item; users now access works through the general “Твори” section.
  - Removed deprecated works language filtering.
  - Updated tests.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Check out this branch.
2. Go to the `/creativity` page.
3. Select a composition inside an Opus group or outside any group.
4. Try to add audio if no audio is already linked to the composition.
5. Add one audio, by clicking 'Додати аудіо'
6. Verify that the selected gallery item is visually highlighted.
7. Verify that adding audio is disabled when audio already exists.
8. Verify that works filtering no longer includes language filters.
9. Verify that the updated sidebar no longer contains the separate “Опуси” navigation item.

## Video / Screenshots

https://github.com/user-attachments/assets/62483e20-344a-4267-a597-e0fa16616b3e

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
 Closes #786