### PR TITLE
bugfix: support multi-paragraph group intro descriptions

### DIFF
--- a/app/shared/components/creativity/group/intro-section/GroupIntroSection.tsx
+++ b/app/shared/components/creativity/group/intro-section/GroupIntroSection.tsx
@@ -1,4 +1,5 @@
 import { Box } from '@mui/material';
+import { JSONContent } from '@tiptap/react';
 
 import { styles } from './GroupIntroSection.styles';
 import { GroupDataField } from '~/constants/creativity';
@@ -7,7 +8,7 @@ import { CustomTextField } from '~/shared/components/design-system/text-field/Te
 
 type MultilingualText = { uk: string; en: string };
 
-type MultilingualRichText = { uk: Record<string, unknown> | null; en: Record<string, unknown> | null };
+type MultilingualRichText = { uk: JSONContent | null; en: JSONContent | null };
 
 type GroupIntroSectionProps = {
   data: {

--- a/app/shared/components/custom-formatting-field/CustomFormattingField.style.ts
+++ b/app/shared/components/custom-formatting-field/CustomFormattingField.style.ts
@@ -34,6 +34,11 @@ export const styles = {
       m: 0,
       lineHeight: '24px'
     },
+
+    '& .ProseMirror p + p': {
+      mt: '12px'
+    },
+
     '& .ProseMirror p.is-editor-empty:first-of-type::before': {
       color: 'text.disabled',
       content: 'attr(data-placeholder)',

--- a/app/shared/components/custom-formatting-field/CustomFormattingField.test.tsx
+++ b/app/shared/components/custom-formatting-field/CustomFormattingField.test.tsx
@@ -6,6 +6,7 @@ import { CustomFormattingField } from './CustomFormattingField';
 
 type EditorConfig = {
   content: JSONContent;
+  extensions: Array<{ name?: string; config?: { content?: string } }>;
   onUpdate: (props: { editor: Editor }) => void;
   onFocus: () => void;
   onBlur: () => void;
@@ -65,6 +66,14 @@ describe('CustomFormattingField', () => {
     jest.clearAllMocks();
     Object.defineProperty(mockEditor, 'isEmpty', { value: true, configurable: true });
     mockGetJSON.mockReturnValue(defaultJSON);
+  });
+
+  it('allows multiple paragraphs in the document schema', () => {
+    render(<CustomFormattingField value={defaultJSON} onChange={mockOnChange} />);
+
+    const documentExtension = mockEditorConfig.extensions.find((extension) => extension.name === 'doc');
+
+    expect(documentExtension?.config?.content).toMatch(/\+$/);
   });
 
   describe('1. Mounting & Rendering', () => {

--- a/app/shared/components/custom-formatting-field/CustomFormattingField.tsx
+++ b/app/shared/components/custom-formatting-field/CustomFormattingField.tsx
@@ -24,8 +24,8 @@ export interface Props {
   helperText?: string;
   onBlur?: () => void;
 }
-const OneLineDoc = Document.extend({
-  content: 'paragraph'
+const FormattingDoc = Document.extend({
+  content: 'paragraph+'
 });
 
 export const CustomFormattingField = ({ value, onChange, label = 'Текст', sx, error = false, helperText, onBlur }: Props) => {
@@ -33,7 +33,7 @@ export const CustomFormattingField = ({ value, onChange, label = 'Текст', s
 
   const editor = useEditor({
     extensions: [
-      OneLineDoc,
+      FormattingDoc,
       Paragraph,
       Text,
       Italic,


### PR DESCRIPTION
## Description

Implements improved paragraph handling for the group intro description field.

### What was changed

- Updated the formatting editor schema to support multiple paragraphs.
- Added spacing between consecutive paragraphs.
- Preserved Tiptap JSON formatting for saved descriptions.
- Updated the group intro description type to use `JSONContent`.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other:

## How to test

1. Check out this branch.
2. Navigate to the group content editor.
3. Open the “Вступна секція” block.
4. Enter text in the “Опис” field.
5. Press Enter and add a second paragraph.
6. Save the group and verify that both paragraphs are preserved.
7. Verify that paragraphs have visible spacing.

## Video / Screenshots

<img width="1478" height="628" alt="image" src="https://github.com/user-attachments/assets/4442071b-8636-4ffb-9a9b-ebc612a5a346" />

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---

Closes #797