### PR TITLE
fix: validate composition fields and publication dates

### DIFF
--- a/app/(logged_in)/creativity/(composition)/useDeleteWorkAction.test.ts
+++ b/app/(logged_in)/creativity/(composition)/useDeleteWorkAction.test.ts
@@ -2,6 +2,7 @@ import { act, renderHook } from '@testing-library/react';
 import toast from 'react-hot-toast';
 
 import { useDeleteWorkAction } from './useDeleteWorkAction';
+import { COMPOSITION_ACTIONS_MESSAGES } from '~/constants/opus';
 import {
   PaginatedWorksDocument,
   useDeleteCompositionMutation,
@@ -109,7 +110,7 @@ describe('useDeleteWorkAction', () => {
       refetchQueries: [PaginatedWorksDocument],
       awaitRefetchQueries: true
     });
-    expect(toast.success).toHaveBeenCalledWith('Твір успішно видалено');
+    expect(toast.success).toHaveBeenCalledWith(COMPOSITION_ACTIONS_MESSAGES.DELETE_SUCCESS);
     expect(onSuccessMock).toHaveBeenCalledWith('work-123');
     expect(result.current.deleteComposition).toBeNull();
   });
@@ -135,7 +136,7 @@ describe('useDeleteWorkAction', () => {
       refetchQueries: [PaginatedWorksDocument],
       awaitRefetchQueries: true
     });
-    expect(toast.success).toHaveBeenCalledWith('Твір успішно видалено з групи');
+    expect(toast.success).toHaveBeenCalledWith(COMPOSITION_ACTIONS_MESSAGES.UNLINK_SUCCESS);
     expect(onSuccessMock).toHaveBeenCalledWith('work-123');
     expect(result.current.unlinkComposition).toBeNull();
   });
@@ -153,7 +154,7 @@ describe('useDeleteWorkAction', () => {
       await result.current.handleConfirmCompositionDelete();
     });
 
-    expect(toast.error).toHaveBeenCalledWith('Помилка при видаленні твору');
+    expect(toast.error).toHaveBeenCalledWith(COMPOSITION_ACTIONS_MESSAGES.DELETE_ERROR);
   });
 
   it('should handle unlink failure and show error toast', async () => {
@@ -169,7 +170,7 @@ describe('useDeleteWorkAction', () => {
       await result.current.handleConfirmUnlinkComposition();
     });
 
-    expect(toast.error).toHaveBeenCalledWith('Помилка при видаленні твору');
+    expect(toast.error).toHaveBeenCalledWith(COMPOSITION_ACTIONS_MESSAGES.DELETE_ERROR);
   });
 
   it('should correctly pass loading state from mutation hooks', () => {

--- a/app/(logged_in)/creativity/(composition)/useDeleteWorkAction.ts
+++ b/app/(logged_in)/creativity/(composition)/useDeleteWorkAction.ts
@@ -3,17 +3,12 @@
 import { useState } from 'react';
 import toast from 'react-hot-toast';
 
+import { COMPOSITION_ACTIONS_MESSAGES } from '~/constants/opus';
 import {
   PaginatedWorksDocument,
   useDeleteCompositionMutation,
   useUnlinkCompositionMutation
 } from '~/types/graphql/generated/graphql';
-
-const TOAST_MESSAGES = {
-  DELETE_SUCCESS: 'Твір успішно видалено',
-  UNLINK_SUCCESS: 'Твір успішно видалено з групи',
-  DELETE_ERROR: 'Помилка при видаленні твору'
-};
 
 interface UseDeleteWorkActionProps {
   onSuccess?: (deletedId: string) => void;
@@ -35,11 +30,11 @@ export function useDeleteWorkAction({ onSuccess }: UseDeleteWorkActionProps = {}
         awaitRefetchQueries: true
       });
 
-      toast.success(TOAST_MESSAGES.DELETE_SUCCESS);
+      toast.success(COMPOSITION_ACTIONS_MESSAGES.DELETE_SUCCESS);
       onSuccess?.(deleteComposition);
       setDeleteComposition(null);
     } catch {
-      toast.error(TOAST_MESSAGES.DELETE_ERROR);
+      toast.error(COMPOSITION_ACTIONS_MESSAGES.DELETE_ERROR);
     }
   };
 
@@ -56,11 +51,11 @@ export function useDeleteWorkAction({ onSuccess }: UseDeleteWorkActionProps = {}
         awaitRefetchQueries: true
       });
 
-      toast.success(TOAST_MESSAGES.UNLINK_SUCCESS);
+      toast.success(COMPOSITION_ACTIONS_MESSAGES.UNLINK_SUCCESS);
       onSuccess?.(unlinkComposition.compositionId);
       setUnlinkComposition(null);
     } catch {
-      toast.error(TOAST_MESSAGES.DELETE_ERROR);
+      toast.error(COMPOSITION_ACTIONS_MESSAGES.DELETE_ERROR);
     }
   };
 

--- a/app/constants/opus.ts
+++ b/app/constants/opus.ts
@@ -48,6 +48,8 @@ export const OPUS_FIELD_LIMITS = {
 
 export const OPUS_YEAR_RANGE = { min: 1900, max: 2100 } as const;
 
+export const COMPOSITION_TITLE_LIMITS = { min: 2, max: 250 } as const;
+
 export const OPUS_VALIDATION_MESSAGES = {
   numberRequired: 'Вкажіть номер.',
   numberInvalid: 'Номер має бути цілим позитивним числом.',

--- a/app/constants/opus.ts
+++ b/app/constants/opus.ts
@@ -49,6 +49,7 @@ export const OPUS_FIELD_LIMITS = {
 export const OPUS_YEAR_RANGE = { min: 1900, max: 2100 } as const;
 
 export const COMPOSITION_TITLE_LIMITS = { min: 2, max: 250 } as const;
+export const COMPOSITION_GENRE_LIMITS = { min: 2, max: 150 } as const;
 
 export const OPUS_VALIDATION_MESSAGES = {
   numberRequired: 'Вкажіть номер.',

--- a/app/constants/opus.ts
+++ b/app/constants/opus.ts
@@ -65,6 +65,15 @@ export const OPUS_VALIDATION_MESSAGES = {
   captionTooLong: 'Текст має містити менше 250 символів.'
 } as const;
 
+export const COMPOSITION_VALIDATION_MESSAGES = {
+  titleRequired: 'Введіть назву твору.',
+  titleTooShort: 'Введіть щонайменше 2 символи.',
+  titleTooLong: 'Назва не може перевищувати 250 символів.',
+  genreTooShort: 'Введіть щонайменше 2 символи.',
+  genreTooLong: 'Жанр не може перевищувати 150 символів.',
+  yearInvalid: 'Введіть коректну дату.'
+} as const;
+
 export const COMPOSITION_MODAL_LABELS = {
   createTitle: 'Нова композиція',
   editTitle: 'Редагування композиції',

--- a/app/constants/opus.ts
+++ b/app/constants/opus.ts
@@ -50,6 +50,7 @@ export const OPUS_YEAR_RANGE = { min: 1900, max: 2100 } as const;
 
 export const COMPOSITION_TITLE_LIMITS = { min: 2, max: 250 } as const;
 export const COMPOSITION_GENRE_LIMITS = { min: 2, max: 150 } as const;
+export const COMPOSITION_YEAR_LIMITS = { min: 4, max: 4 } as const;
 
 export const OPUS_VALIDATION_MESSAGES = {
   numberRequired: 'Вкажіть номер.',

--- a/app/constants/opus.ts
+++ b/app/constants/opus.ts
@@ -74,6 +74,12 @@ export const COMPOSITION_VALIDATION_MESSAGES = {
   yearInvalid: 'Введіть коректну дату.'
 } as const;
 
+export const COMPOSITION_ACTIONS_MESSAGES = {
+  DELETE_SUCCESS: 'Композицію успішно видалено',
+  UNLINK_SUCCESS: 'Композицію успішно видалено з групи',
+  DELETE_ERROR: 'Не вдалося видалити композицію. Спробуйте ще раз.'
+};
+
 export const COMPOSITION_MODAL_LABELS = {
   createTitle: 'Нова композиція',
   editTitle: 'Редагування композиції',

--- a/app/lib/utils/compositionErrors.test.ts
+++ b/app/lib/utils/compositionErrors.test.ts
@@ -1,4 +1,5 @@
 import {
+  getCompositionFieldErrors,
   getCompositionNameRequiredMessage,
   getDuplicateCompositionError,
   getDuplicateCompositionIds,
@@ -8,6 +9,7 @@ import {
   isCompositionNameRequiredError,
   normalizeCompositionName
 } from './compositionErrors';
+import { COMPOSITION_VALIDATION_MESSAGES } from '~/constants/opus';
 
 describe('composition error utilities', () => {
   it('normalizes names using trimming and Ukrainian case folding', () => {
@@ -27,6 +29,32 @@ describe('composition error utilities', () => {
 
   it('finds empty composition names', () => {
     expect(getInvalidCompositionIds([{ id: 'one', name: ' ' }, { id: 'two', name: 'Valid' }])).toEqual(['one']);
+  });
+
+  it('returns consistent name, genre, and year errors for composition fields', () => {
+    expect(
+      getCompositionFieldErrors([
+        { id: 'invalid', name: 'A', genre: 'G', year: '20' },
+        { id: 'valid', name: 'Valid', genre: '', year: '' }
+      ])
+    ).toEqual({
+      'compositions.invalid.name': COMPOSITION_VALIDATION_MESSAGES.titleTooShort,
+      'compositions.invalid.genre': COMPOSITION_VALIDATION_MESSAGES.genreTooShort,
+      'compositions.invalid.year': COMPOSITION_VALIDATION_MESSAGES.yearInvalid
+    });
+  });
+
+  it('handles missing optional composition fields while reporting invalid values', () => {
+    expect(
+      getCompositionFieldErrors([
+        { id: 'missing', name: 'Valid' },
+        { id: 'invalid', name: '', genre: 'A', year: 'bad' }
+      ])
+    ).toEqual({
+      'compositions.invalid.name': COMPOSITION_VALIDATION_MESSAGES.titleRequired,
+      'compositions.invalid.genre': COMPOSITION_VALIDATION_MESSAGES.genreTooShort,
+      'compositions.invalid.year': COMPOSITION_VALIDATION_MESSAGES.yearInvalid
+    });
   });
 
   it('extracts error messages from Error, string, and unknown values', () => {

--- a/app/lib/utils/compositionErrors.ts
+++ b/app/lib/utils/compositionErrors.ts
@@ -1,4 +1,37 @@
 import { COMPOSITION_NAME_REQUIRED_ERROR } from '~/constants/opus';
+import { compositionGenreSchema, compositionTitleSchema, compositionYearSchema } from '~/validators/composition.schema';
+
+type CompositionValidationInput = {
+  id: string;
+  name: string;
+  genre?: unknown;
+  year?: unknown;
+};
+
+export const getCompositionFieldErrors = (
+  compositions: CompositionValidationInput[]
+): Record<string, string> => {
+  const errors: Record<string, string> = {};
+
+  compositions.forEach((composition) => {
+    const basePath = `compositions.${composition.id}`;
+    const titleResult = compositionTitleSchema.safeParse(composition.name);
+    const genreResult = compositionGenreSchema.safeParse(composition.genre ?? '');
+    const yearResult = compositionYearSchema.safeParse(composition.year ?? '');
+
+    if (!titleResult.success) {
+      errors[`${basePath}.name`] = titleResult.error.issues[0].message;
+    }
+    if (!genreResult.success) {
+      errors[`${basePath}.genre`] = genreResult.error.issues[0].message;
+    }
+    if (!yearResult.success) {
+      errors[`${basePath}.year`] = yearResult.error.issues[0].message;
+    }
+  });
+
+  return errors;
+};
 
 export const normalizeCompositionName = (name: string): string =>
   name.trim().toLocaleLowerCase('uk-UA');

--- a/app/shared/components/forms/opus-details-block/OpusDetailsBlock.test.tsx
+++ b/app/shared/components/forms/opus-details-block/OpusDetailsBlock.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import type { Dayjs } from 'dayjs';
 import { ReactElement, ReactNode, useState } from 'react';
 
 import OpusDetailsBlock from './OpusDetailsBlock';
@@ -13,6 +14,12 @@ jest.mock('~/shared/components/media-modal/MediaModal', () => ({
 
 jest.mock('@mui/x-date-pickers/LocalizationProvider', () => ({
   LocalizationProvider: ({ children }: { children: ReactNode }): ReactElement => <>{children}</>
+}));
+
+jest.mock('@mui/x-date-pickers/DatePicker', () => ({
+  DatePicker: ({ label, value }: { label: string; value: Dayjs | null }): ReactElement => (
+    <input aria-label={label} readOnly value={value?.format('DD/MM/YYYY') || ''} />
+  )
 }));
 
 jest.mock('./year-picker/YearPicker', () => ({

--- a/app/shared/components/forms/opus-details-block/composition-modal/CompositionModal.styles.ts
+++ b/app/shared/components/forms/opus-details-block/composition-modal/CompositionModal.styles.ts
@@ -78,7 +78,7 @@ export const styles: Record<string, SxProps<Theme>> = {
   },
 
   mediaDateField: {
-    width: '160px',
+    width: '200px',
     '& .MuiOutlinedInput-root': { borderRadius: '8px' }
   },
 

--- a/app/shared/components/forms/opus-details-block/composition-modal/CompositionModal.test.tsx
+++ b/app/shared/components/forms/opus-details-block/composition-modal/CompositionModal.test.tsx
@@ -1,8 +1,9 @@
+import 'dayjs/locale/uk';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { ReactElement } from 'react';
 
 import CompositionModal from './CompositionModal';
-import { COMPOSITION_MODAL_LABELS, COMPOSITION_MODAL_TEXTS } from '~/constants/opus';
+import { COMPOSITION_MODAL_LABELS, COMPOSITION_MODAL_TEXTS, COMPOSITION_VALIDATION_MESSAGES } from '~/constants/opus';
 import type { MediaModalResult } from '~/shared/components/media-modal/MediaModal.types';
 import type { OpusCompositionData } from '~/types/opus';
 
@@ -48,6 +49,23 @@ const baseProps = {
   onSubmit: jest.fn()
 };
 
+const INPUTS = {
+  title: 'Назва твору *',
+  genre: 'Жанр',
+  year: 'Рік',
+  noteName: 'Назва нот',
+  noteDate: 'Дата видання',
+  audioName: 'Назва аудіо',
+  createButton: 'Створити',
+  addNotesButton: 'Додати ноти',
+  addAudioButton: 'Додати аудіо',
+  saveButton: 'Зберегти'
+} as const;
+
+const MOCK_NOTE_DATE = '01/01/2020';
+const MOCK_UPDATED_NOTE_DATE = '01/01/2022';
+const MOCK_UPDATED_NOTE_NAME = 'Оновлені ноти';
+
 const INITIAL_COMPOSITION_VALUE: OpusCompositionData = {
   id: 'c1',
   name: 'Твір',
@@ -70,7 +88,7 @@ describe('CompositionModal', () => {
     render(<CompositionModal {...baseProps} mode="create" />);
 
     expect(screen.getByText('Нова композиція')).toBeInTheDocument();
-    expect(screen.getByLabelText('Назва твору *')).toHaveValue('');
+    expect(screen.getByLabelText(INPUTS.title)).toHaveValue('');
   });
 
   it('renders the edit heading and prefilled title', () => {
@@ -85,7 +103,7 @@ describe('CompositionModal', () => {
     render(<CompositionModal {...baseProps} mode="edit" initialValue={initialValue} />);
 
     expect(screen.getByText('Редагування композиції')).toBeInTheDocument();
-    expect(screen.getByLabelText('Назва твору *')).toHaveValue('Існуючий твір');
+    expect(screen.getByLabelText(INPUTS.title)).toHaveValue('Існуючий твір');
   });
 
   it('renders nothing while closed', () => {
@@ -110,19 +128,19 @@ describe('CompositionModal', () => {
     const onSubmit = jest.fn();
     render(<CompositionModal {...baseProps} mode="create" onSubmit={onSubmit} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Створити' }));
+    fireEvent.click(screen.getByRole('button', { name: INPUTS.createButton }));
 
     expect(onSubmit).not.toHaveBeenCalled();
-    expect(screen.getByText('Обовʼязкове поле')).toBeInTheDocument();
+    expect(screen.getByText(COMPOSITION_VALIDATION_MESSAGES.titleRequired)).toBeInTheDocument();
   });
 
   it('clears error message when user starts typing in title field', () => {
     render(<CompositionModal {...baseProps} mode="create" />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Створити' }));
-    expect(screen.getByText('Обовʼязкове поле')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: INPUTS.createButton }));
+    expect(screen.getByText(COMPOSITION_VALIDATION_MESSAGES.titleRequired)).toBeInTheDocument();
 
-    const titleInput = screen.getByLabelText('Назва твору *');
+    const titleInput = screen.getByLabelText(INPUTS.title);
     fireEvent.change(titleInput, { target: { value: 'Нова назва' } });
 
     expect(screen.queryByText('Обовʼязкове поле')).not.toBeInTheDocument();
@@ -137,11 +155,11 @@ describe('CompositionModal', () => {
   it('updates the genre and year fields', () => {
     render(<CompositionModal {...baseProps} mode="create" />);
 
-    const genreField = screen.getByLabelText('Жанр');
+    const genreField = screen.getByLabelText(INPUTS.genre);
     fireEvent.change(genreField, { target: { value: 'Ноктюрн' } });
     expect(genreField).toHaveValue('Ноктюрн');
 
-    const yearField = screen.getByLabelText('Рік');
+    const yearField = screen.getByLabelText(INPUTS.year);
     fireEvent.change(yearField, { target: { value: '1888' } });
     expect(yearField).toHaveValue('1888');
   });
@@ -157,7 +175,7 @@ describe('CompositionModal', () => {
     };
     render(<CompositionModal {...baseProps} mode="edit" initialValue={initialValue} />);
 
-    const nameField = screen.getByLabelText('Назва твору *');
+    const nameField = screen.getByLabelText(INPUTS.title);
     expect(nameField).toHaveValue('Твір');
 
     const clearTitleBtn = screen.getAllByRole('button').find((btn) => btn.closest('.MuiInputAdornment-root'));
@@ -171,37 +189,43 @@ describe('CompositionModal', () => {
   it('adds a notes row with name and date fields', () => {
     render(<CompositionModal {...baseProps} mode="create" />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Додати ноти' }));
+    fireEvent.click(screen.getByRole('button', { name: INPUTS.addNotesButton }));
 
-    expect(screen.getByLabelText('Назва нот')).toBeInTheDocument();
-    expect(screen.getByLabelText('Дата видання')).toBeInTheDocument();
+    expect(screen.getByLabelText(INPUTS.noteName)).toBeInTheDocument();
+    expect(screen.getByLabelText(INPUTS.noteDate)).toBeInTheDocument();
   });
 
-  it('validates note publish date and restricts non-numeric input', () => {
+  it('accepts a valid note publication date', () => {
     render(<CompositionModal {...baseProps} mode="create" />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Додати ноти' }));
-    const dateField = screen.getByLabelText('Дата видання');
+    fireEvent.click(screen.getByRole('button', { name: INPUTS.addNotesButton }));
+    const dateField = screen.getByLabelText(INPUTS.noteDate);
 
-    fireEvent.change(dateField, { target: { value: 'abc' } });
-    expect(dateField).toHaveValue('');
+    fireEvent.change(dateField, { target: { value: '01/01/2023' } });
+    expect(dateField).toHaveValue('01/01/2023');
+  });
 
-    fireEvent.change(dateField, { target: { value: '2023' } });
-    expect(dateField).toHaveValue('2023');
+  it('clears a prefilled note publication date with the picker clear action', () => {
+    render(<CompositionModal {...baseProps} mode="edit" initialValue={INITIAL_COMPOSITION_VALUE} />);
+
+    expect(screen.getByDisplayValue(MOCK_NOTE_DATE)).toBeInTheDocument();
+    fireEvent.click(screen.getByTitle('Clear'));
+
+    expect(screen.queryByDisplayValue(MOCK_NOTE_DATE)).not.toBeInTheDocument();
   });
 
   it('shows error on note if publishDate is set without name or file', () => {
     const onSubmit = jest.fn();
     render(<CompositionModal {...baseProps} mode="create" onSubmit={onSubmit} />);
 
-    const titleInput = screen.getByLabelText('Назва твору *');
+    const titleInput = screen.getByLabelText(INPUTS.title);
     fireEvent.change(titleInput, { target: { value: 'Valid Title' } });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Додати ноти' }));
-    const dateField = screen.getByLabelText('Дата видання');
-    fireEvent.change(dateField, { target: { value: '2023' } });
+    fireEvent.click(screen.getByRole('button', { name: INPUTS.addNotesButton }));
+    const dateField = screen.getByLabelText(INPUTS.noteDate);
+    fireEvent.change(dateField, { target: { value: '01/01/2023' } });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Створити' }));
+    fireEvent.click(screen.getByRole('button', { name: INPUTS.createButton }));
 
     expect(onSubmit).not.toHaveBeenCalled();
     expect(
@@ -213,51 +237,51 @@ describe('CompositionModal', () => {
     const onSubmit = jest.fn();
     render(<CompositionModal {...baseProps} mode="create" onSubmit={onSubmit} />);
 
-    fireEvent.change(screen.getByLabelText('Назва твору *'), { target: { value: 'Valid Title' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Додати ноти' }));
+    fireEvent.change(screen.getByLabelText(INPUTS.title), { target: { value: 'Valid Title' } });
+    fireEvent.click(screen.getByRole('button', { name: INPUTS.addNotesButton }));
 
-    const dateField = screen.getByLabelText('Дата видання');
-    fireEvent.change(dateField, { target: { value: '2023' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Створити' }));
+    const dateField = screen.getByLabelText(INPUTS.noteDate);
+    fireEvent.change(dateField, { target: { value: '01/01/2023' } });
+    fireEvent.click(screen.getByRole('button', { name: INPUTS.createButton }));
 
     expect(onSubmit).not.toHaveBeenCalled();
     expect(
       screen.getByText((content) => content.includes(COMPOSITION_MODAL_TEXTS.emptyNoteDateError))
     ).toBeInTheDocument();
 
-    fireEvent.change(screen.getByLabelText('Назва нот'), { target: { value: 'Ноти' } });
+    fireEvent.change(screen.getByLabelText(INPUTS.noteName), { target: { value: 'Ноти' } });
     expect(
       screen.getByText((content) => content.includes(COMPOSITION_MODAL_TEXTS.emptyNoteDateError))
     ).toBeInTheDocument();
 
-    fireEvent.change(dateField, { target: { value: '2024' } });
+    fireEvent.change(dateField, { target: { value: '01/01/2024' } });
     expect(
       screen.queryByText((content) => content.includes(COMPOSITION_MODAL_TEXTS.emptyNoteDateError))
     ).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Створити' }));
+    fireEvent.click(screen.getByRole('button', { name: INPUTS.createButton }));
     expect(onSubmit).toHaveBeenCalledTimes(1);
   });
 
   it('removes a note row using its delete button', () => {
     render(<CompositionModal {...baseProps} mode="create" />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Додати ноти' }));
-    expect(screen.getByLabelText('Назва нот')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: INPUTS.addNotesButton }));
+    expect(screen.getByLabelText(INPUTS.noteName)).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: COMPOSITION_MODAL_TEXTS.deleteAriaLabel }));
-    expect(screen.queryByLabelText('Назва нот')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(INPUTS.noteName)).not.toBeInTheDocument();
   });
 
   it('filters out empty note rows on submit', () => {
     const onSubmit = jest.fn();
     render(<CompositionModal {...baseProps} mode="create" onSubmit={onSubmit} />);
 
-    const titleInput = screen.getByLabelText('Назва твору *');
+    const titleInput = screen.getByLabelText(INPUTS.title);
     fireEvent.change(titleInput, { target: { value: 'Valid Title' } });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Додати ноти' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Створити' }));
+    fireEvent.click(screen.getByRole('button', { name: INPUTS.addNotesButton }));
+    fireEvent.click(screen.getByRole('button', { name: INPUTS.createButton }));
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
     const submitted = onSubmit.mock.calls[0][0] as OpusCompositionData;
@@ -269,7 +293,10 @@ describe('CompositionModal', () => {
       ...INITIAL_COMPOSITION_VALUE,
       genre: 'Соната',
       year: '1900',
-      audios: [...INITIAL_COMPOSITION_VALUE.audios, { id: 'a2', name: '', fileUrl: 'https://files/second.mp3?token=123' }]
+      audios: [
+        ...INITIAL_COMPOSITION_VALUE.audios,
+        { id: 'a2', name: '', fileUrl: 'https://files/second.mp3?token=123' }
+      ]
     };
     render(<CompositionModal {...baseProps} mode="edit" initialValue={initialValue} />);
 
@@ -277,19 +304,31 @@ describe('CompositionModal', () => {
     expect(screen.getByText('second.mp3')).toBeInTheDocument();
     expect(screen.getByText('sheet.pdf')).toBeInTheDocument();
     expect(screen.getByDisplayValue('Ноти 1')).toBeInTheDocument();
-    expect(screen.getByDisplayValue('2020')).toBeInTheDocument();
+    expect(screen.getByDisplayValue(MOCK_NOTE_DATE)).toBeInTheDocument();
     expect(screen.queryByText(/Додайте файли/)).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: COMPOSITION_MODAL_LABELS.addAudio })).toBeDisabled();
+  });
+
+  it('renders an audio row with an empty file URL without crashing', () => {
+    const initialValue: OpusCompositionData = {
+      ...INITIAL_COMPOSITION_VALUE,
+      audios: [{ id: 'empty-url', name: '', fileUrl: '' }],
+      notes: []
+    };
+
+    render(<CompositionModal {...baseProps} mode="edit" initialValue={initialValue} />);
+
+    expect(screen.getByRole('button', { name: COMPOSITION_MODAL_TEXTS.deleteAriaLabel })).toBeInTheDocument();
   });
 
   it('edits, clears and removes prefilled media', () => {
     const initialValue: OpusCompositionData = { ...INITIAL_COMPOSITION_VALUE };
     render(<CompositionModal {...baseProps} mode="edit" initialValue={initialValue} />);
 
-    fireEvent.change(screen.getByDisplayValue('Ноти 1'), { target: { value: 'Оновлені ноти' } });
-    fireEvent.change(screen.getByDisplayValue('2020'), { target: { value: '2022' } });
-    expect(screen.getByDisplayValue('Оновлені ноти')).toBeInTheDocument();
-    expect(screen.getByDisplayValue('2022')).toBeInTheDocument();
+    fireEvent.change(screen.getByDisplayValue('Ноти 1'), { target: { value: MOCK_UPDATED_NOTE_NAME } });
+    fireEvent.change(screen.getByDisplayValue(MOCK_NOTE_DATE), { target: { value: MOCK_UPDATED_NOTE_DATE } });
+    expect(screen.getByDisplayValue(MOCK_UPDATED_NOTE_NAME)).toBeInTheDocument();
+    expect(screen.getByDisplayValue(MOCK_UPDATED_NOTE_DATE)).toBeInTheDocument();
 
     const iconButtons = screen.getAllByRole('button');
     const clearFileBtn = iconButtons.find(
@@ -311,7 +350,7 @@ describe('CompositionModal', () => {
   it('attaches an audio file as a chip via the media modal', () => {
     render(<CompositionModal {...baseProps} mode="create" />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Додати аудіо' }));
+    fireEvent.click(screen.getByRole('button', { name: INPUTS.addAudioButton }));
     fireEvent.click(screen.getByTestId('media-apply'));
 
     expect(screen.getByText('audio.mp3')).toBeInTheDocument();
@@ -324,7 +363,7 @@ describe('CompositionModal', () => {
     };
     render(<CompositionModal {...baseProps} mode="create" />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Додати аудіо' }));
+    fireEvent.click(screen.getByRole('button', { name: INPUTS.addAudioButton }));
     fireEvent.click(screen.getByTestId('media-apply'));
 
     expect(screen.getByText('gallery.mp3')).toBeInTheDocument();
@@ -337,7 +376,7 @@ describe('CompositionModal', () => {
     };
     render(<CompositionModal {...baseProps} mode="create" />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Додати аудіо' }));
+    fireEvent.click(screen.getByRole('button', { name: INPUTS.addAudioButton }));
     fireEvent.click(screen.getByTestId('media-apply'));
 
     expect(screen.getByText(/Додайте файли/)).toBeInTheDocument();
@@ -347,7 +386,7 @@ describe('CompositionModal', () => {
   it('attaches a file to a notes row via the media modal', () => {
     render(<CompositionModal {...baseProps} mode="create" />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Додати ноти' }));
+    fireEvent.click(screen.getByRole('button', { name: INPUTS.addNotesButton }));
     const uploadButtons = screen.getAllByRole('button').filter((btn) => btn.querySelector('svg.lucide-cloud-upload'));
     fireEvent.click(uploadButtons[0]);
     fireEvent.click(screen.getByTestId('media-apply'));
@@ -358,7 +397,7 @@ describe('CompositionModal', () => {
   it('closes media modal on close action without changes', () => {
     render(<CompositionModal {...baseProps} mode="create" />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Додати аудіо' }));
+    fireEvent.click(screen.getByRole('button', { name: INPUTS.addAudioButton }));
     expect(screen.getByTestId('media-close')).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId('media-close'));
@@ -377,18 +416,126 @@ describe('CompositionModal', () => {
     };
     render(<CompositionModal {...baseProps} mode="edit" initialValue={initialValue} onSubmit={onSubmit} />);
 
-    fireEvent.change(screen.getByLabelText('Назва твору *'), { target: { value: '  Редагований твір  ' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Зберегти' }));
+    fireEvent.change(screen.getByLabelText(INPUTS.title), { target: { value: '  Редагований твір  ' } });
+    fireEvent.click(screen.getByRole('button', { name: INPUTS.saveButton }));
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
     const submitted = onSubmit.mock.calls[0][0] as OpusCompositionData;
     expect(submitted.name).toBe('Редагований твір');
   });
 
+  it('rejects a one-character title', () => {
+    const onSubmit = jest.fn();
+    render(<CompositionModal {...baseProps} mode="create" onSubmit={onSubmit} />);
+    fireEvent.change(screen.getByLabelText(INPUTS.title), { target: { value: 'A' } });
+    fireEvent.click(screen.getByRole('button', { name: INPUTS.createButton }));
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByText(COMPOSITION_VALIDATION_MESSAGES.titleTooShort)).toBeInTheDocument();
+  });
+
+  it('accepts exactly 250 title characters and enforces the UI limit', () => {
+    const onSubmit = jest.fn();
+    render(<CompositionModal {...baseProps} mode="create" onSubmit={onSubmit} />);
+    const titleField = screen.getByLabelText(INPUTS.title);
+    const title = 'A'.repeat(250);
+    fireEvent.change(titleField, { target: { value: `${title}B` } });
+    expect(titleField).toHaveValue(title);
+    fireEvent.click(screen.getByRole('button', { name: INPUTS.createButton }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a 251-character title supplied in the initial value', () => {
+    const onSubmit = jest.fn();
+    render(
+      <CompositionModal
+        {...baseProps}
+        mode="edit"
+        initialValue={{ ...INITIAL_COMPOSITION_VALUE, name: 'A'.repeat(251) }}
+        onSubmit={onSubmit}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: INPUTS.saveButton }));
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByText(COMPOSITION_VALIDATION_MESSAGES.titleTooLong)).toBeInTheDocument();
+  });
+
+  it('accepts genre boundary values of 2 and 150 characters', () => {
+    for (const genre of ['AB', 'A'.repeat(150)]) {
+      const onSubmit = jest.fn();
+      const { unmount } = render(<CompositionModal {...baseProps} mode="create" onSubmit={onSubmit} />);
+      fireEvent.change(screen.getByLabelText(INPUTS.title), { target: { value: 'Valid Title' } });
+      fireEvent.change(screen.getByLabelText(INPUTS.genre), { target: { value: genre } });
+      fireEvent.click(screen.getByRole('button', { name: INPUTS.createButton }));
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      unmount();
+    }
+  });
+
+  it.each(['0000', '9999'])('accepts valid boundary year %s', (year) => {
+    const onSubmit = jest.fn();
+    render(<CompositionModal {...baseProps} mode="create" onSubmit={onSubmit} />);
+    fireEvent.change(screen.getByLabelText(INPUTS.title), { target: { value: 'Valid Title' } });
+    fireEvent.change(screen.getByLabelText(INPUTS.year), { target: { value: year } });
+    fireEvent.click(screen.getByRole('button', { name: INPUTS.createButton }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts a whitespace-padded year after normalization', () => {
+    const onSubmit = jest.fn();
+    render(
+      <CompositionModal
+        {...baseProps}
+        mode="edit"
+        initialValue={{ ...INITIAL_COMPOSITION_VALUE, year: ' 2020 ' }}
+        onSubmit={onSubmit}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: INPUTS.saveButton }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('blocks submit and shows an error for an invalid composition year', () => {
+    const onSubmit = jest.fn();
+    render(<CompositionModal {...baseProps} mode="create" onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByLabelText(INPUTS.title), { target: { value: 'Valid Title' } });
+    fireEvent.change(screen.getByLabelText(INPUTS.year), { target: { value: '20' } });
+    fireEvent.click(screen.getByRole('button', { name: INPUTS.createButton }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByText('Введіть коректну дату.')).toBeInTheDocument();
+  });
+
+  it('blocks submit and shows an error for an invalid composition genre', () => {
+    const onSubmit = jest.fn();
+    render(<CompositionModal {...baseProps} mode="create" onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByLabelText(INPUTS.title), { target: { value: 'Valid Title' } });
+    fireEvent.change(screen.getByLabelText(INPUTS.genre), { target: { value: 'A' } });
+    fireEvent.click(screen.getByRole('button', { name: INPUTS.createButton }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByText(COMPOSITION_VALIDATION_MESSAGES.genreTooShort)).toBeInTheDocument();
+  });
+
+  it('blocks submit and shows an error for an invalid note publication date', () => {
+    const onSubmit = jest.fn();
+    const initialValue: OpusCompositionData = {
+      ...INITIAL_COMPOSITION_VALUE,
+      notes: [{ id: 'invalid-date', name: 'Ноти', publishDate: 'not-a-date' }]
+    };
+    render(<CompositionModal {...baseProps} mode="edit" initialValue={initialValue} onSubmit={onSubmit} />);
+
+    fireEvent.click(screen.getByRole('button', { name: INPUTS.saveButton }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByText('Введіть коректну дату.')).toBeInTheDocument();
+  });
+
   it('restricts non-numeric input for the year field', () => {
     render(<CompositionModal {...baseProps} mode="create" />);
 
-    const yearField = screen.getByLabelText('Рік');
+    const yearField = screen.getByLabelText(INPUTS.year);
 
     fireEvent.change(yearField, { target: { value: 'abc' } });
     expect(yearField).toHaveValue('');

--- a/app/shared/components/forms/opus-details-block/composition-modal/CompositionModal.test.tsx
+++ b/app/shared/components/forms/opus-details-block/composition-modal/CompositionModal.test.tsx
@@ -205,11 +205,48 @@ describe('CompositionModal', () => {
     expect(dateField).toHaveValue('01/01/2023');
   });
 
-  it('clears a prefilled note publication date with the picker clear action', () => {
+  it('formats a typed publication date and submits it as an ISO date', () => {
+    const onSubmit = jest.fn();
+    render(<CompositionModal {...baseProps} mode="create" onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByLabelText(INPUTS.title), { target: { value: 'Valid Title' } });
+    fireEvent.click(screen.getByRole('button', { name: INPUTS.addNotesButton }));
+    fireEvent.change(screen.getByLabelText(INPUTS.noteName), { target: { value: 'Ноти' } });
+    const dateField = screen.getByLabelText(INPUTS.noteDate);
+    fireEvent.change(dateField, { target: { value: '01122020' } });
+
+    expect(dateField).toHaveValue('01/12/2020');
+
+    fireEvent.click(screen.getByRole('button', { name: INPUTS.createButton }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ notes: [expect.objectContaining({ publishDate: '2020-12-01' })] })
+    );
+  });
+
+  it('keeps a partial note publication date visible and reports it as invalid', () => {
+    const onSubmit = jest.fn();
+    render(<CompositionModal {...baseProps} mode="create" onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByLabelText(INPUTS.title), { target: { value: 'Valid Title' } });
+    fireEvent.click(screen.getByRole('button', { name: INPUTS.addNotesButton }));
+    fireEvent.change(screen.getByLabelText(INPUTS.noteName), { target: { value: 'Ноти' } });
+    const dateField = screen.getByLabelText(INPUTS.noteDate);
+    fireEvent.change(dateField, { target: { value: '0112' } });
+
+    expect(dateField).toHaveValue('01/12');
+
+    fireEvent.click(screen.getByRole('button', { name: INPUTS.createButton }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByText(COMPOSITION_VALIDATION_MESSAGES.yearInvalid)).toBeInTheDocument();
+  });
+
+  it('clears a prefilled note publication date', () => {
     render(<CompositionModal {...baseProps} mode="edit" initialValue={INITIAL_COMPOSITION_VALUE} />);
 
-    expect(screen.getByDisplayValue(MOCK_NOTE_DATE)).toBeInTheDocument();
-    fireEvent.click(screen.getByTitle('Clear'));
+    const dateField = screen.getByDisplayValue(MOCK_NOTE_DATE);
+    fireEvent.change(dateField, { target: { value: '' } });
 
     expect(screen.queryByDisplayValue(MOCK_NOTE_DATE)).not.toBeInTheDocument();
   });

--- a/app/shared/components/forms/opus-details-block/composition-modal/CompositionModal.tsx
+++ b/app/shared/components/forms/opus-details-block/composition-modal/CompositionModal.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react';
 import { styles } from './CompositionModal.styles';
 import Button from '~/components/design-system/button/Button';
 import {
+  COMPOSITION_GENRE_LIMITS,
   COMPOSITION_MODAL_LABELS,
   COMPOSITION_MODAL_TEXTS,
   COMPOSITION_TITLE_LIMITS
@@ -16,7 +17,7 @@ import type { MediaModalResult } from '~/shared/components/media-modal/MediaModa
 import { isAudioUploadFile, isPdfUploadFile } from '~/shared/components/media-modal/MediaModal.utils';
 import { createCompositionId } from '~/shared/hooks/use-upsert-opus/useUpsertOpus';
 import type { OpusCompositionData, OpusMediaFileData } from '~/types/opus';
-import { compositionTitleSchema } from '~/validators/composition.schema';
+import { compositionGenreSchema, compositionTitleSchema } from '~/validators/composition.schema';
 
 interface CompositionModalProps {
   open: boolean;
@@ -61,6 +62,7 @@ export default function CompositionModal({
 }: Readonly<CompositionModalProps>) {
   const [composition, setComposition] = useState<OpusCompositionData>(emptyComposition);
   const [titleError, setTitleError] = useState('');
+  const [genreError, setGenreError] = useState('');
   const [noteErrors, setNoteErrors] = useState<NoteErrors>({});
   const [mediaTarget, setMediaTarget] = useState<MediaTarget | null>(null);
 
@@ -68,6 +70,7 @@ export default function CompositionModal({
     if (open) {
       setComposition(initialValue ? { ...initialValue } : emptyComposition());
       setTitleError('');
+      setGenreError('');
       setNoteErrors({});
       setMediaTarget(null);
     }
@@ -79,6 +82,10 @@ export default function CompositionModal({
     if (key === 'name' && typeof value === 'string' && value.trim()) {
       setTitleError('');
       onClearError?.();
+    }
+
+    if (key === 'genre' && typeof value === 'string') {
+      setGenreError('');
     }
   };
 
@@ -147,11 +154,18 @@ export default function CompositionModal({
   const handleSubmit = (): void => {
     let isValid = true;
     let newTitleError = '';
+    let newGenreError = '';
     const newNoteErrors: NoteErrors = {};
 
     const titleResult = compositionTitleSchema.safeParse(composition.name);
     if (!titleResult.success) {
       newTitleError = titleResult.error.issues[0]?.message ?? '';
+      isValid = false;
+    }
+
+    const genreResult = compositionGenreSchema.safeParse(composition.genre);
+    if (!genreResult.success) {
+      newGenreError = genreResult.error.issues[0]?.message ?? '';
       isValid = false;
     }
 
@@ -173,6 +187,7 @@ export default function CompositionModal({
     });
 
     setTitleError(newTitleError);
+    setGenreError(newGenreError);
     setNoteErrors(newNoteErrors);
 
     if (!isValid) {
@@ -230,9 +245,12 @@ export default function CompositionModal({
           <TextField
             label={COMPOSITION_MODAL_LABELS.genre}
             value={composition.genre}
-            onChange={(event) => updateField('genre', event.target.value)}
+            onChange={(event) => updateField('genre', event.target.value.slice(0, COMPOSITION_GENRE_LIMITS.max))}
+            error={Boolean(genreError)}
+            helperText={genreError}
             size="small"
             sx={styles.field}
+            slotProps={{ htmlInput: { maxLength: COMPOSITION_GENRE_LIMITS.max } }}
           />
           <TextField
             label={COMPOSITION_MODAL_LABELS.year}

--- a/app/shared/components/forms/opus-details-block/composition-modal/CompositionModal.tsx
+++ b/app/shared/components/forms/opus-details-block/composition-modal/CompositionModal.tsx
@@ -15,6 +15,7 @@ import {
   COMPOSITION_MODAL_LABELS,
   COMPOSITION_MODAL_TEXTS,
   COMPOSITION_TITLE_LIMITS,
+  COMPOSITION_VALIDATION_MESSAGES,
   COMPOSITION_YEAR_LIMITS
 } from '~/constants/opus';
 import { MediaModal } from '~/shared/components/media-modal/MediaModal';
@@ -202,7 +203,7 @@ export default function CompositionModal({
       const hasFile = Boolean(note.fileUrl);
 
       if (hasDate && !publishDateToDayjs(note.publishDate)) {
-        errs.publishDate = 'Введіть коректну дату.';
+        errs.publishDate = COMPOSITION_VALIDATION_MESSAGES.yearInvalid;
         isValid = false;
       }
 

--- a/app/shared/components/forms/opus-details-block/composition-modal/CompositionModal.tsx
+++ b/app/shared/components/forms/opus-details-block/composition-modal/CompositionModal.tsx
@@ -1,10 +1,8 @@
 'use client';
 
 import { Box, Dialog, IconButton, InputAdornment, TextField, Typography } from '@mui/material';
-import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import dayjs, { Dayjs } from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
 import { CloudUpload, FileText, Info, Music, Trash2, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
@@ -24,6 +22,8 @@ import { isAudioUploadFile, isPdfUploadFile } from '~/shared/components/media-mo
 import { createCompositionId } from '~/shared/hooks/use-upsert-opus/useUpsertOpus';
 import type { OpusCompositionData, OpusMediaFileData } from '~/types/opus';
 import { compositionGenreSchema, compositionTitleSchema, compositionYearSchema } from '~/validators/composition.schema';
+
+dayjs.extend(customParseFormat);
 
 interface CompositionModalProps {
   open: boolean;
@@ -60,8 +60,19 @@ const fileNameFromUrl = (url?: string): string => {
 const publishDateToDayjs = (value?: string): Dayjs | null => {
   if (!value) return null;
 
-  const parsed = dayjs(value);
+  const parsed = dayjs(value, ['YYYY-MM-DD', 'DD/MM/YYYY', 'YYYY'], true);
   return parsed.isValid() ? parsed : null;
+};
+
+const formatPublishDate = (value?: string): string => publishDateToDayjs(value)?.format('DD/MM/YYYY') ?? value ?? '';
+
+const formatPublishDateInput = (value: string): string => {
+  const digits = value.replace(/\D/g, '').slice(0, 8);
+
+  if (digits.length <= 2) return digits;
+  if (digits.length <= 4) return `${digits.slice(0, 2)}/${digits.slice(2)}`;
+
+  return `${digits.slice(0, 2)}/${digits.slice(2, 4)}/${digits.slice(4)}`;
 };
 
 export default function CompositionModal({
@@ -199,10 +210,11 @@ export default function CompositionModal({
       const errs: { name?: string; publishDate?: string } = {};
       const noteName = note.name ?? '';
       const hasName = Boolean(noteName.trim());
-      const hasDate = Boolean(note.publishDate && String(note.publishDate).trim());
+      const dateValue = note.publishDate ?? '';
+      const hasDate = Boolean(dateValue.trim());
       const hasFile = Boolean(note.fileUrl);
 
-      if (hasDate && !publishDateToDayjs(note.publishDate)) {
+      if (hasDate && !publishDateToDayjs(dateValue)) {
         errs.publishDate = COMPOSITION_VALIDATION_MESSAGES.yearInvalid;
         isValid = false;
       }
@@ -232,7 +244,7 @@ export default function CompositionModal({
       )
       .map((note) => ({
         ...note,
-        publishDate: note.publishDate ? dayjs(note.publishDate).format('YYYY-MM-DD') : ''
+        publishDate: publishDateToDayjs(note.publishDate)?.format('YYYY-MM-DD') ?? ''
       }));
 
     onSubmit({ ...composition, name: composition.name.trim(), notes: filteredNotes });
@@ -361,32 +373,18 @@ export default function CompositionModal({
                     size="small"
                     sx={styles.mediaNameField}
                   />
-                  <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="uk">
-                    <DatePicker
-                      label={COMPOSITION_MODAL_LABELS.publishDate}
-                      format="DD/MM/YYYY"
-                      sx={styles.mediaDateField}
-                      enableAccessibleFieldDOMStructure={false}
-                      value={publishDateToDayjs(note.publishDate)}
-                      onChange={(date) => {
-                        if (date?.isValid()) {
-                          updateNoteRow(note.id, { publishDate: date.format('YYYY-MM-DD') });
-                        } else if (date === null) {
-                          updateNoteRow(note.id, { publishDate: '' });
-                        }
-                      }}
-                      slotProps={{
-                        field: {
-                          clearable: true,
-                          onClear: () => updateNoteRow(note.id, { publishDate: '' })
-                        },
-                        textField: {
-                          error: Boolean(errs.publishDate),
-                          helperText: errs.publishDate
-                        }
-                      }}
-                    />
-                  </LocalizationProvider>
+                  <TextField
+                    label={COMPOSITION_MODAL_LABELS.publishDate}
+                    sx={styles.mediaDateField}
+                    value={formatPublishDate(note.publishDate)}
+                    placeholder="ДД/ММ/РРРР"
+                    onChange={(event) =>
+                      updateNoteRow(note.id, { publishDate: formatPublishDateInput(event.target.value) })
+                    }
+                    error={Boolean(errs.publishDate)}
+                    helperText={errs.publishDate}
+                    size="small"
+                  />
                   <IconButton
                     aria-label={COMPOSITION_MODAL_TEXTS.uploadFileAriaLabel}
                     onClick={() => setMediaTarget({ field: 'notes', rowId: note.id })}

--- a/app/shared/components/forms/opus-details-block/composition-modal/CompositionModal.tsx
+++ b/app/shared/components/forms/opus-details-block/composition-modal/CompositionModal.tsx
@@ -6,12 +6,17 @@ import { useEffect, useState } from 'react';
 
 import { styles } from './CompositionModal.styles';
 import Button from '~/components/design-system/button/Button';
-import { COMPOSITION_MODAL_LABELS, COMPOSITION_MODAL_TEXTS, REQUIRED_FIELD_ERROR } from '~/constants/opus';
+import {
+  COMPOSITION_MODAL_LABELS,
+  COMPOSITION_MODAL_TEXTS,
+  COMPOSITION_TITLE_LIMITS
+} from '~/constants/opus';
 import { MediaModal } from '~/shared/components/media-modal/MediaModal';
 import type { MediaModalResult } from '~/shared/components/media-modal/MediaModal.types';
 import { isAudioUploadFile, isPdfUploadFile } from '~/shared/components/media-modal/MediaModal.utils';
 import { createCompositionId } from '~/shared/hooks/use-upsert-opus/useUpsertOpus';
 import type { OpusCompositionData, OpusMediaFileData } from '~/types/opus';
+import { compositionTitleSchema } from '~/validators/composition.schema';
 
 interface CompositionModalProps {
   open: boolean;
@@ -144,8 +149,9 @@ export default function CompositionModal({
     let newTitleError = '';
     const newNoteErrors: NoteErrors = {};
 
-    if (!composition.name.trim()) {
-      newTitleError = REQUIRED_FIELD_ERROR;
+    const titleResult = compositionTitleSchema.safeParse(composition.name);
+    if (!titleResult.success) {
+      newTitleError = titleResult.error.issues[0]?.message ?? '';
       isValid = false;
     }
 
@@ -198,12 +204,13 @@ export default function CompositionModal({
         <TextField
           label={`${COMPOSITION_MODAL_LABELS.name} *`}
           value={composition.name}
-          onChange={(event) => updateField('name', event.target.value)}
+          onChange={(event) => updateField('name', event.target.value.slice(0, COMPOSITION_TITLE_LIMITS.max))}
           error={Boolean(titleError || error)}
           helperText={titleError || error}
           fullWidth
           size="small"
           sx={styles.field}
+          slotProps={{ htmlInput: { maxLength: COMPOSITION_TITLE_LIMITS.max } }}
           InputProps={{
             endAdornment: composition.name ? (
               <InputAdornment position="end">

--- a/app/shared/components/forms/opus-details-block/composition-modal/CompositionModal.tsx
+++ b/app/shared/components/forms/opus-details-block/composition-modal/CompositionModal.tsx
@@ -10,14 +10,15 @@ import {
   COMPOSITION_GENRE_LIMITS,
   COMPOSITION_MODAL_LABELS,
   COMPOSITION_MODAL_TEXTS,
-  COMPOSITION_TITLE_LIMITS
+  COMPOSITION_TITLE_LIMITS,
+  COMPOSITION_YEAR_LIMITS
 } from '~/constants/opus';
 import { MediaModal } from '~/shared/components/media-modal/MediaModal';
 import type { MediaModalResult } from '~/shared/components/media-modal/MediaModal.types';
 import { isAudioUploadFile, isPdfUploadFile } from '~/shared/components/media-modal/MediaModal.utils';
 import { createCompositionId } from '~/shared/hooks/use-upsert-opus/useUpsertOpus';
 import type { OpusCompositionData, OpusMediaFileData } from '~/types/opus';
-import { compositionGenreSchema, compositionTitleSchema } from '~/validators/composition.schema';
+import { compositionGenreSchema, compositionTitleSchema, compositionYearSchema } from '~/validators/composition.schema';
 
 interface CompositionModalProps {
   open: boolean;
@@ -63,6 +64,7 @@ export default function CompositionModal({
   const [composition, setComposition] = useState<OpusCompositionData>(emptyComposition);
   const [titleError, setTitleError] = useState('');
   const [genreError, setGenreError] = useState('');
+  const [yearError, setYearError] = useState('');
   const [noteErrors, setNoteErrors] = useState<NoteErrors>({});
   const [mediaTarget, setMediaTarget] = useState<MediaTarget | null>(null);
 
@@ -71,6 +73,7 @@ export default function CompositionModal({
       setComposition(initialValue ? { ...initialValue } : emptyComposition());
       setTitleError('');
       setGenreError('');
+      setYearError('');
       setNoteErrors({});
       setMediaTarget(null);
     }
@@ -87,6 +90,11 @@ export default function CompositionModal({
     if (key === 'genre' && typeof value === 'string') {
       setGenreError('');
     }
+
+    if (key === 'year' && typeof value === 'string') {
+      setYearError('');
+    }
+
   };
 
   const addNoteRow = (): void => {
@@ -155,6 +163,7 @@ export default function CompositionModal({
     let isValid = true;
     let newTitleError = '';
     let newGenreError = '';
+    let newYearError = '';
     const newNoteErrors: NoteErrors = {};
 
     const titleResult = compositionTitleSchema.safeParse(composition.name);
@@ -166,6 +175,12 @@ export default function CompositionModal({
     const genreResult = compositionGenreSchema.safeParse(composition.genre);
     if (!genreResult.success) {
       newGenreError = genreResult.error.issues[0]?.message ?? '';
+      isValid = false;
+    }
+
+    const yearResult = compositionYearSchema.safeParse(composition.year);
+    if (!yearResult.success) {
+      newYearError = yearResult.error.issues[0]?.message ?? '';
       isValid = false;
     }
 
@@ -188,6 +203,7 @@ export default function CompositionModal({
 
     setTitleError(newTitleError);
     setGenreError(newGenreError);
+    setYearError(newYearError);
     setNoteErrors(newNoteErrors);
 
     if (!isValid) {
@@ -258,11 +274,14 @@ export default function CompositionModal({
             onChange={(event) => {
               const val = event.target.value;
               if (/^\d*$/.test(val)) {
-                updateField('year', val);
+                updateField('year', val.slice(0, COMPOSITION_YEAR_LIMITS.max));
               }
             }}
             size="small"
             sx={styles.field}
+            error={Boolean(yearError)}
+            helperText={yearError}
+            slotProps={{ htmlInput: { maxLength: COMPOSITION_YEAR_LIMITS.max, inputMode: 'numeric' } }}
           />
         </Box>
 

--- a/app/shared/components/forms/opus-details-block/composition-modal/CompositionModal.tsx
+++ b/app/shared/components/forms/opus-details-block/composition-modal/CompositionModal.tsx
@@ -1,6 +1,10 @@
 'use client';
 
 import { Box, Dialog, IconButton, InputAdornment, TextField, Typography } from '@mui/material';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import dayjs, { Dayjs } from 'dayjs';
 import { CloudUpload, FileText, Info, Music, Trash2, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
@@ -52,6 +56,13 @@ const fileNameFromUrl = (url?: string): string => {
   return decodeURIComponent(segment.split('?')[0]);
 };
 
+const publishDateToDayjs = (value?: string): Dayjs | null => {
+  if (!value) return null;
+
+  const parsed = dayjs(value);
+  return parsed.isValid() ? parsed : null;
+};
+
 export default function CompositionModal({
   open,
   mode,
@@ -94,7 +105,6 @@ export default function CompositionModal({
     if (key === 'year' && typeof value === 'string') {
       setYearError('');
     }
-
   };
 
   const addNoteRow = (): void => {
@@ -191,6 +201,11 @@ export default function CompositionModal({
       const hasDate = Boolean(note.publishDate && String(note.publishDate).trim());
       const hasFile = Boolean(note.fileUrl);
 
+      if (hasDate && !publishDateToDayjs(note.publishDate)) {
+        errs.publishDate = 'Введіть коректну дату.';
+        isValid = false;
+      }
+
       if (hasDate && !hasName && !hasFile) {
         errs.publishDate = COMPOSITION_MODAL_TEXTS.emptyNoteDateError;
         isValid = false;
@@ -210,9 +225,14 @@ export default function CompositionModal({
       return;
     }
 
-    const filteredNotes = composition.notes.filter(
-      (note) => (note.name ?? '').trim() || (note.publishDate && String(note.publishDate).trim()) || note.fileUrl
-    );
+    const filteredNotes = composition.notes
+      .filter(
+        (note) => (note.name ?? '').trim() || (note.publishDate && String(note.publishDate).trim()) || note.fileUrl
+      )
+      .map((note) => ({
+        ...note,
+        publishDate: note.publishDate ? dayjs(note.publishDate).format('YYYY-MM-DD') : ''
+      }));
 
     onSubmit({ ...composition, name: composition.name.trim(), notes: filteredNotes });
   };
@@ -340,20 +360,32 @@ export default function CompositionModal({
                     size="small"
                     sx={styles.mediaNameField}
                   />
-                  <TextField
-                    label={COMPOSITION_MODAL_LABELS.publishDate}
-                    value={note.publishDate ?? ''}
-                    onChange={(event) => {
-                      const val = event.target.value;
-                      if (/^\d*$/.test(val)) {
-                        updateNoteRow(note.id, { publishDate: val });
-                      }
-                    }}
-                    error={Boolean(errs.publishDate)}
-                    helperText={errs.publishDate}
-                    size="small"
-                    sx={styles.mediaDateField}
-                  />
+                  <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="uk">
+                    <DatePicker
+                      label={COMPOSITION_MODAL_LABELS.publishDate}
+                      format="DD/MM/YYYY"
+                      sx={styles.mediaDateField}
+                      enableAccessibleFieldDOMStructure={false}
+                      value={publishDateToDayjs(note.publishDate)}
+                      onChange={(date) => {
+                        if (date?.isValid()) {
+                          updateNoteRow(note.id, { publishDate: date.format('YYYY-MM-DD') });
+                        } else if (date === null) {
+                          updateNoteRow(note.id, { publishDate: '' });
+                        }
+                      }}
+                      slotProps={{
+                        field: {
+                          clearable: true,
+                          onClear: () => updateNoteRow(note.id, { publishDate: '' })
+                        },
+                        textField: {
+                          error: Boolean(errs.publishDate),
+                          helperText: errs.publishDate
+                        }
+                      }}
+                    />
+                  </LocalizationProvider>
                   <IconButton
                     aria-label={COMPOSITION_MODAL_TEXTS.uploadFileAriaLabel}
                     onClick={() => setMediaTarget({ field: 'notes', rowId: note.id })}

--- a/app/shared/components/forms/opus-details-block/composition-title-input/CompositionTitleInput.test.tsx
+++ b/app/shared/components/forms/opus-details-block/composition-title-input/CompositionTitleInput.test.tsx
@@ -36,6 +36,15 @@ describe('CompositionTitleInput', () => {
     expect(onChangeText).toHaveBeenCalledWith('Соната');
   });
 
+  it('limits typed titles to 250 characters', () => {
+    const onChangeText = jest.fn();
+    render(<CompositionTitleInput {...baseProps} onChangeText={onChangeText} />);
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'a'.repeat(251) } });
+
+    expect(onChangeText).toHaveBeenCalledWith('a'.repeat(250));
+  });
+
   it('calls onCreateNew when the create option is chosen', () => {
     const onCreateNew = jest.fn();
     render(<CompositionTitleInput {...baseProps} value="Нова" onCreateNew={onCreateNew} />);

--- a/app/shared/components/forms/opus-details-block/composition-title-input/CompositionTitleInput.tsx
+++ b/app/shared/components/forms/opus-details-block/composition-title-input/CompositionTitleInput.tsx
@@ -5,7 +5,7 @@ import { Plus } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
 import { styles } from './CompositionTitleInput.styles';
-import { COMPOSITION_SEARCH_LABELS } from '~/constants/opus';
+import { COMPOSITION_SEARCH_LABELS, COMPOSITION_TITLE_LIMITS } from '~/constants/opus';
 import { useDebounce } from '~/shared/hooks/use-debounce/useDebounce';
 import { useSearchCompositions } from '~/shared/hooks/use-opuses/useOpuses';
 import type { OpusCompositionSuggestion } from '~/types/opus';
@@ -89,7 +89,7 @@ export default function CompositionTitleInput({
       getOptionDisabled={(option) => typeof option !== 'string' && !!option.isNoResults}
       onInputChange={(_, nextInput, reason) => {
         if (reason === 'input' || reason === 'clear') {
-          onChangeText(nextInput);
+          onChangeText(nextInput.slice(0, COMPOSITION_TITLE_LIMITS.max));
         }
       }}
       onChange={(_, selected) => {
@@ -134,7 +134,19 @@ export default function CompositionTitleInput({
         );
       }}
       renderInput={(params) => (
-        <TextField {...params} size="small" error={error} helperText={helperMessage} sx={styles.input} />
+        <TextField
+          {...params}
+          size="small"
+          error={error}
+          helperText={helperMessage}
+          sx={styles.input}
+          slotProps={{
+            htmlInput: {
+              ...params.inputProps,
+              maxLength: COMPOSITION_TITLE_LIMITS.max
+            }
+          }}
+        />
       )}
     />
   );

--- a/app/shared/hooks/use-group-content/useGroupContent.test.ts
+++ b/app/shared/hooks/use-group-content/useGroupContent.test.ts
@@ -3,6 +3,14 @@ import * as nextNavigation from 'next/navigation';
 import toast from 'react-hot-toast';
 
 import { useGroupContent } from './useGroupContent';
+import {
+  COMPOSITION_DUPLICATE_ERROR,
+  COMPOSITION_NAME_REQUIRED_ERROR,
+  COMPOSITION_REQUIRED_FIELDS_ERROR,
+  OPUS_MUTATION_RESULTS,
+  OPUS_VALIDATION_MESSAGES,
+  REQUIRED_FIELD_ERROR
+} from '~/constants/opus';
 import { useNavigationGuard } from '~/shared/hooks/use-navigation-guard/useNavigationGuard';
 import { useDeleteOpus, useOpusById, useUpdateOpus } from '~/shared/hooks/use-opuses/useOpuses';
 import { useUnsavedChanges } from '~/shared/hooks/use-unsaved-changes/useUnsavedChanges';
@@ -40,33 +48,6 @@ jest.mock('~/shared/hooks/use-opuses/useOpuses', () => ({
   useDeleteOpus: jest.fn()
 }));
 
-jest.mock('~/constants/opus', () => ({
-  OPUS_FIELD_LIMITS: {
-    name: { min: 2, max: 250 },
-    caption: { min: 2, max: 250 },
-    altText: { min: 2, max: 250 },
-    maxPhotos: 20
-  },
-  OPUS_VALIDATION_MESSAGES: {
-    nameRequired: 'nameRequired',
-    nameTooShort: 'nameTooShort',
-    numberInvalid: 'numberInvalid',
-    performanceUrl: 'performanceUrl',
-    performanceSignature: 'performanceSignature',
-    photoAltText: 'photoAltText',
-    photoTextTooShort: 'photoTextTooShort',
-    captionTooLong: 'captionTooLong'
-  },
-  OPUS_MUTATION_RESULTS: {
-    deleted: 'deleted',
-    createFailed: 'createFailed',
-    updateFailed: 'updateFailed'
-  },
-  COMPOSITION_DUPLICATE_ERROR: 'duplicate compositions',
-  COMPOSITION_NAME_REQUIRED_ERROR: 'required composition name',
-  COMPOSITION_REQUIRED_FIELDS_ERROR: 'Заповніть усі обов’язкові поля перед публікацією.',
-  REQUIRED_FIELD_ERROR: 'REQUIRED_FIELD_ERROR'
-}));
 
 const mockFetchedOpus = {
   id: 'test-id',
@@ -276,7 +257,7 @@ describe('useGroupContent Hook', () => {
       await act(async () => {
         await result.current.handleMenuOptionClick('PUBLISH');
       });
-      expect(toast.error).toHaveBeenCalledWith('Заповніть усі обов’язкові поля перед публікацією.');
+      expect(toast.error).toHaveBeenCalledWith(COMPOSITION_REQUIRED_FIELDS_ERROR);
       expect(result.current.isDetailsExpanded).toBe(true);
       expect(mockUpdateOpus).not.toHaveBeenCalled();
     });
@@ -509,7 +490,7 @@ describe('useGroupContent Hook', () => {
         await result.current.handlePublishClick();
       });
 
-      expect(toast.error).toHaveBeenCalledWith('required composition name');
+      expect(toast.error).toHaveBeenCalledWith(COMPOSITION_NAME_REQUIRED_ERROR);
       expect(result.current.errors['compositions.comp-1.name']).toBe('');
       expect(result.current.isDirty).toBe(false);
     });
@@ -646,7 +627,7 @@ describe('useGroupContent Hook', () => {
       });
 
       expect(mockUpdateOpus).not.toHaveBeenCalled();
-      expect(result.current.errors.groupNumber).toBe('numberInvalid');
+      expect(result.current.errors.groupNumber).toBe(OPUS_VALIDATION_MESSAGES.numberInvalid);
       expect(result.current.isDetailsExpanded).toBe(true);
     });
 
@@ -664,9 +645,9 @@ describe('useGroupContent Hook', () => {
         await result.current.handlePublishClick();
       });
 
-      expect(result.current.errors['groupTitle.uk']).toBe('nameRequired');
-      expect(result.current.errors.creationYear).toBe('REQUIRED_FIELD_ERROR');
-      expect(toast.error).toHaveBeenCalledWith('Заповніть усі обов’язкові поля перед публікацією.');
+      expect(result.current.errors['groupTitle.uk']).toBe(OPUS_VALIDATION_MESSAGES.nameRequired);
+      expect(result.current.errors.creationYear).toBe(REQUIRED_FIELD_ERROR);
+      expect(toast.error).toHaveBeenCalledWith(COMPOSITION_REQUIRED_FIELDS_ERROR);
     });
 
     it('should successfully save data and show success toast on handlePublishClick', async () => {
@@ -743,7 +724,7 @@ describe('useGroupContent Hook', () => {
         await result.current.handlePublishClick();
       });
 
-      expect(result.current.errors.titlePrefix).toBe('REQUIRED_FIELD_ERROR');
+      expect(result.current.errors.titlePrefix).toBe(REQUIRED_FIELD_ERROR);
     });
 
     it('should expand details and return early when validation fails on publish', async () => {
@@ -768,7 +749,7 @@ describe('useGroupContent Hook', () => {
       await act(async () => {
         await result.current.handlePublishClick();
       });
-      expect(toast.error).toHaveBeenCalledWith('Заповніть усі обов’язкові поля перед публікацією.');
+      expect(toast.error).toHaveBeenCalledWith(COMPOSITION_REQUIRED_FIELDS_ERROR);
       expect(result.current.isDetailsExpanded).toBe(true);
     });
 
@@ -890,7 +871,7 @@ describe('useGroupContent Hook', () => {
       });
 
       expect(mockDeleteOpus).toHaveBeenCalledWith({ variables: { id: 'test-id' } });
-      expect(toast.success).toHaveBeenCalledWith('deleted');
+      expect(toast.success).toHaveBeenCalledWith(OPUS_MUTATION_RESULTS.deleted);
       expect(result.current.isDeleteModalOpen).toBe(false);
       expect(mockNavigate).toHaveBeenCalledWith('/creativity');
     });
@@ -925,7 +906,7 @@ describe('useGroupContent Hook', () => {
 
       expect(mockUpdateOpus).not.toHaveBeenCalled();
 
-      expect(toast.error).toHaveBeenCalledWith('Заповніть усі обов’язкові поля перед публікацією.');
+      expect(toast.error).toHaveBeenCalledWith(COMPOSITION_REQUIRED_FIELDS_ERROR);
     });
 
     it('should return early from handleSave if groupData is null', async () => {
@@ -1040,7 +1021,7 @@ describe('useGroupContent Hook', () => {
         await result.current.handlePublishClick();
       });
 
-      expect(result.current.errors['groupTitle.uk']).toBe('nameTooShort');
+      expect(result.current.errors['groupTitle.uk']).toBe(OPUS_VALIDATION_MESSAGES.nameTooShort);
 
       expect(mockUpdateOpus).not.toHaveBeenCalled();
     });
@@ -1102,12 +1083,12 @@ describe('useGroupContent Hook', () => {
         await result.current.handlePublishClick();
       });
 
-      expect(result.current.errors['performances[perf-1].caption.uk']).toBe('captionTooLong');
-      expect(result.current.errors['performances[perf-2].caption.en']).toBe('performanceSignature');
-      expect(result.current.errors['performances[perf-3].caption.en']).toBe('nameTooShort');
-      expect(result.current.errors['performances[perf-4].caption.en']).toBe('captionTooLong');
-      expect(result.current.errors['performances[perf-5].caption.uk']).toBe('performanceSignature');
-      expect(result.current.errors['performances[perf-6].caption.uk']).toBe('nameTooShort');
+      expect(result.current.errors['performances[perf-1].caption.uk']).toBe(OPUS_VALIDATION_MESSAGES.captionTooLong);
+      expect(result.current.errors['performances[perf-2].caption.en']).toBe(OPUS_VALIDATION_MESSAGES.performanceSignature);
+      expect(result.current.errors['performances[perf-3].caption.en']).toBe(OPUS_VALIDATION_MESSAGES.nameTooShort);
+      expect(result.current.errors['performances[perf-4].caption.en']).toBe(OPUS_VALIDATION_MESSAGES.captionTooLong);
+      expect(result.current.errors['performances[perf-5].caption.uk']).toBe(OPUS_VALIDATION_MESSAGES.performanceSignature);
+      expect(result.current.errors['performances[perf-6].caption.uk']).toBe(OPUS_VALIDATION_MESSAGES.nameTooShort);
     });
 
     it('should trigger validation errors for photos altText and caption length', async () => {
@@ -1173,15 +1154,15 @@ describe('useGroupContent Hook', () => {
         await result.current.handlePublishClick();
       });
 
-      expect(result.current.errors['photos[photo-1].altText.uk']).toBe('captionTooLong');
-      expect(result.current.errors['photos[photo-2].altText.en']).toBe('photoAltText');
-      expect(result.current.errors['photos[photo-3].altText.en']).toBe('photoTextTooShort');
-      expect(result.current.errors['photos[photo-4].altText.en']).toBe('captionTooLong');
-      expect(result.current.errors['photos[photo-5].altText.uk']).toBe('photoAltText');
-      expect(result.current.errors['photos[photo-6].altText.uk']).toBe('photoTextTooShort');
+      expect(result.current.errors['photos[photo-1].altText.uk']).toBe(OPUS_VALIDATION_MESSAGES.captionTooLong);
+      expect(result.current.errors['photos[photo-2].altText.en']).toBe(OPUS_VALIDATION_MESSAGES.photoAltText);
+      expect(result.current.errors['photos[photo-3].altText.en']).toBe(OPUS_VALIDATION_MESSAGES.photoTextTooShort);
+      expect(result.current.errors['photos[photo-4].altText.en']).toBe(OPUS_VALIDATION_MESSAGES.captionTooLong);
+      expect(result.current.errors['photos[photo-5].altText.uk']).toBe(OPUS_VALIDATION_MESSAGES.photoAltText);
+      expect(result.current.errors['photos[photo-6].altText.uk']).toBe(OPUS_VALIDATION_MESSAGES.photoTextTooShort);
 
-      expect(result.current.errors['photos[photo-3].caption.uk']).toBe('photoTextTooShort');
-      expect(result.current.errors['photos[photo-4].caption.en']).toBe('photoTextTooShort');
+      expect(result.current.errors['photos[photo-3].caption.uk']).toBe(OPUS_VALIDATION_MESSAGES.photoTextTooShort);
+      expect(result.current.errors['photos[photo-4].caption.en']).toBe(OPUS_VALIDATION_MESSAGES.photoTextTooShort);
     });
 
     it('should trigger validation errors when groupTitle.en is missing or too short', async () => {
@@ -1201,7 +1182,7 @@ describe('useGroupContent Hook', () => {
         await resultMissing.current.handlePublishClick();
       });
 
-      expect(resultMissing.current.errors['groupTitle.en']).toBe('nameRequired');
+      expect(resultMissing.current.errors['groupTitle.en']).toBe(OPUS_VALIDATION_MESSAGES.nameRequired);
       expect(resultMissing.current.currentLanguage).toBe('EN');
 
       (useOpusById as jest.Mock).mockReturnValue({
@@ -1220,7 +1201,7 @@ describe('useGroupContent Hook', () => {
         await resultShort.current.handlePublishClick();
       });
 
-      expect(resultShort.current.errors['groupTitle.en']).toBe('nameTooShort');
+      expect(resultShort.current.errors['groupTitle.en']).toBe(OPUS_VALIDATION_MESSAGES.nameTooShort);
       expect(resultShort.current.currentLanguage).toBe('EN');
     });
 
@@ -1256,8 +1237,8 @@ describe('useGroupContent Hook', () => {
         await result.current.handlePublishClick();
       });
 
-      expect(result.current.errors['photos[photo-uk-caption].caption.uk']).toBe('captionTooLong');
-      expect(result.current.errors['photos[photo-en-caption].caption.en']).toBe('captionTooLong');
+      expect(result.current.errors['photos[photo-uk-caption].caption.uk']).toBe(OPUS_VALIDATION_MESSAGES.captionTooLong);
+      expect(result.current.errors['photos[photo-en-caption].caption.en']).toBe(OPUS_VALIDATION_MESSAGES.captionTooLong);
       expect(result.current.currentLanguage).toBe('EN');
     });
 
@@ -1279,7 +1260,7 @@ describe('useGroupContent Hook', () => {
       await act(async () => {
         await duplicateResult.result.current.handlePublishClick();
       });
-      expect(toast.error).toHaveBeenCalledWith('duplicate compositions');
+      expect(toast.error).toHaveBeenCalledWith(COMPOSITION_DUPLICATE_ERROR);
 
       (useOpusById as jest.Mock).mockReturnValue({
         data: {
@@ -1295,7 +1276,7 @@ describe('useGroupContent Hook', () => {
       await act(async () => {
         await emptyResult.result.current.handlePublishClick();
       });
-      expect(toast.error).toHaveBeenCalledWith('required composition name');
+      expect(toast.error).toHaveBeenCalledWith(COMPOSITION_NAME_REQUIRED_ERROR);
       expect(emptyResult.result.current.errors['compositions.empty.name']).toBe('');
     });
 
@@ -1324,7 +1305,7 @@ describe('useGroupContent Hook', () => {
         await result.current.handlePublishClick();
       });
 
-      expect(result.current.errors['performances[perf-no-url].url']).toBe('performanceUrl');
+      expect(result.current.errors['performances[perf-no-url].url']).toBe(OPUS_VALIDATION_MESSAGES.performanceUrl);
     });
 
     it('should preserve explicit block order and clear composition errors when compositions change', async () => {
@@ -1415,7 +1396,7 @@ describe('useGroupContent Hook', () => {
         await result.current.handleMenuOptionClick('PUBLISH');
       });
 
-      expect(toast.error).toHaveBeenCalledWith('duplicate compositions');
+      expect(toast.error).toHaveBeenCalledWith(COMPOSITION_DUPLICATE_ERROR);
     });
 
     it('should show required-name feedback when publishing an empty composition from the menu', async () => {
@@ -1434,7 +1415,7 @@ describe('useGroupContent Hook', () => {
         await result.current.handleMenuOptionClick('PUBLISH');
       });
 
-      expect(toast.error).toHaveBeenCalledWith('required composition name');
+      expect(toast.error).toHaveBeenCalledWith(COMPOSITION_NAME_REQUIRED_ERROR);
     });
   });
 

--- a/app/shared/hooks/use-group-content/useGroupContent.test.ts
+++ b/app/shared/hooks/use-group-content/useGroupContent.test.ts
@@ -7,6 +7,7 @@ import {
   COMPOSITION_DUPLICATE_ERROR,
   COMPOSITION_NAME_REQUIRED_ERROR,
   COMPOSITION_REQUIRED_FIELDS_ERROR,
+  COMPOSITION_VALIDATION_MESSAGES,
   OPUS_MUTATION_RESULTS,
   OPUS_VALIDATION_MESSAGES,
   REQUIRED_FIELD_ERROR
@@ -446,6 +447,30 @@ describe('useGroupContent Hook', () => {
   });
 
   describe('Validation & Saving', () => {
+    it('shows a field error when a composition name is shorter than two characters', async () => {
+      (useOpusById as jest.Mock).mockReturnValue({ data: { opusById: mockFetchedOpus }, loading: false });
+
+      const { result } = renderHook(() => useGroupContent('test-id'));
+
+      await waitFor(() => {
+        expect(result.current.groupData).not.toBeNull();
+      });
+
+      act(() => {
+        result.current.handleFieldChange('compositions', [
+          { ...result.current.groupData!.compositions[0], name: 'A' },
+          ...result.current.groupData!.compositions.slice(1)
+        ]);
+      });
+
+      await act(async () => {
+        await result.current.handlePublishClick();
+      });
+
+      expect(result.current.errors['compositions.comp-1.name']).toBe(COMPOSITION_VALIDATION_MESSAGES.titleTooShort);
+      expect(mockUpdateOpus).not.toHaveBeenCalled();
+    });
+
     it('should catch server errors during save and display error toast', async () => {
       (useOpusById as jest.Mock).mockReturnValue({ data: { opusById: mockFetchedOpus }, loading: false });
 
@@ -1277,7 +1302,7 @@ describe('useGroupContent Hook', () => {
         await emptyResult.result.current.handlePublishClick();
       });
       expect(toast.error).toHaveBeenCalledWith(COMPOSITION_NAME_REQUIRED_ERROR);
-      expect(emptyResult.result.current.errors['compositions.empty.name']).toBe('');
+      expect(emptyResult.result.current.errors['compositions.empty.name']).toBe(COMPOSITION_VALIDATION_MESSAGES.titleRequired);
     });
 
     it('should trigger validation error when performance URL is missing but row is not empty', async () => {
@@ -1501,7 +1526,7 @@ describe('useGroupContent Hook', () => {
         result.current.handleFieldChange('compositions', [
           {
             id: 'c3',
-            name: 'T',
+            name: 'Test',
             genre: '   ',
             year: '   ',
             audios: undefined,

--- a/app/shared/hooks/use-group-content/useGroupContent.ts
+++ b/app/shared/hooks/use-group-content/useGroupContent.ts
@@ -16,6 +16,7 @@ import {
 } from '~/constants/opus';
 import { EditorLanguage } from '~/constants/publications';
 import {
+  getCompositionFieldErrors,
   getDuplicateCompositionError,
   getDuplicateCompositionIds,
   getInvalidCompositionIds,
@@ -450,10 +451,7 @@ export const useGroupContent = (id: string) => {
       newErrors.creationYear = REQUIRED_FIELD_ERROR;
     }
 
-    const emptyCompositionIds = getInvalidCompositionIds(groupData?.compositions || []);
-    emptyCompositionIds.forEach((id) => {
-      newErrors[`compositions.${id}.name`] = '';
-    });
+    Object.assign(newErrors, getCompositionFieldErrors(groupData?.compositions || []));
 
     const hasDuplicateCompositionNames = getDuplicateCompositionIds(groupData?.compositions || []).length > 0;
 

--- a/app/shared/hooks/use-upsert-opus/useUpsertOpus.test.ts
+++ b/app/shared/hooks/use-upsert-opus/useUpsertOpus.test.ts
@@ -5,6 +5,7 @@ import { createCompositionId, toCompositionInput,useUpsertOpus } from './useUpse
 import {
   COMPOSITION_DUPLICATE_ERROR,
   COMPOSITION_NAME_REQUIRED_ERROR,
+  COMPOSITION_REQUIRED_FIELDS_ERROR,
   COMPOSITION_VALIDATION_MESSAGES,
   OPUS_VALIDATION_MESSAGES
 } from '~/constants/opus';
@@ -268,6 +269,30 @@ describe('useUpsertOpus', () => {
     expect(result.current.compositionErrors['compositions.composition.genre']).toBe(
       COMPOSITION_VALIDATION_MESSAGES.genreTooShort
     );
+  });
+
+  it('shows a toast and field error for a one-character composition name', async () => {
+    const { result } = renderHook(() => useUpsertOpus());
+
+    act(() => {
+      result.current.setDetails((prev) => ({
+        ...prev,
+        number: '5',
+        name: 'Група',
+        creationYear: '1922',
+        compositions: [{ id: 'composition', name: 'A', genre: '', year: '', audios: [], notes: [] }]
+      }));
+    });
+
+    await act(async () => {
+      await result.current.handleSave(BaseContentStatuses.Draft);
+    });
+
+    expect(result.current.compositionErrors['compositions.composition.name']).toBe(
+      COMPOSITION_VALIDATION_MESSAGES.titleTooShort
+    );
+    expect(toast.error).toHaveBeenCalledWith(COMPOSITION_REQUIRED_FIELDS_ERROR);
+    expect(mockCreateOpus).not.toHaveBeenCalled();
   });
 
   it('maps duplicate mutation errors to matching composition fields', async () => {

--- a/app/shared/hooks/use-upsert-opus/useUpsertOpus.test.ts
+++ b/app/shared/hooks/use-upsert-opus/useUpsertOpus.test.ts
@@ -5,6 +5,7 @@ import { createCompositionId, toCompositionInput,useUpsertOpus } from './useUpse
 import {
   COMPOSITION_DUPLICATE_ERROR,
   COMPOSITION_NAME_REQUIRED_ERROR,
+  COMPOSITION_VALIDATION_MESSAGES,
   OPUS_VALIDATION_MESSAGES
 } from '~/constants/opus';
 import { BaseContentStatuses } from '~/types/enums/common.enums';
@@ -239,9 +240,34 @@ describe('useUpsertOpus', () => {
     });
 
     expect(mockCreateOpus).not.toHaveBeenCalled();
-    expect(result.current.compositionErrors).toEqual({ 'compositions.empty.name': '' });
+    expect(result.current.compositionErrors).toEqual({
+      'compositions.empty.name': COMPOSITION_VALIDATION_MESSAGES.titleRequired,
+    });
     expect(toast.error).toHaveBeenCalledWith(COMPOSITION_DUPLICATE_ERROR);
     expect(toast.error).toHaveBeenCalledWith(COMPOSITION_NAME_REQUIRED_ERROR);
+  });
+
+  it('rejects a composition with a one-character genre before mutation', async () => {
+    const { result } = renderHook(() => useUpsertOpus());
+
+    act(() => {
+      result.current.setDetails((prev) => ({
+        ...prev,
+        number: '5',
+        name: 'Соната',
+        creationYear: '1922',
+        compositions: [{ id: 'composition', name: 'Соната', genre: 'a', year: '', audios: [], notes: [] }]
+      }));
+    });
+
+    await act(async () => {
+      await result.current.handleSave(BaseContentStatuses.Draft);
+    });
+
+    expect(mockCreateOpus).not.toHaveBeenCalled();
+    expect(result.current.compositionErrors['compositions.composition.genre']).toBe(
+      COMPOSITION_VALIDATION_MESSAGES.genreTooShort
+    );
   });
 
   it('maps duplicate mutation errors to matching composition fields', async () => {

--- a/app/shared/hooks/use-upsert-opus/useUpsertOpus.ts
+++ b/app/shared/hooks/use-upsert-opus/useUpsertOpus.ts
@@ -34,6 +34,7 @@ import type {
   OpusDetailsErrors,
   OpusDetailsValue
 } from '~/types/opus';
+import { compositionTitleSchema } from '~/validators/composition.schema';
 
 export const createCompositionId = (): string => generateUniqueId();
 
@@ -278,9 +279,16 @@ export const useUpsertOpus = (
     setDetailsErrors(errors);
 
     const invalidIds = getInvalidCompositionIds(value.compositions);
-    setCompositionErrors(
-      Object.fromEntries(invalidIds.map((id) => [`compositions.${id}.name`, '']))
-    );
+    const titleErrors: Record<string, string> = {};
+    value.compositions.forEach((composition) => {
+      const fieldPath = `compositions.${composition.id}.name`;
+      const titleResult = compositionTitleSchema.safeParse(composition.name);
+
+      if (!titleResult.success) {
+        titleErrors[fieldPath] = titleResult.error.issues[0]?.message ?? '';
+      }
+    });
+    setCompositionErrors(titleErrors);
 
     const duplicateIds = getDuplicateCompositionIds(value.compositions);
     if (duplicateIds.length > 0) {
@@ -296,6 +304,7 @@ export const useUpsertOpus = (
       !nameError &&
       !creationYearError &&
       invalidIds.length === 0 &&
+      Object.keys(titleErrors).length === 0 &&
       duplicateIds.length === 0
     );
   };

--- a/app/shared/hooks/use-upsert-opus/useUpsertOpus.ts
+++ b/app/shared/hooks/use-upsert-opus/useUpsertOpus.ts
@@ -34,7 +34,7 @@ import type {
   OpusDetailsErrors,
   OpusDetailsValue
 } from '~/types/opus';
-import { compositionTitleSchema } from '~/validators/composition.schema';
+import { compositionGenreSchema, compositionTitleSchema } from '~/validators/composition.schema';
 
 export const createCompositionId = (): string => generateUniqueId();
 
@@ -286,6 +286,11 @@ export const useUpsertOpus = (
 
       if (!titleResult.success) {
         titleErrors[fieldPath] = titleResult.error.issues[0]?.message ?? '';
+      }
+
+      const genreResult = compositionGenreSchema.safeParse(composition.genre);
+      if (!genreResult.success) {
+        titleErrors[`compositions.${composition.id}.genre`] = genreResult.error.issues[0]?.message ?? '';
       }
     });
     setCompositionErrors(titleErrors);

--- a/app/shared/hooks/use-upsert-opus/useUpsertOpus.ts
+++ b/app/shared/hooks/use-upsert-opus/useUpsertOpus.ts
@@ -4,6 +4,7 @@ import toast from 'react-hot-toast';
 import {
   COMPOSITION_DUPLICATE_ERROR,
   COMPOSITION_NAME_REQUIRED_ERROR,
+  COMPOSITION_REQUIRED_FIELDS_ERROR,
   initialOpusDetails,
   initialOpusSeoValue,
   OPUS_FIELD_LIMITS,
@@ -11,6 +12,7 @@ import {
   OPUS_VALIDATION_MESSAGES
 } from '~/constants/opus';
 import {
+  getCompositionFieldErrors,
   getDuplicateCompositionError,
   getDuplicateCompositionIds,
   getErrorMessage,
@@ -34,7 +36,6 @@ import type {
   OpusDetailsErrors,
   OpusDetailsValue
 } from '~/types/opus';
-import { compositionGenreSchema, compositionTitleSchema } from '~/validators/composition.schema';
 
 export const createCompositionId = (): string => generateUniqueId();
 
@@ -279,20 +280,7 @@ export const useUpsertOpus = (
     setDetailsErrors(errors);
 
     const invalidIds = getInvalidCompositionIds(value.compositions);
-    const titleErrors: Record<string, string> = {};
-    value.compositions.forEach((composition) => {
-      const fieldPath = `compositions.${composition.id}.name`;
-      const titleResult = compositionTitleSchema.safeParse(composition.name);
-
-      if (!titleResult.success) {
-        titleErrors[fieldPath] = titleResult.error.issues[0]?.message ?? '';
-      }
-
-      const genreResult = compositionGenreSchema.safeParse(composition.genre);
-      if (!genreResult.success) {
-        titleErrors[`compositions.${composition.id}.genre`] = genreResult.error.issues[0]?.message ?? '';
-      }
-    });
+    const titleErrors = getCompositionFieldErrors(value.compositions);
     setCompositionErrors(titleErrors);
 
     const duplicateIds = getDuplicateCompositionIds(value.compositions);
@@ -302,6 +290,14 @@ export const useUpsertOpus = (
 
     if (invalidIds.length > 0) {
       toast.error( COMPOSITION_NAME_REQUIRED_ERROR);
+    }
+
+    const hasTopLevelValidationErrors = Boolean(numberError || nameError || creationYearError);
+    const hasCompositionValidationErrors =
+      Object.keys(titleErrors).length > 0 && invalidIds.length === 0 && duplicateIds.length === 0;
+
+    if (hasTopLevelValidationErrors || hasCompositionValidationErrors) {
+      toast.error(COMPOSITION_REQUIRED_FIELDS_ERROR);
     }
 
     return (

--- a/src/interfaces/graphql/resolvers/compositions/compositionNameValidation.test.ts
+++ b/src/interfaces/graphql/resolvers/compositions/compositionNameValidation.test.ts
@@ -1,11 +1,14 @@
 import { GraphQLError } from 'graphql';
 
 import {
+  assertCompositionGenreValid,
   assertCompositionNameNotTaken,
+  assertCompositionYearValid,
   compositionNameTakenError,
   normalizeCompositionName,
   throwIfCompositionNameDuplicateKey
 } from './compositionNameValidation';
+import { COMPOSITION_VALIDATION_MESSAGES } from '~/constants/opus';
 import type { Composition } from '~/domain/entities/Composition';
 import type { ICompositionRepository } from '~/domain/repositories/compositionRepository';
 
@@ -39,7 +42,7 @@ describe('composition name validation', () => {
     const findByName = jest.fn();
 
     await expect(assertCompositionNameNotTaken(repository(findByName), '   ')).rejects.toMatchObject({
-      message: 'Composition name is required',
+      message: COMPOSITION_VALIDATION_MESSAGES.titleRequired,
       extensions: { code: 'BAD_USER_INPUT' }
     });
     expect(findByName).not.toHaveBeenCalled();
@@ -59,6 +62,21 @@ describe('composition name validation', () => {
       message: 'Композиція "Sonata" вже існує',
       extensions: { code: 'COMPOSITION_NAME_TAKEN' }
     });
+  });
+
+  it('validates optional genre', () => {
+    expect(() => assertCompositionGenreValid(undefined)).not.toThrow();
+    expect(() => assertCompositionGenreValid(null)).not.toThrow();
+    expect(() => assertCompositionGenreValid('Classical')).not.toThrow();
+    expect(() => assertCompositionGenreValid('a')).toThrow(COMPOSITION_VALIDATION_MESSAGES.genreTooShort);
+    expect(() => assertCompositionGenreValid('a'.repeat(151))).toThrow(COMPOSITION_VALIDATION_MESSAGES.genreTooLong);
+  });
+
+  it('validates optional year values', () => {
+    expect(() => assertCompositionYearValid(undefined)).not.toThrow();
+    expect(() => assertCompositionYearValid(null)).not.toThrow();
+    expect(() => assertCompositionYearValid(2026)).not.toThrow();
+    expect(() => assertCompositionYearValid(202)).toThrow(COMPOSITION_VALIDATION_MESSAGES.yearInvalid);
   });
 
   it('translates Mongo duplicate-key errors and ignores other errors', () => {

--- a/src/interfaces/graphql/resolvers/compositions/compositionNameValidation.ts
+++ b/src/interfaces/graphql/resolvers/compositions/compositionNameValidation.ts
@@ -1,7 +1,8 @@
 import { GraphQLError } from 'graphql';
 
-import { compositionsServiceErrors, opusServiceErrors } from '~/back-constants/errors';
+import { compositionsServiceErrors } from '~/back-constants/errors';
 import { ICompositionRepository } from '~/domain/repositories/compositionRepository';
+import { compositionTitleSchema } from '~/validators/composition.schema';
 
 type DuplicateKeyError = {
   code?: unknown;
@@ -23,12 +24,14 @@ export const assertCompositionNameNotTaken = async (
   ukName: string,
   excludeId?: string
 ): Promise<void> => {
-  const name = normalizeCompositionName(ukName);
-  if (!name) {
-    throw new GraphQLError(opusServiceErrors.COMPOSITION_NAME_REQUIRED, {
+  const titleResult = compositionTitleSchema.safeParse(ukName);
+  if (!titleResult.success) {
+    throw new GraphQLError(titleResult.error.issues[0]?.message ?? 'Введіть назву композиції.', {
       extensions: { code: 'BAD_USER_INPUT' }
     });
   }
+
+  const name = titleResult.data;
 
   const existing = await repo.findByName(name);
 

--- a/src/interfaces/graphql/resolvers/compositions/compositionNameValidation.ts
+++ b/src/interfaces/graphql/resolvers/compositions/compositionNameValidation.ts
@@ -2,7 +2,7 @@ import { GraphQLError } from 'graphql';
 
 import { compositionsServiceErrors } from '~/back-constants/errors';
 import { ICompositionRepository } from '~/domain/repositories/compositionRepository';
-import { compositionGenreSchema, compositionTitleSchema } from '~/validators/composition.schema';
+import { compositionGenreSchema, compositionTitleSchema, compositionYearSchema } from '~/validators/composition.schema';
 
 type DuplicateKeyError = {
   code?: unknown;
@@ -46,6 +46,17 @@ export const assertCompositionGenreValid = (genre?: string | null): void => {
   const result = compositionGenreSchema.safeParse(genre);
   if (!result.success) {
     throw new GraphQLError(result.error.issues[0]?.message ?? 'Некоректний жанр.', {
+      extensions: { code: 'BAD_USER_INPUT' }
+    });
+  }
+};
+
+export const assertCompositionYearValid = (year?: number | null): void => {
+  if (year === undefined || year === null) return;
+
+  const result = compositionYearSchema.safeParse(String(year));
+  if (!result.success) {
+    throw new GraphQLError(result.error.issues[0]?.message ?? 'Введіть коректну дату.', {
       extensions: { code: 'BAD_USER_INPUT' }
     });
   }

--- a/src/interfaces/graphql/resolvers/compositions/compositionNameValidation.ts
+++ b/src/interfaces/graphql/resolvers/compositions/compositionNameValidation.ts
@@ -2,7 +2,7 @@ import { GraphQLError } from 'graphql';
 
 import { compositionsServiceErrors } from '~/back-constants/errors';
 import { ICompositionRepository } from '~/domain/repositories/compositionRepository';
-import { compositionTitleSchema } from '~/validators/composition.schema';
+import { compositionGenreSchema, compositionTitleSchema } from '~/validators/composition.schema';
 
 type DuplicateKeyError = {
   code?: unknown;
@@ -37,6 +37,17 @@ export const assertCompositionNameNotTaken = async (
 
   if (existing && existing.id !== excludeId) {
     throw compositionNameTakenError(name);
+  }
+};
+
+export const assertCompositionGenreValid = (genre?: string | null): void => {
+  if (genre === undefined || genre === null) return;
+
+  const result = compositionGenreSchema.safeParse(genre);
+  if (!result.success) {
+    throw new GraphQLError(result.error.issues[0]?.message ?? 'Некоректний жанр.', {
+      extensions: { code: 'BAD_USER_INPUT' }
+    });
   }
 };
 

--- a/src/interfaces/graphql/resolvers/compositions/compositionsMutation.test.ts
+++ b/src/interfaces/graphql/resolvers/compositions/compositionsMutation.test.ts
@@ -200,6 +200,20 @@ describe('CompositionsMutation', () => {
       expect(context.requestContainer.cradle.compositionsRepository.create).not.toHaveBeenCalled();
     });
 
+    it.each([
+      ['genre', { genre: 'a' }],
+      ['year', { year: 202 }]
+    ])('should reject an invalid composition %s before creating', async (_field, input) => {
+      const createMock = jest.fn();
+      const context = createMockContext(MOCK_ADMIN, { create: createMock });
+
+      await expect(
+        CompositionsMutation.createComposition(null, { input: { ...MOCK_INPUT, ...input } }, context)
+      ).rejects.toMatchObject({ extensions: { code: 'BAD_USER_INPUT' } });
+
+      expect(createMock).not.toHaveBeenCalled();
+    });
+
     it('should trim localized names and translate a duplicate-key create error', async () => {
       const createMock = jest.fn().mockRejectedValue({ code: 11000, keyValue: { 'name.uk': 'Trimmed' } });
       const context = createMockContext(MOCK_ADMIN, {
@@ -368,6 +382,27 @@ describe('CompositionsMutation', () => {
         message: 'Композиція "Taken" вже існує',
         extensions: { code: 'COMPOSITION_NAME_TAKEN' }
       });
+    });
+
+    it.each([
+      ['genre', { genre: 'a' }],
+      ['year', { year: 202 }]
+    ])('should reject an invalid composition %s before updating', async (_field, input) => {
+      const updateMock = jest.fn();
+      const context = createMockContext(MOCK_ADMIN, {
+        findById: jest.fn().mockResolvedValue(MOCK_COMPOSITION),
+        update: updateMock
+      });
+
+      await expect(
+        CompositionsMutation.updateComposition(
+          null,
+          { id: MOCK_COMPOSITION_ID, input: input as UpdateCompositionInput },
+          context
+        )
+      ).rejects.toMatchObject({ extensions: { code: 'BAD_USER_INPUT' } });
+
+      expect(updateMock).not.toHaveBeenCalled();
     });
 
     it('should process undefined and null values in update input correctly', async () => {

--- a/src/interfaces/graphql/resolvers/compositions/compositionsMutation.ts
+++ b/src/interfaces/graphql/resolvers/compositions/compositionsMutation.ts
@@ -3,6 +3,7 @@ import { GraphQLError } from 'graphql';
 import {
   assertCompositionGenreValid,
   assertCompositionNameNotTaken,
+  assertCompositionYearValid,
   normalizeCompositionName,
   throwIfCompositionNameDuplicateKey
 } from './compositionNameValidation';
@@ -62,6 +63,7 @@ export const CompositionsMutation = {
 
     await assertCompositionNameNotTaken(repo, input.name.uk);
     assertCompositionGenreValid(input.genre);
+    assertCompositionYearValid(input.year);
 
     const compositionData = mapCompositionInput(input);
 
@@ -93,6 +95,7 @@ export const CompositionsMutation = {
       await assertCompositionNameNotTaken(repo, input.name.uk, id);
     }
     assertCompositionGenreValid(input.genre);
+    assertCompositionYearValid(input.year);
 
     const updateData: CompositionInput = {
       ...(input.name && { name: mapCompositionName(input.name) }),

--- a/src/interfaces/graphql/resolvers/compositions/compositionsMutation.ts
+++ b/src/interfaces/graphql/resolvers/compositions/compositionsMutation.ts
@@ -1,6 +1,7 @@
 import { GraphQLError } from 'graphql';
 
 import {
+  assertCompositionGenreValid,
   assertCompositionNameNotTaken,
   normalizeCompositionName,
   throwIfCompositionNameDuplicateKey
@@ -60,6 +61,7 @@ export const CompositionsMutation = {
     const { compositionsRepository: repo, opusRepository: opusRepo } = context.requestContainer.cradle;
 
     await assertCompositionNameNotTaken(repo, input.name.uk);
+    assertCompositionGenreValid(input.genre);
 
     const compositionData = mapCompositionInput(input);
 
@@ -90,6 +92,7 @@ export const CompositionsMutation = {
     if (input.name != null) {
       await assertCompositionNameNotTaken(repo, input.name.uk, id);
     }
+    assertCompositionGenreValid(input.genre);
 
     const updateData: CompositionInput = {
       ...(input.name && { name: mapCompositionName(input.name) }),

--- a/src/interfaces/graphql/resolvers/opus/opusMutation.test.ts
+++ b/src/interfaces/graphql/resolvers/opus/opusMutation.test.ts
@@ -853,7 +853,7 @@ describe('OpusMutation Resolvers', () => {
     });
 
     describe('Edge Cases (Parsers & Helpers)', () => {
-      it('should map compositions gracefully with invalid years and empty sheet URLs', async () => {
+      it('should map compositions gracefully with empty years and empty sheet URLs', async () => {
         mockOpusRepo.findById.mockResolvedValue(MOCK_OPUS_ENTITY);
         mockOpusRepo.update.mockResolvedValue(MOCK_OPUS_ENTITY);
         mockCompositionsRepo.syncForOpus.mockResolvedValue([]);
@@ -867,7 +867,7 @@ describe('OpusMutation Resolvers', () => {
               compositions: [
                 {
                   name: 'Test',
-                  year: 'invalid-year',
+                  year: '',
                   genre: null,
                   notes: [{ name: MAPPED_SHEETS[1].name, fileUrl: MAPPED_SHEETS[1].url }],
                   audios: [{ name: '', fileUrl: '' }]
@@ -888,6 +888,28 @@ describe('OpusMutation Resolvers', () => {
             audios: []
           })
         ], expect.anything());
+      });
+
+      it('should reject compositions with invalid years before syncing', async () => {
+        mockOpusRepo.findById.mockResolvedValue(MOCK_OPUS_ENTITY);
+        mockOpusRepo.update.mockResolvedValue(MOCK_OPUS_ENTITY);
+        mockCompositionsRepo.syncForOpus.mockResolvedValue([]);
+
+        await expect(
+          OpusMutation.updateOpus(
+            {},
+            {
+              id: OPUS_ID,
+              input: {
+                ...BASE_UPDATE_INPUT,
+                compositions: [{ name: 'Test', year: 'invalid-year', genre: null }]
+              }
+            },
+            adminContext
+          )
+        ).rejects.toMatchObject({ extensions: { code: 'BAD_USER_INPUT' } });
+
+        expect(mockCompositionsRepo.syncForOpus).not.toHaveBeenCalled();
       });
 
       it('should skip gallery item validation if src is empty', async () => {

--- a/src/interfaces/graphql/resolvers/opus/opusMutation.ts
+++ b/src/interfaces/graphql/resolvers/opus/opusMutation.ts
@@ -4,6 +4,7 @@ import { ClientSession } from 'mongoose';
 import {
   assertCompositionGenreValid,
   assertCompositionNameNotTaken,
+  assertCompositionYearValid,
   compositionNameTakenError,
   throwIfCompositionNameDuplicateKey
 } from '../compositions/compositionNameValidation';
@@ -120,6 +121,9 @@ async function assertCompositionsNamesNotTaken(
 
     await assertCompositionNameNotTaken(compositionsRepo, name, composition.id);
     assertCompositionGenreValid(composition.genre);
+    assertCompositionYearValid(
+      !composition.year?.trim() ? null : Number(composition.year)
+    );
   }
 }
 

--- a/src/interfaces/graphql/resolvers/opus/opusMutation.ts
+++ b/src/interfaces/graphql/resolvers/opus/opusMutation.ts
@@ -2,6 +2,7 @@ import { GraphQLError } from 'graphql';
 import { ClientSession } from 'mongoose';
 
 import {
+  assertCompositionGenreValid,
   assertCompositionNameNotTaken,
   compositionNameTakenError,
   throwIfCompositionNameDuplicateKey
@@ -118,6 +119,7 @@ async function assertCompositionsNamesNotTaken(
     submittedNames.add(normalizedName);
 
     await assertCompositionNameNotTaken(compositionsRepo, name, composition.id);
+    assertCompositionGenreValid(composition.genre);
   }
 }
 

--- a/src/validators/composition.schema.ts
+++ b/src/validators/composition.schema.ts
@@ -1,19 +1,21 @@
 import { z } from 'zod';
 
+import { COMPOSITION_VALIDATION_MESSAGES } from '~/constants/opus';
+
 export const compositionTitleSchema = z
   .string()
   .trim()
-  .min(1, 'Введіть назву композиції.')
-  .min(2, 'Введіть щонайменше 2 символи.')
-  .max(250, 'Назва не може перевищувати 250 символів.');
+  .min(1, COMPOSITION_VALIDATION_MESSAGES.titleRequired)
+  .min(2, COMPOSITION_VALIDATION_MESSAGES.titleTooShort)
+  .max(250, COMPOSITION_VALIDATION_MESSAGES.titleTooLong);
 
 export const compositionGenreSchema = z
   .string()
   .trim()
-  .refine((genre) => !genre || genre.length >= 2, 'Введіть щонайменше 2 символи.')
-  .max(150, 'Жанр не може перевищувати 150 символів.');
+  .refine((genre) => !genre || genre.length >= 2, COMPOSITION_VALIDATION_MESSAGES.genreTooShort)
+  .max(150, COMPOSITION_VALIDATION_MESSAGES.genreTooLong);
 
 export const compositionYearSchema = z
   .string()
   .trim()
-  .refine((year) => !year || /^\d{4}$/.test(year), 'Введіть коректну дату.');
+  .refine((year) => !year || /^\d{4}$/.test(year), COMPOSITION_VALIDATION_MESSAGES.yearInvalid);

--- a/src/validators/composition.schema.ts
+++ b/src/validators/composition.schema.ts
@@ -6,3 +6,9 @@ export const compositionTitleSchema = z
   .min(1, 'Введіть назву композиції.')
   .min(2, 'Введіть щонайменше 2 символи.')
   .max(250, 'Назва не може перевищувати 250 символів.');
+
+export const compositionGenreSchema = z
+  .string()
+  .trim()
+  .refine((genre) => !genre || genre.length >= 2, 'Введіть щонайменше 2 символи.')
+  .max(150, 'Жанр не може перевищувати 150 символів.');

--- a/src/validators/composition.schema.ts
+++ b/src/validators/composition.schema.ts
@@ -12,3 +12,8 @@ export const compositionGenreSchema = z
   .trim()
   .refine((genre) => !genre || genre.length >= 2, 'Введіть щонайменше 2 символи.')
   .max(150, 'Жанр не може перевищувати 150 символів.');
+
+export const compositionYearSchema = z
+  .string()
+  .trim()
+  .refine((year) => !year || /^\d{4}$/.test(year), 'Введіть коректну дату.');

--- a/src/validators/composition.schema.ts
+++ b/src/validators/composition.schema.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const compositionTitleSchema = z
+  .string()
+  .trim()
+  .min(1, 'Введіть назву композиції.')
+  .min(2, 'Введіть щонайменше 2 символи.')
+  .max(250, 'Назва не може перевищувати 250 символів.');


### PR DESCRIPTION
## Description

Implements composition field validation according to the user stories across the editor and GraphQL mutations for name, year, and genre fields. Sheet publication dates now support typed `DD/MM/YYYY` input with automatic separators, reject incomplete or invalid dates, and are sent to the backend in ISO format.

### What was changed

*Composition*
* Added shared Zod validation schemas for composition name, genre, and year.
* Limited composition name to 2–250 characters and genre to 2–150 characters.
* Added frontend validation, length limits, and field-level error messages.
* Added backend validation for composition create and update mutations.
* Applied composition validation when saving opus data.
* Updated composition deletion messages and related tests.

*Composition: sheet music*
* Added automatic DD/MM/YYYY formatting for publication dates.
* Rejects incomplete or invalid dates.
* Normalizes valid dates to YYYY-MM-DD before submission.

*Opus*
* Centralize composition field validation and error mapping in compositionErrors, then reuse it in useUpsertOpus and useGroupContent. Display validation feedback for invalid opus fields and composition name, genre, or year before saving.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Check out this branch.
2. Navigate to the Opus create/edit form.
3. Create or edit a composition with valid title, genre, year, and publication date values.
4. Verify that invalid or overly long title and genre values show validation errors.
5. Verify that the year must contain four digits.
6. Verify that publication dates can be selected, cleared, and are saved in `YYYY-MM-DD` format.
7. Verify that the previously implemented behavior still works: duplicate composition names and invalid values are rejected when saving.

## Video / Screenshots


https://github.com/user-attachments/assets/628a8131-d5ee-40ca-9365-7888f72faa87


https://github.com/user-attachments/assets/725628fc-9ab0-48c8-bcfa-c05967617b29


https://github.com/user-attachments/assets/4f00095e-fb7f-42d4-9618-2dd837b34c6a



## Checklist

- [ ] Code compiles and runs correctly
- [ ] Tests pass successfully
- [ ] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [ ] Linked issue/task included
- [ ] Task moved to the review column on the board

---

Closes #801
