### PR TITLE
bugfix: allow saving composition notes without PDF URLs

### DIFF
--- a/src/interfaces/graphql/resolvers/opus/opusMutation.test.ts
+++ b/src/interfaces/graphql/resolvers/opus/opusMutation.test.ts
@@ -36,6 +36,11 @@ const DUP_OPUS_NUMBER = 20;
 const SLUG_VALUE = 'slug-test';
 const CREATION_YEAR = '2020';
 
+const MAPPED_SHEETS = [
+  { url: 'http://file.pdf', name: 'Note 1', publishDate: '2020-01-01', isFree: true },
+  { url: null, name: 'Note 2', publishDate: null, isFree: true }
+];
+
 const BASE_CREATE_INPUT = {
   numberKind: 'op' as const,
   number: OPUS_NUMBER,
@@ -231,12 +236,7 @@ describe('OpusMutation Resolvers', () => {
           audioAvailable: true,
           sheetAvailable: true,
           sheetMusic: [
-            {
-              url: 'http://file.pdf',
-              name: 'Note 1',
-              publishDate: '2020-01-01',
-              isFree: true
-            }
+            ...MAPPED_SHEETS
           ],
           audios: [
             { name: 'Audio 1', url: 'http://audio.mp3' },
@@ -853,7 +853,7 @@ describe('OpusMutation Resolvers', () => {
     });
 
     describe('Edge Cases (Parsers & Helpers)', () => {
-      it('should map compositions gracefully ignoring invalid years and filtering empty files', async () => {
+      it('should map compositions gracefully with invalid years and empty sheet URLs', async () => {
         mockOpusRepo.findById.mockResolvedValue(MOCK_OPUS_ENTITY);
         mockOpusRepo.update.mockResolvedValue(MOCK_OPUS_ENTITY);
         mockCompositionsRepo.syncForOpus.mockResolvedValue([]);
@@ -869,7 +869,7 @@ describe('OpusMutation Resolvers', () => {
                   name: 'Test',
                   year: 'invalid-year',
                   genre: null,
-                  notes: [{ name: 'Empty note', fileUrl: '' }],
+                  notes: [{ name: MAPPED_SHEETS[1].name, fileUrl: MAPPED_SHEETS[1].url }],
                   audios: [{ name: '', fileUrl: '' }]
                 }
               ]
@@ -881,7 +881,10 @@ describe('OpusMutation Resolvers', () => {
         expect(mockCompositionsRepo.syncForOpus).toHaveBeenCalledWith([
           expect.objectContaining({
             year: null,
-            sheetMusic: [],
+            sheetAvailable: true,
+            sheetMusic: [
+              MAPPED_SHEETS[1]
+            ],
             audios: []
           })
         ], expect.anything());

--- a/src/interfaces/graphql/resolvers/opus/opusMutation.ts
+++ b/src/interfaces/graphql/resolvers/opus/opusMutation.ts
@@ -122,7 +122,9 @@ async function assertCompositionsNamesNotTaken(
 }
 
 const mapComposition = (composition: GQLComposition): CompositionInput => {
-  const notesWithFiles = (composition.notes ?? []).filter((note) => note.fileUrl);
+  const notes = (composition.notes ?? []).filter(
+    (note) => note.name?.trim() || note.fileUrl || note.publishDate?.trim()
+  );
   const audios = (composition.audios ?? []).filter((audio) => audio.fileUrl || audio.name);
 
   return {
@@ -131,9 +133,9 @@ const mapComposition = (composition: GQLComposition): CompositionInput => {
     year: parseYear(composition.year ?? undefined),
     genre: composition.genre ?? null,
     audioAvailable: audios.length > 0,
-    sheetAvailable: notesWithFiles.length > 0,
-    sheetMusic: notesWithFiles.map((note) => ({
-      url: note.fileUrl as string,
+    sheetAvailable: notes.length > 0,
+    sheetMusic: notes.map((note) => ({
+      url: note.fileUrl?.trim() || null,
       name: note.name ?? null,
       publishDate: note.publishDate ?? null,
       isFree: true


### PR DESCRIPTION
## Description

Implements support for saving composition notes that contain metadata but no PDF URL, preserving note names and publication dates while storing missing URLs as null.

### What was changed

- Preserve composition notes when they contain a name, file URL, or publication date.
- Store missing or whitespace-only note URLs as null.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

  1. Check out this branch.
  2. Create or update a composition with a note name and no PDF URL.
  3. Save the composition.
  4. Verify the note is preserved with a null URL.

## Video / Screenshots

<img width="866" height="770" alt="image" src="https://github.com/user-attachments/assets/b181db64-6770-4bc1-89c4-46bc5a0b75f9" />

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---

Closes #799